### PR TITLE
Spanify TsavoriteLogRecoveryInfo deserialization

### DIFF
--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicationReplicaAofSync.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicationReplicaAofSync.cs
@@ -79,7 +79,7 @@ namespace Garnet.cluster
                             throw new Exception("Received FastCommit request at replica AOF processor, but FastCommit is not enabled");
                         }
                         TsavoriteLogRecoveryInfo info = new();
-                        info.Initialize(new BinaryReader(new UnmanagedMemoryStream(ptr + entryLength, -payloadLength)));
+                        info.Initialize(new ReadOnlySpan<byte>(ptr + entryLength, -payloadLength));
                         storeWrapper.appendOnlyFile?.UnsafeCommitMetadataOnly(info);
                         entryLength += storeWrapper.appendOnlyFile.UnsafeAlign(-payloadLength);
                     }

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -2254,10 +2254,7 @@ namespace Tsavorite.core
             }
 
             info = new TsavoriteLogRecoveryInfo();
-            using (BinaryReader r = new(new MemoryStream(commitInfo)))
-            {
-                info.Initialize(r);
-            }
+            info.Initialize(commitInfo);
 
             if (info.CommitNum == -1)
                 info.CommitNum = commitNum;

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogIterator.cs
@@ -282,7 +282,7 @@ namespace Tsavorite.core
                 if (isCommitRecord)
                 {
                     TsavoriteLogRecoveryInfo info = new();
-                    info.Initialize(new BinaryReader(new UnmanagedMemoryStream((byte*)(headerSize + physicalAddress), entryLength)));
+                    info.Initialize(new ReadOnlySpan<byte>((byte*)(headerSize + physicalAddress), entryLength));
                     if (info.CommitNum != long.MaxValue) continue;
 
                     // Otherwise, no more entries
@@ -379,7 +379,7 @@ namespace Tsavorite.core
                 if (isCommitRecord)
                 {
                     TsavoriteLogRecoveryInfo info = new();
-                    info.Initialize(new BinaryReader(new UnmanagedMemoryStream((byte*)physicalAddress, entryLength)));
+                    info.Initialize(new ReadOnlySpan<byte>((byte*)physicalAddress, entryLength));
                     if (info.CommitNum != long.MaxValue) continue;
 
                     // Otherwise, no more entries
@@ -442,7 +442,7 @@ namespace Tsavorite.core
                 if (isCommitRecord)
                 {
                     TsavoriteLogRecoveryInfo info = new();
-                    info.Initialize(new BinaryReader(new UnmanagedMemoryStream((byte*)physicalAddress, entryLength)));
+                    info.Initialize(new ReadOnlySpan<byte>((byte*)physicalAddress, entryLength));
                     if (info.CommitNum != long.MaxValue) continue;
 
                     // Otherwise, no more entries
@@ -590,7 +590,7 @@ namespace Tsavorite.core
                 if (isCommitRecord)
                 {
                     TsavoriteLogRecoveryInfo info = new();
-                    info.Initialize(new BinaryReader(new UnmanagedMemoryStream(entry, entryLength)));
+                    info.Initialize(new ReadOnlySpan<byte>(entry, entryLength));
                     if (info.CommitNum != long.MaxValue) continue;
 
                     // Otherwise, no more entries
@@ -715,12 +715,7 @@ namespace Tsavorite.core
                     if (!isCommitRecord) continue;
 
                     foundCommit = true;
-                    byte[] entry;
-                    // We allocate a byte array from heap
-                    entry = new byte[entryLength];
-                    fixed (byte* bp = entry)
-                        Buffer.MemoryCopy((void*)(headerSize + physicalAddress), bp, entryLength, entryLength);
-                    info.Initialize(new BinaryReader(new MemoryStream(entry)));
+                    info.Initialize(new ReadOnlySpan<byte>((void*)(headerSize + physicalAddress), entryLength));
 
                     Debug.Assert(info.CommitNum != -1);
 


### PR DESCRIPTION
This PR uses `BinaryPrimitives.Read*` overloads to deserialize `TsavoriteLogRecoveryInfo` from a span instead of a stream that was always either ``MemoryStream`` or ``UnmanagedMemoryStream`` created from `byte[]` or a pointer.

I started to spanify the serialization too but got annoyed by potential cost of multiple UTF8 encoding calls, which cost is much harder to reason about mentally, so I'll leave that for later.