### PR TITLE
Publish additional docker images to the registry

### DIFF
--- a/.github/workflows/docker-linux.yml
+++ b/.github/workflows/docker-linux.yml
@@ -1,4 +1,4 @@
-name: Garnet Docker images
+name: Garnet Docker images for Linux
 
 on:
   workflow_dispatch: # allow manual run
@@ -7,13 +7,30 @@ on:
     types: [completed]
     branches: [main]
 
-permissions:
-   contents: read
-   packages: write
-
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - dockerfile: Dockerfile
+            image: ghcr.io/${{ github.repository }}
+            os: ubuntu-latest
+          - dockerfile: Dockerfile.alpine
+            image: ghcr.io/${{ github.repository }}-alpine
+            os: ubuntu-latest
+          - dockerfile: Dockerfile.ubuntu
+            image: ghcr.io/${{ github.repository }}-jammy
+            os: ubuntu-latest
+          - dockerfile: Dockerfile.chiseled
+            image: ghcr.io/${{ github.repository }}-jammy-chiseled
+            os: ubuntu-latest
+          - dockerfile: Dockerfile.cbl-mariner
+            image: ghcr.io/${{ github.repository }}-cbl-mariner2.0
+            os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      packages: write
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:
       -
@@ -24,7 +41,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ matrix.image }}
           tags: |
             # generate Docker tags based on the following events/attributes
             type=ref,event=branch
@@ -53,7 +70,8 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v5
         with:
-          file: Dockerfile
+          file: ${{ matrix.dockerfile }}
+          provenance: false
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-windows.yml
+++ b/.github/workflows/docker-windows.yml
@@ -1,0 +1,56 @@
+name: Garnet Docker images for Windows
+
+on:
+  workflow_dispatch: # allow manual run
+  workflow_run:
+    workflows: ['Garnet .NET CI']
+    types: [completed]
+    branches: [main]
+
+permissions:
+   contents: read
+   packages: write
+
+jobs:
+  docker:
+    runs-on: windows-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}-nanoserver-ltsc2022
+          tags: |
+            # generate Docker tags based on the following events/attributes
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+      
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Build and push
+        if: github.event_name != 'pull_request'
+        run: |
+          docker build -f Dockerfile.nanoserver `
+            --tag ${{ fromJSON(steps.meta.outputs.json).tags[0] }} `
+            --tag ${{ fromJSON(steps.meta.outputs.json).tags[1] }} `
+            --tag ${{ fromJSON(steps.meta.outputs.json).tags[2] }} .
+
+          docker push ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          docker push ${{ fromJSON(steps.meta.outputs.json).tags[1] }}
+          docker push ${{ fromJSON(steps.meta.outputs.json).tags[2] }}


### PR DESCRIPTION
Currently, the repository contains Dockerfiles for various Linux distributions and nanoserver, but only the default (debian) image is being published to the registry. This pull request addresses this limitation by extending the publication process to include all Docker images for supported Linux distributions and nanoserver.

Due to the lack of support for Windows in [buildx](https://github.com/moby/buildkit/issues/616), I've split the pipeline into separate ones for Linux and Windows, ensuring that all images are properly built and published. The registry should look like [this](https://github.com/akoken/garnet/packages) after changes have been merged.