### PR TITLE
Fix deploy command in getting-started doc

### DIFF
--- a/website/docs/getting-started/build.md
+++ b/website/docs/getting-started/build.md
@@ -16,6 +16,7 @@ git clone git@github.com:microsoft/garnet.git
 ## Build the Project
 
 Make sure .NET 8 is installed, following instructions [here](https://dotnet.microsoft.com/en-us/download). You can use either Linux or Windows; Garnet works equally well on both platforms.
+You can also use it on Mac OS X.
 
 Go to the root folder of the repo and build using dotnet, or open Garnet.sln and build using Visual Studio 2022 (we recommend the Preview version for the latest features). Make sure Visual Studio is up to date by checking for updates.
 
@@ -43,7 +44,7 @@ Now, you are ready to deploy the Garnet server. This is simple, run the below::
 
 ```bash
 cd main/GarnetServer
-dotnet run -c Release --f net8.0
+dotnet run -c Release -f net8.0
 ```
 
 :::tip
@@ -53,7 +54,7 @@ By default, Garnet listens to TCP port 3278, make sure to adjust your firewall s
 To see the configurable options and their defaults, run the below command. You can configure index size, memory size, page size, data file paths and checkpoint paths, IP address to bind to, port number to run on, etc.
 
 ```bash
-dotnet run -c Release --f net8.0 -- --help
+dotnet run -c Release -f net8.0 -- --help
 ```
 
 :::tip


### PR DESCRIPTION
Fixed a typo in deploy command: `--f` should be `-f`. 