### PR TITLE
Remove redundant Clear() calls

### DIFF
--- a/libs/storage/Tsavorite/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/BlittableAllocator.cs
@@ -151,7 +151,6 @@ namespace Tsavorite.core
 
             byte[] tmp = GC.AllocateArray<byte>(adjustedSize, true);
             long p = (long)Unsafe.AsPointer(ref tmp[0]);
-            Array.Clear(tmp, 0, adjustedSize);
             pointers[index] = (p + (sectorSize - 1)) & ~((long)sectorSize - 1);
             values[index] = tmp;
         }

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/BlittableFrame.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/BlittableFrame.cs
@@ -31,7 +31,6 @@ namespace Tsavorite.core
 
             byte[] tmp = GC.AllocateArray<byte>(adjustedSize, true);
             long p = (long)Unsafe.AsPointer(ref tmp[0]);
-            Array.Clear(tmp, 0, adjustedSize);
             pointers[index] = (p + (sectorSize - 1)) & ~((long)sectorSize - 1);
             frame[index] = tmp;
         }

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/GenericAllocator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/GenericAllocator.cs
@@ -286,13 +286,7 @@ namespace Tsavorite.core
             if (overflowPagePool.TryGet(out var item))
                 return item;
 
-            Record<Key, Value>[] tmp;
-            if (PageSize % RecordSize == 0)
-                tmp = new Record<Key, Value>[PageSize / RecordSize];
-            else
-                tmp = new Record<Key, Value>[1 + (PageSize / RecordSize)];
-            Array.Clear(tmp, 0, tmp.Length);
-            return tmp;
+            return new Record<Key, Value>[(PageSize + RecordSize - 1) / RecordSize];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/GenericFrame.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/GenericFrame.cs
@@ -24,13 +24,7 @@ namespace Tsavorite.core
 
         public void Allocate(int index)
         {
-            Record<Key, Value>[] tmp;
-            if (pageSize % RecordSize == 0)
-                tmp = new Record<Key, Value>[pageSize / RecordSize];
-            else
-                tmp = new Record<Key, Value>[1 + (pageSize / RecordSize)];
-            Array.Clear(tmp, 0, tmp.Length);
-            frame[index] = tmp;
+            frame[index] = new Record<Key, Value>[(pageSize + RecordSize - 1) / RecordSize];
         }
 
         public void Clear(int pageIndex)

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/MallocFixedPageSize.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/MallocFixedPageSize.cs
@@ -3,8 +3,6 @@
 
 #pragma warning disable 0162
 
-#define CALLOC
-
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -112,10 +110,6 @@ namespace Tsavorite.core
             {
                 pointers[0] = (IntPtr)(((long)Unsafe.AsPointer(ref values[0][0]) + (SectorSize - 1)) & ~(SectorSize - 1));
             }
-
-#if !(CALLOC)
-            Array.Clear(values[0], 0, PageSize);
-#endif
 
             writeCacheLevel = -1;
             Interlocked.MemoryBarrier();
@@ -236,9 +230,6 @@ namespace Tsavorite.core
                     if (IsBlittable)
                         pointers[1] = (IntPtr)(((long)Unsafe.AsPointer(ref tmp[0]) + (SectorSize - 1)) & ~(SectorSize - 1));
 
-#if !(CALLOC)
-                    Array.Clear(tmp, 0, PageSize);
-#endif
                     values[1] = tmp;
                     Interlocked.MemoryBarrier();
                 }
@@ -287,9 +278,6 @@ namespace Tsavorite.core
                 if (IsBlittable)
                     pointers[newBaseAddr] = (IntPtr)(((long)Unsafe.AsPointer(ref tmp[0]) + (SectorSize - 1)) & ~(SectorSize - 1));
 
-#if !(CALLOC)
-                Array.Clear(tmp, 0, PageSize);
-#endif
                 values[newBaseAddr] = tmp;
 
                 Interlocked.MemoryBarrier();

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/SpanByteAllocator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/SpanByteAllocator.cs
@@ -218,7 +218,6 @@ namespace Tsavorite.core
 
             byte[] tmp = GC.AllocateArray<byte>(adjustedSize, true);
             long p = (long)Unsafe.AsPointer(ref tmp[0]);
-            Array.Clear(tmp, 0, adjustedSize);
             pointers[index] = (p + (sectorSize - 1)) & ~((long)sectorSize - 1);
             values[index] = tmp;
         }


### PR DESCRIPTION
fix #241

1. removes redundant `Clear()` calls from new arrays that are already zero-initialized by the runtime
2. removes a branch in paging math for allocations