### PR TITLE
Optimize NumUtils.CRC16

### DIFF
--- a/libs/common/NumUtils.cs
+++ b/libs/common/NumUtils.cs
@@ -403,8 +403,9 @@ namespace Garnet.common
         /// <summary>
         /// This table is based on the CRC-16-CCITT polynomial (0x1021)
         /// </summary>
-        private static ReadOnlySpan<ushort> Crc16Table =>
-        [
+#pragma warning disable IDE0300 // Simplify collection initialization
+        private static ReadOnlySpan<ushort> Crc16Table => new ushort[256]
+        {
             0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50A5, 0x60C6, 0x70E7,
             0x8108, 0x9129, 0xA14A, 0xB16B, 0xC18C, 0xD1AD, 0xE1CE, 0xF1EF,
             0x1231, 0x0210, 0x3273, 0x2252, 0x52B5, 0x4294, 0x72F7, 0x62D6,
@@ -437,7 +438,8 @@ namespace Garnet.common
             0x7C26, 0x6C07, 0x5C64, 0x4C45, 0x3CA2, 0x2C83, 0x1CE0, 0x0CC1,
             0xEF1F, 0xFF3E, 0xCF5D, 0xDF7C, 0xAF9B, 0xBFBA, 0x8FD9, 0x9FF8,
             0x6E17, 0x7E36, 0x4E55, 0x5E74, 0x2E93, 0x3EB2, 0x0ED1, 0x1EF0
-        ];
+        };
+#pragma warning restore IDE0300 // Simplify collection initialization
 
         public static unsafe ushort CRC16(byte* data, int len)
         {

--- a/libs/common/NumUtils.cs
+++ b/libs/common/NumUtils.cs
@@ -403,7 +403,7 @@ namespace Garnet.common
         /// <summary>
         /// This table is based on the CRC-16-CCITT polynomial (0x1021)
         /// </summary>
-#pragma warning disable IDE0300 // Simplify collection initialization
+#pragma warning disable IDE0300 // Simplify collection initialization. Ignored to avoid dotnet-format bug, see https://github.com/dotnet/sdk/issues/39898
         private static ReadOnlySpan<ushort> Crc16Table => new ushort[256]
         {
             0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50A5, 0x60C6, 0x70E7,

--- a/libs/common/NumUtils.cs
+++ b/libs/common/NumUtils.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Garnet.common
@@ -399,8 +400,11 @@ namespace Garnet.common
             return -1;
         }
 
-        static readonly ushort[] CRC_TABLE = new ushort[256]
-        {
+        /// <summary>
+        /// This table is based on the CRC-16-CCITT polynomial (0x1021)
+        /// </summary>
+        private static ReadOnlySpan<ushort> Crc16Table =>
+        [
             0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50A5, 0x60C6, 0x70E7,
             0x8108, 0x9129, 0xA14A, 0xB16B, 0xC18C, 0xD1AD, 0xE1CE, 0xF1EF,
             0x1231, 0x0210, 0x3273, 0x2252, 0x52B5, 0x4294, 0x72F7, 0x62D6,
@@ -433,38 +437,17 @@ namespace Garnet.common
             0x7C26, 0x6C07, 0x5C64, 0x4C45, 0x3CA2, 0x2C83, 0x1CE0, 0x0CC1,
             0xEF1F, 0xFF3E, 0xCF5D, 0xDF7C, 0xAF9B, 0xBFBA, 0x8FD9, 0x9FF8,
             0x6E17, 0x7E36, 0x4E55, 0x5E74, 0x2E93, 0x3EB2, 0x0ED1, 0x1EF0
-        };
+        ];
 
-        // No need to free or track until end of process
-        static readonly ushort* crc_table_ptr = (ushort*)GCHandle.Alloc(CRC_TABLE, GCHandleType.Pinned).AddrOfPinnedObject();
-
-        /// <summary>
-        /// Compute CRC of given data
-        /// </summary>
-        /// <param name="data"></param>
-        /// <param name="len"></param>
-        /// <returns></returns>
         public static unsafe ushort CRC16(byte* data, int len)
         {
             ushort result = 0;
             byte* end = data + len;
             while (data < end)
-                result = (ushort)(*(crc_table_ptr + (((result >> 8) ^ *data++) & 0xff)) ^ (result << 8));
-            return result;
-        }
-
-        /// <summary>
-        /// Compute CRC16 of given data (via array access)
-        /// </summary>
-        /// <param name="data"></param>
-        /// <param name="len"></param>
-        /// <returns></returns>
-        public static unsafe ushort CRC16v2(byte* data, int len)
-        {
-            ushort result = 0;
-            byte* end = data + len;
-            while (data < end)
-                result = (ushort)(CRC_TABLE[((result >> 8) ^ *data++) & 0xff] ^ (result << 8));
+            {
+                nuint index = (nuint)(uint)((result >> 8) ^ *data++) & 0xff;
+                result = (ushort)(Unsafe.Add(ref MemoryMarshal.GetReference(Crc16Table), index) ^ (result << 8));
+            }
             return result;
         }
 


### PR DESCRIPTION
This PR changes the `NumUtils.CRC16` method to use RVA instead of `readonly static` for the precomputed CRC16 table.

```diff
-; Total bytes of code 121, prolog size 11, PerfScore 53.06, instruction count 41, allocated bytes for code 121 (MethodHash=13cde191) for method Garnet.common.NumUtils:CRC16(ulong,int):ushort (FullOpts)
+; Total bytes of code 65, prolog size 0, PerfScore 36.06, instruction count 21, allocated bytes for code 65 (MethodHash=13cde191) for method Garnet.common.NumUtils:CRC16(ulong,int):ushort (FullOpts)
```

### Full diff
<details>
<summary>Garnet.common.NumUtils:CRC16</summary>

```diff
 method Garnet.common.NumUtils:CRC16(ulong,int):ushort (FullOpts)
 ; Emitting BLENDED_CODE for X64 with AVX - Windows
 ; FullOpts code
 ; optimized code
 ; rsp based frame
 ; fully interruptible
 ; No PGO data
+; 0 inlinees with PGO data; 2 single block inlinees; 0 inlinees without PGO data
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00,T01] (  7, 16   )    long  ->  registers  
-;  V01 arg1         [V01,T04] (  3,  3   )     int  ->  rdx         single-def
-;  V02 loc0         [V02,T02] (  5, 14   )  ushort  ->  rsi        
-;  V03 loc1         [V03,T03] (  3,  6   )    long  ->  rdi         single-def
-;  V04 OutArgs      [V04    ] (  1,  1   )  struct (32) [rsp+0x00]  do-not-enreg[XS] addr-exposed "OutgoingArgSpace"
-;  V05 tmp1         [V05,T00] (  3, 24   )    long  ->  rbx         "impSpillLclRefs"
-;* V06 cse0         [V06,T06] (  0,  0   )    long  ->  zero-ref    hoist "CSE #01: aggressive"
-;  V07 cse1         [V07,T05] (  2,  4.25)    long  ->  rax         hoist "CSE #02: aggressive"
+;  V01 arg1         [V01,T05] (  3,  3   )     int  ->  rdx         single-def
+;  V02 loc0         [V02,T02] (  5, 14   )  ushort  ->  rax        
+;  V03 loc1         [V03,T04] (  3,  6   )    long  ->  rdx         single-def
+;  V04 loc2         [V04,T03] (  2,  8   )    long  ->  rcx        
+;# V05 OutArgs      [V05    ] (  1,  1   )  struct ( 0) [rsp+0x00]  do-not-enreg[XS] addr-exposed "OutgoingArgSpace"
+;  V06 tmp1         [V06,T00] (  3, 24   )    long  ->  rcx         "impSpillLclRefs"
+;* V07 tmp2         [V07    ] (  0,  0   )  struct (16) zero-ref    "spilled call-like call argument" <System.ReadOnlySpan`1[ushort]>
+;* V08 tmp3         [V08    ] (  0,  0   )  struct (16) zero-ref    "ReadOnlySpan<T> for CreateSpan<T>" <System.ReadOnlySpan`1[ushort]>
+;* V09 tmp4         [V09    ] (  0,  0   )  struct (16) zero-ref    ld-addr-op "Inlining Arg" <System.ReadOnlySpan`1[ushort]>
+;* V10 tmp5         [V10    ] (  0,  0   )   byref  ->  zero-ref    "field V07._reference (fldOffset=0x0)" P-INDEP
+;* V11 tmp6         [V11    ] (  0,  0   )     int  ->  zero-ref    "field V07._length (fldOffset=0x8)" P-INDEP
+;* V12 tmp7         [V12    ] (  0,  0   )   byref  ->  zero-ref    "field V08._reference (fldOffset=0x0)" P-INDEP
+;* V13 tmp8         [V13    ] (  0,  0   )     int  ->  zero-ref    "field V08._length (fldOffset=0x8)" P-INDEP
+;* V14 tmp9         [V14    ] (  0,  0   )   byref  ->  zero-ref    "field V09._reference (fldOffset=0x0)" P-INDEP
+;* V15 tmp10        [V15    ] (  0,  0   )     int  ->  zero-ref    "field V09._length (fldOffset=0x8)" P-INDEP
+;  V16 cse0         [V16,T06] (  2,  4.25)    long  ->   r8         hoist "CSE #01: aggressive"
 ;
-; Lcl frame size = 40
+; Lcl frame size = 0
 
 G_M7790_IG01:  ;; offset=0x0000
-       push     rdi
-       push     rsi
-       push     rbp
-       push     rbx
-       sub      rsp, 40
-       mov      rbx, rcx
-						;; size=11 bbWeight=1 PerfScore 4.50
-G_M7790_IG02:  ;; offset=0x000B
-       xor      esi, esi
-       movsxd   rdi, edx
-       add      rdi, rbx
-       cmp      rbx, rdi
-       jae      SHORT G_M7790_IG06
+						;; size=0 bbWeight=1 PerfScore 0.00
+G_M7790_IG02:  ;; offset=0x0000
+       xor      eax, eax
+       movsxd   rdx, edx
+       add      rdx, rcx
+       cmp      rcx, rdx
+       jae      SHORT G_M7790_IG05
 						;; size=13 bbWeight=1 PerfScore 2.00
-G_M7790_IG03:  ;; offset=0x0018
-       test     byte  ptr [(reloc 0x7ffc59808bf6)], 1      ; global ptr
-       je       SHORT G_M7790_IG08
-						;; size=9 bbWeight=0.25 PerfScore 1.00
-G_M7790_IG04:  ;; offset=0x0021
-       mov      rax, 0x7FFC59808C18      ; static handle
-       align    [0 bytes for IG05]
+G_M7790_IG03:  ;; offset=0x000D
+       mov      r8, 0x2195CA42EB0      ; static handle
+       align    [0 bytes for IG04]
 						;; size=10 bbWeight=0.25 PerfScore 0.06
-G_M7790_IG05:  ;; offset=0x002B
-       lea      rcx, [rbx+0x01]
-       mov      rbp, rcx
-       mov      rcx, qword ptr [rax]
-       mov      edx, esi
-       sar      edx, 8
-       movzx    r8, byte  ptr [rbx]
-       xor      edx, r8d
-       movzx    rdx, dl
-       movzx    rcx, word  ptr [rcx+2*rdx]
-       shl      esi, 8
-       xor      ecx, esi
-       movzx    rsi, cx
-       cmp      rbp, rdi
-       mov      rbx, rbp
-       jb       SHORT G_M7790_IG05
-						;; size=45 bbWeight=4 PerfScore 42.00
-G_M7790_IG06:  ;; offset=0x0058
-       mov      eax, esi
-						;; size=2 bbWeight=1 PerfScore 0.25
-G_M7790_IG07:  ;; offset=0x005A
-       add      rsp, 40
-       pop      rbx
-       pop      rbp
-       pop      rsi
-       pop      rdi
+G_M7790_IG04:  ;; offset=0x0017
+       lea      r10, [rcx+0x01]
+       mov      r9d, eax
+       sar      r9d, 8
+       movzx    rcx, byte  ptr [rcx]
+       xor      ecx, r9d
+       movzx    rcx, cl
+       movzx    rcx, word  ptr [r8+2*rcx]
+       shl      eax, 8
+       xor      eax, ecx
+       movzx    rax, ax
+       cmp      r10, rdx
+       mov      rcx, r10
+       jb       SHORT G_M7790_IG04
+						;; size=41 bbWeight=4 PerfScore 33.00
+G_M7790_IG05:  ;; offset=0x0040
        ret      
-						;; size=9 bbWeight=1 PerfScore 3.25
-G_M7790_IG08:  ;; offset=0x0063
-       mov      rcx, 0x7FFC59808B98
-       mov      edx, 46
-       call     CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE
-       jmp      SHORT G_M7790_IG04
-						;; size=22 bbWeight=0 PerfScore 0.00
+						;; size=1 bbWeight=1 PerfScore 1.00
 
-; Total bytes of code 121, prolog size 11, PerfScore 53.06, instruction count 41, allocated bytes for code 121 (MethodHash=13cde191) for method Garnet.common.NumUtils:CRC16(ulong,int):ushort (FullOpts)
+; Total bytes of code 65, prolog size 0, PerfScore 36.06, instruction count 21, allocated bytes for code 65 (MethodHash=13cde191) for method Garnet.common.NumUtils:CRC16(ulong,int):ushort (FullOpts)
 ; ============================================================
```

</details>
