### PR TITLE
Increment/Decrement Valid Number Check

### DIFF
--- a/benchmark/BDN.benchmark/BDN.benchmark.csproj
+++ b/benchmark/BDN.benchmark/BDN.benchmark.csproj
@@ -5,12 +5,20 @@
     <ImplicitUsings>enable</ImplicitUsings>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
+		<SignAssembly>true</SignAssembly>
+		<AssemblyOriginatorKeyFile>../../Garnet.snk</AssemblyOriginatorKeyFile>
+		<DelaySign>false</DelaySign>
   </PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
 	</ItemGroup>
 	<ItemGroup>
+		<ProjectReference Include="..\..\libs\host\Garnet.host.csproj" />
 		<ProjectReference Include="..\..\libs\common\Garnet.common.csproj" />
+		<ProjectReference Include="..\..\libs\server\Garnet.server.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="..\..\playground\Embedded.perftest\EmbeddedRespServer.cs" Link="EmbeddedRespServer.cs" />
+		<Compile Include="..\..\playground\Embedded.perftest\DummyNetworkSender.cs" Link="DummyNetworkSender.cs" />
 	</ItemGroup>
 </Project>

--- a/benchmark/BDN.benchmark/Resp/RespIncrementStress.cs
+++ b/benchmark/BDN.benchmark/Resp/RespIncrementStress.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Embedded.perftest;
+using Garnet.common;
+using Garnet.server;
+
+namespace BDN.benchmark.Resp
+{
+    public unsafe class RespIncrementStress
+    {
+        EmbeddedRespServer server;
+        RespServerSession session;
+
+        static ReadOnlySpan<byte> SINGLE_INCR => "*2\r\n$4\r\nINCR\r\n$1\r\nx\r\n"u8;
+        static ReadOnlySpan<byte> SINGLE_DECR => "*2\r\n$4\r\nDECR\r\n$1\r\nx\r\n"u8;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            var opt = new GarnetServerOptions
+            {
+                QuietMode = true
+            };
+            server = new EmbeddedRespServer(opt);
+            session = server.GetRespSession();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            session.Dispose();
+            server.Dispose();
+        }
+
+        [Benchmark]
+        public void Increment()
+        {
+            fixed (byte* ptr = SINGLE_INCR)
+            {
+                _ = session.TryConsumeMessages(ptr, SINGLE_INCR.Length);
+            }
+        }
+
+        [Benchmark]
+        public void Decrement()
+        {
+            fixed (byte* ptr = SINGLE_DECR)
+            {
+                _ = session.TryConsumeMessages(ptr, SINGLE_DECR.Length);
+            }
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(IncrByBenchInput))]
+        public void IncrementBy(byte[] input)
+        {
+            fixed (byte* ptr = input)
+            {
+                _ = session.TryConsumeMessages(ptr, input.Length);
+            }
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(DecrByBenchInput))]
+        public void DecrementBy(byte[] input)
+        {
+            fixed (byte* ptr = input)
+            {
+                _ = session.TryConsumeMessages(ptr, input.Length);
+            }
+        }
+
+        public static IEnumerable<object> IncrByBenchInput => values.Select(x => Get(RespCommand.INCRBY, x));
+        public static IEnumerable<object> DecrByBenchInput => values.Select(x => Get(RespCommand.DECRBY, x));
+
+        public static int[] values => [int.MinValue, -1, 0, int.MaxValue];
+
+        public static byte[] Get(RespCommand cmd, long val)
+        {
+            var length = NumUtils.NumDigitsInLong(val);
+            return cmd switch
+            {
+                RespCommand.INCRBY => Encoding.ASCII.GetBytes($"*2\r\n$6\r\nINCRBY\r\n$1\r\nx\r\n${length}\r\n{val}\r\n"),
+                RespCommand.DECRBY => Encoding.ASCII.GetBytes($"*2\r\n$6\r\nDECRBY\r\n$1\r\nx\r\n${length}\r\n{val}\r\n"),
+                _ => throw new Exception($"Option {cmd} not supported")
+            };
+        }
+    }
+}

--- a/benchmark/Resp.benchmark/RespOnlineBench.cs
+++ b/benchmark/Resp.benchmark/RespOnlineBench.cs
@@ -6,7 +6,6 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Garnet.client;

--- a/libs/client/ClientSession/GarnetClientSessionReplicationExtensions.cs
+++ b/libs/client/ClientSession/GarnetClientSessionReplicationExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Garnet.common;

--- a/libs/common/NumUtils.cs
+++ b/libs/common/NumUtils.cs
@@ -114,10 +114,16 @@ namespace Garnet.common
             var fNeg = *source == '-';
             var beg = fNeg ? source + 1 : source;
             var end = source + length;
+            var digit = *beg - '0';
             result = 0;
+
+            // Check first digit which needs to be non-zero
+            if (digit is <= 0 or > 9)
+                return false;
+
             while (beg < end)
             {
-                var digit = *beg++ - '0';
+                digit = *beg++ - '0';
                 if (digit is < 0 or > 9)
                     return false;
                 result = (result * 10) + digit;

--- a/libs/common/NumUtils.cs
+++ b/libs/common/NumUtils.cs
@@ -13,6 +13,8 @@ namespace Garnet.common
     /// </summary>
     public static unsafe class NumUtils
     {
+        public const int MaximumFormatInt64Length = 20;   // 19 + sign (i.e. -9223372036854775808)
+
         /// <summary>
         /// Convert long number into sequence of ASCII bytes
         /// </summary>
@@ -126,7 +128,7 @@ namespace Garnet.common
                 digit = *beg++ - '0';
                 if (digit is < 0 or > 9)
                     return false;
-                result = (result * 10) + digit;
+                checked { result = (result * 10) + digit; }
             }
             result = fNeg ? -result : result;
             return true;
@@ -542,6 +544,5 @@ namespace Garnet.common
             result = fNeg ? -(result) : result;
             return true;
         }
-
     }
 }

--- a/libs/common/NumUtils.cs
+++ b/libs/common/NumUtils.cs
@@ -103,6 +103,40 @@ namespace Garnet.common
         }
 
         /// <summary>
+        /// Convert sequence of ASCII bytes into long number
+        /// </summary>
+        /// <param name="source">Source bytes</param>
+        /// <returns>Result</returns>
+        public static bool TryBytesToLong(ReadOnlySpan<byte> source, out long result)
+        {
+            fixed (byte* ptr = source)
+                return BytesToLong(source.Length, ptr, out result);
+        }
+
+        /// <summary>
+        /// Convert sequence of ASCII bytes into long number
+        /// </summary>
+        /// <param name="length">Length of number</param>
+        /// <param name="source">Source bytes</param>
+        /// <returns>Result</returns>
+        public static bool BytesToLong(int length, byte* source, out long result)
+        {
+            var fNeg = *source == '-';
+            var beg = fNeg ? source + 1 : source;
+            var end = source + length;
+            result = 0;
+            while (beg < end)
+            {
+                var digit = *beg++ - '0';
+                if (digit is < 0 or > 9)
+                    return false;
+                result = (result * 10) + digit;
+            }
+            result = fNeg ? -result : result;
+            return true;
+        }
+
+        /// <summary>
         /// Convert sequence of ASCII bytes into ulong number
         /// </summary>
         /// <param name="length">Length of number</param>

--- a/libs/common/NumUtils.cs
+++ b/libs/common/NumUtils.cs
@@ -105,21 +105,11 @@ namespace Garnet.common
         /// <summary>
         /// Convert sequence of ASCII bytes into long number
         /// </summary>
-        /// <param name="source">Source bytes</param>
-        /// <returns>Result</returns>
-        public static bool TryBytesToLong(ReadOnlySpan<byte> source, out long result)
-        {
-            fixed (byte* ptr = source)
-                return BytesToLong(source.Length, ptr, out result);
-        }
-
-        /// <summary>
-        /// Convert sequence of ASCII bytes into long number
-        /// </summary>
         /// <param name="length">Length of number</param>
         /// <param name="source">Source bytes</param>
-        /// <returns>Result</returns>
-        public static bool BytesToLong(int length, byte* source, out long result)
+        /// <param name="result">Long value extracted from sequence</param>
+        /// <returns>True if sequence contains only numeric values otherwise false</returns>
+        public static bool TryBytesToLong(int length, byte* source, out long result)
         {
             var fNeg = *source == '-';
             var beg = fNeg ? source + 1 : source;

--- a/libs/common/NumUtils.cs
+++ b/libs/common/NumUtils.cs
@@ -110,7 +110,7 @@ namespace Garnet.common
         /// <param name="length">Length of number</param>
         /// <param name="source">Source bytes</param>
         /// <param name="result">Long value extracted from sequence</param>
-        /// <returns>True if sequence contains only numeric values otherwise false</returns>
+        /// <returns>True if sequence contains only numeric digits, otherwise false</returns>
         public static bool TryBytesToLong(int length, byte* source, out long result)
         {
             var fNeg = *source == '-';

--- a/libs/server/Custom/CustomRespCommands.cs
+++ b/libs/server/Custom/CustomRespCommands.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Text;
 using Garnet.common;
 using Tsavorite.core;
 

--- a/libs/server/IncrErrorType.cs
+++ b/libs/server/IncrErrorType.cs
@@ -3,6 +3,9 @@
 
 namespace Garnet.server
 {
+    /// <summary>
+    /// Type of error when executing Increment/Decrement commands
+    /// </summary>
     public enum IncrErrorType : byte
     {
         /// <summary>

--- a/libs/server/IncrErrorType.cs
+++ b/libs/server/IncrErrorType.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace Garnet.server
+{
+    public enum IncrErrorType : byte
+    {
+        /// <summary>
+        /// Increment/Decrement Success
+        /// </summary>
+        SUCCESS,
+        /// <summary>
+        /// Increment/Decrement Invalid Numeric Value
+        /// </summary>
+        INVALID_NUMBER
+    }
+}

--- a/libs/server/Metrics/Info/InfoCommand.cs
+++ b/libs/server/Metrics/Info/InfoCommand.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Garnet.common;
 
 namespace Garnet.server

--- a/libs/server/OperationError.cs
+++ b/libs/server/OperationError.cs
@@ -4,17 +4,17 @@
 namespace Garnet.server
 {
     /// <summary>
-    /// Type of error when executing Increment/Decrement commands
+    /// Operation error type
     /// </summary>
-    public enum IncrErrorType : byte
+    public enum OperationError : byte
     {
         /// <summary>
-        /// Increment/Decrement Success
+        /// Operation on data type succeeded
         /// </summary>
         SUCCESS,
         /// <summary>
-        /// Increment/Decrement Invalid Numeric Value
+        /// Operation failed due to incompatible type
         /// </summary>
-        INVALID_NUMBER
+        INVALID_TYPE
     }
 }

--- a/libs/server/Properties/AssemblyInfo.cs
+++ b/libs/server/Properties/AssemblyInfo.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Garnet.test" + AssemblyRef.GarnetPublicKey)]
 [assembly: InternalsVisibleTo("Embedded.perftest" + AssemblyRef.GarnetPublicKey)]
+[assembly: InternalsVisibleTo("BDN.benchmark" + AssemblyRef.GarnetPublicKey)]
 
 /// <summary>
 /// Sets public key string for friend assemblies.

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -775,15 +775,15 @@ namespace Garnet.server
             var output = new ArgSlice(pbOutput, 21);
 
             var status = storageApi.Increment(key, input, ref output);
-            var errorFlag = output.Length == 21 ? (IncrErrorType)output.Span[0] : IncrErrorType.SUCCESS;
+            var errorFlag = output.Length == 21 ? (OperationError)output.Span[0] : OperationError.SUCCESS;
 
             switch (errorFlag)
             {
-                case IncrErrorType.SUCCESS:
+                case OperationError.SUCCESS:
                     while (!RespWriteUtils.WriteIntegerFromBytes(pbOutput, output.Length, ref dcurr, dend))
                         SendAndReset();
                     break;
-                case IncrErrorType.INVALID_NUMBER:
+                case OperationError.INVALID_TYPE:
                     while (!RespWriteUtils.WriteError(CmdStrings.RESP_ERR_GENERIC_VALUE_IS_NOT_INTEGER, ref dcurr, dend))
                         SendAndReset();
                     break;

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -770,12 +770,11 @@ namespace Garnet.server
                 return true;
 
             var key = new ArgSlice(keyPtr, ksize);
-
-            var pbOutput = stackalloc byte[21];
-            var output = new ArgSlice(pbOutput, 21);
+            var pbOutput = stackalloc byte[NumUtils.MaximumFormatInt64Length + 1];
+            var output = new ArgSlice(pbOutput, NumUtils.MaximumFormatInt64Length + 1);
 
             var status = storageApi.Increment(key, input, ref output);
-            var errorFlag = output.Length == 21 ? (OperationError)output.Span[0] : OperationError.SUCCESS;
+            var errorFlag = output.Length == NumUtils.MaximumFormatInt64Length + 1 ? (OperationError)output.Span[0] : OperationError.SUCCESS;
 
             switch (errorFlag)
             {
@@ -788,7 +787,7 @@ namespace Garnet.server
                         SendAndReset();
                     break;
                 default:
-                    throw new GarnetException($"Invalid IncrErrorType {errorFlag}");
+                    throw new GarnetException($"Invalid OperationError {errorFlag}");
             }
             return true;
         }

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -775,7 +775,6 @@ namespace Garnet.server
             var output = new ArgSlice(pbOutput, 21);
 
             var status = storageApi.Increment(key, input, ref output);
-
             var flag = output.Span[^1];
 
             switch (flag)

--- a/libs/server/Resp/Bitmap/BitmapCommands.cs
+++ b/libs/server/Resp/Bitmap/BitmapCommands.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 using Garnet.common;
 using Microsoft.Extensions.Logging;
 using Tsavorite.core;

--- a/libs/server/Resp/CmdStrings.cs
+++ b/libs/server/Resp/CmdStrings.cs
@@ -123,7 +123,6 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_REGISTERCS_UNSUPPORTED_CLASS => "ERR unable to register one or more unsupported classes."u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_VALUE_IS_NOT_INTEGER => "ERR value is not an integer or out of range."u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_UKNOWN_SUBCOMMAND => "ERR Unknown subcommand. Try LATENCY HELP."u8;
-        public static ReadOnlySpan<byte> RESP_ERR_GENERIC_OVERFLOW_ERROR => "increment or decrement would overflow"u8;
 
         /// <summary>
         /// Response string templates

--- a/libs/server/Resp/CmdStrings.cs
+++ b/libs/server/Resp/CmdStrings.cs
@@ -123,6 +123,7 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_REGISTERCS_UNSUPPORTED_CLASS => "ERR unable to register one or more unsupported classes."u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_VALUE_IS_NOT_INTEGER => "ERR value is not an integer or out of range."u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_UKNOWN_SUBCOMMAND => "ERR Unknown subcommand. Try LATENCY HELP."u8;
+
         /// <summary>
         /// Response string templates
         /// </summary>

--- a/libs/server/Resp/CmdStrings.cs
+++ b/libs/server/Resp/CmdStrings.cs
@@ -123,6 +123,7 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_REGISTERCS_UNSUPPORTED_CLASS => "ERR unable to register one or more unsupported classes."u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_VALUE_IS_NOT_INTEGER => "ERR value is not an integer or out of range."u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_UKNOWN_SUBCOMMAND => "ERR Unknown subcommand. Try LATENCY HELP."u8;
+        public static ReadOnlySpan<byte> RESP_ERR_GENERIC_OVERFLOW_ERROR => "increment or decrement would overflow"u8;
 
         /// <summary>
         /// Response string templates

--- a/libs/server/Resp/KeyAdminCommands.cs
+++ b/libs/server/Resp/KeyAdminCommands.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Text;
 using Garnet.common;
 using Tsavorite.core;
 

--- a/libs/server/Resp/Objects/ListCommands.cs
+++ b/libs/server/Resp/Objects/ListCommands.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using System.Text;
 using Garnet.common;
 using Tsavorite.core;
 

--- a/libs/server/Resp/Objects/SortedSetCommands.cs
+++ b/libs/server/Resp/Objects/SortedSetCommands.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Text;
 using Garnet.common;
 using Tsavorite.core;
 

--- a/libs/server/Resp/PubSubCommands.cs
+++ b/libs/server/Resp/PubSubCommands.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text;
 using Garnet.common;
 using Tsavorite.core;
 

--- a/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
@@ -418,6 +418,14 @@ namespace Garnet.server
             CopyUpdateNumber(val, ref newValue, ref output);
         }
 
+        /// <summary>
+        /// Parse ASCII byte array into long and validate that only contains ASCII decimal characters
+        /// </summary>
+        /// <param name="length">Length of byte array</param>
+        /// <param name="source">Pointer to byte array</param>
+        /// <param name="output">Output error flag</param>
+        /// <param name="val">Parsed long value</param>
+        /// <returns>True if input contained only ASCII decimal characters, otherwise false</returns>
         static bool IsValidNumber(int length, byte* source, Span<byte> output, out long val)
         {
             val = 0;

--- a/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
@@ -465,7 +465,7 @@ namespace Garnet.server
             if (!NumUtils.TryBytesToLong(length, source, out val))
             {
                 // Signal value is not a valid number
-                output.SpanByte.AsSpan()[^1] = 1;
+                output.SpanByte.AsSpan()[0] = (byte)IncrErrorType.INVALID_NUMBER;
                 return false;
             }
             return true;

--- a/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
@@ -383,6 +383,13 @@ namespace Garnet.server
             output.SpanByte.Length = newValue.LengthWithoutMetadata;
         }
 
+        /// <summary>
+        /// Copy update from old value to new value while also validating whether oldValue is a numerical value.
+        /// </summary>
+        /// <param name="oldValue">Old value copying from</param>
+        /// <param name="newValue">New value copying to</param>
+        /// <param name="output">Output value</param>
+        /// <param name="input">Parsed input value</param>
         static void TryCopyUpdateNumber(ref SpanByte oldValue, ref SpanByte newValue, ref SpanByteAndMemory output, long input)
         {
             newValue.ExtraMetadata = oldValue.ExtraMetadata;
@@ -390,7 +397,8 @@ namespace Garnet.server
             // Check if value contains a valid number
             if (!IsValidNumber(oldValue.LengthWithoutMetadata, oldValue.ToPointer(), output.SpanByte.AsSpan(), out var val))
             {
-                // Move to tail of the log
+                // Move to tail of the log even when oldValue is alphanumeric
+                // We have already paid the cost of bringing from disk so we are treating as a regular access and bring it into memory
                 oldValue.CopyTo(ref newValue);
                 return;
             }

--- a/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
@@ -459,10 +459,10 @@ namespace Garnet.server
             functionsState.appendOnlyFile.Enqueue(new AofHeader { opType = AofEntryType.StoreDelete, version = version, sessionID = sessionID }, ref key, ref def, out _);
         }
 
-        static bool IsValidNumber(ref SpanByte value, ref SpanByteAndMemory output, out long val)
+        static bool IsValidNumber(int length, byte* source, ref SpanByteAndMemory output, out long val)
         {
             // Check for valid number
-            if (!NumUtils.TryBytesToLong(value.AsSpan(), out val))
+            if (!NumUtils.TryBytesToLong(length, source, out val))
             {
                 // Signal value is not a valid number
                 output.SpanByte.AsSpan()[^1] = 1;

--- a/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
@@ -465,7 +465,7 @@ namespace Garnet.server
             if (!NumUtils.TryBytesToLong(length, source, out val))
             {
                 // Signal value is not a valid number
-                output.SpanByte.AsSpan()[0] = (byte)IncrErrorType.INVALID_NUMBER;
+                output.SpanByte.AsSpan()[0] = (byte)OperationError.INVALID_TYPE;
                 return false;
             }
             return true;

--- a/libs/server/Storage/Functions/MainStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/RMWMethods.cs
@@ -293,26 +293,40 @@ namespace Garnet.server
 
                 case RespCommand.INCR:
                     // Check if value contains a valid number
-                    if (!IsValidNumber(ref value, ref output, out var val))
+                    if (!IsValidNumber(value.LengthWithoutMetadata, value.ToPointer(), ref output, out var val))
                         return true;
                     var old = val++;
                     return InPlaceUpdateNumber(val, ref value, ref output, ref rmwInfo, ref recordInfo);
 
                 case RespCommand.DECR:
                     // Check if value contains a valid number
-                    if (!IsValidNumber(ref value, ref output, out val))
+                    if (!IsValidNumber(value.LengthWithoutMetadata, value.ToPointer(), ref output, out val))
                         return true;
                     val--;
                     return InPlaceUpdateNumber(val, ref value, ref output, ref rmwInfo, ref recordInfo);
 
                 case RespCommand.INCRBY:
-                    val = NumUtils.BytesToLong(value.LengthWithoutMetadata, value.ToPointer());
-                    val += NumUtils.BytesToLong(input.LengthWithoutMetadata - RespInputHeader.Size, inputPtr + RespInputHeader.Size);
+                    // Check if value contains a valid number
+                    if (!IsValidNumber(value.LengthWithoutMetadata, value.ToPointer(), ref output, out val))
+                        return true;
+
+                    // Check if input contains a valid number
+                    if (!IsValidNumber(input.LengthWithoutMetadata - RespInputHeader.Size, inputPtr + RespInputHeader.Size, ref output, out var by))
+                        return true;
+
+                    val += by;
                     return InPlaceUpdateNumber(val, ref value, ref output, ref rmwInfo, ref recordInfo);
 
                 case RespCommand.DECRBY:
-                    val = NumUtils.BytesToLong(value.LengthWithoutMetadata, value.ToPointer());
-                    val -= NumUtils.BytesToLong(input.LengthWithoutMetadata - RespInputHeader.Size, inputPtr + RespInputHeader.Size);
+                    // Check if value contains a valid number
+                    if (!IsValidNumber(value.LengthWithoutMetadata, value.ToPointer(), ref output, out val))
+                        return true;
+
+                    // Check if input contains a valid number
+                    if (!IsValidNumber(input.LengthWithoutMetadata - RespInputHeader.Size, inputPtr + RespInputHeader.Size, ref output, out by))
+                        return true;
+
+                    val -= by;
                     return InPlaceUpdateNumber(val, ref value, ref output, ref rmwInfo, ref recordInfo);
 
                 case RespCommand.SETBIT:

--- a/libs/server/Storage/Functions/MainStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/RMWMethods.cs
@@ -134,9 +134,22 @@ namespace Garnet.server
                     CopyValueLengthToOutput(ref value, ref output);
                     break;
 
+                case RespCommand.INCRBY:
+                    value.UnmarkExtraMetadata();
+                    // Check if input contains a valid number
+                    length = input.LengthWithoutMetadata - RespInputHeader.Size;
+                    if (!IsValidNumber(length, inputPtr + RespInputHeader.Size, output.SpanByte.AsSpan(), out var incrBy))
+                        return false;
+                    CopyUpdateNumber(incrBy, ref value, ref output);
+                    break;
+
                 case RespCommand.DECRBY:
                     value.UnmarkExtraMetadata();
-                    CopyUpdateNumber(-NumUtils.BytesToLong(input.LengthWithoutMetadata - RespInputHeader.Size, inputPtr + RespInputHeader.Size), ref value, ref output);
+                    // Check if input contains a valid number
+                    length = input.LengthWithoutMetadata - RespInputHeader.Size;
+                    if (!IsValidNumber(length, inputPtr + RespInputHeader.Size, output.SpanByte.AsSpan(), out var decrBy))
+                        return false;
+                    CopyUpdateNumber(-decrBy, ref value, ref output);
                     break;
 
                 default:
@@ -292,52 +305,24 @@ namespace Garnet.server
                     return true;
 
                 case RespCommand.INCR:
-                    // Check if value contains a valid number
-                    if (!IsValidNumber(value.LengthWithoutMetadata, value.ToPointer(), ref output, out var val))
-                        return true;
-
-                    try
-                    {
-                        checked { val++; }
-                    }
-                    catch
-                    {
-
-                        return true;
-                    }
-
-                    return InPlaceUpdateNumber(val, ref value, ref output, ref rmwInfo, ref recordInfo);
+                    return TryInPlaceUpdateNumber(ref value, ref output, ref rmwInfo, ref recordInfo, input: 1);
 
                 case RespCommand.DECR:
-                    // Check if value contains a valid number
-                    if (!IsValidNumber(value.LengthWithoutMetadata, value.ToPointer(), ref output, out val))
-                        return true;
-                    val--;
-                    return InPlaceUpdateNumber(val, ref value, ref output, ref rmwInfo, ref recordInfo);
+                    return TryInPlaceUpdateNumber(ref value, ref output, ref rmwInfo, ref recordInfo, input: -1);
 
                 case RespCommand.INCRBY:
-                    // Check if value contains a valid number
-                    if (!IsValidNumber(value.LengthWithoutMetadata, value.ToPointer(), ref output, out val))
-                        return true;
-
+                    var length = input.LengthWithoutMetadata - RespInputHeader.Size;
                     // Check if input contains a valid number
-                    if (!IsValidNumber(input.LengthWithoutMetadata - RespInputHeader.Size, inputPtr + RespInputHeader.Size, ref output, out var by))
+                    if (!IsValidNumber(length, inputPtr + RespInputHeader.Size, output.SpanByte.AsSpan(), out var incrBy))
                         return true;
-
-                    val += by;
-                    return InPlaceUpdateNumber(val, ref value, ref output, ref rmwInfo, ref recordInfo);
+                    return TryInPlaceUpdateNumber(ref value, ref output, ref rmwInfo, ref recordInfo, input: incrBy);
 
                 case RespCommand.DECRBY:
-                    // Check if value contains a valid number
-                    if (!IsValidNumber(value.LengthWithoutMetadata, value.ToPointer(), ref output, out val))
-                        return true;
-
+                    length = input.LengthWithoutMetadata - RespInputHeader.Size;
                     // Check if input contains a valid number
-                    if (!IsValidNumber(input.LengthWithoutMetadata - RespInputHeader.Size, inputPtr + RespInputHeader.Size, ref output, out by))
+                    if (!IsValidNumber(length, inputPtr + RespInputHeader.Size, output.SpanByte.AsSpan(), out var decrBy))
                         return true;
-
-                    val -= by;
-                    return InPlaceUpdateNumber(val, ref value, ref output, ref rmwInfo, ref recordInfo);
+                    return TryInPlaceUpdateNumber(ref value, ref output, ref rmwInfo, ref recordInfo, input: -decrBy);
 
                 case RespCommand.SETBIT:
                     byte* i = inputPtr + RespInputHeader.Size;
@@ -595,31 +580,35 @@ namespace Garnet.server
                     break;
 
                 case RespCommand.INCR:
-                    // Copy over metadata
-                    newValue.ExtraMetadata = oldValue.ExtraMetadata;
-                    long curr = NumUtils.BytesToLong(oldValue.AsSpan());
-                    CopyUpdateNumber(curr + 1, ref newValue, ref output);
-                    break;
-
-                case RespCommand.INCRBY:
-                    // Copy over metadata
-                    newValue.ExtraMetadata = oldValue.ExtraMetadata;
-                    curr = NumUtils.BytesToLong(oldValue.AsSpan());
-                    CopyUpdateNumber(curr + NumUtils.BytesToLong(input.LengthWithoutMetadata - RespInputHeader.Size, inputPtr + RespInputHeader.Size), ref newValue, ref output);
+                    TryCopyUpdateNumber(ref oldValue, ref newValue, ref output, input: 1);
                     break;
 
                 case RespCommand.DECR:
-                    // Copy over metadata
-                    newValue.ExtraMetadata = oldValue.ExtraMetadata;
-                    curr = NumUtils.BytesToLong(oldValue.AsSpan());
-                    CopyUpdateNumber(curr - 1, ref newValue, ref output);
+                    TryCopyUpdateNumber(ref oldValue, ref newValue, ref output, input: -1);
+                    break;
+
+                case RespCommand.INCRBY:
+                    var length = input.LengthWithoutMetadata - RespInputHeader.Size;
+                    // Check if input contains a valid number
+                    if (!IsValidNumber(length, input.ToPointer() + RespInputHeader.Size, output.SpanByte.AsSpan(), out var incrBy))
+                    {
+                        // Move to tail of the log
+                        oldValue.CopyTo(ref newValue);
+                        break;
+                    }
+                    TryCopyUpdateNumber(ref oldValue, ref newValue, ref output, input: incrBy);
                     break;
 
                 case RespCommand.DECRBY:
-                    // Copy over metadata
-                    newValue.ExtraMetadata = oldValue.ExtraMetadata;
-                    curr = NumUtils.BytesToLong(oldValue.AsSpan());
-                    CopyUpdateNumber(curr - NumUtils.BytesToLong(input.LengthWithoutMetadata - RespInputHeader.Size, inputPtr + RespInputHeader.Size), ref newValue, ref output);
+                    length = input.LengthWithoutMetadata - RespInputHeader.Size;
+                    // Check if input contains a valid number
+                    if (!IsValidNumber(length, input.ToPointer() + RespInputHeader.Size, output.SpanByte.AsSpan(), out var decrBy))
+                    {
+                        // Move to tail of the log
+                        oldValue.CopyTo(ref newValue);
+                        break;
+                    }
+                    TryCopyUpdateNumber(ref oldValue, ref newValue, ref output, input: -decrBy);
                     break;
 
                 case RespCommand.SETBIT:

--- a/libs/server/Storage/Functions/MainStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/RMWMethods.cs
@@ -292,12 +292,16 @@ namespace Garnet.server
                     return true;
 
                 case RespCommand.INCR:
-                    long val = NumUtils.BytesToLong(value.AsSpan());
-                    val++;
+                    // Check if value contains a valid number
+                    if (!IsValidNumber(ref value, ref output, out var val))
+                        return true;
+                    var old = val++;
                     return InPlaceUpdateNumber(val, ref value, ref output, ref rmwInfo, ref recordInfo);
 
                 case RespCommand.DECR:
-                    val = NumUtils.BytesToLong(value.AsSpan());
+                    // Check if value contains a valid number
+                    if (!IsValidNumber(ref value, ref output, out val))
+                        return true;
                     val--;
                     return InPlaceUpdateNumber(val, ref value, ref output, ref rmwInfo, ref recordInfo);
 

--- a/libs/server/Storage/Functions/MainStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/RMWMethods.cs
@@ -295,7 +295,17 @@ namespace Garnet.server
                     // Check if value contains a valid number
                     if (!IsValidNumber(value.LengthWithoutMetadata, value.ToPointer(), ref output, out var val))
                         return true;
-                    var old = val++;
+
+                    try
+                    {
+                        checked { val++; }
+                    }
+                    catch
+                    {
+
+                        return true;
+                    }
+
                     return InPlaceUpdateNumber(val, ref value, ref output, ref rmwInfo, ref recordInfo);
 
                 case RespCommand.DECR:

--- a/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
@@ -40,11 +40,19 @@ namespace Garnet.server
                     var valueLength = *(int*)(inputPtr + RespInputHeader.Size);
                     return sizeof(int) + valueLength;
 
-                case RespCommand.DECRBY:
-                    var next = -NumUtils.BytesToLong(input.LengthWithoutMetadata - RespInputHeader.Size, inputPtr + RespInputHeader.Size);
+                case RespCommand.INCRBY:
+                    var next = NumUtils.BytesToLong(input.LengthWithoutMetadata - RespInputHeader.Size, inputPtr + RespInputHeader.Size);
 
                     var fNeg = false;
                     var ndigits = NumUtils.NumDigitsInLong(next, ref fNeg);
+
+                    return sizeof(int) + ndigits + (fNeg ? 1 : 0);
+
+                case RespCommand.DECRBY:
+                    next = -NumUtils.BytesToLong(input.LengthWithoutMetadata - RespInputHeader.Size, inputPtr + RespInputHeader.Size);
+
+                    fNeg = false;
+                    ndigits = NumUtils.NumDigitsInLong(next, ref fNeg);
 
                     return sizeof(int) + ndigits + (fNeg ? 1 : 0);
 

--- a/libs/server/TLS/IGarnetTlsOptions.cs
+++ b/libs/server/TLS/IGarnetTlsOptions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System;
 using System.Net.Security;
 
 namespace Garnet.server.TLS

--- a/libs/server/Transaction/TxnRespCommands.cs
+++ b/libs/server/Transaction/TxnRespCommands.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Garnet.common;
 using Microsoft.Extensions.Logging;
 

--- a/playground/Embedded.perftest/EmbeddedRespServer.cs
+++ b/playground/Embedded.perftest/EmbeddedRespServer.cs
@@ -24,6 +24,11 @@ namespace Embedded.perftest
         }
 
         /// <summary>
+        /// Dispose server
+        /// </summary>
+        public new void Dispose() => base.Dispose();
+
+        /// <summary>
         /// Return a RESP session to this server
         /// </summary>
         /// <returns>A new RESP server session</returns>

--- a/test/Garnet.test/Resp/ACL/BasicTests.cs
+++ b/test/Garnet.test/Resp/ACL/BasicTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using NUnit.Framework.Internal;

--- a/test/Garnet.test/RespSortedSetTests.cs
+++ b/test/Garnet.test/RespSortedSetTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Garnet.server;
 using NUnit.Framework;
 using StackExchange.Redis;
-using Tsavorite.core;
 
 namespace Garnet.test
 {

--- a/test/Garnet.test/TestProcedureHash.cs
+++ b/test/Garnet.test/TestProcedureHash.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using System.Text;
 using Garnet.common;
 using Garnet.server;
 using Tsavorite.core;


### PR DESCRIPTION
Added validity check to catch increment/decrement of alphanumeric strings.
This is a proposed solution that minimizes the perf overhead of passing the error from RMWMethods.
However, the overhead of TryBytesToLong will not be avoided.
Maybe it is possible to include a type at upsert and avoid TryBytesToLong validation every time INCR/DECR is executed.

Second iteration updated the PR to catch overflow exceptions and to validate operands on copy update and at InitialUpdate.

Third iteration combined bdn.benchmark with embedded bench to evaluate performance of new validity checks.

**Main without validity checks**

| Method      | Job    | EnvironmentVariables | Runtime  | input    | Mean     | Error   | StdDev  |
|------------ |------- |--------------------- |--------- |--------- |---------:|--------:|--------:|
| Increment   | .NET 6 | Empty                | .NET 6.0 | ?        | 297.4 ns | 0.51 ns | 0.47 ns |
| Decrement   | .NET 6 | Empty                | .NET 6.0 | ?        | 303.4 ns | 0.49 ns | 0.38 ns |
| Increment   | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | ?        | 206.5 ns | 0.28 ns | 0.25 ns |
| Decrement   | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | ?        | 214.2 ns | 0.55 ns | 0.49 ns |
| IncrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[30] | 210.0 ns | 0.34 ns | 0.32 ns |
| DecrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[30] | 214.8 ns | 0.30 ns | 0.28 ns |
| IncrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[30] | 132.7 ns | 0.30 ns | 0.29 ns |
| DecrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[30] | 131.2 ns | 0.36 ns | 0.34 ns |
| IncrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[31] | 227.9 ns | 1.09 ns | 1.02 ns |
| DecrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[31] | 236.1 ns | 0.86 ns | 0.81 ns |
| IncrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[31] | 146.0 ns | 0.27 ns | 0.25 ns |
| DecrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[31] | 145.0 ns | 0.50 ns | 0.44 ns |
| IncrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[40] | 240.3 ns | 0.80 ns | 0.75 ns |
| DecrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[40] | 242.9 ns | 0.62 ns | 0.58 ns |
| IncrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[40] | 157.1 ns | 0.17 ns | 0.16 ns |
| DecrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[40] | 156.7 ns | 0.25 ns | 0.23 ns |
| IncrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[41] | 234.3 ns | 1.43 ns | 1.34 ns |
| DecrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[41] | 244.8 ns | 0.78 ns | 0.73 ns |
| IncrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[41] | 158.0 ns | 0.83 ns | 0.77 ns |
| DecrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[41] | 161.9 ns | 0.48 ns | 0.45 ns |


**PR with validity checks**

| Method      | Job    | EnvironmentVariables | Runtime  | input    | Mean     | Error   | StdDev  |
|------------ |------- |--------------------- |--------- |--------- |---------:|--------:|--------:|
| Increment   | .NET 6 | Empty                | .NET 6.0 | ?        | 327.6 ns | 0.90 ns | 0.84 ns |
| Decrement   | .NET 6 | Empty                | .NET 6.0 | ?        | 259.3 ns | 1.09 ns | 1.02 ns |
| Increment   | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | ?        | 232.5 ns | 1.10 ns | 1.03 ns |
| Decrement   | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | ?        | 175.2 ns | 0.28 ns | 0.26 ns |
| IncrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[30] | 201.1 ns | 1.03 ns | 0.97 ns |
| DecrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[30] | 200.0 ns | 0.29 ns | 0.26 ns |
| IncrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[30] | 135.1 ns | 0.27 ns | 0.25 ns |
| DecrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[30] | 134.6 ns | 0.13 ns | 0.12 ns |
| IncrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[31] | 226.6 ns | 0.16 ns | 0.13 ns |
| DecrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[31] | 234.0 ns | 1.32 ns | 1.24 ns |
| IncrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[31] | 150.1 ns | 0.22 ns | 0.19 ns |
| DecrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[31] | 153.0 ns | 0.38 ns | 0.34 ns |
| IncrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[40] | 244.4 ns | 1.61 ns | 1.50 ns |
| DecrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[40] | 248.5 ns | 2.54 ns | 2.38 ns |
| IncrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[40] | 163.0 ns | 0.30 ns | 0.26 ns |
| DecrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[40] | 162.9 ns | 0.15 ns | 0.14 ns |
| IncrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[41] | 252.9 ns | 1.95 ns | 1.83 ns |
| DecrementBy | .NET 6 | Empty                | .NET 6.0 | Byte[41] | 242.2 ns | 2.31 ns | 2.16 ns |
| IncrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[41] | 164.5 ns | 0.35 ns | 0.32 ns |
| DecrementBy | .NET 8 | DOTNET_TieredPGO=0   | .NET 8.0 | Byte[41] | 163.2 ns | 0.26 ns | 0.22 ns |