### PR TITLE
feat: add SISMEMBER command

### DIFF
--- a/libs/server/API/GarnetApiObjectCommands.cs
+++ b/libs/server/API/GarnetApiObjectCommands.cs
@@ -277,6 +277,10 @@ namespace Garnet.server
             => storageSession.SetMembers(key, input, ref outputFooter, ref objectContext);
 
         /// <inheritdoc />
+        public GarnetStatus SetIsMember(byte[] key, ArgSlice input, ref GarnetObjectStoreOutput outputFooter)
+            => storageSession.SetIsMember(key, input, ref outputFooter, ref objectContext);
+
+        /// <inheritdoc />
         public GarnetStatus SetPop(ArgSlice key, out ArgSlice member)
             => storageSession.SetPop(key, out member, ref objectContext);
 

--- a/libs/server/API/GarnetWatchApi.cs
+++ b/libs/server/API/GarnetWatchApi.cs
@@ -224,6 +224,13 @@ namespace Garnet.server
         }
 
         /// <inheritdoc />
+        public GarnetStatus SetIsMember(byte[] key, ArgSlice input, ref GarnetObjectStoreOutput outputFooter)
+        {
+            garnetApi.WATCH(key, StoreType.Object);
+            return garnetApi.SetIsMember(key, input, ref outputFooter);
+        }
+
+        /// <inheritdoc />
         public GarnetStatus SetMembers(byte[] key, ArgSlice input, ref GarnetObjectStoreOutput outputFooter)
         {
             garnetApi.WATCH(key, StoreType.Object);

--- a/libs/server/API/IGarnetApi.cs
+++ b/libs/server/API/IGarnetApi.cs
@@ -1156,6 +1156,15 @@ namespace Garnet.server
         GarnetStatus SetMembers(byte[] key, ArgSlice input, ref GarnetObjectStoreOutput outputFooter);
 
         /// <summary>
+        /// Returns if member is a member of the set stored at key.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="input"></param>
+        /// <param name="outputFooter"></param>
+        /// <returns></returns>
+        GarnetStatus SetIsMember(byte[] key, ArgSlice input, ref GarnetObjectStoreOutput outputFooter);
+        
+        /// <summary>
         /// Iterates over the members of the Set with the given key using a cursor,
         /// a match pattern and count parameters.
         /// </summary>

--- a/libs/server/Objects/Set/SetObject.cs
+++ b/libs/server/Objects/Set/SetObject.cs
@@ -23,6 +23,7 @@ namespace Garnet.server
         SMEMBERS,
         SCARD,
         SSCAN,
+        SISMEMBER,
     }
 
 
@@ -110,6 +111,9 @@ namespace Garnet.server
                         break;
                     case SetOperation.SMEMBERS:
                         SetMembers(_input, input.Length, ref output);
+                        break;
+                    case SetOperation.SISMEMBER:
+                        SetIsMember(_input, input.Length, ref output);
                         break;
                     case SetOperation.SREM:
                         SetRemove(_input, input.Length, _output);

--- a/libs/server/Objects/Set/SetObjectImpl.cs
+++ b/libs/server/Objects/Set/SetObjectImpl.cs
@@ -93,6 +93,43 @@ namespace Garnet.server
             }
         }
 
+        private void SetIsMember(byte* input, int length, ref SpanByteAndMemory output)
+        {
+            byte* input_startptr = input + sizeof(ObjectInputHeader);
+            byte* input_currptr = input_startptr;
+
+            bool isMemory = false;
+            MemoryHandle ptrHandle = default;
+            byte* ptr = output.SpanByte.ToPointer();
+
+            var curr = ptr;
+            var end = curr + output.Length;
+
+            ObjectOutputHeader _output = default;
+            try
+            {
+                if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var member, ref input_currptr, input + length))
+                    return;
+
+                bool isMember = set.Contains(member);
+
+                while (!RespWriteUtils.WriteInteger(isMember ? 1 : 0, ref curr, end))
+                    ObjectUtils.ReallocateOutput(ref output, ref isMemory, ref ptr, ref ptrHandle, ref curr, ref end);
+
+                _output.opsDone = 1;
+                _output.bytesDone = (int)(input_currptr - input_startptr);
+                _output.countDone = 1;
+            }
+            finally
+            {
+                while (!RespWriteUtils.WriteDirect(ref _output, ref curr, end))
+                    ObjectUtils.ReallocateOutput(ref output, ref isMemory, ref ptr, ref ptrHandle, ref curr, ref end);
+
+                if (isMemory) ptrHandle.Dispose();
+                output.Length = (int)(curr - ptr);
+            }
+        }
+
         private void SetRemove(byte* input, int length, byte* output)
         {
             var _input = (ObjectInputHeader*)input;

--- a/libs/server/Resp/Objects/SetCommands.cs
+++ b/libs/server/Resp/Objects/SetCommands.cs
@@ -308,6 +308,71 @@ namespace Garnet.server
             return true;
         }
 
+        private unsafe bool SetIsMember<TGarnetApi>(int count, byte* ptr, ref TGarnetApi storageApi)
+            where TGarnetApi : IGarnetApi
+        {
+            ptr += 15;
+
+            // Get the key
+            if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var key, ref ptr, recvBufferPtr + bytesRead))
+                return false;
+
+            if (NetworkSingleKeySlotVerify(key, true))
+            {
+                var bufSpan = new ReadOnlySpan<byte>(recvBufferPtr, bytesRead);
+                if (!DrainCommands(bufSpan, count))
+                    return false;
+                return true;
+            }
+
+            // Prepare input
+            var inputPtr = (ObjectInputHeader*)(ptr - sizeof(ObjectInputHeader));
+
+            // Save old values
+            var save = *inputPtr;
+
+            // Prepare length of header in input buffer
+            var inputLength = (int)(recvBufferPtr + bytesRead - (byte*)inputPtr);
+
+            // Prepare header in input buffer
+            inputPtr->header.type = GarnetObjectType.Set;
+            inputPtr->header.SetOp = SetOperation.SISMEMBER;
+            inputPtr->count = count;
+            inputPtr->done = 0;
+
+            // Prepare GarnetObjectStore output
+            var outputFooter = new GarnetObjectStoreOutput { spanByteAndMemory = new SpanByteAndMemory(dcurr, (int)(dend - dcurr)) };
+
+            var status = storageApi.SetIsMember(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+
+            // Restore input buffer
+            *inputPtr = save;
+
+            switch (status)
+            {
+                case GarnetStatus.OK:
+                    // Process output
+                    var objOutputHeader = ProcessOutputWithHeader(outputFooter.spanByteAndMemory);
+                    ptr += objOutputHeader.bytesDone;
+                    setItemsDoneCount += objOutputHeader.countDone;
+                    if (setItemsDoneCount > objOutputHeader.opsDone)
+                        return false;
+                    break;
+                case GarnetStatus.NOTFOUND:
+                    while (!RespWriteUtils.WriteResponse(CmdStrings.RESP_RETURN_VAL_0, ref dcurr, dend))
+                        SendAndReset();
+                    ReadLeftToken(count - 2, ref ptr);
+                    break;
+            }
+
+            // Reset session counters
+            setItemsDoneCount = setOpsCount = 0;
+
+            // Move input head
+            readHead = (int)(ptr - recvBufferPtr);
+            return true;
+        }
+
         /// <summary>
         /// Removes and returns one or more random members from the set at key.
         /// </summary>

--- a/libs/server/Resp/RespCommand.cs
+++ b/libs/server/Resp/RespCommand.cs
@@ -643,6 +643,9 @@ namespace Garnet.server
                     //[$8|SMEMBERS|] = 14 bytes = 8 (long) + 2 (ushort) + 2 bytes
                     if (*(long*)ptr == 5567941533359749156L && *(ushort*)(ptr + 8) == 17730 && *(ptr + 13) == 10)
                         return (RespCommand.Set, (byte)SetOperation.SMEMBERS);
+                    //[$9\r\nSISM EMBER\r\n]
+                    if (*(long*)ptr == 5571877784987187492L && *(ushort*)(ptr + 8) == 19781 && *(ptr + 14) == 10)
+                        return (RespCommand.Set, (byte)SetOperation.SISMEMBER);
                     //[$4|SREM|] = 10 bytes = 8 (long) + 2 (ushort) 
                     if (*(long*)ptr == 5567947030917887012L && *(ushort*)(ptr + 8) == 2573 && *(ptr + 9) == 10)
                         return (RespCommand.Set, (byte)SetOperation.SREM);

--- a/libs/server/Resp/RespCommandsInfo.cs
+++ b/libs/server/Resp/RespCommandsInfo.cs
@@ -204,6 +204,7 @@ namespace Garnet.server
             {(byte)SetOperation.SCARD,      new RespCommandsInfo("SCARD",    RespCommand.Set,    2, null, (byte)SetOperation.SCARD)},
             {(byte)SetOperation.SPOP,       new RespCommandsInfo("SPOP",     RespCommand.Set,   -2, null, (byte)SetOperation.SPOP) },
             {(byte)SetOperation.SSCAN,      new RespCommandsInfo("SSCAN",    RespCommand.Set,   -3, null, (byte)SetOperation.SSCAN) },
+            {(byte)SetOperation.SISMEMBER,  new RespCommandsInfo("SISMEMBER",RespCommand.Set,    3, null, (byte)SetOperation.SISMEMBER) },
         };
 
         private static readonly Dictionary<RespCommand, RespCommandsInfo> customCommandsInfoMap = new Dictionary<RespCommand, RespCommandsInfo>

--- a/libs/server/Resp/RespInfo.cs
+++ b/libs/server/Resp/RespInfo.cs
@@ -38,7 +38,7 @@ namespace Garnet.server
                 // Pub/sub
                 "PUBLISH", "SUBSCRIBE", "PSUBSCRIBE", "UNSUBSCRIBE", "PUNSUBSCRIBE",
                 // Set
-                "SADD", "SREM", "SPOP", "SMEMBERS", "SCARD", "SSCAN",
+                "SADD", "SREM", "SPOP", "SMEMBERS", "SCARD", "SSCAN", "SISMEMBER",
                 //Scan ops
                 "DBSIZE", "KEYS","SCAN",
                 // Geospatial commands

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -489,6 +489,7 @@ namespace Garnet.server
                 // Set Commands
                 (RespCommand.Set, (byte)SetOperation.SADD) => SetAdd(count, ptr, ref storageApi),
                 (RespCommand.Set, (byte)SetOperation.SMEMBERS) => SetMembers(count, ptr, ref storageApi),
+                (RespCommand.Set, (byte)SetOperation.SISMEMBER) => SetIsMember(count, ptr, ref storageApi),
                 (RespCommand.Set, (byte)SetOperation.SREM) => SetRemove(count, ptr, ref storageApi),
                 (RespCommand.Set, (byte)SetOperation.SCARD) => SetLength(count, ptr, ref storageApi),
                 (RespCommand.Set, (byte)SetOperation.SPOP) => SetPop(count, ptr, ref storageApi),

--- a/libs/server/Storage/Session/ObjectStore/SetOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/SetOps.cs
@@ -418,6 +418,19 @@ namespace Garnet.server
             => ReadObjectStoreOperationWithOutput(key, input, ref objectContext, ref outputFooter);
 
         /// <summary>
+        /// Returns if member is a member of the set stored at key.
+        /// </summary>
+        /// <typeparam name="TObjectContext"></typeparam>
+        /// <param name="key"></param>
+        /// <param name="input"></param>
+        /// <param name="outputFooter"></param>
+        /// <param name="objectContext"></param>
+        /// <returns></returns>
+        public GarnetStatus SetIsMember<TObjectContext>(byte[] key, ArgSlice input, ref GarnetObjectStoreOutput outputFooter, ref TObjectContext objectContext)
+            where TObjectContext : ITsavoriteContext<byte[], IGarnetObject, SpanByte, GarnetObjectStoreOutput, long>
+            => ReadObjectStoreOperationWithOutput(key, input, ref objectContext, ref outputFooter);
+        
+        /// <summary>
         /// Removes and returns one or more random members from the set at key.
         /// </summary>
         /// <typeparam name="TObjectContext"></typeparam>

--- a/libs/server/Transaction/TxnKeyManager.cs
+++ b/libs/server/Transaction/TxnKeyManager.cs
@@ -179,6 +179,7 @@ namespace Garnet.server
                 (byte)SetOperation.SREM => SingleKey(1, true, LockType.Exclusive),
                 (byte)SetOperation.SCARD => SingleKey(1, true, LockType.Exclusive),
                 (byte)SetOperation.SPOP => SingleKey(1, true, LockType.Exclusive),
+                (byte)SetOperation.SISMEMBER => SingleKey(1, true, LockType.Shared),
                 _ => -1
             };
         }

--- a/test/Garnet.test/RespSetTest.cs
+++ b/test/Garnet.test/RespSetTest.cs
@@ -50,6 +50,24 @@ namespace Garnet.test
             Assert.AreEqual(expectedResponse, actualValue);
         }
 
+        [Test]
+        public void CanCheckIfMemberExistsInSet()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+            var key = new RedisKey("user1:set");
+
+            db.KeyDelete(key);
+
+            db.SetAdd(key, new RedisValue[] { "Hello", "World" });
+
+            var existingMemberExists = db.SetContains(key, "Hello");
+            Assert.IsTrue(existingMemberExists);
+
+            var nonExistingMemberExists = db.SetContains(key, "NonExistingMember");
+            Assert.IsFalse(nonExistingMemberExists);
+        }
+
 
         [Test]
         public void CanAddAndGetAllMembersWithPendingStatus()
@@ -95,6 +113,9 @@ namespace Garnet.test
             var db = redis.GetDatabase(0);
             var result = db.SetAdd(new RedisKey("user1:set"), new RedisValue[] { "ItemOne", "ItemTwo", "ItemThree", "ItemFour" });
             Assert.AreEqual(4, result);
+
+            var existingMemberExists = db.SetContains(new RedisKey("user1:set"), "ItemOne");
+            Assert.IsTrue(existingMemberExists, "Existing member 'ItemOne' does not exist in the set.");
 
             var memresponse = db.Execute("MEMORY", "USAGE", "user1:set");
             var actualValue = ResultType.Integer == memresponse.Type ? Int32.Parse(memresponse.ToString()) : -1;


### PR DESCRIPTION
I was going to finish this earlier: https://github.com/microsoft/garnet/issues/76. 
But before I raised the PR, I realized someone had already submitted it: https://github.com/microsoft/garnet/pull/115
So I went back and added the API that is not in garnet but is in Redis: SISMEMBER
Usage: SISMEMBER key member
which returns if member is a member of the set stored at key.
I'm happy to contribute code, looking forward to your review!

