### PR TITLE
Remove ifdefs from ClusterStress to fix build

### DIFF
--- a/playground/ClusterStress/OnlineReqGen.cs
+++ b/playground/ClusterStress/OnlineReqGen.cs
@@ -75,10 +75,10 @@ namespace Resp.benchmark
             int key = randomGen ? (zipf ? zipfg.Next() : keyRandomGen.Next(DbSize)) : (keyIndex++ % DbSize);
             slot = Garnet.common.NumUtils.HashSlot(Encoding.ASCII.GetBytes(key.ToString()));
             byte[] keyBytes = GetClusterKeyBytes(key);
-#if DEBUG
+
             int _slot = Garnet.common.NumUtils.HashSlot(keyBytes);
             Debug.Assert(_slot == slot, $"GenerateKeyBytes slot number incosistence {_slot}:{slot}");
-#endif
+
             return keyBytes;
         }
 
@@ -87,10 +87,10 @@ namespace Resp.benchmark
             int key = randomGen ? (zipf ? zipfg.Next() : keyRandomGen.Next(DbSize)) : (keyIndex++ % DbSize);
             slot = Garnet.common.NumUtils.HashSlot(Encoding.ASCII.GetBytes(key.ToString()));
             byte[] keyBytes = GetClusterKeyBytes(key);
-#if DEBUG
+
             int _slot = Garnet.common.NumUtils.HashSlot(keyBytes);
             Debug.Assert(_slot == slot, $"GenerateKeyBytes slot number incosistence {_slot}:{slot}");
-#endif
+
             return Encoding.ASCII.GetString(keyBytes);
         }
 

--- a/playground/ClusterStress/OnlineReqGen.cs
+++ b/playground/ClusterStress/OnlineReqGen.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -77,7 +76,7 @@ namespace Resp.benchmark
             byte[] keyBytes = GetClusterKeyBytes(key);
 #if DEBUG
             int _slot = Garnet.common.NumUtils.HashSlot(keyBytes);
-            Debug.Assert(_slot == slot, $"GenerateKeyBytes slot number incosistence {_slot}:{slot}");
+            System.Diagnostics.Debug.Assert(_slot == slot, $"GenerateKeyBytes slot number incosistence {_slot}:{slot}");
 #endif
             return keyBytes;
         }
@@ -89,7 +88,7 @@ namespace Resp.benchmark
             byte[] keyBytes = GetClusterKeyBytes(key);
 #if DEBUG
             int _slot = Garnet.common.NumUtils.HashSlot(keyBytes);
-            Debug.Assert(_slot == slot, $"GenerateKeyBytes slot number incosistence {_slot}:{slot}");
+            System.Diagnostics.Debug.Assert(_slot == slot, $"GenerateKeyBytes slot number incosistence {_slot}:{slot}");
 #endif
             return Encoding.ASCII.GetString(keyBytes);
         }

--- a/playground/ClusterStress/OnlineReqGen.cs
+++ b/playground/ClusterStress/OnlineReqGen.cs
@@ -75,10 +75,10 @@ namespace Resp.benchmark
             int key = randomGen ? (zipf ? zipfg.Next() : keyRandomGen.Next(DbSize)) : (keyIndex++ % DbSize);
             slot = Garnet.common.NumUtils.HashSlot(Encoding.ASCII.GetBytes(key.ToString()));
             byte[] keyBytes = GetClusterKeyBytes(key);
-
+#if DEBUG
             int _slot = Garnet.common.NumUtils.HashSlot(keyBytes);
             Debug.Assert(_slot == slot, $"GenerateKeyBytes slot number incosistence {_slot}:{slot}");
-
+#endif
             return keyBytes;
         }
 
@@ -87,10 +87,10 @@ namespace Resp.benchmark
             int key = randomGen ? (zipf ? zipfg.Next() : keyRandomGen.Next(DbSize)) : (keyIndex++ % DbSize);
             slot = Garnet.common.NumUtils.HashSlot(Encoding.ASCII.GetBytes(key.ToString()));
             byte[] keyBytes = GetClusterKeyBytes(key);
-
+#if DEBUG
             int _slot = Garnet.common.NumUtils.HashSlot(keyBytes);
             Debug.Assert(_slot == slot, $"GenerateKeyBytes slot number incosistence {_slot}:{slot}");
-
+#endif
             return Encoding.ASCII.GetString(keyBytes);
         }
 


### PR DESCRIPTION
`dotnet build` kept failing for me. Seems like either wrapping the `using System.Diagnostics` into `#ifdef` or removing them from logic should fix it. `Debug.Assert` is still only a guard for the Debug builds unless the intent was to keep cost of the `NumUtils.GetHashSlot` from Release configuration stresstest?