### PR TITLE
Fix parsing for object store commands with wrong number of arguments

### DIFF
--- a/libs/server/Resp/Objects/HashCommands.cs
+++ b/libs/server/Resp/Objects/HashCommands.cs
@@ -293,7 +293,7 @@ namespace Garnet.server
             if (count < 2)
             {
                 hashItemsDoneCount = hashOpsCount = 0;
-                return AbortWithWrongNumberOfArguments("DEL", count);
+                return AbortWithWrongNumberOfArguments("HDEL", count);
             }
             else
             {

--- a/libs/server/Resp/Objects/HashCommands.cs
+++ b/libs/server/Resp/Objects/HashCommands.cs
@@ -119,9 +119,7 @@ namespace Garnet.server
                 (op == HashOperation.HGET && count != 3) ||
                 (op == HashOperation.HMGET && count < 3))
             {
-                // Send error to output
-                WriteErrorTokenNumberInCommand(op.ToString());
-                ReadLeftToken(count - 1, ref ptr);
+                return AbortWithWrongNumberOfArguments(op.ToString(), count);
             }
             else
             {
@@ -221,11 +219,10 @@ namespace Garnet.server
         {
             ptr += 10;
 
-            if (count - 2 < 0)
+            if (count != 2)
             {
                 hashItemsDoneCount = hashOpsCount = 0;
-                // Send error to output
-                WriteErrorTokenNumberInCommand("HLEN");
+                return AbortWithWrongNumberOfArguments("HLEN", count);
             }
             else
             {
@@ -293,11 +290,10 @@ namespace Garnet.server
         {
             ptr += 10;
 
-            if (count - 2 <= 0)
+            if (count < 2)
             {
                 hashItemsDoneCount = hashOpsCount = 0;
-                // Send error to output
-                WriteErrorTokenNumberInCommand("HDEL");
+                return AbortWithWrongNumberOfArguments("DEL", count);
             }
             else
             {
@@ -375,11 +371,10 @@ namespace Garnet.server
         {
             ptr += 13;
 
-            if (count < 3)
+            if (count != 3)
             {
                 hashItemsDoneCount = hashOpsCount = 0;
-                // Send error to output
-                WriteErrorTokenNumberInCommand("HEXISTS");
+                return AbortWithWrongNumberOfArguments("HEXISTS", count);
             }
             else
             {
@@ -534,11 +529,9 @@ namespace Garnet.server
             ptr += op == HashOperation.HINCRBY ? 13 : 19;
 
             // Check if parameters number is right
-            if (count < 4)
+            if (count != 4)
             {
-                // Send error to output
-                WriteErrorTokenNumberInCommand(op == HashOperation.HINCRBY ? "HINCRBY" : "HINCRBYFLOAT");
-                ReadLeftToken(count - 1, ref ptr);
+                return AbortWithWrongNumberOfArguments(op == HashOperation.HINCRBY ? "HINCRBY" : "HINCRBYFLOAT", count);
             }
             else
             {

--- a/libs/server/Resp/Objects/ListCommands.cs
+++ b/libs/server/Resp/Objects/ListCommands.cs
@@ -268,11 +268,7 @@ namespace Garnet.server
 
             if (count != 4)
             {
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand("LTRIM");
+                return AbortWithWrongNumberOfArguments("LTRIM", count);
             }
             else
             {
@@ -342,11 +338,7 @@ namespace Garnet.server
 
             if (count != 4)
             {
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand("LRANGE");
+                return AbortWithWrongNumberOfArguments("LRANGE", count);
             }
             else
             {
@@ -424,11 +416,7 @@ namespace Garnet.server
 
             if (count != 3)
             {
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand("LINDEX");
+                return AbortWithWrongNumberOfArguments("LINDEX", count);
             }
             else
             {
@@ -511,11 +499,7 @@ namespace Garnet.server
 
             if (count != 5)
             {
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand("LINSERT");
+                return AbortWithWrongNumberOfArguments("LINSERT", count);
             }
             else
             {
@@ -599,11 +583,7 @@ namespace Garnet.server
             // if params are missing return error
             if (count != 4)
             {
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand("LREM");
+                return AbortWithWrongNumberOfArguments("LREM", count);
             }
             else
             {
@@ -684,11 +664,7 @@ namespace Garnet.server
 
             if (count != 5)
             {
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand("LMOVE");
+                return AbortWithWrongNumberOfArguments("LMOVE", count);
             }
             else
             {
@@ -742,11 +718,7 @@ namespace Garnet.server
 
             if (count != 3)
             {
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand("RPOPLPUSH");
+                return AbortWithWrongNumberOfArguments("RPOPLPUSH", count);
             }
             else
             {

--- a/libs/server/Resp/Objects/ObjectStoreUtils.cs
+++ b/libs/server/Resp/Objects/ObjectStoreUtils.cs
@@ -35,12 +35,12 @@ namespace Garnet.server
         /// Aborts the execution of the current object store command and outputs
         /// an error message to indicate a wrong number of arguments for the given command.
         /// </summary>
-        /// <param name="cmdName">Name of the command that caused the error message</param>
-        /// <param name="count">Number of remaining tokens belonging to this command on the receive buffer</param>
-        /// <returns>true if the command was completely consumed, false if the input on the receive buffer was incomplete</returns>
+        /// <param name="cmdName">Name of the command that caused the error message.</param>
+        /// <param name="count">Number of remaining tokens belonging to this command on the receive buffer.</param>
+        /// <returns>true if the command was completely consumed, false if the input on the receive buffer was incomplete.</returns>
         private bool AbortWithWrongNumberOfArguments(string cmdName, int count)
         {
-            // Abort command and discard any remaining tokens on the input buffer.
+            // Abort command and discard any remaining tokens on the input buffer
             var bufSpan = new ReadOnlySpan<byte>(recvBufferPtr, bytesRead);
 
             if (!DrainCommands(bufSpan, count))

--- a/libs/server/Resp/Objects/ObjectStoreUtils.cs
+++ b/libs/server/Resp/Objects/ObjectStoreUtils.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Text;
 using Garnet.common;
 
@@ -11,18 +12,6 @@ namespace Garnet.server
     /// </summary>
     internal sealed unsafe partial class RespServerSession : ServerSessionBase
     {
-        /// <summary>
-        /// Send the error of missing arguments for any command
-        /// </summary>
-        /// <param name="cmdName"></param>
-        //todo move this method to write utils ??
-        private void WriteErrorTokenNumberInCommand(string cmdName)
-        {
-            var errorMessage = Encoding.ASCII.GetBytes($"-ERR wrong number of arguments for {cmdName} command.\r\n");
-            while (!RespWriteUtils.WriteResponse(errorMessage, ref dcurr, dend))
-                SendAndReset();
-        }
-
         /// <summary>
         /// Reads the n tokens from the current buffer, and returns
         /// total tokens read
@@ -40,6 +29,29 @@ namespace Garnet.server
             }
 
             return totalTokens;
+        }
+
+        /// <summary>
+        /// Aborts the execution of the current object store command and outputs
+        /// an error message to indicate a wrong number of arguments for the given command.
+        /// </summary>
+        /// <param name="cmdName">Name of the command that caused the error message</param>
+        /// <param name="count">Number of remaining tokens belonging to this command on the receive buffer</param>
+        /// <returns>true if the command was completely consumed, false if the input on the receive buffer was incomplete</returns>
+        private bool AbortWithWrongNumberOfArguments(string cmdName, int count)
+        {
+            // Abort command and discard any remaining tokens on the input buffer.
+            var bufSpan = new ReadOnlySpan<byte>(recvBufferPtr, bytesRead);
+
+            if (!DrainCommands(bufSpan, count))
+                return false;
+
+            // Print error message to result stream
+            var errorMessage = Encoding.ASCII.GetBytes($"-ERR wrong number of arguments for {cmdName} command.\r\n");
+            while (!RespWriteUtils.WriteResponse(errorMessage, ref dcurr, dend))
+                SendAndReset();
+
+            return true;
         }
     }
 }

--- a/libs/server/Resp/Objects/SetCommands.cs
+++ b/libs/server/Resp/Objects/SetCommands.cs
@@ -177,11 +177,11 @@ namespace Garnet.server
         {
             ptr += 11;
 
-            if (count - 2 < 0)
+            if (count != 2)
             {
                 setItemsDoneCount = setOpsCount = 0;
-                // Send error to output
-                WriteErrorTokenNumberInCommand("SCARD");
+                return AbortWithWrongNumberOfArguments("SCARD", count);
+
             }
             else
             {

--- a/libs/server/Resp/Objects/SortedSetCommands.cs
+++ b/libs/server/Resp/Objects/SortedSetCommands.cs
@@ -103,11 +103,10 @@ namespace Garnet.server
         {
             ptr += 10;
 
-            if (count - 2 <= 0)
+            if (count < 3)
             {
                 zaddDoneCount = zaddAddCount = 0;
-                // send error to output and forward pointers to the end
-                WriteErrorTokenNumberInCommand("ZREM");
+                return AbortWithWrongNumberOfArguments("ZREM", count);
             }
             else
             {
@@ -191,11 +190,10 @@ namespace Garnet.server
         {
             ptr += 11;
 
-            if (count - 2 < 0)
+            if (count != 2)
             {
                 zaddDoneCount = zaddAddCount = 0;
-                // send error to output
-                WriteErrorTokenNumberInCommand("ZCARD");
+                return AbortWithWrongNumberOfArguments("ZCARD", count);
             }
             else
             {
@@ -386,11 +384,9 @@ namespace Garnet.server
             ptr += 12;
 
             //validation if minimum args
-            if (count - 3 != 0)
+            if (count != 3)
             {
-                // send error to output
-                WriteErrorTokenNumberInCommand("ZSCORE");
-                ReadLeftToken(count - 1, ref ptr);
+                return AbortWithWrongNumberOfArguments("ZSCORE", count);
             }
             else
             {
@@ -467,11 +463,9 @@ namespace Garnet.server
              where TGarnetApi : IGarnetApi
         {
             ptr += 13;
-            if (count - 1 > 2 || count - 1 == 0)
+            if (count < 2 || count > 3)
             {
-                // send error to output
-                WriteErrorTokenNumberInCommand(op == SortedSetOperation.ZPOPMAX ? "ZPOPMAX" : "ZPOPMIN");
-                ReadLeftToken(count - 1, ref ptr);
+                return AbortWithWrongNumberOfArguments(op == SortedSetOperation.ZPOPMAX ? "ZPOPMAX" : "ZPOPMIN", count);
             }
             else
             {
@@ -559,12 +553,7 @@ namespace Garnet.server
 
             if (count != 4)
             {
-                zaddDoneCount = zaddAddCount = 0;
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand("ZCOUNT");
+                return AbortWithWrongNumberOfArguments("ZCOUNT", count);
             }
             else
             {
@@ -655,11 +644,7 @@ namespace Garnet.server
             if (count != 4)
             {
                 zaddDoneCount = zaddAddCount = 0;
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand(op == SortedSetOperation.ZLEXCOUNT ? "ZLEXCOUNT" : "ZREMRANGEBYLEX");
+                return AbortWithWrongNumberOfArguments(op == SortedSetOperation.ZLEXCOUNT ? "ZLEXCOUNT" : "ZREMRANGEBYLEX", count);
             }
             else
             {
@@ -749,11 +734,7 @@ namespace Garnet.server
             //validation of required args
             if (count != 4)
             {
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand("ZINCRBY");
+                return AbortWithWrongNumberOfArguments("ZINCRBY", count);
             }
             else
             {
@@ -850,11 +831,7 @@ namespace Garnet.server
             //validation of required args
             if (count < 3 || count > 4)
             {
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand(op == SortedSetOperation.ZRANK ? "ZRANK" : "ZREVRANK");
+                return AbortWithWrongNumberOfArguments(op == SortedSetOperation.ZRANK ? "ZRANK" : "ZREVRANK", count);
             }
             else
             {
@@ -935,11 +912,7 @@ namespace Garnet.server
 
             if (count != 4)
             {
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand(op == SortedSetOperation.ZREMRANGEBYRANK ? "ZREMRANGEBYRANK" : "ZREMRANGEBYSCORE");
+                return AbortWithWrongNumberOfArguments(op == SortedSetOperation.ZREMRANGEBYRANK ? "ZREMRANGEBYRANK" : "ZREMRANGEBYSCORE", count);
             }
             else
             {
@@ -1021,13 +994,9 @@ namespace Garnet.server
         {
             ptr += 18;
 
-            if (count - 2 < 0 || count > 4)
+            if (count < 2 || count > 4)
             {
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand("ZRANDMEMBER");
+                return AbortWithWrongNumberOfArguments("ZRANDMEMBER", count);
             }
             else
             {
@@ -1126,13 +1095,9 @@ namespace Garnet.server
              where TGarnetApi : IGarnetApi
         {
             ptr += 11;
-            if (count - 3 < 0)
+            if (count < 3)
             {
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand("ZDIFF");
+                return AbortWithWrongNumberOfArguments("ZDIFF", count);
             }
             else
             {

--- a/libs/server/Resp/Objects/SortedSetGeoCommands.cs
+++ b/libs/server/Resp/Objects/SortedSetGeoCommands.cs
@@ -26,11 +26,7 @@ namespace Garnet.server
             // validate the number of parameters
             if (count < 5)
             {
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand("GEOADD");
+                return AbortWithWrongNumberOfArguments("GEOADD", count);
             }
             else
             {
@@ -135,11 +131,7 @@ namespace Garnet.server
             if (count < paramsRequiredInCommand)
             {
                 zaddDoneCount = zaddAddCount = 0;
-                var tokens = ReadLeftToken(count - 1, ref ptr);
-                if (tokens < count - 1)
-                    return false;
-                // send error to output
-                WriteErrorTokenNumberInCommand(cmd);
+                return AbortWithWrongNumberOfArguments(cmd, count);
             }
             else
             {


### PR DESCRIPTION
This PR addresses a critical bug related to object store commands, where command invocations with incorrect numbers of arguments can corrupt the command stream by prematurely exiting the parsing loop without fully consuming the RESP command.

## Bug Description

### Steps to Reproduce

```
redis> HSET x y "Hello"
(integer) 1
redis> HLEN x y # <- Incorrect input
(integer) 0
redis> HGET x y
(error) ERR unknown command
```

### Expected Result
```
redis> HGET x y
"Hello"
```

### Actual Result
Due to the parsing stream assuming that “y” is the next command name, the subsequent command is incorrectly flagged as unknown.

## Changes
To fix this issue, the following changes have been made:

- Replaced `WriteErrorTokenNumberInCommand()` with a new function called `AbortWithWrongNumberOfArguments()`. This new function ensures that any remaining arguments left in the input stream are properly drained before returning the error related to incorrect #arguments.
- Corrected the maximum number of arguments for the following commands: HLEN, HEXISTS, HINCRBY, HINCRBYFLOAT, SCARD, and ZCARD.
