### PR TITLE
Update type in Cluster Overview docs

### DIFF
--- a/website/docs/cluster/overview.md
+++ b/website/docs/cluster/overview.md
@@ -71,7 +71,7 @@ If you don't specify the `--checkpointdir` option Garnet will you the startup fo
 ```bash
 	GarnetServer --cluster --checkpointdir clusterData/7000 --port 7000
 	GarnetServer --cluster --checkpointdir clusterData/7001 --port 7001
-	GarnetServer --cluster --checkpointdir clusterData/7001 --port 7002
+	GarnetServer --cluster --checkpointdir clusterData/7002 --port 7002
 ```
 
 Once the instance are up and running, you can use any kind of redis compatible client to initialize


### PR DESCRIPTION
The command line arguments for clustering incorrectly had the 2nd and 3rd servers using the same checkpoint directory.