### PR TITLE
Use cryptographically random values where required

### DIFF
--- a/libs/cluster/Server/GarnetClusterConnectionStore.cs
+++ b/libs/cluster/Server/GarnetClusterConnectionStore.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Security.Cryptography;
 using Garnet.common;
 using Microsoft.Extensions.Logging;
 
@@ -13,8 +14,6 @@ namespace Garnet.cluster
         GarnetServerNode[] connections;
         int numConnection;
         bool _disposed;
-
-        Random rand = new Random(Guid.NewGuid().GetHashCode());
 
         SingleWriterMultiReaderLock _lock;
 
@@ -220,7 +219,7 @@ namespace Garnet.cluster
                 if (_disposed) return false;
                 if (numConnection == 0) return false;
 
-                var offset = rand.Next(0, numConnection);
+                var offset = RandomNumberGenerator.GetInt32(0, numConnection);
                 conn = connections[offset];
                 return true;
             }

--- a/libs/common/Generator.cs
+++ b/libs/common/Generator.cs
@@ -2,17 +2,15 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Text;
+using System.Security.Cryptography;
 
 namespace Garnet.common
 {
     /// <summary>
     /// Collection of methods generating hex ids
     /// </summary>
-    public class Generator
+    public static class Generator
     {
-        static ReadOnlySpan<byte> hexchars => "0123456789abcdef"u8;
-
         /// <summary>
         /// Random hex id
         /// </summary>
@@ -20,10 +18,9 @@ namespace Garnet.common
         /// <returns></returns>
         public static string CreateHexId(int size = 40)
         {
-            var NodeId = new byte[size];
-            new Random(Guid.NewGuid().GetHashCode()).NextBytes(NodeId);
-            for (int i = 0; i < NodeId.Length; i++) NodeId[i] = hexchars[NodeId[i] & 0xf];
-            return Encoding.ASCII.GetString(NodeId);
+            Span<byte> nodeIdBuffer = stackalloc byte[size];
+            RandomNumberGenerator.Fill(nodeIdBuffer);
+            return Convert.ToHexString(nodeIdBuffer).ToLowerInvariant();
         }
 
         /// <summary>
@@ -33,9 +30,9 @@ namespace Garnet.common
         /// <returns></returns>
         public static string DefaultHexId(int size = 40)
         {
-            var NodeId = new byte[size];
-            for (int i = 0; i < NodeId.Length; i++) NodeId[i] = hexchars[0];
-            return Encoding.ASCII.GetString(NodeId);
+            Span<byte> nodeIdBuffer = stackalloc byte[size];
+            nodeIdBuffer.Clear();
+            return Convert.ToHexString(nodeIdBuffer).ToLowerInvariant();
         }
     }
 }

--- a/libs/common/Generator.cs
+++ b/libs/common/Generator.cs
@@ -12,25 +12,25 @@ namespace Garnet.common
     public static class Generator
     {
         /// <summary>
-        /// Random hex id
+        /// Generates a random hex string of specified length
         /// </summary>
-        /// <param name="size"></param>
+        /// <param name="size">The length of the hex identifier string</param>
         /// <returns></returns>
         public static string CreateHexId(int size = 40)
         {
-            Span<byte> nodeIdBuffer = stackalloc byte[size];
+            Span<byte> nodeIdBuffer = stackalloc byte[size / 2];
             RandomNumberGenerator.Fill(nodeIdBuffer);
             return Convert.ToHexString(nodeIdBuffer).ToLowerInvariant();
         }
 
         /// <summary>
-        /// Default hex id
+        /// Generates a default hex string of specified length (all zeros)
         /// </summary>
-        /// <param name="size"></param>
+        /// <param name="size">The length of the hex identifier string</param>
         /// <returns></returns>
         public static string DefaultHexId(int size = 40)
         {
-            Span<byte> nodeIdBuffer = stackalloc byte[size];
+            Span<byte> nodeIdBuffer = stackalloc byte[size / 2];
             nodeIdBuffer.Clear();
             return Convert.ToHexString(nodeIdBuffer).ToLowerInvariant();
         }

--- a/libs/server/Objects/Hash/HashObjectImpl.cs
+++ b/libs/server/Objects/Hash/HashObjectImpl.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using Garnet.common;
 using Tsavorite.core;
@@ -215,7 +216,6 @@ namespace Garnet.server
             ObjectOutputHeader _output = default;
             try
             {
-                Random random = new();
                 var withValues = false;
                 int[] indexes = default;
 
@@ -270,9 +270,7 @@ namespace Garnet.server
                             countParameter = Math.Abs(countParameter);
                             indexes = new int[countParameter];
                             for (int i = 0; i < countParameter; i++)
-                                indexes[i] = random.Next(0, hash.Count);
-                            // Shuffle
-                            indexes = indexes.OrderBy(x => random.Next()).ToArray();
+                                indexes[i] = RandomNumberGenerator.GetInt32(0, hash.Count);
                         }
 
                         // Write the size of the array reply
@@ -296,7 +294,7 @@ namespace Garnet.server
                 else if (count == 2) // No count parameter or withvalues is present, we just return a random field
                 {
                     // Write a bulk string value of a random field from the hash value stored at key.
-                    int index = random.Next(hash.Count);
+                    int index = RandomNumberGenerator.GetInt32(0, hash.Count);
                     var pair = hash.ElementAt(index);
                     while (!RespWriteUtils.WriteBulkString(pair.Key, ref curr, end))
                         ObjectUtils.ReallocateOutput(ref output, ref isMemory, ref ptr, ref ptrHandle, ref curr, ref end);

--- a/libs/server/Objects/Set/SetObjectImpl.cs
+++ b/libs/server/Objects/Set/SetObjectImpl.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System;
 using System.Buffers;
 using System.Linq;
+using System.Security.Cryptography;
 using Garnet.common;
 using Tsavorite.core;
 
@@ -142,8 +142,6 @@ namespace Garnet.server
             _output->bytesDone = 0;
         }
 
-        static readonly Random random = new();
-
         private void SetPop(byte* input, int length, ref SpanByteAndMemory output)
         {
             // SPOP key[count]
@@ -178,7 +176,7 @@ namespace Garnet.server
                     for (int i = 0; i < countParameter; i++)
                     {
                         // Generate a new index based on the elements left in the set
-                        var index = random.Next(0, set.Count - 1);
+                        var index = RandomNumberGenerator.GetInt32(0, set.Count - 1);
                         var item = set.ElementAt(index);
                         set.Remove(item);
                         this.UpdateSize(item, false);
@@ -190,7 +188,7 @@ namespace Garnet.server
                 else if (count == int.MinValue) // no count parameter is present, we just pop and return a random item of the set
                 {
                     // Write a bulk string value of a random field from the hash value stored at key.
-                    int index = random.Next(set.Count);
+                    int index = RandomNumberGenerator.GetInt32(0, set.Count);
                     var item = set.ElementAt(index);
                     set.Remove(item);
                     this.UpdateSize(item, false);

--- a/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using Garnet.common;
 using Tsavorite.core;
@@ -651,7 +652,6 @@ namespace Garnet.server
             MemoryHandle ptrHandle = default;
             byte* ptr = output.SpanByte.ToPointer();
 
-            Random random = new();
             var curr = ptr;
             var end = curr + output.Length;
 
@@ -680,10 +680,7 @@ namespace Garnet.server
                     // The order of fields in the reply is truly random.
                     indexes = new int[Math.Abs(count)];
                     for (int i = 0; i < indexes.Length; i++)
-                        indexes[i] = random.Next(0, sortedSetDict.Count);
-
-                    // Guarantee random order
-                    indexes = indexes.OrderBy(x => random.Next()).ToArray();
+                        indexes[i] = RandomNumberGenerator.GetInt32(0, sortedSetDict.Count);
                 }
 
                 foreach (var item in indexes)


### PR DESCRIPTION
Contributes to #86 

This PR changes uses of the pseudo-RNG `System.Random` to the OS provided cryptographic RNG API `System.Security.Cryptography.RandomNumberGenerator` where applicable. These randomizations can be optimized further but let's make it secure first 😅 

For example, [`ZRANDMEMBER`](https://redis.io/commands/zrandmember/) specifies that the values must be "truly random".

Didn't touch pseudo-random usage in tests. 
