### PR TITLE
bugfix: variable length parameter judge error

### DIFF
--- a/libs/server/Resp/Objects/HashCommands.cs
+++ b/libs/server/Resp/Objects/HashCommands.cs
@@ -38,61 +38,70 @@ namespace Garnet.server
         {
             ptr += hop == HashOperation.HSET ? 10 : (hop == HashOperation.HSETNX ? 12 : 11);
 
-            // Get the key for Hash
-            if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var key, ref ptr, recvBufferPtr + bytesRead))
-                return false;
-
-            if (NetworkSingleKeySlotVerify(key, false))
+            if (((hop == HashOperation.HSET || hop == HashOperation.HMSET) 
+                  && (count < 3 || count % 2 != 0)) ||
+                (hop == HashOperation.HSETNX && count != 4)) 
             {
-                var bufSpan = new ReadOnlySpan<byte>(recvBufferPtr, bytesRead);
-                if (!DrainCommands(bufSpan, count))
-                    return false;
-                return true;
-            }
-
-            // Prepare input
-            var inputPtr = (ObjectInputHeader*)(ptr - sizeof(ObjectInputHeader));
-
-            // Save old values on buffer for possible revert
-            var save = *inputPtr;
-
-            // Prepare length of header in input buffer
-            var inputLength = (int)(recvBufferPtr + bytesRead - ptr) + sizeof(ObjectInputHeader);
-
-            var inputCount = (count - 2) / 2;
-
-            // Prepare header in input buffer
-            inputPtr->header.type = GarnetObjectType.Hash;
-            inputPtr->header.HashOp = hop;
-            inputPtr->count = inputCount;
-            inputPtr->done = hashOpsCount;
-
-            storageApi.HashSet(key, new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
-
-            *inputPtr = save; // reset input buffer
-
-            hashItemsDoneCount += output.countDone;
-            hashOpsCount += output.opsDone;
-
-            // Reset buffer and return if HSET did not process the entire command tokens
-            if (hashItemsDoneCount < inputCount)
-                return false;
-
-            // Move head, write result to output, reset session counters
-            ptr += output.bytesDone;
-            readHead = (int)(ptr - recvBufferPtr);
-
-            if (hop == HashOperation.HMSET)
-            {
-                while (!RespWriteUtils.WriteResponse(CmdStrings.RESP_OK, ref dcurr, dend))
-                    SendAndReset();
+                return AbortWithWrongNumberOfArguments(hop.ToString(), count);
             }
             else
             {
-                while (!RespWriteUtils.WriteInteger(hashOpsCount, ref dcurr, dend))
-                    SendAndReset();
-            }
+                // Get the key for Hash
+                if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var key, ref ptr, recvBufferPtr + bytesRead))
+                    return false;
 
+                if (NetworkSingleKeySlotVerify(key, false))
+                {
+                    var bufSpan = new ReadOnlySpan<byte>(recvBufferPtr, bytesRead);
+                    if (!DrainCommands(bufSpan, count))
+                        return false;
+                    return true;
+                }
+
+                // Prepare input
+                var inputPtr = (ObjectInputHeader*)(ptr - sizeof(ObjectInputHeader));
+
+                // Save old values on buffer for possible revert
+                var save = *inputPtr;
+
+                // Prepare length of header in input buffer
+                var inputLength = (int)(recvBufferPtr + bytesRead - ptr) + sizeof(ObjectInputHeader);
+
+                var inputCount = (count - 2) / 2;
+
+                // Prepare header in input buffer
+                inputPtr->header.type = GarnetObjectType.Hash;
+                inputPtr->header.HashOp = hop;
+                inputPtr->count = inputCount;
+                inputPtr->done = hashOpsCount;
+
+                storageApi.HashSet(key, new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
+
+                *inputPtr = save; // reset input buffer
+
+                hashItemsDoneCount += output.countDone;
+                hashOpsCount += output.opsDone;
+
+                // Reset buffer and return if HSET did not process the entire command tokens
+                if (hashItemsDoneCount < inputCount)
+                    return false;
+
+                // Move head, write result to output, reset session counters
+                ptr += output.bytesDone;
+                readHead = (int)(ptr - recvBufferPtr);
+
+                if (hop == HashOperation.HMSET)
+                {
+                    while (!RespWriteUtils.WriteResponse(CmdStrings.RESP_OK, ref dcurr, dend))
+                        SendAndReset();
+                }
+                else
+                {
+                    while (!RespWriteUtils.WriteInteger(hashOpsCount, ref dcurr, dend))
+                        SendAndReset();
+                }
+            }
+            
             hashItemsDoneCount = hashOpsCount = 0;
             return true;
         }

--- a/libs/server/Resp/Objects/ListCommands.cs
+++ b/libs/server/Resp/Objects/ListCommands.cs
@@ -202,50 +202,57 @@ namespace Garnet.server
         {
             ptr += 10;
 
-            // Get the key for List
-            if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var key, ref ptr, recvBufferPtr + bytesRead))
-                return false;
-
-            if (NetworkSingleKeySlotVerify(key, true))
+            if (count != 2)
             {
-                var bufSpan = new ReadOnlySpan<byte>(recvBufferPtr, bytesRead);
-                if (!DrainCommands(bufSpan, count))
-                    return false;
-                return true;
-            }
-
-            // Prepare input
-            var inputPtr = (ObjectInputHeader*)(ptr - sizeof(ObjectInputHeader));
-
-            // save old values
-            var save = *inputPtr;
-
-            // Prepare length of header in input buffer
-            var inputLength = (int)(recvBufferPtr + bytesRead - ptr) + sizeof(ObjectInputHeader);
-
-            // Prepare header in input buffer
-            inputPtr->header.type = GarnetObjectType.List;
-            inputPtr->header.ListOp = ListOperation.LLEN;
-            inputPtr->count = count;
-            inputPtr->done = 0;
-
-            var status = storageApi.ListLength(key, new ArgSlice((byte*)inputPtr, inputLength), out var output);
-
-            //restore input buffer
-            *inputPtr = save;
-
-            if (status == GarnetStatus.NOTFOUND)
-            {
-                while (!RespWriteUtils.WriteResponse(CmdStrings.RESP_RETURN_VAL_0, ref dcurr, dend))
-                    SendAndReset();
+                return AbortWithWrongNumberOfArguments("LLEN", count);
             }
             else
             {
-                // Process output
-                while (!RespWriteUtils.WriteInteger(output.countDone, ref dcurr, dend))
-                    SendAndReset();
-            }
+                // Get the key for List
+                if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var key, ref ptr, recvBufferPtr + bytesRead))
+                    return false;
 
+                if (NetworkSingleKeySlotVerify(key, true))
+                {
+                    var bufSpan = new ReadOnlySpan<byte>(recvBufferPtr, bytesRead);
+                    if (!DrainCommands(bufSpan, count))
+                        return false;
+                    return true;
+                }
+
+                // Prepare input
+                var inputPtr = (ObjectInputHeader*)(ptr - sizeof(ObjectInputHeader));
+
+                // save old values
+                var save = *inputPtr;
+
+                // Prepare length of header in input buffer
+                var inputLength = (int)(recvBufferPtr + bytesRead - ptr) + sizeof(ObjectInputHeader);
+
+                // Prepare header in input buffer
+                inputPtr->header.type = GarnetObjectType.List;
+                inputPtr->header.ListOp = ListOperation.LLEN;
+                inputPtr->count = count;
+                inputPtr->done = 0;
+
+                var status = storageApi.ListLength(key, new ArgSlice((byte*)inputPtr, inputLength), out var output);
+
+                //restore input buffer
+                *inputPtr = save;
+
+                if (status == GarnetStatus.NOTFOUND)
+                {
+                    while (!RespWriteUtils.WriteResponse(CmdStrings.RESP_RETURN_VAL_0, ref dcurr, dend))
+                        SendAndReset();
+                }
+                else
+                {
+                    // Process output
+                    while (!RespWriteUtils.WriteInteger(output.countDone, ref dcurr, dend))
+                        SendAndReset();
+                }
+            }
+            
             // Move input head, write result to output
             readHead = (int)(ptr - recvBufferPtr);
 

--- a/libs/server/Resp/Objects/SetCommands.cs
+++ b/libs/server/Resp/Objects/SetCommands.cs
@@ -38,51 +38,59 @@ namespace Garnet.server
         {
             ptr += 10;
 
-            // Get the key for the Set
-            if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var key, ref ptr, recvBufferPtr + bytesRead))
-                return false;
-
-            if (NetworkSingleKeySlotVerify(key, false))
+            if (count < 3)
             {
-                var bufSpan = new ReadOnlySpan<byte>(recvBufferPtr, bytesRead);
-                if (!DrainCommands(bufSpan, count)) return false;
-                return true;
+                setItemsDoneCount = setOpsCount = 0;
+                return AbortWithWrongNumberOfArguments("SADD", count);
             }
+            else
+            {
+                // Get the key for the Set
+                if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var key, ref ptr, recvBufferPtr + bytesRead))
+                    return false;
 
-            var inputCount = count - 2;
-            // Prepare input
-            var inputPtr = (ObjectInputHeader*)(ptr - sizeof(ObjectInputHeader));
+                if (NetworkSingleKeySlotVerify(key, false))
+                {
+                    var bufSpan = new ReadOnlySpan<byte>(recvBufferPtr, bytesRead);
+                    if (!DrainCommands(bufSpan, count)) return false;
+                    return true;
+                }
 
-            // Save old values on buffer for possible revert
-            var save = *inputPtr;
+                var inputCount = count - 2;
+                // Prepare input
+                var inputPtr = (ObjectInputHeader*)(ptr - sizeof(ObjectInputHeader));
 
-            // Prepare length of header in input buffer
-            var inputLength = (int)(recvBufferPtr + bytesRead - (byte*)inputPtr);
+                // Save old values on buffer for possible revert
+                var save = *inputPtr;
 
-            // Prepare header in input buffer
-            inputPtr->header.type = GarnetObjectType.Set;
-            inputPtr->header.SetOp = SetOperation.SADD;
-            inputPtr->count = inputCount;
-            inputPtr->done = setOpsCount;
+                // Prepare length of header in input buffer
+                var inputLength = (int)(recvBufferPtr + bytesRead - (byte*)inputPtr);
 
-            storageApi.SetAdd(key, new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
+                // Prepare header in input buffer
+                inputPtr->header.type = GarnetObjectType.Set;
+                inputPtr->header.SetOp = SetOperation.SADD;
+                inputPtr->count = inputCount;
+                inputPtr->done = setOpsCount;
 
-            // Restore input buffer
-            *inputPtr = save;
+                storageApi.SetAdd(key, new ArgSlice((byte*)inputPtr, inputLength), out ObjectOutputHeader output);
 
-            setItemsDoneCount += output.countDone;
-            setOpsCount += output.opsDone;
+                // Restore input buffer
+                *inputPtr = save;
 
-            // Reset buffer and return if SADD is only partially done
-            if (setOpsCount < inputCount)
-                return false;
+                setItemsDoneCount += output.countDone;
+                setOpsCount += output.opsDone;
 
-            // Move head, write result to output, reset session counters
-            ptr += output.bytesDone;
-            readHead = (int)(ptr - recvBufferPtr);
+                // Reset buffer and return if SADD is only partially done
+                if (setOpsCount < inputCount)
+                    return false;
 
-            while (!RespWriteUtils.WriteInteger(setItemsDoneCount, ref dcurr, dend))
-                SendAndReset();
+                // Move head, write result to output, reset session counters
+                ptr += output.bytesDone;
+                readHead = (int)(ptr - recvBufferPtr);
+
+                while (!RespWriteUtils.WriteInteger(setItemsDoneCount, ref dcurr, dend))
+                    SendAndReset();
+            }
 
             setItemsDoneCount = setOpsCount = 0;
             return true;
@@ -103,63 +111,71 @@ namespace Garnet.server
         {
             ptr += 10;
 
-            // Get the key 
-            if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var key, ref ptr, recvBufferPtr + bytesRead))
-                return false;
-
-            if (NetworkSingleKeySlotVerify(key, false))
+            if (count < 3) 
             {
-                var bufSpan = new ReadOnlySpan<byte>(recvBufferPtr, bytesRead);
-                if (!DrainCommands(bufSpan, count))
-                    return false;
-                return true;
-            }
-            var inputCount = count - 2; // only identifiers
-
-            // Prepare input
-            var inputPtr = (ObjectInputHeader*)(ptr - sizeof(ObjectInputHeader));
-
-            // Save old values on buffer for possible revert
-            var save = *inputPtr;
-
-            // Prepare length of header in input buffer
-            var inputLength = (int)(recvBufferPtr + bytesRead - (byte*)inputPtr);
-
-            // Prepare header in input buffer
-            inputPtr->header.type = GarnetObjectType.Set;
-            inputPtr->header.SetOp = SetOperation.SREM;
-            inputPtr->count = inputCount;
-            inputPtr->done = setItemsDoneCount;
-
-            var status = storageApi.SetRemove(key, new ArgSlice((byte*)inputPtr, inputLength), out var output);
-
-            // Restore input buffer
-            *inputPtr = save;
-
-            if (status == GarnetStatus.NOTFOUND)
-            {
-                while (!RespWriteUtils.WriteResponse(CmdStrings.RESP_RETURN_VAL_0, ref dcurr, dend))
-                    SendAndReset();
-                ReadLeftToken(count - 2, ref ptr);
+                setItemsDoneCount = setOpsCount = 0;
+                return AbortWithWrongNumberOfArguments("SREM", count);
             }
             else
             {
-                setItemsDoneCount += output.countDone;
-                setOpsCount += output.opsDone;
-
-                // Reset buffer and return if command is only partially done
-                if (setOpsCount < inputCount)
+                // Get the key 
+                if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var key, ref ptr, recvBufferPtr + bytesRead))
                     return false;
 
-                // Move head, write result to output, reset session counters
-                ptr += output.bytesDone;
+                if (NetworkSingleKeySlotVerify(key, false))
+                {
+                    var bufSpan = new ReadOnlySpan<byte>(recvBufferPtr, bytesRead);
+                    if (!DrainCommands(bufSpan, count))
+                        return false;
+                    return true;
+                }
+                var inputCount = count - 2; // only identifiers
 
-                while (!RespWriteUtils.WriteInteger(setItemsDoneCount, ref dcurr, dend))
-                    SendAndReset();
+                // Prepare input
+                var inputPtr = (ObjectInputHeader*)(ptr - sizeof(ObjectInputHeader));
 
-                setOpsCount = setItemsDoneCount = 0;
+                // Save old values on buffer for possible revert
+                var save = *inputPtr;
+
+                // Prepare length of header in input buffer
+                var inputLength = (int)(recvBufferPtr + bytesRead - (byte*)inputPtr);
+
+                // Prepare header in input buffer
+                inputPtr->header.type = GarnetObjectType.Set;
+                inputPtr->header.SetOp = SetOperation.SREM;
+                inputPtr->count = inputCount;
+                inputPtr->done = setItemsDoneCount;
+
+                var status = storageApi.SetRemove(key, new ArgSlice((byte*)inputPtr, inputLength), out var output);
+
+                // Restore input buffer
+                *inputPtr = save;
+
+                if (status == GarnetStatus.NOTFOUND)
+                {
+                    while (!RespWriteUtils.WriteResponse(CmdStrings.RESP_RETURN_VAL_0, ref dcurr, dend))
+                        SendAndReset();
+                    ReadLeftToken(count - 2, ref ptr);
+                }
+                else
+                {
+                    setItemsDoneCount += output.countDone;
+                    setOpsCount += output.opsDone;
+
+                    // Reset buffer and return if command is only partially done
+                    if (setOpsCount < inputCount)
+                        return false;
+
+                    // Move head, write result to output, reset session counters
+                    ptr += output.bytesDone;
+
+                    while (!RespWriteUtils.WriteInteger(setItemsDoneCount, ref dcurr, dend))
+                        SendAndReset();
+
+                    setOpsCount = setItemsDoneCount = 0;
+                }
             }
-
+            
             readHead = (int)(ptr - recvBufferPtr);
             return true;
         }
@@ -181,7 +197,6 @@ namespace Garnet.server
             {
                 setItemsDoneCount = setOpsCount = 0;
                 return AbortWithWrongNumberOfArguments("SCARD", count);
-
             }
             else
             {
@@ -248,58 +263,66 @@ namespace Garnet.server
         {
             ptr += 14;
 
-            // Get the key
-            if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var key, ref ptr, recvBufferPtr + bytesRead))
-                return false;
-
-            if (NetworkSingleKeySlotVerify(key, true))
+            if (count < 1 || count > 2) 
             {
-                var bufSpan = new ReadOnlySpan<byte>(recvBufferPtr, bytesRead);
-                if (!DrainCommands(bufSpan, count))
+                setItemsDoneCount = setOpsCount = 0;
+                return AbortWithWrongNumberOfArguments("SMEMBERS", count);
+            }
+            else
+            {
+                // Get the key
+                if (!RespReadUtils.ReadByteArrayWithLengthHeader(out var key, ref ptr, recvBufferPtr + bytesRead))
                     return false;
-                return true;
-            }
 
-            // Prepare input
-            var inputPtr = (ObjectInputHeader*)(ptr - sizeof(ObjectInputHeader));
-
-            // Save old values
-            var save = *inputPtr;
-
-            // Prepare length of header in input buffer
-            var inputLength = (int)(recvBufferPtr + bytesRead - (byte*)inputPtr);
-
-            // Prepare header in input buffer
-            inputPtr->header.type = GarnetObjectType.Set;
-            inputPtr->header.SetOp = SetOperation.SMEMBERS;
-            inputPtr->count = count;
-            inputPtr->done = setItemsDoneCount;
-
-            // Prepare GarnetObjectStore output
-            var outputFooter = new GarnetObjectStoreOutput { spanByteAndMemory = new SpanByteAndMemory(dcurr, (int)(dend - dcurr)) };
-
-            var status = storageApi.SetMembers(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
-
-            // Restore input buffer
-            *inputPtr = save;
-
-            switch (status)
-            {
-                case GarnetStatus.OK:
-                    // Process output
-                    var objOutputHeader = ProcessOutputWithHeader(outputFooter.spanByteAndMemory);
-                    ptr += objOutputHeader.bytesDone;
-                    setItemsDoneCount += objOutputHeader.countDone;
-                    if (setItemsDoneCount > objOutputHeader.opsDone)
+                if (NetworkSingleKeySlotVerify(key, true))
+                {
+                    var bufSpan = new ReadOnlySpan<byte>(recvBufferPtr, bytesRead);
+                    if (!DrainCommands(bufSpan, count))
                         return false;
-                    break;
-                case GarnetStatus.NOTFOUND:
-                    while (!RespWriteUtils.WriteEmptyArray(ref dcurr, dend))
-                        SendAndReset();
-                    ReadLeftToken(count - 2, ref ptr);
-                    break;
-            }
+                    return true;
+                }
 
+                // Prepare input
+                var inputPtr = (ObjectInputHeader*)(ptr - sizeof(ObjectInputHeader));
+
+                // Save old values
+                var save = *inputPtr;
+
+                // Prepare length of header in input buffer
+                var inputLength = (int)(recvBufferPtr + bytesRead - (byte*)inputPtr);
+
+                // Prepare header in input buffer
+                inputPtr->header.type = GarnetObjectType.Set;
+                inputPtr->header.SetOp = SetOperation.SMEMBERS;
+                inputPtr->count = count;
+                inputPtr->done = setItemsDoneCount;
+
+                // Prepare GarnetObjectStore output
+                var outputFooter = new GarnetObjectStoreOutput { spanByteAndMemory = new SpanByteAndMemory(dcurr, (int)(dend - dcurr)) };
+
+                var status = storageApi.SetMembers(key, new ArgSlice((byte*)inputPtr, inputLength), ref outputFooter);
+
+                // Restore input buffer
+                *inputPtr = save;
+
+                switch (status)
+                {
+                    case GarnetStatus.OK:
+                        // Process output
+                        var objOutputHeader = ProcessOutputWithHeader(outputFooter.spanByteAndMemory);
+                        ptr += objOutputHeader.bytesDone;
+                        setItemsDoneCount += objOutputHeader.countDone;
+                        if (setItemsDoneCount > objOutputHeader.opsDone)
+                            return false;
+                        break;
+                    case GarnetStatus.NOTFOUND:
+                        while (!RespWriteUtils.WriteEmptyArray(ref dcurr, dend))
+                            SendAndReset();
+                        ReadLeftToken(count - 2, ref ptr);
+                        break;
+                }
+            }
+            
             // Reset session counters
             setItemsDoneCount = setOpsCount = 0;
 


### PR DESCRIPTION
**The bug is not completely fixed in this PR**: https://github.com/microsoft/garnet/pull/103
There is also a lack of judgment about commands that can receive multiple parameters.
Examples：
![image](https://github.com/microsoft/garnet/assets/61727602/85b55d86-ef6e-4aab-872d-89a5e9b7121f)
![image](https://github.com/microsoft/garnet/assets/61727602/e98a4dc4-a686-430b-886b-02dacff5fd0b)
But in Redis:
![image](https://github.com/microsoft/garnet/assets/61727602/c81522ec-074b-4206-905d-779ab732881a)
![image](https://github.com/microsoft/garnet/assets/61727602/0ba90b2e-8d1c-4f7c-8996-4815cace9938)
