### PR TITLE
GarnetClientSample commands to match both GarnetClient and SE.Redis

### DIFF
--- a/samples/GarnetClientSample/GarnetClientSamples.cs
+++ b/samples/GarnetClientSample/GarnetClientSamples.cs
@@ -32,7 +32,13 @@ namespace GarnetClientSample
             await PingAsync();
             await SetGetAsync();
             SetGetSync();
-            await IncrementByAsync();
+            await IncrAsync();
+            await IncrByAsync(99);
+            await DecrByAsync(99);
+            await DecrAsync("test", 5);
+            await IncrNoKeyAsync();
+            await ExistsAsync();
+            await DeleteAsync();
             await SetGetMemoryAsync();
         }
 
@@ -43,6 +49,7 @@ namespace GarnetClientSample
             var pong = await db.PingAsync();
             if (pong != "PONG")
                 throw new Exception("PingAsync: Error");
+            Console.WriteLine("Ping: Success");
         }
 
         async Task SetGetAsync()
@@ -57,6 +64,7 @@ namespace GarnetClientSample
 
             if (origValue != retValue)
                 throw new Exception("SetGetAsync: Error");
+            Console.WriteLine("SetGetAsync: Success");
         }
 
         void SetGetSync()
@@ -70,15 +78,40 @@ namespace GarnetClientSample
             ManualResetEventSlim e = new();
             db.StringGet("mykey", (c, s) => { if (s != origValue) throw new Exception("SetGetSync: Error"); e.Set(); });
             e.Wait();
+            Console.WriteLine("SetGetSync: Success");
         }
 
-        async Task IncrementByAsync()
+        async Task IncrAsync()
         {
             using var db = new GarnetClient(address, port, GetSslOpts());
             await db.ConnectAsync();
 
             // Key storing integer
-            int nVal = 1000, nIncr = 25;
+            int nVal = 1000;
+            var strKey = "key1";
+            await db.StringSetAsync(strKey, $"{nVal}");
+            var s = await db.StringGetAsync(strKey);
+
+            if (s != $"{nVal}")
+                throw new Exception("IncrementAsync: Error");
+
+            long n = await db.StringIncrement(strKey);
+            if (n != nVal + 1)
+                throw new Exception("IncrementAsync: Error");
+
+            int nRetVal = int.Parse(await db.StringGetAsync(strKey));
+            if (n != nRetVal)
+                throw new Exception("IncrementAsync: Error");
+            Console.WriteLine("IncrementAsync: Success");
+        }
+
+        async Task IncrByAsync(long nIncr)
+        {
+            using var db = new GarnetClient(address, port, GetSslOpts());
+            await db.ConnectAsync();
+
+            // Key storing integer
+            int nVal = 1000;
 
             var strKey = "key1";
             await db.StringSetAsync(strKey, $"{nVal}");
@@ -94,7 +127,108 @@ namespace GarnetClientSample
             int nRetVal = int.Parse(await db.StringGetAsync(strKey));
             if (n != nRetVal)
                 throw new Exception("IncrementByAsync: Error");
+            Console.WriteLine("IncrementByAsync: Success");
         }
+
+        async Task DecrByAsync(long nDecr)
+        {
+            using var db = new GarnetClient(address, port, GetSslOpts());
+            await db.ConnectAsync();
+
+            // Key storing integer
+            int nVal = 900;
+
+            var strKey = "key1";
+            await db.StringSetAsync(strKey, $"{nVal}");
+            var s = await db.StringGetAsync(strKey);
+
+            if (s != $"{nVal}")
+                throw new Exception("DecrByAsync: Error");
+
+            long n = int.Parse(await db.ExecuteForStringResultAsync("DECRBY", new string[] { strKey, nDecr.ToString() }));
+            if (n != nVal - nDecr)
+                throw new Exception("DecrByAsync: Error");
+
+            int nRetVal = int.Parse(await db.StringGetAsync(strKey));
+            if (n != nRetVal)
+                throw new Exception("DecrByAsync: Error");
+            Console.WriteLine("DecrByAsync: Success");
+        }
+
+        async Task DecrAsync(string strKey, int nVal)
+        {
+            using var db = new GarnetClient(address, port, GetSslOpts());
+            await db.ConnectAsync();
+
+            await db.StringSetAsync(strKey, $"{nVal}");
+            var s = await db.StringGetAsync(strKey);
+
+            if (s != $"{nVal}")
+                throw new Exception("DecrAsync: Error");
+
+            long n = await db.StringDecrement(strKey);
+            if (n != nVal - 1)
+                throw new Exception("DecrAsync: Error");
+
+            int nRetVal = int.Parse(await db.StringGetAsync(strKey));
+            if (n != nRetVal)
+                throw new Exception("DecrAsync: Error");
+            Console.WriteLine("DecrAsync: Success");
+        }
+
+        async Task IncrNoKeyAsync()
+        {
+            using var db = new GarnetClient(address, port, GetSslOpts());
+            await db.ConnectAsync();
+
+            // Key storing integer
+            var strKey = "key1";
+            int init = int.Parse(await db.StringGetAsync(strKey));
+            await db.StringIncrement(strKey);
+
+            var retVal = int.Parse(await db.StringGetAsync(strKey));
+
+            await db.StringIncrement(strKey);
+            retVal = int.Parse(await db.StringGetAsync(strKey));
+            
+            if (init + 2 != retVal)
+                throw new Exception("IncrNoKeyAsync: Error");
+            Console.WriteLine("IncrNoKeyAsync: Success");
+        }
+
+        async Task ExistsAsync()
+        {
+            using var db = new GarnetClient(address, port, GetSslOpts());
+            await db.ConnectAsync();
+
+            // Key storing integer
+            int nVal = 100;
+            var strKey = "key1";
+            await db.StringSetAsync(strKey, $"{nVal}");
+
+            bool fExists = int.Parse(await db.ExecuteForStringResultAsync("EXISTS", new string[] { strKey })) == 1 ? true : false;
+            if (!fExists)
+                throw new Exception("ExistsAsync: Error");
+            Console.WriteLine("ExistsAsync: Success");
+        }
+
+        async Task DeleteAsync()
+        {
+            using var db = new GarnetClient(address, port, GetSslOpts());
+            await db.ConnectAsync();
+
+            // Key storing integer
+            var nVal = 100;
+            var strKey = "key1";
+            await db.StringSetAsync(strKey, $"{nVal}");
+            await db.KeyDeleteAsync(strKey);
+
+            bool fExists = int.Parse(await db.ExecuteForStringResultAsync("EXISTS", new string[] { strKey })) == 1 ? true : false;
+            if (fExists)
+                throw new Exception("DeleteAsync: Error");
+            Console.WriteLine("DeleteAsync: Success");
+        }
+
 
         async Task SetGetMemoryAsync()
         {
@@ -114,6 +248,8 @@ namespace GarnetClientSample
 
             if (!origValue.Span.SequenceEqual(retValue.Span))
                 throw new Exception("SetGetAsync: Error");
+
+            Console.WriteLine("SetGetMemoryAsync: Success");
         }
 
         SslClientAuthenticationOptions GetSslOpts() => useTLS ? new()

--- a/samples/GarnetClientSample/SERedisSamples.cs
+++ b/samples/GarnetClientSample/SERedisSamples.cs
@@ -143,9 +143,9 @@ namespace GarnetClientSample
             long n = db.StringDecrement(strKey, nDecr);
             int nRetVal = Convert.ToInt32(db.StringGet(strKey));
             if (nVal - nDecr != nRetVal)
-                Console.WriteLine("SingleIncr: Error");
+                Console.WriteLine("SingleDecrBy: Error");
             else
-                Console.WriteLine("SingleIncr: Success");
+                Console.WriteLine("SingleDecrBy: Success");
         }
 
         void SingleDecr(string strKey, int nVal)
@@ -170,6 +170,7 @@ namespace GarnetClientSample
 
             // Key storing integer
             var strKey = "key1";
+            int init = Convert.ToInt32(db.StringGet(strKey));
             db.StringIncrement(strKey);
 
             int retVal = Convert.ToInt32(db.StringGet(strKey));
@@ -177,10 +178,10 @@ namespace GarnetClientSample
             db.StringIncrement(strKey);
             retVal = Convert.ToInt32(db.StringGet(strKey));
 
-            if (2 != retVal)
-                Console.WriteLine("SingleSetGet: Error");
+            if (init + 2 != retVal)
+                Console.WriteLine("SingleIncrNoKey: Error");
             else
-                Console.WriteLine("SingleSetGet: Success");
+                Console.WriteLine("SingleIncrNoKey: Success");
         }
 
         void SingleExists()
@@ -211,7 +212,7 @@ namespace GarnetClientSample
             db.StringSet(strKey, nVal);
             db.KeyDelete(strKey);
 
-            bool fExists = false;
+            bool fExists = db.KeyExists("key1", CommandFlags.None);
             if (!fExists)
                 Console.WriteLine("Pass: strKey, Key does not exists");
             else


### PR DESCRIPTION
## tl;dr;

GarnetClientSamples missing some commands compare to SERedisSamples. Match samples commands makes user easy to check how each command works.

Also added Console output for GarnetClientSamples, as user cannot recognize succeeded or not.

## Added commands

The following commands have been added to the GarnetClientSamples, which exist in SERedisSamples.

* IncrAsync
* DecrByAsync
* DecrAsync
* IncrNoKeyAsync
* ExistsAsync
* DeleteAsync

Change signature to match with SERedisSamples.

* IncrByAsync (add `long nIncr` parameter)
