### PR TITLE
Fix CRC16 perf regression on .NET 6

### DIFF
--- a/libs/common/NumUtils.cs
+++ b/libs/common/NumUtils.cs
@@ -436,7 +436,11 @@ namespace Garnet.common
         /// This table is based on the CRC-16-CCITT polynomial (0x1021)
         /// </summary>
 #pragma warning disable IDE0300 // Simplify collection initialization. Ignored to avoid dotnet-format bug, see https://github.com/dotnet/sdk/issues/39898
+#if NET7_0_OR_GREATER
         private static ReadOnlySpan<ushort> Crc16Table => new ushort[256]
+#else
+        private static readonly ushort[] Crc16Table = new ushort[256]
+#endif
         {
             0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50A5, 0x60C6, 0x70E7,
             0x8108, 0x9129, 0xA14A, 0xB16B, 0xC18C, 0xD1AD, 0xE1CE, 0xF1EF,
@@ -476,11 +480,17 @@ namespace Garnet.common
         public static unsafe ushort CRC16(byte* data, int len)
         {
             ushort result = 0;
+
+#if NET7_0_OR_GREATER
+            ref var crc16Base = ref MemoryMarshal.GetReference(Crc16Table);
+#else
+            ref var crc16Base = ref MemoryMarshal.GetArrayDataReference(Crc16Table);
+#endif
             byte* end = data + len;
             while (data < end)
             {
                 nuint index = (nuint)(uint)((result >> 8) ^ *data++) & 0xff;
-                result = (ushort)(Unsafe.Add(ref MemoryMarshal.GetReference(Crc16Table), index) ^ (result << 8));
+                result = (ushort)(Unsafe.Add(ref crc16Base, index) ^ (result << 8));
             }
             return result;
         }


### PR DESCRIPTION
In #198 I switched the CRC16 table to use RVA statics which as implementation detail places the constant data table to `.data` section (and does endianness fix-ups for big-endian platforms). However the support non-byte sized primitives in RVA supported from .NET 7 onwards which made current code allocate this table on each getter call.. Oops.

This PR restores performance characteristics of the original implementation for .NET 6.