### PR TITLE
Added expiration to garnet objects at time of serialization deserialization

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -3,7 +3,7 @@
 #      1) update the name: string below (line 6)     -- this is the version for the nuget package (e.g. 1.0.0)
 #      2) update \libs\host\GarnetServer.cs readonly string version  (~line 45)   -- NOTE - these two values need to be the same 
 ###################################### 
-name: 1.0.0
+name: 1.0.1
 trigger: none
 resources:
   repositories:

--- a/libs/cluster/Server/Migration/MigrateSessionKeys.cs
+++ b/libs/cluster/Server/Migration/MigrateSessionKeys.cs
@@ -4,10 +4,8 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 using Garnet.server;
 using Microsoft.Extensions.Logging;
 using Tsavorite.core;
@@ -128,11 +126,7 @@ namespace Garnet.cluster
 
                 if (!ClusterSession.Expired(ref value.garnetObject))
                 {
-                    var ms = new MemoryStream();
-                    var writer = new BinaryWriter(ms, Encoding.ASCII);
-
-                    value.garnetObject.Serialize(writer);
-                    byte[] objectData = ms.ToArray();
+                    byte[] objectData = clusterProvider.storeWrapper.SerializeGarnetObject(value.garnetObject);
 
                     if (!WriteOrSendObjectStoreKeyValuePair(key, objectData, value.garnetObject.Expiration))
                         return false;

--- a/libs/cluster/Server/Migration/MigrationKeyIterationFunctions.cs
+++ b/libs/cluster/Server/Migration/MigrationKeyIterationFunctions.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using Garnet.common;
 using Garnet.server;
 using Tsavorite.core;
@@ -60,11 +58,7 @@ namespace Garnet.cluster
 
                     if (slots.Contains(slot) && !ClusterSession.Expired(ref value))
                     {
-                        using var ms = new MemoryStream();
-                        using var writer = new BinaryWriter(ms, Encoding.ASCII);
-
-                        value.Serialize(writer);
-                        byte[] objectData = ms.ToArray();
+                        byte[] objectData = session.clusterProvider.storeWrapper.SerializeGarnetObject(value);
                         if (!session.WriteOrSendObjectStoreKeyValuePair(key, objectData, value.Expiration))
                             return false;
                     }

--- a/libs/cluster/Session/ClusterCommands.cs
+++ b/libs/cluster/Session/ClusterCommands.cs
@@ -1256,7 +1256,7 @@ namespace Garnet.cluster
 
                             migrateSetCount++;
 
-                            var value = GarnetObject.Create(data);
+                            var value = this.clusterProvider.storeWrapper.CreateGarnetObject(data);
                             value.Expiration = expiration;
 
                             // Set if key replace flag is set or key does not exist

--- a/libs/cluster/Session/ClusterCommands.cs
+++ b/libs/cluster/Session/ClusterCommands.cs
@@ -1256,7 +1256,7 @@ namespace Garnet.cluster
 
                             migrateSetCount++;
 
-                            var value = this.clusterProvider.storeWrapper.CreateGarnetObject(data);
+                            var value = clusterProvider.storeWrapper.DeserializeGarnetObject(data);
                             value.Expiration = expiration;
 
                             // Set if key replace flag is set or key does not exist

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -42,7 +42,7 @@ namespace Garnet
         protected StoreWrapper storeWrapper;
 
         // IMPORTANT: Keep the version in sync with .azure\pipelines\azure-pipelines-external-release.yml line ~6.
-        readonly string version = "1.0.0";
+        readonly string version = "1.0.1";
 
         /// <summary>
         /// Metrics API

--- a/libs/server/AOF/AofProcessor.cs
+++ b/libs/server/AOF/AofProcessor.cs
@@ -295,7 +295,7 @@ namespace Garnet.server
             ref var input = ref Unsafe.AsRef<SpanByte>(ptr + sizeof(AofHeader) + key.TotalSize);
             ref var value = ref Unsafe.AsRef<SpanByte>(ptr + sizeof(AofHeader) + key.TotalSize + input.TotalSize);
 
-            var valB = storeWrapper.CreateGarnetObject(value.ToByteArray());
+            var valB = storeWrapper.DeserializeGarnetObject(value.ToByteArray());
 
             var output = new GarnetObjectStoreOutput { spanByteAndMemory = new(outputPtr, outputLength) };
             session.Upsert(ref keyB, ref valB);

--- a/libs/server/AOF/AofProcessor.cs
+++ b/libs/server/AOF/AofProcessor.cs
@@ -243,7 +243,7 @@ namespace Garnet.server
                     ObjectStoreRMW(objectStoreSession, entryPtr, bufferPtr, buffer.Length);
                     break;
                 case AofEntryType.ObjectStoreUpsert:
-                    ObjectStoreUpsert(objectStoreSession, entryPtr, bufferPtr, buffer.Length);
+                    ObjectStoreUpsert(objectStoreSession, entryPtr, bufferPtr, buffer.Length, storeWrapper);
                     break;
                 case AofEntryType.ObjectStoreDelete:
                     ObjectStoreDelete(objectStoreSession, entryPtr);
@@ -288,13 +288,14 @@ namespace Garnet.server
             session.Delete(ref key);
         }
 
-        static unsafe void ObjectStoreUpsert(ClientSession<byte[], IGarnetObject, SpanByte, GarnetObjectStoreOutput, long, ObjectStoreFunctions> session, byte* ptr, byte* outputPtr, int outputLength)
+        static unsafe void ObjectStoreUpsert(ClientSession<byte[], IGarnetObject, SpanByte, GarnetObjectStoreOutput, long, ObjectStoreFunctions> session, byte* ptr, byte* outputPtr, int outputLength, StoreWrapper storeWrapper)
         {
             ref var key = ref Unsafe.AsRef<SpanByte>(ptr + sizeof(AofHeader));
             var keyB = key.ToByteArray();
             ref var input = ref Unsafe.AsRef<SpanByte>(ptr + sizeof(AofHeader) + key.TotalSize);
             ref var value = ref Unsafe.AsRef<SpanByte>(ptr + sizeof(AofHeader) + key.TotalSize + input.TotalSize);
-            var valB = GarnetObject.Create(value.ToByteArray());
+
+            var valB = storeWrapper.CreateGarnetObject(value.ToByteArray());
 
             var output = new GarnetObjectStoreOutput { spanByteAndMemory = new(outputPtr, outputLength) };
             session.Upsert(ref keyB, ref valB);

--- a/libs/server/Custom/CustomObjectBase.cs
+++ b/libs/server/Custom/CustomObjectBase.cs
@@ -30,19 +30,16 @@ namespace Garnet.server
         /// </summary>
         /// <param name="type">Object type</param>
         /// <param name="size"></param>
-        protected CustomObjectBase(byte type, long size = 0)
+        protected CustomObjectBase(byte type, long expiration, long size = 0) : base(expiration, size)
         {
-            Debug.Assert(size >= 0);
-
             this.type = type;
-            this.Size = size;
         }
 
         /// <summary>
         /// Base copy constructor
         /// </summary>
         /// <param name="obj">Other object</param>
-        protected CustomObjectBase(CustomObjectBase obj) : this(obj.type, obj.Size) { }
+        protected CustomObjectBase(CustomObjectBase obj) : this(obj.type, obj.Expiration, obj.Size) { }
 
         /// <summary>
         /// Create output as simple string, from given string

--- a/libs/server/Custom/CustomObjectBase.cs
+++ b/libs/server/Custom/CustomObjectBase.cs
@@ -48,7 +48,7 @@ namespace Garnet.server
         protected CustomObjectBase(CustomObjectBase obj) : this(obj.type, obj.Expiration, obj.Size) { }
 
         /// <inheritdoc />
-        public override byte Type => type;
+        protected override byte Type => type;
 
         /// <summary>
         /// Create output as simple string, from given string
@@ -167,9 +167,7 @@ namespace Garnet.server
         /// <returns></returns>
         public sealed override GarnetObjectBase Clone() => CloneObject();
 
-        /// <summary>
-        /// Serialize to giver writer
-        /// </summary>
+        /// <inheritdoc />
         public sealed override void DoSerialize(BinaryWriter writer)
         {
             base.DoSerialize(writer);

--- a/libs/server/Custom/CustomObjectBase.cs
+++ b/libs/server/Custom/CustomObjectBase.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Buffers;
-using System.Diagnostics;
 using System.IO;
 using Garnet.common;
 using Tsavorite.core;

--- a/libs/server/Custom/CustomObjectBase.cs
+++ b/libs/server/Custom/CustomObjectBase.cs
@@ -48,7 +48,7 @@ namespace Garnet.server
         protected CustomObjectBase(CustomObjectBase obj) : this(obj.type, obj.Expiration, obj.Size) { }
 
         /// <inheritdoc />
-        protected override byte Type => type;
+        public override byte Type => type;
 
         /// <summary>
         /// Create output as simple string, from given string

--- a/libs/server/Custom/CustomObjectBase.cs
+++ b/libs/server/Custom/CustomObjectBase.cs
@@ -30,7 +30,14 @@ namespace Garnet.server
         /// </summary>
         /// <param name="type">Object type</param>
         /// <param name="size"></param>
-        protected CustomObjectBase(byte type, long expiration, long size = 0) : base(expiration, size)
+        protected CustomObjectBase(byte type, long expiration, long size = 0)
+            : base(expiration, size)
+        {
+            this.type = type;
+        }
+
+        protected CustomObjectBase(byte type, BinaryReader reader, long size = 0)
+            : base(reader, size)
         {
             this.type = type;
         }
@@ -40,6 +47,9 @@ namespace Garnet.server
         /// </summary>
         /// <param name="obj">Other object</param>
         protected CustomObjectBase(CustomObjectBase obj) : this(obj.type, obj.Expiration, obj.Size) { }
+
+        /// <inheritdoc />
+        public override byte Type => type;
 
         /// <summary>
         /// Create output as simple string, from given string
@@ -163,7 +173,7 @@ namespace Garnet.server
         /// </summary>
         public sealed override void DoSerialize(BinaryWriter writer)
         {
-            writer.Write(type);
+            base.DoSerialize(writer);
             SerializeObject(writer);
         }
 

--- a/libs/server/Custom/CustomObjectFactory.cs
+++ b/libs/server/Custom/CustomObjectFactory.cs
@@ -13,13 +13,13 @@ namespace Garnet.server
         /// <summary>
         /// Create new (empty) instance of custom object
         /// </summary>
-        public abstract CustomObjectBase Create(byte type);
+        public abstract CustomObjectBase Create(byte type, long expiration = 0);
 
         /// <summary>
         /// Deserialize value object from given reader
         /// </summary>
         /// <param name="type"></param>
         /// <param name="reader"></param>
-        public abstract CustomObjectBase Deserialize(byte type, BinaryReader reader);
+        public abstract CustomObjectBase Deserialize(byte type, long expiration, BinaryReader reader);
     }
 }

--- a/libs/server/Custom/CustomObjectFactory.cs
+++ b/libs/server/Custom/CustomObjectFactory.cs
@@ -13,13 +13,13 @@ namespace Garnet.server
         /// <summary>
         /// Create new (empty) instance of custom object
         /// </summary>
-        public abstract CustomObjectBase Create(byte type, long expiration = 0);
+        public abstract CustomObjectBase Create(byte type);
 
         /// <summary>
         /// Deserialize value object from given reader
         /// </summary>
         /// <param name="type"></param>
         /// <param name="reader"></param>
-        public abstract CustomObjectBase Deserialize(byte type, long expiration, BinaryReader reader);
+        public abstract CustomObjectBase Deserialize(byte type, BinaryReader reader);
     }
 }

--- a/libs/server/Objects/Hash/HashObject.cs
+++ b/libs/server/Objects/Hash/HashObject.cs
@@ -43,26 +43,22 @@ namespace Garnet.server
         readonly Dictionary<byte[], byte[]> hash;
 
         /// <summary>
-        ///  HashObject Constructor
+        ///  Constructor
         /// </summary>
-        public HashObject(long expiration = 0) : base(expiration, MemoryUtils.DictionaryOverhead)
+        public HashObject(long expiration = 0)
+            : base(expiration, MemoryUtils.DictionaryOverhead)
         {
             hash = new Dictionary<byte[], byte[]>(new ByteArrayComparer());
         }
 
         /// <summary>
-        /// Copy constructor
-        /// </summary>
-        public HashObject(Dictionary<byte[], byte[]> hash, long expiration, long size) : base(expiration, size)
-        {
-            this.hash = hash;
-        }
-
-        /// <summary>
         /// Construct from binary serialized form
         /// </summary>
-        public HashObject(BinaryReader reader, long expiration) : this(expiration)
+        public HashObject(BinaryReader reader)
+            : base(reader, MemoryUtils.DictionaryOverhead)
         {
+            hash = new Dictionary<byte[], byte[]>(new ByteArrayComparer());
+
             int count = reader.ReadInt32();
             for (int i = 0; i < count; i++)
             {
@@ -74,10 +70,23 @@ namespace Garnet.server
             }
         }
 
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        public HashObject(Dictionary<byte[], byte[]> hash, long expiration, long size)
+            : base(expiration, size)
+        {
+            this.hash = hash;
+        }
+
+        /// <inheritdoc />
+        public override byte Type => (byte)GarnetObjectType.Hash;
+
         /// <inheritdoc />
         public override void DoSerialize(BinaryWriter writer)
         {
-            writer.Write((byte)GarnetObjectType.Hash);
+            base.DoSerialize(writer);
+
             int count = hash.Count;
             writer.Write(count);
             foreach (var kvp in hash)

--- a/libs/server/Objects/Hash/HashObject.cs
+++ b/libs/server/Objects/Hash/HashObject.cs
@@ -45,25 +45,23 @@ namespace Garnet.server
         /// <summary>
         ///  HashObject Constructor
         /// </summary>
-        public HashObject()
+        public HashObject(long expiration = 0) : base(expiration, MemoryUtils.DictionaryOverhead)
         {
             hash = new Dictionary<byte[], byte[]>(new ByteArrayComparer());
-            this.Size = MemoryUtils.DictionaryOverhead;
         }
 
         /// <summary>
         /// Copy constructor
         /// </summary>
-        public HashObject(Dictionary<byte[], byte[]> hash, long size)
+        public HashObject(Dictionary<byte[], byte[]> hash, long expiration, long size) : base(expiration, size)
         {
             this.hash = hash;
-            this.Size = size;
         }
 
         /// <summary>
         /// Construct from binary serialized form
         /// </summary>
-        public HashObject(BinaryReader reader) : this()
+        public HashObject(BinaryReader reader, long expiration) : this(expiration)
         {
             int count = reader.ReadInt32();
             for (int i = 0; i < count; i++)
@@ -97,7 +95,7 @@ namespace Garnet.server
         public override void Dispose() { }
 
         /// <inheritdoc />
-        public override GarnetObjectBase Clone() => new HashObject(hash, Size);
+        public override GarnetObjectBase Clone() => new HashObject(hash, Expiration, Size);
 
         /// <inheritdoc />
         public override unsafe bool Operate(ref SpanByte input, ref SpanByteAndMemory output, out long sizeChange)

--- a/libs/server/Objects/Hash/HashObject.cs
+++ b/libs/server/Objects/Hash/HashObject.cs
@@ -80,7 +80,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc />
-        protected override byte Type => (byte)GarnetObjectType.Hash;
+        public override byte Type => (byte)GarnetObjectType.Hash;
 
         /// <inheritdoc />
         public override void DoSerialize(BinaryWriter writer)

--- a/libs/server/Objects/Hash/HashObject.cs
+++ b/libs/server/Objects/Hash/HashObject.cs
@@ -80,7 +80,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc />
-        public override byte Type => (byte)GarnetObjectType.Hash;
+        protected override byte Type => (byte)GarnetObjectType.Hash;
 
         /// <inheritdoc />
         public override void DoSerialize(BinaryWriter writer)

--- a/libs/server/Objects/List/ListObject.cs
+++ b/libs/server/Objects/List/ListObject.cs
@@ -94,7 +94,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc />
-        protected override byte Type => (byte)GarnetObjectType.List;
+        public override byte Type => (byte)GarnetObjectType.List;
 
         /// <summary>
         /// Public getter for the list

--- a/libs/server/Objects/List/ListObject.cs
+++ b/libs/server/Objects/List/ListObject.cs
@@ -60,19 +60,17 @@ namespace Garnet.server
         /// <summary>
         /// ListObject Constructor
         /// </summary>
-        public ListObject()
+        public ListObject(long expiration = 0) : base(expiration, MemoryUtils.ListOverhead)
         {
             list = new LinkedList<byte[]>();
-            this.Size = MemoryUtils.ListOverhead;
         }
 
         /// <summary>
         /// Copy constructor
         /// </summary>
-        public ListObject(LinkedList<byte[]> list, long size)
+        public ListObject(LinkedList<byte[]> list, long expiration, long size) : base(expiration, size)
         {
             this.list = list;
-            this.Size = size;
         }
 
         /// <summary>
@@ -83,7 +81,7 @@ namespace Garnet.server
         /// <summary>
         /// Construct from binary serialized form
         /// </summary>
-        public ListObject(BinaryReader reader) : this()
+        public ListObject(BinaryReader reader, long expiration) : this(expiration)
         {
             int count = reader.ReadInt32();
             for (int i = 0; i < count; i++)
@@ -114,7 +112,7 @@ namespace Garnet.server
         public override void Dispose() { }
 
         /// <inheritdoc />
-        public override GarnetObjectBase Clone() => new ListObject(list, Size);
+        public override GarnetObjectBase Clone() => new ListObject(list, Expiration, Size);
 
         /// <inheritdoc />
         public override unsafe bool Operate(ref SpanByte input, ref SpanByteAndMemory output, out long sizeChange)

--- a/libs/server/Objects/List/ListObject.cs
+++ b/libs/server/Objects/List/ListObject.cs
@@ -94,7 +94,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc />
-        public override byte Type => (byte)GarnetObjectType.List;
+        protected override byte Type => (byte)GarnetObjectType.List;
 
         /// <summary>
         /// Public getter for the list

--- a/libs/server/Objects/Set/SetObject.cs
+++ b/libs/server/Objects/Set/SetObject.cs
@@ -36,25 +36,23 @@ namespace Garnet.server
         /// <summary>
         ///  SetObject Constructor
         /// </summary>
-        public SetObject()
+        public SetObject(long expiration = 0) : base(expiration, MemoryUtils.HashSetOverhead)
         {
             set = new HashSet<byte[]>(new ByteArrayComparer());
-            this.Size = MemoryUtils.HashSetOverhead;
         }
 
         /// <summary>
         /// Copy constructor
         /// </summary>
-        public SetObject(HashSet<byte[]> set, long size)
+        public SetObject(HashSet<byte[]> set, long expiration, long size) : base(expiration, size)
         {
             this.set = set;
-            this.Size = size;
         }
 
         /// <summary>
         /// Construct from binary serialized form
         /// </summary>
-        public SetObject(BinaryReader reader) : this()
+        public SetObject(BinaryReader reader, long expiration) : this(expiration)
         {
             int count = reader.ReadInt32();
             for (int i = 0; i < count; i++)
@@ -85,7 +83,7 @@ namespace Garnet.server
         public override void Dispose() { }
 
         /// <inheritdoc />
-        public override GarnetObjectBase Clone() => new SetObject(set, Size);
+        public override GarnetObjectBase Clone() => new SetObject(set, Expiration, Size);
 
         /// <inheritdoc />
         public override unsafe bool Operate(ref SpanByte input, ref SpanByteAndMemory output, out long sizeChange)

--- a/libs/server/Objects/Set/SetObject.cs
+++ b/libs/server/Objects/Set/SetObject.cs
@@ -34,26 +34,22 @@ namespace Garnet.server
         readonly HashSet<byte[]> set;
 
         /// <summary>
-        ///  SetObject Constructor
+        ///  Constructor
         /// </summary>
-        public SetObject(long expiration = 0) : base(expiration, MemoryUtils.HashSetOverhead)
+        public SetObject(long expiration = 0)
+            : base(expiration, MemoryUtils.HashSetOverhead)
         {
             set = new HashSet<byte[]>(new ByteArrayComparer());
         }
 
         /// <summary>
-        /// Copy constructor
-        /// </summary>
-        public SetObject(HashSet<byte[]> set, long expiration, long size) : base(expiration, size)
-        {
-            this.set = set;
-        }
-
-        /// <summary>
         /// Construct from binary serialized form
         /// </summary>
-        public SetObject(BinaryReader reader, long expiration) : this(expiration)
+        public SetObject(BinaryReader reader)
+            : base(reader, MemoryUtils.HashSetOverhead)
         {
+            set = new HashSet<byte[]>(new ByteArrayComparer());
+
             int count = reader.ReadInt32();
             for (int i = 0; i < count; i++)
             {
@@ -64,10 +60,23 @@ namespace Garnet.server
             }
         }
 
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        public SetObject(HashSet<byte[]> set, long expiration, long size)
+            : base(expiration, size)
+        {
+            this.set = set;
+        }
+
+        /// <inheritdoc />
+        public override byte Type => (byte)GarnetObjectType.Set;
+
         /// <inheritdoc />
         public override void DoSerialize(BinaryWriter writer)
         {
-            writer.Write((byte)GarnetObjectType.Set);
+            base.DoSerialize(writer);
+
             int count = set.Count;
             writer.Write(count);
             foreach (var item in set)

--- a/libs/server/Objects/Set/SetObject.cs
+++ b/libs/server/Objects/Set/SetObject.cs
@@ -70,7 +70,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc />
-        public override byte Type => (byte)GarnetObjectType.Set;
+        protected override byte Type => (byte)GarnetObjectType.Set;
 
         /// <inheritdoc />
         public override void DoSerialize(BinaryWriter writer)

--- a/libs/server/Objects/Set/SetObject.cs
+++ b/libs/server/Objects/Set/SetObject.cs
@@ -70,7 +70,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc />
-        protected override byte Type => (byte)GarnetObjectType.Set;
+        public override byte Type => (byte)GarnetObjectType.Set;
 
         /// <inheritdoc />
         public override void DoSerialize(BinaryWriter writer)

--- a/libs/server/Objects/SortedSet/SortedSetObject.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObject.cs
@@ -119,7 +119,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc />
-        public override byte Type => (byte)GarnetObjectType.SortedSet;
+        protected override byte Type => (byte)GarnetObjectType.SortedSet;
 
         /// <summary>
         /// Get sorted set as a dictionary

--- a/libs/server/Objects/SortedSet/SortedSetObject.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObject.cs
@@ -80,11 +80,10 @@ namespace Garnet.server
         /// <summary>
         /// Constructor
         /// </summary>
-        public SortedSetObject()
+        public SortedSetObject(long expiration = 0) : base(expiration, MemoryUtils.SortedSetOverhead + MemoryUtils.DictionaryOverhead)
         {
             sortedSet = new(sortedSetComparer);
             sortedSetDict = new Dictionary<byte[], double>(byteArrayComparer);
-            this.Size = MemoryUtils.SortedSetOverhead + MemoryUtils.DictionaryOverhead;
         }
 
         /// <summary>
@@ -97,18 +96,16 @@ namespace Garnet.server
         /// </summary>
         public SortedSetObject(
             SortedSet<(double, byte[])> sortedSet,
-            Dictionary<byte[], double> sortedSetDict, long expiration, long size)
+            Dictionary<byte[], double> sortedSetDict, long expiration, long size) : base(expiration, size)
         {
             this.sortedSet = sortedSet;
             this.sortedSetDict = sortedSetDict;
-            Expiration = expiration;
-            this.Size = size;
         }
 
         /// <summary>
         /// Construct from binary serialized form
         /// </summary>
-        public SortedSetObject(BinaryReader reader) : this()
+        public SortedSetObject(BinaryReader reader, long expiration) : this(expiration)
         {
             int count = reader.ReadInt32();
             for (int i = 0; i < count; i++)

--- a/libs/server/Objects/SortedSet/SortedSetObject.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObject.cs
@@ -119,7 +119,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc />
-        protected override byte Type => (byte)GarnetObjectType.SortedSet;
+        public override byte Type => (byte)GarnetObjectType.SortedSet;
 
         /// <summary>
         /// Get sorted set as a dictionary

--- a/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
@@ -16,7 +16,7 @@ namespace Garnet.server
     /// <summary>
     /// Sorted Set - RESP specific operations
     /// </summary>
-    public unsafe partial class SortedSetObject : IGarnetObject
+    public unsafe partial class SortedSetObject : GarnetObjectBase
     {
         /// <summary>
         /// Small struct to store options for ZRange command

--- a/libs/server/Objects/SortedSetGeo/SortedSetGeoObjectImpl.cs
+++ b/libs/server/Objects/SortedSetGeo/SortedSetGeoObjectImpl.cs
@@ -14,7 +14,7 @@ namespace Garnet.server
     /// <summary>
     /// Sorted Set - RESP specific operations for GEO Commands
     /// </summary>
-    public unsafe partial class SortedSetObject : IGarnetObject
+    public unsafe partial class SortedSetObject : GarnetObjectBase
     {
         /// <summary>
         /// Use this struct for the reply of GEOSEARCH command

--- a/libs/server/Objects/Types/GarnetObject.cs
+++ b/libs/server/Objects/Types/GarnetObject.cs
@@ -87,10 +87,10 @@ namespace Garnet.server
             var type = (GarnetObjectType)reader.ReadByte();
             return type switch
             {
-                GarnetObjectType.SortedSet => new SortedSetObject(reader, expiration),
-                GarnetObjectType.List => new ListObject(reader, expiration),
-                GarnetObjectType.Hash => new HashObject(reader, expiration),
-                GarnetObjectType.Set => new SetObject(reader, expiration),
+                GarnetObjectType.SortedSet => new SortedSetObject(reader),
+                GarnetObjectType.List => new ListObject(reader),
+                GarnetObjectType.Hash => new HashObject(reader),
+                GarnetObjectType.Set => new SetObject(reader),
                 _ => throw new Exception("Unsupported data type"),
             };
         }

--- a/libs/server/Objects/Types/GarnetObject.cs
+++ b/libs/server/Objects/Types/GarnetObject.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 using System;
-using System.IO;
 
 namespace Garnet.server
 {
@@ -70,28 +69,6 @@ namespace Garnet.server
                 GarnetObjectType.Expire => false,
                 GarnetObjectType.Persist => false,
                 _ => true,
-            };
-        }
-
-        /// <summary>
-        /// Create an IGarnetObject from an input array.
-        /// </summary>
-        /// <param name="data"></param>
-        /// <returns></returns>
-        /// <exception cref="Exception"></exception>
-        public static IGarnetObject Create(byte[] data)
-        {
-            using var ms = new MemoryStream(data);
-            using var reader = new BinaryReader(ms);
-            var type = (GarnetObjectType)reader.ReadByte();
-
-            return type switch
-            {
-                GarnetObjectType.SortedSet => new SortedSetObject(reader),
-                GarnetObjectType.List => new ListObject(reader),
-                GarnetObjectType.Hash => new HashObject(reader),
-                GarnetObjectType.Set => new SetObject(reader),
-                _ => throw new Exception("Unsupported data type"),
             };
         }
     }

--- a/libs/server/Objects/Types/GarnetObject.cs
+++ b/libs/server/Objects/Types/GarnetObject.cs
@@ -16,14 +16,14 @@ namespace Garnet.server
         /// </summary>
         /// <param name="garnetObjectType"></param>
         /// <returns></returns>
-        internal static IGarnetObject Create(GarnetObjectType garnetObjectType)
+        internal static IGarnetObject Create(GarnetObjectType garnetObjectType, long expiration = 0)
         {
             return garnetObjectType switch
             {
-                GarnetObjectType.SortedSet => new SortedSetObject(),
-                GarnetObjectType.List => new ListObject(),
-                GarnetObjectType.Hash => new HashObject(),
-                GarnetObjectType.Set => new SetObject(),
+                GarnetObjectType.SortedSet => new SortedSetObject(expiration),
+                GarnetObjectType.List => new ListObject(expiration),
+                GarnetObjectType.Hash => new HashObject(expiration),
+                GarnetObjectType.Set => new SetObject(expiration),
                 _ => throw new Exception("Unsupported data type"),
             };
         }
@@ -83,14 +83,14 @@ namespace Garnet.server
         {
             using var ms = new MemoryStream(data);
             using var reader = new BinaryReader(ms);
+            var expiration = reader.ReadInt64();
             var type = (GarnetObjectType)reader.ReadByte();
-
             return type switch
             {
-                GarnetObjectType.SortedSet => new SortedSetObject(reader),
-                GarnetObjectType.List => new ListObject(reader),
-                GarnetObjectType.Hash => new HashObject(reader),
-                GarnetObjectType.Set => new SetObject(reader),
+                GarnetObjectType.SortedSet => new SortedSetObject(reader, expiration),
+                GarnetObjectType.List => new ListObject(reader, expiration),
+                GarnetObjectType.Hash => new HashObject(reader, expiration),
+                GarnetObjectType.Set => new SetObject(reader, expiration),
                 _ => throw new Exception("Unsupported data type"),
             };
         }

--- a/libs/server/Objects/Types/GarnetObject.cs
+++ b/libs/server/Objects/Types/GarnetObject.cs
@@ -86,10 +86,10 @@ namespace Garnet.server
             var type = (GarnetObjectType)reader.ReadByte();
             return type switch
             {
-                GarnetObjectType.SortedSet => new SortedSetObject(reader, expiration),
-                GarnetObjectType.List => new ListObject(reader, expiration),
-                GarnetObjectType.Hash => new HashObject(reader, expiration),
-                GarnetObjectType.Set => new SetObject(reader, expiration),
+                GarnetObjectType.SortedSet => new SortedSetObject(reader),
+                GarnetObjectType.List => new ListObject(reader),
+                GarnetObjectType.Hash => new HashObject(reader),
+                GarnetObjectType.Set => new SetObject(reader),
                 _ => throw new Exception("Unsupported data type"),
             };
         }

--- a/libs/server/Objects/Types/GarnetObject.cs
+++ b/libs/server/Objects/Types/GarnetObject.cs
@@ -84,13 +84,12 @@ namespace Garnet.server
             using var ms = new MemoryStream(data);
             using var reader = new BinaryReader(ms);
             var type = (GarnetObjectType)reader.ReadByte();
-            var expiration = reader.ReadInt64();
             return type switch
             {
-                GarnetObjectType.SortedSet => new SortedSetObject(reader),
-                GarnetObjectType.List => new ListObject(reader),
-                GarnetObjectType.Hash => new HashObject(reader),
-                GarnetObjectType.Set => new SetObject(reader),
+                GarnetObjectType.SortedSet => new SortedSetObject(reader, expiration),
+                GarnetObjectType.List => new ListObject(reader, expiration),
+                GarnetObjectType.Hash => new HashObject(reader, expiration),
+                GarnetObjectType.Set => new SetObject(reader, expiration),
                 _ => throw new Exception("Unsupported data type"),
             };
         }

--- a/libs/server/Objects/Types/GarnetObject.cs
+++ b/libs/server/Objects/Types/GarnetObject.cs
@@ -83,8 +83,8 @@ namespace Garnet.server
         {
             using var ms = new MemoryStream(data);
             using var reader = new BinaryReader(ms);
-            var expiration = reader.ReadInt64();
             var type = (GarnetObjectType)reader.ReadByte();
+            var expiration = reader.ReadInt64();
             return type switch
             {
                 GarnetObjectType.SortedSet => new SortedSetObject(reader),

--- a/libs/server/Objects/Types/GarnetObject.cs
+++ b/libs/server/Objects/Types/GarnetObject.cs
@@ -84,7 +84,7 @@ namespace Garnet.server
             using var ms = new MemoryStream(data);
             using var reader = new BinaryReader(ms);
             var type = (GarnetObjectType)reader.ReadByte();
-            var expiration = reader.ReadInt64();
+
             return type switch
             {
                 GarnetObjectType.SortedSet => new SortedSetObject(reader),

--- a/libs/server/Objects/Types/GarnetObject.cs
+++ b/libs/server/Objects/Types/GarnetObject.cs
@@ -84,6 +84,7 @@ namespace Garnet.server
             using var ms = new MemoryStream(data);
             using var reader = new BinaryReader(ms);
             var type = (GarnetObjectType)reader.ReadByte();
+            var expiration = reader.ReadInt64();
             return type switch
             {
                 GarnetObjectType.SortedSet => new SortedSetObject(reader),

--- a/libs/server/Objects/Types/GarnetObjectBase.cs
+++ b/libs/server/Objects/Types/GarnetObjectBase.cs
@@ -107,10 +107,10 @@ namespace Garnet.server
 
         /// <summary>
         /// Serialize to given writer
+        /// NOTE: Make sure to first call base.DoSerialize(writer) in all derived classes.
         /// </summary>
         public virtual void DoSerialize(BinaryWriter writer)
         {
-            writer.Write(Type);
             writer.Write(Expiration);
         }
 

--- a/libs/server/Objects/Types/GarnetObjectBase.cs
+++ b/libs/server/Objects/Types/GarnetObjectBase.cs
@@ -18,10 +18,8 @@ namespace Garnet.server
         int serializationState;
         byte[] serialized;
 
-        /// <summary>
-        /// Type of object
-        /// </summary>
-        protected abstract byte Type { get; }
+        /// <inheritdoc />
+        public abstract byte Type { get; }
 
         /// <inheritdoc />
         public long Expiration { get; set; }

--- a/libs/server/Objects/Types/GarnetObjectBase.cs
+++ b/libs/server/Objects/Types/GarnetObjectBase.cs
@@ -21,7 +21,7 @@ namespace Garnet.server
         /// <summary>
         /// Type of object
         /// </summary>
-        public abstract byte Type { get; }
+        protected abstract byte Type { get; }
 
         /// <inheritdoc />
         public long Expiration { get; set; }
@@ -37,7 +37,7 @@ namespace Garnet.server
         }
 
         protected GarnetObjectBase(BinaryReader reader, long size)
-            : this(reader.ReadInt64(), size)
+            : this(expiration: reader.ReadInt64(), size: size)
         {
         }
 

--- a/libs/server/Objects/Types/GarnetObjectBase.cs
+++ b/libs/server/Objects/Types/GarnetObjectBase.cs
@@ -79,7 +79,6 @@ namespace Garnet.server
                     using (var ms = new MemoryStream())
                     {
                         using var writer = new BinaryWriter(ms, new UTF8Encoding(), true);
-                        writer.Write(Expiration);
                         DoSerialize(writer);
                         serialized = ms.ToArray();
                     }

--- a/libs/server/Objects/Types/GarnetObjectBase.cs
+++ b/libs/server/Objects/Types/GarnetObjectBase.cs
@@ -24,6 +24,13 @@ namespace Garnet.server
         /// <inheritdoc />
         public long Size { get; set; }
 
+        protected GarnetObjectBase(long expiration, long size)
+        {
+            Debug.Assert(size >= 0);
+            this.Expiration = expiration;
+            this.Size = size;
+        }
+
         /// <inheritdoc />
         public void Serialize(BinaryWriter writer)
         {
@@ -32,6 +39,7 @@ namespace Garnet.server
                 if (serializationState == (int)SerializationPhase.REST && MakeTransition(SerializationPhase.REST, SerializationPhase.SERIALIZING))
                 {
                     // Directly serialize to wire, do not cache serialized state
+                    writer.Write(Expiration);
                     DoSerialize(writer);
                     serializationState = (int)SerializationPhase.REST;
                     return;
@@ -62,6 +70,7 @@ namespace Garnet.server
                     using (var ms = new MemoryStream())
                     {
                         using var writer = new BinaryWriter(ms, new UTF8Encoding(), true);
+                        writer.Write(Expiration);
                         DoSerialize(writer);
                         serialized = ms.ToArray();
                     }

--- a/libs/server/Objects/Types/GarnetObjectSerializer.cs
+++ b/libs/server/Objects/Types/GarnetObjectSerializer.cs
@@ -43,7 +43,7 @@ namespace Garnet.server
         /// <inheritdoc />
         public override void Serialize(ref IGarnetObject obj)
         {
-            writer.Write((byte)obj.Type);
+            writer.Write(obj.Type);
             obj.Serialize(writer);
         }
     }

--- a/libs/server/Objects/Types/GarnetObjectSerializer.cs
+++ b/libs/server/Objects/Types/GarnetObjectSerializer.cs
@@ -23,21 +23,22 @@ namespace Garnet.server
         /// <inheritdoc />
         public override void Deserialize(out IGarnetObject obj)
         {
+            var expiration = reader.ReadInt64();
             var type = (GarnetObjectType)reader.ReadByte();
             obj = type switch
             {
-                GarnetObjectType.SortedSet => new SortedSetObject(reader),
-                GarnetObjectType.List => new ListObject(reader),
-                GarnetObjectType.Hash => new HashObject(reader),
-                GarnetObjectType.Set => new SetObject(reader),
-                _ => CustomDeserialize((byte)type),
+                GarnetObjectType.SortedSet => new SortedSetObject(reader, expiration),
+                GarnetObjectType.List => new ListObject(reader, expiration),
+                GarnetObjectType.Hash => new HashObject(reader, expiration),
+                GarnetObjectType.Set => new SetObject(reader, expiration),
+                _ => CustomDeserialize((byte)type, expiration),
             };
         }
 
-        private IGarnetObject CustomDeserialize(byte type)
+        private IGarnetObject CustomDeserialize(byte type, long expiration)
         {
             if (type < CustomCommandManager.StartOffset) return null;
-            return customCommands[type - CustomCommandManager.StartOffset].factory.Deserialize(type, reader);
+            return customCommands[type - CustomCommandManager.StartOffset].factory.Deserialize(type, expiration, reader);
         }
 
         /// <inheritdoc />

--- a/libs/server/Objects/Types/GarnetObjectSerializer.cs
+++ b/libs/server/Objects/Types/GarnetObjectSerializer.cs
@@ -41,6 +41,10 @@ namespace Garnet.server
         }
 
         /// <inheritdoc />
-        public override void Serialize(ref IGarnetObject obj) => obj.Serialize(writer);
+        public override void Serialize(ref IGarnetObject obj)
+        {
+            writer.Write((byte)obj.Type);
+            obj.Serialize(writer);
+        }
     }
 }

--- a/libs/server/Objects/Types/GarnetObjectSerializer.cs
+++ b/libs/server/Objects/Types/GarnetObjectSerializer.cs
@@ -23,22 +23,21 @@ namespace Garnet.server
         /// <inheritdoc />
         public override void Deserialize(out IGarnetObject obj)
         {
-            var expiration = reader.ReadInt64();
             var type = (GarnetObjectType)reader.ReadByte();
             obj = type switch
             {
-                GarnetObjectType.SortedSet => new SortedSetObject(reader, expiration),
-                GarnetObjectType.List => new ListObject(reader, expiration),
-                GarnetObjectType.Hash => new HashObject(reader, expiration),
-                GarnetObjectType.Set => new SetObject(reader, expiration),
-                _ => CustomDeserialize((byte)type, expiration),
+                GarnetObjectType.SortedSet => new SortedSetObject(reader),
+                GarnetObjectType.List => new ListObject(reader),
+                GarnetObjectType.Hash => new HashObject(reader),
+                GarnetObjectType.Set => new SetObject(reader),
+                _ => CustomDeserialize((byte)type),
             };
         }
 
-        private IGarnetObject CustomDeserialize(byte type, long expiration)
+        private IGarnetObject CustomDeserialize(byte type)
         {
             if (type < CustomCommandManager.StartOffset) return null;
-            return customCommands[type - CustomCommandManager.StartOffset].factory.Deserialize(type, expiration, reader);
+            return customCommands[type - CustomCommandManager.StartOffset].factory.Deserialize(type, reader);
         }
 
         /// <inheritdoc />

--- a/libs/server/Objects/Types/IGarnetObject.cs
+++ b/libs/server/Objects/Types/IGarnetObject.cs
@@ -14,6 +14,11 @@ namespace Garnet.server
     public interface IGarnetObject : IDisposable
     {
         /// <summary>
+        /// Type of object
+        /// </summary>
+        byte Type { get; }
+
+        /// <summary>
         /// Expiration time of object
         /// </summary>
         long Expiration { get; set; }

--- a/libs/server/Objects/Types/IGarnetObject.cs
+++ b/libs/server/Objects/Types/IGarnetObject.cs
@@ -14,11 +14,6 @@ namespace Garnet.server
     public interface IGarnetObject : IDisposable
     {
         /// <summary>
-        /// Type of object
-        /// </summary>
-        byte Type { get; }
-
-        /// <summary>
         /// Expiration time of object
         /// </summary>
         long Expiration { get; set; }

--- a/libs/server/Storage/Session/ObjectStore/ListOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/ListOps.cs
@@ -254,7 +254,7 @@ namespace Garnet.server
                             dstListObject.LnkList.AddLast(element);
 
                         dstListObject.UpdateSize(element);
-                        newListValue = new ListObject(dstListObject.LnkList, dstListObject.Size);
+                        newListValue = new ListObject(dstListObject.LnkList, dstListObject.Expiration, dstListObject.Size);
                     }
                     else
                     {

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -163,6 +164,26 @@ namespace Garnet.server
 
             ctsCommit = new();
             run_id = Generator.CreateHexId();
+        }
+
+        public byte[] SerializeGarnetObject(IGarnetObject garnetObject)
+        {
+            using var ms = new MemoryStream();
+            var serializer = new GarnetObjectSerializer(customCommandManager);
+            serializer.BeginSerialize(ms);
+            serializer.Serialize(ref garnetObject);
+            serializer.EndSerialize();
+            return ms.ToArray();
+        }
+
+        public IGarnetObject CreateGarnetObject(byte[] data)
+        {
+            using var ms = new MemoryStream(data);
+            var serializer = new GarnetObjectSerializer(customCommandManager);
+            serializer.BeginDeserialize(ms);
+            serializer.Deserialize(out var obj);
+            serializer.EndDeserialize();
+            return obj;
         }
 
         /// <summary>

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -176,7 +176,7 @@ namespace Garnet.server
             return ms.ToArray();
         }
 
-        public IGarnetObject CreateGarnetObject(byte[] data)
+        public IGarnetObject DeserializeGarnetObject(byte[] data)
         {
             using var ms = new MemoryStream(data);
             var serializer = new GarnetObjectSerializer(customCommandManager);

--- a/main/GarnetServer/Extensions/MyDictObject.cs
+++ b/main/GarnetServer/Extensions/MyDictObject.cs
@@ -13,33 +13,43 @@ namespace Garnet
 {
     class MyDictFactory : CustomObjectFactory
     {
-        public override CustomObjectBase Create(byte type, long expiration)
-            => new MyDict(type, expiration);
+        public override CustomObjectBase Create(byte type)
+            => new MyDict(type);
 
-        public override CustomObjectBase Deserialize(byte type, long expiration, BinaryReader reader)
-            => new MyDict(type, expiration, reader);
+        public override CustomObjectBase Deserialize(byte type, BinaryReader reader)
+            => new MyDict(type, reader);
     }
 
     class MyDict : CustomObjectBase
     {
         readonly Dictionary<byte[], byte[]> dict;
 
-        public MyDict(byte type, long expiration) : base(type, expiration, MemoryUtils.DictionaryOverhead)
-            => dict = new(new ByteArrayComparer());
-
-        public MyDict(MyDict obj) : base(obj)
-            => dict = obj.dict;
-
-        public MyDict(byte type, long expiration, BinaryReader reader) : this(type, expiration)
+        public MyDict(byte type)
+            : base(type, MemoryUtils.DictionaryOverhead)
         {
+            dict = new(new ByteArrayComparer());
+        }
+
+        public MyDict(byte type, BinaryReader reader)
+            : base(type, reader, MemoryUtils.DictionaryOverhead)
+        {
+            dict = new(new ByteArrayComparer());
+
             int count = reader.ReadInt32();
             for (int i = 0; i < count; i++)
             {
                 var key = reader.ReadBytes(reader.ReadInt32());
                 var value = reader.ReadBytes(reader.ReadInt32());
                 dict.Add(key, value);
+
                 UpdateSize(key, value);
             }
+        }
+
+        public MyDict(MyDict obj)
+            : base(obj)
+        {
+            dict = obj.dict;
         }
 
         public override CustomObjectBase CloneObject() => new MyDict(this);

--- a/main/GarnetServer/Extensions/MyDictObject.cs
+++ b/main/GarnetServer/Extensions/MyDictObject.cs
@@ -13,24 +13,24 @@ namespace Garnet
 {
     class MyDictFactory : CustomObjectFactory
     {
-        public override CustomObjectBase Create(byte type)
-            => new MyDict(type);
+        public override CustomObjectBase Create(byte type, long expiration)
+            => new MyDict(type, expiration);
 
-        public override CustomObjectBase Deserialize(byte type, BinaryReader reader)
-            => new MyDict(type, reader);
+        public override CustomObjectBase Deserialize(byte type, long expiration, BinaryReader reader)
+            => new MyDict(type, expiration, reader);
     }
 
     class MyDict : CustomObjectBase
     {
         readonly Dictionary<byte[], byte[]> dict;
 
-        public MyDict(byte type) : base(type, MemoryUtils.DictionaryOverhead)
+        public MyDict(byte type, long expiration) : base(type, expiration, MemoryUtils.DictionaryOverhead)
             => dict = new(new ByteArrayComparer());
 
         public MyDict(MyDict obj) : base(obj)
             => dict = obj.dict;
 
-        public MyDict(byte type, BinaryReader reader) : this(type)
+        public MyDict(byte type, long expiration, BinaryReader reader) : this(type, expiration)
         {
             int count = reader.ReadInt32();
             for (int i = 0; i < count; i++)

--- a/main/GarnetServer/Extensions/MyDictObject.cs
+++ b/main/GarnetServer/Extensions/MyDictObject.cs
@@ -25,7 +25,7 @@ namespace Garnet
         readonly Dictionary<byte[], byte[]> dict;
 
         public MyDict(byte type)
-            : base(type, MemoryUtils.DictionaryOverhead)
+            : base(type, 0, MemoryUtils.DictionaryOverhead)
         {
             dict = new(new ByteArrayComparer());
         }

--- a/test/Garnet.test/GarnetObjectTests.cs
+++ b/test/Garnet.test/GarnetObjectTests.cs
@@ -172,13 +172,14 @@ namespace Garnet.test
         /// <inheritdoc />
         public override void Deserialize(out IGarnetObject obj)
         {
+            var expiration = reader.ReadInt64();
             var type = (GarnetObjectType)reader.ReadByte();
             obj = type switch
             {
-                GarnetObjectType.SortedSet => new SortedSetObject(reader),
-                GarnetObjectType.List => new ListObject(reader),
-                GarnetObjectType.Hash => new HashObject(reader),
-                GarnetObjectType.Set => new SetObject(reader),
+                GarnetObjectType.SortedSet => new SortedSetObject(reader, expiration),
+                GarnetObjectType.List => new ListObject(reader, expiration),
+                GarnetObjectType.Hash => new HashObject(reader, expiration),
+                GarnetObjectType.Set => new SetObject(reader, expiration),
                 _ => null,
             };
         }

--- a/test/Garnet.test/GarnetObjectTests.cs
+++ b/test/Garnet.test/GarnetObjectTests.cs
@@ -172,14 +172,13 @@ namespace Garnet.test
         /// <inheritdoc />
         public override void Deserialize(out IGarnetObject obj)
         {
-            var expiration = reader.ReadInt64();
             var type = (GarnetObjectType)reader.ReadByte();
             obj = type switch
             {
-                GarnetObjectType.SortedSet => new SortedSetObject(reader, expiration),
-                GarnetObjectType.List => new ListObject(reader, expiration),
-                GarnetObjectType.Hash => new HashObject(reader, expiration),
-                GarnetObjectType.Set => new SetObject(reader, expiration),
+                GarnetObjectType.SortedSet => new SortedSetObject(reader),
+                GarnetObjectType.List => new ListObject(reader),
+                GarnetObjectType.Hash => new HashObject(reader),
+                GarnetObjectType.Set => new SetObject(reader),
                 _ => null,
             };
         }

--- a/test/Garnet.test/GarnetObjectTests.cs
+++ b/test/Garnet.test/GarnetObjectTests.cs
@@ -186,7 +186,7 @@ namespace Garnet.test
         /// <inheritdoc />
         public override void Serialize(ref IGarnetObject obj)
         {
-            writer.Write((byte)obj.Type);
+            writer.Write(obj.Type);
             obj.Serialize(writer);
         }
     }

--- a/test/Garnet.test/GarnetObjectTests.cs
+++ b/test/Garnet.test/GarnetObjectTests.cs
@@ -184,6 +184,10 @@ namespace Garnet.test
         }
 
         /// <inheritdoc />
-        public override void Serialize(ref IGarnetObject obj) => obj.Serialize(writer);
+        public override void Serialize(ref IGarnetObject obj)
+        {
+            writer.Write((byte)obj.Type);
+            obj.Serialize(writer);
+        }
     }
 }


### PR DESCRIPTION
This fix addresses a bug where expiration is not being added to serialization, potentially causing some objects to become live again after recovery from a checkpoint.

If you are using the object store, please clean up older checkpoints as it will not be able to deserialize them due to the breaking nature of this change.