### PR TITLE
Fix NullReferenceException when outputting CustomObjectCommand error message

### DIFF
--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -585,7 +585,7 @@ namespace Garnet.server
 
                 if (count - 1 != ocmd.NumKeys + ocmd.NumParams)
                 {
-                    while (!RespWriteUtils.WriteDirect(Encoding.ASCII.GetBytes($"-ERR Invalid number of parameters, expected {cmd.NumKeys + cmd.NumParams}, actual {count - 1}\r\n"), ref dcurr, dend))
+                    while (!RespWriteUtils.WriteDirect(Encoding.ASCII.GetBytes($"-ERR Invalid number of parameters, expected {ocmd.NumKeys + ocmd.NumParams}, actual {count - 1}\r\n"), ref dcurr, dend))
                         SendAndReset();
                     return true;
                 }


### PR DESCRIPTION
the error message is:
```
08::34::20 crit: Session[0] [198.18.0.1:3278] [127.0.0.1:58858] [020A9EF0] ProcessMessages threw exception System.NullReferenceException: Object reference not set to an instance of an object.    
at Garnet.server.RespServerSession.ProcessOtherCommands[TGarnetApi](Int32 count, TGarnetApi& storageApi) in /Users/argsno/Projects/garnet/libs/server/Resp/RespServerSession.cs:line 588    
at Garnet.server.RespServerSession.ProcessArrayCommands[TGarnetApi](TGarnetApi& storageApi) in /Users/argsno/Projects/garnet/libs/server/Resp/RespServerSession.cs:line 496    
at Garnet.server.RespServerSession.ProcessBasicCommands[TGarnetApi](Byte* ptr, RespCommand cmd, TGarnetApi& storageApi) in /Users/argsno/Projects/garnet/libs/server/Resp/RespServerSession.cs:line 368    
at Garnet.server.RespServerSession.ProcessMessages() in /Users/argsno/Projects/garnet/libs/server/Resp/RespServerSession.cs:line 273    
at Garnet.server.RespServerSession.TryConsumeMessages(Byte* reqBuffer, Int32 bytesReceived) in /Users/argsno/Projects/garnet/libs/server/Resp/RespServerSession.cs:line 199
```