### PR TITLE
Fix build error when configuration is Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
       - name: Build Garnet
-        run: dotnet build
+        run: dotnet build -c Release
       - name: Test Garnet
         run: dotnet test -f ${{ matrix.framework }} --logger "console;verbosity=detailed" --logger trx --results-directory "GarnetTestResults-${{ matrix.os }}-${{ matrix.framework }}"
       - name: Upload test results

--- a/playground/ClusterStress/OnlineReqGen.cs
+++ b/playground/ClusterStress/OnlineReqGen.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 


### PR DESCRIPTION
The error log looks like
```
→ dotnet build -c Release
MSBuild version 17.9.4+90725d08d for .NET
  Determining projects to restore...
...
/home/vbox/workspace/build/garnet/playground/ClusterStress/OnlineReqGen.cs(6,1): error IDE0005: Using directive is unnecessary. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005) [/home/vbox/workspace/build/garnet/playground/ClusterStress/ClusterStress.csproj::TargetFramework=net7.0]
/home/vbox/workspace/build/garnet/playground/ClusterStress/OnlineReqGen.cs(6,1): error IDE0005: Using directive is unnecessary. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005) [/home/vbox/workspace/build/garnet/playground/ClusterStress/ClusterStress.csproj::TargetFramework=net6.0]
/home/vbox/workspace/build/garnet/playground/ClusterStress/OnlineReqGen.cs(6,1): error IDE0005: Using directive is unnecessary. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005) [/home/vbox/workspace/build/garnet/playground/ClusterStress/ClusterStress.csproj::TargetFramework=net8.0]
```