### PR TITLE
Update to link in Readme.md of Resp.benchmark tool

### DIFF
--- a/benchmark/Resp.benchmark/README.md
+++ b/benchmark/Resp.benchmark/README.md
@@ -3,7 +3,7 @@
 
 **Garnet** project contains a Benchmark tool for running RESP benchmarking using different clients, different workloads and different strategies for measuring throughput, performance and latency.
 
-Please visit our website documentation about how to use it in the following link: [The Resp.benchmark tool](https://improved-winner-4ggm2nm.pages.github.io/docs/benchmarking/resp-bench)
+Please visit our website documentation about how to use it in the following link: [The Resp.benchmark tool](https://microsoft.github.io/garnet/docs/benchmarking/resp-bench)
 
 ## Privacy
 


### PR DESCRIPTION
Updating the link that was wrong to the Resp.benchmark readme.md to have the link to the page in the documentation website.