### PR TITLE
Bugfix: Limit Basic Commands to Authenticated Users

### DIFF
--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -353,6 +353,11 @@ namespace Garnet.server
         private bool ProcessBasicCommands<TGarnetApi>(RespCommand cmd, byte subcmd, int count, byte* ptr, ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetApi
         {
+            if (!_authenticator.IsAuthenticated)
+            {
+                return ProcessArrayCommands(cmd, subcmd, count, ref storageApi);
+            }
+
             bool success = cmd switch
             {
                 RespCommand.GET => NetworkGET(ptr, ref storageApi),
@@ -393,7 +398,6 @@ namespace Garnet.server
                 RespCommand.READWRITE => NetworkREADWRITE(),
 
                 _ => ProcessArrayCommands(cmd, subcmd, count, ref storageApi)
-
             };
             return success;
         }

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -353,10 +353,7 @@ namespace Garnet.server
         private bool ProcessBasicCommands<TGarnetApi>(RespCommand cmd, byte subcmd, int count, byte* ptr, ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetApi
         {
-            if (!_authenticator.IsAuthenticated)
-            {
-                return ProcessArrayCommands(cmd, subcmd, count, ref storageApi);
-            }
+            if (!_authenticator.IsAuthenticated) return ProcessArrayCommands(cmd, subcmd, count, ref storageApi);
 
             bool success = cmd switch
             {


### PR DESCRIPTION
This PR addresses a critical bug related to permissions checking during the processing of basic commands, where some RESP commands could be executed by unauthenticated users. Unauthenticated users should only be allowed to execute the AUTH command.

## Bug Description

### Steps to Reproduce
Start Garnet with password authentication enabled:
```
dotnet run -c Release -f net8.0 -- --auth password --password test
```

Connect to Garnet without authenticating and issue a common command other than AUTH (e.g. PING, GET or SET):

```
> PING
PONG 
> AUTH test
OK
> PING
PONG
```

### Expected Result
```
> PING
(error) NOAUTH Authentication required.
> AUTH test
OK
> PING
PONG
```

### Actual Result
Commands that are part of the basic command group are executed even when the client is not authenticated.

## Changes
To fix this issue, the following changes have been made:

- Added authentication check to ProcessBasicCommands()
