### PR TITLE
Use collection-expression

### DIFF
--- a/benchmark/Resp.benchmark/RespPerfBench.cs
+++ b/benchmark/Resp.benchmark/RespPerfBench.cs
@@ -426,7 +426,7 @@ namespace Resp.benchmark
             {
                 var reqArgs = rg.GetRequestArgs();
                 reqArgs.Insert(0, "MSET");
-                c.Execute(reqArgs.ToArray());
+                c.Execute([.. reqArgs]);
                 c.CompletePending(true);
                 numReqs++;
                 if (numReqs == maxReqs) break;

--- a/libs/cluster/Session/ClusterCommands.cs
+++ b/libs/cluster/Session/ClusterCommands.cs
@@ -641,7 +641,7 @@ namespace Garnet.cluster
 
                     if (resp.SequenceEqual(CmdStrings.RESP_OK))
                     {
-                        clusterProvider.clusterManager.TryAddSlots(slots.ToList(), out var slotIndex);
+                        clusterProvider.clusterManager.TryAddSlots([.. slots], out var slotIndex);
                         if (slotIndex != -1)
                             resp = new ReadOnlySpan<byte>(Encoding.ASCII.GetBytes($"-ERR Slot {slotIndex} is already busy\r\n"));
                     }
@@ -673,7 +673,7 @@ namespace Garnet.cluster
 
                     if (resp.SequenceEqual(CmdStrings.RESP_OK))
                     {
-                        clusterProvider.clusterManager.TryAddSlots(slots.ToList(), out var slotIndex);
+                        clusterProvider.clusterManager.TryAddSlots([.. slots], out var slotIndex);
                         if (slotIndex != -1)
                             resp = new ReadOnlySpan<byte>(Encoding.ASCII.GetBytes($"-ERR Slot {slotIndex} is already busy\r\n"));
                     }
@@ -761,7 +761,7 @@ namespace Garnet.cluster
                     readHead = (int)(ptr - recvBufferPtr);
                     if (resp.SequenceEqual(CmdStrings.RESP_OK))
                     {
-                        clusterProvider.clusterManager.TryRemoveSlots(slots.ToList(), out var slotIndex);
+                        clusterProvider.clusterManager.TryRemoveSlots([.. slots], out var slotIndex);
                         if (slotIndex != -1)
                             resp = new ReadOnlySpan<byte>(Encoding.ASCII.GetBytes($"-ERR Slot {slotIndex} is already not assigned\r\n"));
                     }
@@ -793,7 +793,7 @@ namespace Garnet.cluster
                     readHead = (int)(ptr - recvBufferPtr);
                     if (resp.SequenceEqual(CmdStrings.RESP_OK))
                     {
-                        clusterProvider.clusterManager.TryRemoveSlots(slots.ToList(), out var slotIndex);
+                        clusterProvider.clusterManager.TryRemoveSlots([.. slots], out var slotIndex);
                         if (slotIndex != -1)
                             resp = new ReadOnlySpan<byte>(Encoding.ASCII.GetBytes($"-ERR Slot {slotIndex} is already not assigned\r\n"));
                     }

--- a/libs/host/ServerSettingsManager.cs
+++ b/libs/host/ServerSettingsManager.cs
@@ -352,7 +352,7 @@ Please check the syntax of your command. For detailed usage information run with
                 }
             }
 
-            return consolidatedArgs.ToArray();
+            return [.. consolidatedArgs];
         }
     }
 }

--- a/libs/server/Auth/Aad/IssuerSigningTokenProvider.cs
+++ b/libs/server/Auth/Aad/IssuerSigningTokenProvider.cs
@@ -60,7 +60,7 @@ namespace Garnet.server.Auth.Aad
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>(configUrl, new OpenIdConnectConfigurationRetriever(), new HttpDocumentRetriever());
             var doc = configManager.GetConfigurationAsync().GetAwaiter().GetResult();
 
-            return doc.SigningKeys.ToList();
+            return [.. doc.SigningKeys];
         }
 
         /// <summary>

--- a/libs/server/Custom/CustomCommandRegistration.cs
+++ b/libs/server/Custom/CustomCommandRegistration.cs
@@ -108,7 +108,7 @@ namespace Garnet.server.Custom
                 }
             }
 
-            return supportedTypes.ToArray();
+            return [.. supportedTypes];
         });
 
         public abstract void Register(CustomCommandManager customCommandManager);

--- a/libs/server/Metrics/Info/InfoCommand.cs
+++ b/libs/server/Metrics/Info/InfoCommand.cs
@@ -75,7 +75,7 @@ namespace Garnet.server
             }
             else
             {
-                InfoMetricsType[] sectionsArr = sections == null ? GarnetInfoMetrics.defaultInfo : sections.ToArray();
+                InfoMetricsType[] sectionsArr = sections == null ? GarnetInfoMetrics.defaultInfo : [.. sections];
                 GarnetInfoMetrics garnetInfo = new();
                 string info = garnetInfo.GetRespInfo(sectionsArr, storeWrapper);
                 while (!RespWriteUtils.WriteBulkString(Encoding.ASCII.GetBytes(info), ref dcurr, dend))

--- a/libs/server/Metrics/Latency/RespLatencyCommands.cs
+++ b/libs/server/Metrics/Latency/RespLatencyCommands.cs
@@ -52,7 +52,7 @@ namespace Garnet.server
                         }
                     }
                     else
-                        events = GarnetLatencyMetrics.defaultLatencyTypes.ToHashSet();
+                        events = [.. GarnetLatencyMetrics.defaultLatencyTypes];
 
                     byte[] response = null;
                     if (invalid)
@@ -107,7 +107,7 @@ namespace Garnet.server
                             }
                         }
                         else
-                            events = GarnetLatencyMetrics.defaultLatencyTypes.ToHashSet();
+                            events = [.. GarnetLatencyMetrics.defaultLatencyTypes];
 
                         ReadOnlySpan<byte> response = null;
                         if (invalid)

--- a/libs/storage/Tsavorite/cs/src/core/Index/Recovery/Checkpoint.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Recovery/Checkpoint.cs
@@ -50,7 +50,7 @@ namespace Tsavorite.core
             if (CommitCookie != null && CommitCookie.Length != 0)
             {
                 var convertedCookie = Convert.ToBase64String(CommitCookie);
-                metadata = metadata.Concat(Encoding.Default.GetBytes(convertedCookie)).ToArray();
+                metadata = [.. metadata, .. Encoding.Default.GetBytes(convertedCookie)];
             }
             checkpointManager.CommitLogCheckpoint(_hybridLogCheckpointToken, metadata);
             Log.ShiftBeginAddress(_hybridLogCheckpoint.info.beginAddress, truncateLog: true);
@@ -62,7 +62,7 @@ namespace Tsavorite.core
             if (CommitCookie != null && CommitCookie.Length != 0)
             {
                 var convertedCookie = Convert.ToBase64String(CommitCookie);
-                metadata = metadata.Concat(Encoding.Default.GetBytes(convertedCookie)).ToArray();
+                metadata = [.. metadata, .. Encoding.Default.GetBytes(convertedCookie)];
             }
             checkpointManager.CommitLogIncrementalCheckpoint(_hybridLogCheckpointToken, _hybridLogCheckpoint.info.version, metadata, deltaLog);
             Log.ShiftBeginAddress(_hybridLogCheckpoint.info.beginAddress, truncateLog: true);

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/Revivification/FreeRecordPool.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/Revivification/FreeRecordPool.cs
@@ -480,7 +480,7 @@ namespace Tsavorite.core
                 binList.Add(bin);
                 prevBinRecordSize = bin.maxRecordSize;
             }
-            bins = binList.ToArray();
+            bins = [.. binList];
             numBins = bins.Length;
             numberOfBinsToSearch = settings.NumberOfBinsToSearch;
         }

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/Revivification/RevivificationSettings.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/Revivification/RevivificationSettings.cs
@@ -262,7 +262,7 @@ namespace Tsavorite.core
                 RecordSize = RevivificationBin.MaxRecordSize,
                 NumberOfRecords = RevivificationBin.DefaultRecordsPerBin
             });
-            FreeRecordBins = binList.ToArray();
+            FreeRecordBins = [.. binList];
         }
     }
 }

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -2500,7 +2500,7 @@ namespace Tsavorite.core
             var recoveredIterators = info.Iterators;
             if (recoveredIterators != null)
             {
-                List<string> keys = recoveredIterators.Keys.ToList();
+                List<string> keys = [.. recoveredIterators.Keys];
                 foreach (var key in keys)
                     if (recoveredIterators[key] > SafeTailAddress)
                         recoveredIterators[key] = SafeTailAddress;

--- a/libs/storage/Tsavorite/cs/src/core/Utilities/SafeConcurrentDictionary.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Utilities/SafeConcurrentDictionary.cs
@@ -191,7 +191,7 @@ namespace Tsavorite.core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public KeyValuePair<TKey, TValue>[] ToArray()
         {
-            return dictionary.ToArray();
+            return [.. dictionary];
         }
 
         /// <summary>

--- a/playground/ClusterStress/ShardedRespOnlineBench.cs
+++ b/playground/ClusterStress/ShardedRespOnlineBench.cs
@@ -179,8 +179,8 @@ namespace Resp.benchmark
         private void UpdateSlotMap(ClusterConfiguration clusterConfig)
         {
             var nodes = clusterConfig.Nodes.ToArray();
-            primaryNodes = nodes.ToList().FindAll(p => !p.IsReplica).ToArray();
-            replicaNodes = nodes.ToList().FindAll(p => p.IsReplica).ToArray();
+            primaryNodes = [.. nodes.ToList().FindAll(p => !p.IsReplica)];
+            replicaNodes = [.. nodes.ToList().FindAll(p => p.IsReplica)];
             ushort j = 0;
             foreach (var node in nodes)
             {


### PR DESCRIPTION
## Background

Collection expression in most cases will provide more performant code than Linq or initializing a new collection from the results of another. For example below is the gist where you can see the generated code comparing two approaches
https://gist.github.com/unsafePtr/cb8eb3ab44e56c3549e3788a0bdfcc74
Performance wise, while there is [extra room for optimization](https://github.com/dotnet/roslyn/issues/71183), it's still faster than standard way.
```markdown
| Method      | Mean     | Error     | StdDev    | Gen0   | Allocated |
|------------ |---------:|----------:|----------:|-------:|----------:|
| Standard    | 6.720 ns | 0.0994 ns | 0.0830 ns | 0.0046 |      72 B |
| Initializer | 5.745 ns | 0.0507 ns | 0.0450 ns | 0.0046 |      72 B |
```

Collections expression are supported in all .net core versions and we can safely use it. While it's small performance improvement, I believe it's critical for cache server. 

I've refactored all files using [IDE0305](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0305), except for the test files. Haven't included it by default in .editorconfig as that's something to be decided by the core-team.

