### PR TITLE
Apply CA1825, CA1827, CA1829 and CA1836

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -207,6 +207,9 @@ dotnet_diagnostic.CA1852.severity = suggestion
 # CA1813: Avoid unsealed attributes
 dotnet_diagnostic.CA1813.severity = suggestion
 
+# CA1825: Avoid zero-length array allocations
+dotnet_diagnostic.CA1825.severity = suggestion
+
 # Xml project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -201,6 +201,8 @@ csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = true:suggestion
 
+# CA18xx: Performance
+
 # CA1852: Seal internal types
 dotnet_diagnostic.CA1852.severity = suggestion
 
@@ -209,6 +211,9 @@ dotnet_diagnostic.CA1813.severity = suggestion
 
 # CA1825: Avoid zero-length array allocations
 dotnet_diagnostic.CA1825.severity = suggestion
+
+# CA1827: Do not use Count()/LongCount() when Any() can be used
+dotnet_diagnostic.CA1827.severity = suggestion
 
 # Xml project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -215,6 +215,9 @@ dotnet_diagnostic.CA1825.severity = suggestion
 # CA1827: Do not use Count()/LongCount() when Any() can be used
 dotnet_diagnostic.CA1827.severity = suggestion
 
+# CA1829: Use Length/Count property instead of Enumerable.Count method
+dotnet_diagnostic.CA1829.severity = suggestion
+
 # Xml project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -218,6 +218,9 @@ dotnet_diagnostic.CA1827.severity = suggestion
 # CA1829: Use Length/Count property instead of Enumerable.Count method
 dotnet_diagnostic.CA1829.severity = suggestion
 
+# CA1836: Prefer IsEmpty over Count when available
+dotnet_diagnostic.CA1836.severity = warning
+
 # Xml project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
 indent_size = 2

--- a/libs/server/Objects/List/ListObjectImpl.cs
+++ b/libs/server/Objects/List/ListObjectImpl.cs
@@ -47,7 +47,7 @@ namespace Garnet.server
             }
             else
             {
-                while (rem_count < Math.Abs(count) && list.Count() > 0)
+                while (rem_count < Math.Abs(count) && list.Count > 0)
                 {
                     var node = count > 0 ? list.FirstOrDefault(i => i.SequenceEqual(item)) : list.LastOrDefault(i => i.SequenceEqual(item));
                     if (node != null)

--- a/libs/storage/Tsavorite/cs/src/core/Device/LocalMemoryDevice.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Device/LocalMemoryDevice.cs
@@ -183,7 +183,7 @@ namespace Tsavorite.core
         public override void Dispose()
         {
             foreach (var q in ioQueue)
-                while (q.Count != 0) { }
+                while (!q.IsEmpty) { }
             terminated = true;
             for (int i = 0; i != ioProcessors.Length; i++)
                 ioProcessors[i].Join();

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogRecoveryInfo.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogRecoveryInfo.cs
@@ -231,7 +231,7 @@ namespace Tsavorite.core
         {
             Iterators = new Dictionary<string, long>();
 
-            if (persistedIterators.Count > 0)
+            if (!persistedIterators.IsEmpty)
             {
                 foreach (var kvp in persistedIterators)
                 {

--- a/test/Garnet.test/Resp/ACL/AclConfigurationFileTests.cs
+++ b/test/Garnet.test/Resp/ACL/AclConfigurationFileTests.cs
@@ -95,7 +95,7 @@ namespace Garnet.test.Resp.ACL
                 if (user.StartsWith("user default"))
                 {
                     // No password should have been defined
-                    Assert.IsTrue(user.Count(x => x == '#') == 0);
+                    Assert.IsTrue(!user.Contains('#'));
                 }
             }
         }

--- a/test/Garnet.test/Resp/ACL/SetUserTests.cs
+++ b/test/Garnet.test/Resp/ACL/SetUserTests.cs
@@ -377,7 +377,7 @@ namespace Garnet.test.Resp.ACL
             {
                 if (user.StartsWith($"user {TestUserA}"))
                 {
-                    Assert.IsTrue(user.Count(x => x == '#') == 0);
+                    Assert.IsTrue(!user.Contains('#'));
                 }
             }
         }

--- a/test/Garnet.test/RespHashTests.cs
+++ b/test/Garnet.test/RespHashTests.cs
@@ -294,7 +294,7 @@ namespace Garnet.test
             // HSCAN non existing key
             var members = db.HashScan("foo");
             Assert.IsTrue(((IScanningCursor)members).Cursor == 0);
-            Assert.IsTrue(members.Count() == 0, "HSCAN non existing key failed.");
+            Assert.IsEmpty(members, "HSCAN non existing key failed.");
 
             db.HashSet("user:user1", new HashEntry[] { new HashEntry("name", "Alice"), new HashEntry("email", "email@example.com"), new HashEntry("age", "30") });
 

--- a/test/Garnet.test/RespListTests.cs
+++ b/test/Garnet.test/RespListTests.cs
@@ -468,7 +468,7 @@ namespace Garnet.test
             db.ListRightPush(key, "Value-three");
 
             var result = db.ListRightPopLeftPush("mylist", "myotherlist");
-            Assert.AreEqual(result, "Value-three");
+            Assert.AreEqual("Value-three", result);
 
             var response = db.Execute("MEMORY", "USAGE", key);
             var actualValue = ResultType.Integer == response.Type ? Int32.Parse(response.ToString()) : -1;
@@ -476,16 +476,16 @@ namespace Garnet.test
             Assert.AreEqual(expectedResponse, actualValue);
 
             var lrange = db.ListRange(key, 0, -1);
-            Assert.AreEqual(lrange.Count(), 2);
-            Assert.AreEqual(lrange[0], "Value-one");
-            Assert.AreEqual(lrange[1], "Value-two");
+            Assert.AreEqual(2, lrange.Length);
+            Assert.AreEqual("Value-one", lrange[0]);
+            Assert.AreEqual("Value-two", lrange[1]);
 
             lrange = db.ListRange("myotherlist", 0, -1);
-            Assert.AreEqual(lrange.Count(), 1);
-            Assert.AreEqual(lrange[0], "Value-three");
+            Assert.AreEqual(1, lrange.Length);
+            Assert.AreEqual("Value-three", lrange[0]);
 
             result = db.ListRightPopLeftPush(key, key);
-            Assert.AreEqual(result, "Value-two");
+            Assert.AreEqual("Value-two", result);
 
             response = db.Execute("MEMORY", "USAGE", key);
             actualValue = ResultType.Integer == response.Type ? Int32.Parse(response.ToString()) : -1;
@@ -493,9 +493,9 @@ namespace Garnet.test
             Assert.AreEqual(expectedResponse, actualValue);
 
             lrange = db.ListRange(key, 0, -1);
-            Assert.AreEqual(lrange.Count(), 2);
-            Assert.AreEqual(lrange[0], "Value-two");
-            Assert.AreEqual(lrange[1], "Value-one");
+            Assert.AreEqual(2, lrange.Length);
+            Assert.AreEqual("Value-two", lrange[0]);
+            Assert.AreEqual("Value-one", lrange[1]);
         }
 
         [Test]

--- a/test/Garnet.test/RespSetTest.cs
+++ b/test/Garnet.test/RespSetTest.cs
@@ -313,7 +313,7 @@ namespace Garnet.test
 
             try
             {
-                db.SetCombine(SetOperation.Union, new RedisKey[] { });
+                db.SetCombine(SetOperation.Union, []);
                 Assert.Fail();
             }
             catch (RedisServerException e)

--- a/test/Garnet.test/RespSetTest.cs
+++ b/test/Garnet.test/RespSetTest.cs
@@ -164,7 +164,7 @@ namespace Garnet.test
 
             // Use setscan on non existing key
             var items = db.SetScan(new RedisKey("foo"), new RedisValue("*"), pageSize: 10);
-            Assert.IsTrue(items.Count() == 0, "Failed to use SetScan on non existing key");
+            Assert.IsEmpty(items, "Failed to use SetScan on non existing key");
 
             RedisValue[] entries = new RedisValue[] { "item-a", "item-b", "item-c", "item-d", "item-e", "item-aaa" };
 
@@ -185,7 +185,7 @@ namespace Garnet.test
             // No matching elements
             members = db.SetScan(new RedisKey("myset"), new RedisValue("x"));
             Assert.IsTrue(((IScanningCursor)members).Cursor == 0);
-            Assert.IsTrue(members.Count() == 0);
+            Assert.IsEmpty(members);
         }
 
         [Test]

--- a/test/Garnet.test/RespSortedSetTests.cs
+++ b/test/Garnet.test/RespSortedSetTests.cs
@@ -477,7 +477,7 @@ namespace Garnet.test
 
             // Use sortedsetscan on non existing key
             var items = db.SortedSetScan(new RedisKey("foo"), new RedisValue("*"), pageSize: 10);
-            Assert.IsTrue(items.Count() == 0, "Failed to use SortedSetScan on non existing key");
+            Assert.IsEmpty(items, "Failed to use SortedSetScan on non existing key");
 
             // Add some items
             var added = db.SortedSetAdd("myss", entries);
@@ -590,7 +590,7 @@ namespace Garnet.test
             // Test for no matching members
             members = db.SortedSetScan(key, new RedisValue("key*"), (Int32)ssLen);
             Assert.IsTrue(((IScanningCursor)members).Cursor == 0);
-            Assert.IsTrue(members.Count() == 0);
+            Assert.IsEmpty(members);
         }
 
         [Test]


### PR DESCRIPTION
This set of analyzers in the Performance-category is nits in collection/enumable length calculation. Mostly tests but will otherwise pop up in the Performance analyzer radar if not fixed or supressed. Decided to fix them, I don't feel too strongly about these.