### PR TITLE
A work flow to run secondary configurations every night - currently only MacOS

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,7 +42,7 @@ jobs:
           path: GarnetTestResults-${{ matrix.os }}-${{ matrix.framework }}-${{ matrix.configuration }}-${{ matrix.test }}
         if: ${{ always() }}
 
-  # Job to build and test Tsavorite code (only if there were changes to it)
+  # Job to build and test Tsavorite code
   build-test-tsavorite:        
     name: Tsavorite
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,100 @@
+name: Garnet Nightly Tests
+on:
+  schedule:
+    - cron:  '0 7 * * *' # Runs at 07:00 UTC, which is 11:00 PM PST
+  workflow_dispatch:
+  
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+
+jobs:
+  build-test-garnet:
+    name: Garnet
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ macos-latest ]
+        framework: [ 'net6.0', 'net8.0' ]
+        configuration: [ 'Debug', 'Release' ]
+        test: [ 'Garnet.test', 'Garnet.test.cluster' ]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Check style format
+        run: dotnet format --verify-no-changes --verbosity diagnostic
+      - name: Build Garnet
+        run: dotnet build --configuration ${{ matrix.configuration }}
+      - name: Run tests ${{ matrix.test }}
+        run: dotnet test test/${{ matrix.test }} -f ${{ matrix.framework }} --logger "console;verbosity=detailed" --logger trx --results-directory "GarnetTestResults-${{ matrix.os }}-${{ matrix.framework }}-${{ matrix.configuration }}-${{ matrix.test }}"
+        timeout-minutes: 30 
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: dotnet-garnet-results-${{ matrix.os }}-${{ matrix.framework }}-${{ matrix.configuration }}-${{ matrix.test }}
+          path: GarnetTestResults-${{ matrix.os }}-${{ matrix.framework }}-${{ matrix.configuration }}-${{ matrix.test }}
+        if: ${{ always() }}
+
+  # Job to build and test Tsavorite code (only if there were changes to it)
+  build-test-tsavorite:        
+    name: Tsavorite
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ macos-latest ]
+        framework: [ 'net6.0', 'net8.0' ]
+        configuration: [ 'Debug', 'Release' ]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set environment variable for Linux
+        run: echo "RunAzureTests=yes" >> $GITHUB_ENV
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Set environment variable for Windows
+        run: echo ("RunAzureTests=yes") >> $env:GITHUB_ENV
+        if: ${{ matrix.os == 'windows-latest' }}
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Setup Node.js for Azurite
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install and Run Azurite
+        shell: bash
+        run: |
+          npm install -g azurite
+          azurite &
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Format
+        run: dotnet format --verify-no-changes --verbosity diagnostic
+      - name: Build Tsavorite
+        run: dotnet build libs/storage/Tsavorite/cs/test/Tsavorite.test.csproj --configuration ${{ matrix.configuration }}
+      - name: Run Tsavorite tests
+        run: dotnet test libs/storage/Tsavorite/cs/test/Tsavorite.test.csproj -f ${{ matrix.framework }} --logger "console;verbosity=detailed" --logger trx --results-directory "TsavoriteTestResults-${{ matrix.os }}-${{ matrix.framework }}-${{ matrix.configuration }}"
+        timeout-minutes: 30 
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: dotnet-tsavorite-results-${{ matrix.os }}-${{ matrix.framework }}-${{ matrix.configuration }}
+          path: TsavoriteTestResults-${{ matrix.os }}-${{ matrix.framework }}-${{ matrix.configuration }}
+        if: ${{ always() }}
+
+  pipeline-success:
+    name: Garnet Nightly (Complete)
+    runs-on: ubuntu-latest
+    needs: [ build-test-garnet,  build-test-tsavorite ]
+    steps:
+    - run: echo Done!
+    if: ${{ !(failure() || cancelled()) }}
+    


### PR DESCRIPTION
These secondary configurations could be not only MacOS (which is set up for now) but could also include other flavors of Linux and some perf tests. This is meant to run on a schedule (nightly) and doesn't matter if files changed or not. The tests that are ran are Garnet, Garnet Cluster and Tsvaorite.

NOTE: This work flow has been ran in a private fork and there are test failures in all three areas, so it is recommended that this will be "disabled" until we get tests fixed. However, I feel it is a good idea to get this merged and in place so when devs start fixing the test failures, they will have the workflow available to verify their fixes.