### PR TITLE
Make Tsavorite.test path handling OS-aware

### DIFF
--- a/libs/storage/Tsavorite/cs/test/AdvancedLockTests.cs
+++ b/libs/storage/Tsavorite/cs/test/AdvancedLockTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -136,7 +137,7 @@ namespace Tsavorite.test.LockTests
         public void Setup()
         {
             DeleteDirectory(MethodTestDir, wait: true);
-            log = Devices.CreateLogDevice(MethodTestDir + "/GenericStringTests.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "GenericStringTests.log"), deleteOnClose: true);
             var readCacheSettings = new ReadCacheSettings { MemorySizeBits = 15, PageSizeBits = 9 };
 
             var concurrencyControlMode = ConcurrencyControlMode.None;
@@ -310,8 +311,8 @@ namespace Tsavorite.test.LockTests
             public void Setup()
             {
                 DeleteDirectory(MethodTestDir, wait: true);
-                checkpointDir = MethodTestDir + $"/checkpoints";
-                log = Devices.CreateLogDevice(MethodTestDir + "/test.log", deleteOnClose: true);
+                checkpointDir = Path.Join(MethodTestDir, "checkpoints");
+                log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "test.log"), deleteOnClose: true);
 
                 store1 = new TsavoriteKV<int, int>(128,
                     logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },

--- a/libs/storage/Tsavorite/cs/test/AsyncLargeObjectTests.cs
+++ b/libs/storage/Tsavorite/cs/test/AsyncLargeObjectTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Tsavorite.core;
@@ -14,20 +15,18 @@ namespace Tsavorite.test.async
         private TsavoriteKV<MyKey, MyLargeValue> store1;
         private TsavoriteKV<MyKey, MyLargeValue> store2;
         private IDevice log, objlog;
-        private string test_path;
         private readonly MyLargeFunctions functions = new();
 
         [SetUp]
         public void Setup()
         {
-            test_path = TestUtils.MethodTestDir;
-            TestUtils.RecreateDirectory(test_path);
+            TestUtils.RecreateDirectory(TestUtils.MethodTestDir);
         }
 
         [TearDown]
         public void TearDown()
         {
-            TestUtils.DeleteDirectory(test_path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         [Test]
@@ -37,12 +36,12 @@ namespace Tsavorite.test.async
             MyInput input = default;
             MyLargeOutput output = new();
 
-            log = Devices.CreateLogDevice(test_path + "/LargeObjectTest.log");
-            objlog = Devices.CreateLogDevice(test_path + "/LargeObjectTest.obj.log");
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "LargeObjectTest.log"));
+            objlog = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "LargeObjectTest.obj.log"));
 
             store1 = new(128,
                 new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 21, MemorySizeBits = 26 },
-                new CheckpointSettings { CheckpointDir = test_path },
+                new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir },
                 new SerializerSettings<MyKey, MyLargeValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyLargeValueSerializer() }
                 );
 
@@ -67,12 +66,12 @@ namespace Tsavorite.test.async
             log.Dispose();
             objlog.Dispose();
 
-            log = Devices.CreateLogDevice(test_path + "/LargeObjectTest.log");
-            objlog = Devices.CreateLogDevice(test_path + "/LargeObjectTest.obj.log");
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "LargeObjectTest.log"));
+            objlog = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "LargeObjectTest.obj.log"));
 
             store2 = new(128,
                 new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 21, MemorySizeBits = 26 },
-                new CheckpointSettings { CheckpointDir = test_path },
+                new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir },
                 new SerializerSettings<MyKey, MyLargeValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyLargeValueSerializer() }
                 );
 

--- a/libs/storage/Tsavorite/cs/test/AsyncTests.cs
+++ b/libs/storage/Tsavorite/cs/test/AsyncTests.cs
@@ -28,9 +28,9 @@ namespace Tsavorite.test.async
         public async Task AsyncRecoveryTest1(CheckpointType checkpointType)
         {
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
-            log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/AsyncRecoveryTest1.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "AsyncRecoveryTest1.log"), deleteOnClose: true);
 
-            string testPath = TestUtils.MethodTestDir + "/checkpoints4";
+            string testPath = Path.Join(TestUtils.MethodTestDir, "checkpoints4");
             Directory.CreateDirectory(testPath);
 
             store1 = new TsavoriteKV<AdId, NumClicks>

--- a/libs/storage/Tsavorite/cs/test/BasicLockTests.cs
+++ b/libs/storage/Tsavorite/cs/test/BasicLockTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -80,7 +81,7 @@ namespace Tsavorite.test.LockTests
         public void Setup()
         {
             DeleteDirectory(MethodTestDir, wait: true);
-            log = Devices.CreateLogDevice(MethodTestDir + "/GenericStringTests.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "GenericStringTests.log"), deleteOnClose: true);
             store = new TsavoriteKV<int, int>(1L << 20, new LogSettings { LogDevice = log, ObjectLogDevice = null }, comparer: new LocalComparer(), concurrencyControlMode: ConcurrencyControlMode.RecordIsolation);
             session = store.NewSession<int, int, Empty, Functions>(new Functions());
         }

--- a/libs/storage/Tsavorite/cs/test/BasicStorageTests.cs
+++ b/libs/storage/Tsavorite/cs/test/BasicStorageTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 using Tsavorite.devices;
@@ -16,7 +17,7 @@ namespace Tsavorite.test
         [Category("TsavoriteKV")]
         public void LocalStorageWriteRead()
         {
-            TestDeviceWriteRead(Devices.CreateLogDevice(TestUtils.MethodTestDir + "/BasicDiskTests.log", deleteOnClose: true));
+            TestDeviceWriteRead(Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "BasicDiskTests.log"), deleteOnClose: true));
         }
 
         [Test]
@@ -44,7 +45,7 @@ namespace Tsavorite.test
         {
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
             IDevice tested;
-            IDevice localDevice = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/BasicDiskTests.log", deleteOnClose: true, capacity: 1 << 30);
+            IDevice localDevice = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "BasicDiskTests.log"), deleteOnClose: true, capacity: 1 << 30);
             if (TestUtils.IsRunningAzureTests)
             {
                 IDevice cloudDevice = new AzureStorageDevice(TestUtils.AzureEmulatedStorageString, TestUtils.AzureTestContainer, TestUtils.AzureTestDirectory, "BasicDiskTests", logger: TestUtils.TestLoggerFactory.CreateLogger("asd"));
@@ -53,7 +54,7 @@ namespace Tsavorite.test
             else
             {
                 // If no Azure is enabled, just use another disk
-                IDevice localDevice2 = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/BasicDiskTests2.log", deleteOnClose: true, capacity: 1 << 30);
+                IDevice localDevice2 = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "BasicDiskTests2.log"), deleteOnClose: true, capacity: 1 << 30);
                 tested = new TieredStorageDevice(1, localDevice, localDevice2);
 
             }
@@ -65,8 +66,8 @@ namespace Tsavorite.test
         [Category("Smoke")]
         public void ShardedWriteRead()
         {
-            IDevice localDevice1 = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/BasicDiskTests1.log", deleteOnClose: true, capacity: 1 << 30);
-            IDevice localDevice2 = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/BasicDiskTests2.log", deleteOnClose: true, capacity: 1 << 30);
+            IDevice localDevice1 = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "BasicDiskTests1.log"), deleteOnClose: true, capacity: 1 << 30);
+            IDevice localDevice2 = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "BasicDiskTests2.log"), deleteOnClose: true, capacity: 1 << 30);
             var device = new ShardedStorageDevice(new UniformPartitionScheme(512, localDevice1, localDevice2));
             TestDeviceWriteRead(device);
         }
@@ -76,7 +77,7 @@ namespace Tsavorite.test
         [Category("Smoke")]
         public void OmitSegmentIdTest([Values] TestUtils.DeviceType deviceType)
         {
-            var filename = TestUtils.MethodTestDir + "/test.log";
+            var filename = Path.Join(TestUtils.MethodTestDir, "test.log");
             var omit = false;
             for (var ii = 0; ii < 2; ++ii)
             {

--- a/libs/storage/Tsavorite/cs/test/BlittableIterationTests.cs
+++ b/libs/storage/Tsavorite/cs/test/BlittableIterationTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Tsavorite.core;
@@ -15,15 +16,12 @@ namespace Tsavorite.test
     {
         private TsavoriteKV<KeyStruct, ValueStruct> store;
         private IDevice log;
-        private string path;
 
         [SetUp]
         public void Setup()
         {
-            path = MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
-            DeleteDirectory(path, wait: true);
+            DeleteDirectory(MethodTestDir, wait: true);
         }
 
         [TearDown]
@@ -33,7 +31,7 @@ namespace Tsavorite.test
             store = null;
             log?.Dispose();
             log = null;
-            DeleteDirectory(path);
+            DeleteDirectory(MethodTestDir);
         }
 
         internal struct BlittablePushIterationTestFunctions : IScanIteratorFunctions<KeyStruct, ValueStruct>
@@ -62,7 +60,7 @@ namespace Tsavorite.test
         [Category(SmokeTestCategory)]
         public void BlittableIterationBasicTest([Values] DeviceType deviceType, [Values] ScanIteratorType scanIteratorType)
         {
-            log = CreateTestDevice(deviceType, $"{path}{deviceType}.log");
+            log = CreateTestDevice(deviceType, Path.Join(MethodTestDir, $"{deviceType}.log"));
             store = new TsavoriteKV<KeyStruct, ValueStruct>
                  (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 9, SegmentSizeBits = 22 },
                  concurrencyControlMode: scanIteratorType == ScanIteratorType.Pull ? ConcurrencyControlMode.None : ConcurrencyControlMode.LockTable);
@@ -146,7 +144,7 @@ namespace Tsavorite.test
         [Category(SmokeTestCategory)]
         public void BlittableIterationPushStopTest()
         {
-            log = Devices.CreateLogDevice($"{path}stop_test.log");
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "stop_test.log"));
             store = new TsavoriteKV<KeyStruct, ValueStruct>
                  (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 9, SegmentSizeBits = 22 });
 
@@ -184,7 +182,7 @@ namespace Tsavorite.test
         [Category(SmokeTestCategory)]
         public unsafe void BlittableIterationPushLockTest([Values(1, 4)] int scanThreads, [Values(1, 4)] int updateThreads, [Values] ConcurrencyControlMode concurrencyControlMode, [Values] ScanMode scanMode)
         {
-            log = Devices.CreateLogDevice($"{path}lock_test.log");
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "lock_test.log"));
             // Must be large enough to contain all records in memory to exercise locking
             store = new TsavoriteKV<KeyStruct, ValueStruct>(1L << 20,
                  new LogSettings { LogDevice = log, MemorySizeBits = 25, PageSizeBits = 20, SegmentSizeBits = 22 },

--- a/libs/storage/Tsavorite/cs/test/BlittableLogCompactionTests.cs
+++ b/libs/storage/Tsavorite/cs/test/BlittableLogCompactionTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 using static Tsavorite.test.TestUtils;
@@ -37,7 +38,7 @@ namespace Tsavorite.test
         public void Setup()
         {
             DeleteDirectory(MethodTestDir, wait: true);
-            log = Devices.CreateLogDevice(MethodTestDir + "/BlittableLogCompactionTests.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "BlittableLogCompactionTests.log"), deleteOnClose: true);
 
             var concurrencyControlMode = ConcurrencyControlMode.LockTable;
             var hashMod = HashModulo.NoMod;

--- a/libs/storage/Tsavorite/cs/test/BlittableLogScanTests.cs
+++ b/libs/storage/Tsavorite/cs/test/BlittableLogScanTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 using static Tsavorite.test.TestUtils;
@@ -50,7 +51,7 @@ namespace Tsavorite.test
                 }
             }
 
-            log = Devices.CreateLogDevice(MethodTestDir + "/test.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "test.log"), deleteOnClose: true);
             store = new TsavoriteKV<KeyStruct, ValueStruct>(1L << 20,
                 new LogSettings { LogDevice = log, MemorySizeBits = 24, PageSizeBits = PageSizeBits }, concurrencyControlMode: ConcurrencyControlMode.None, comparer: comparer);
         }

--- a/libs/storage/Tsavorite/cs/test/CancellationTests.cs
+++ b/libs/storage/Tsavorite/cs/test/CancellationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 using static Tsavorite.test.TestUtils;
@@ -127,7 +128,7 @@ namespace Tsavorite.test.Cancellation
         {
             DeleteDirectory(MethodTestDir, wait: true);
 
-            log = Devices.CreateLogDevice(MethodTestDir + "/hlog.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "hlog.log"), deleteOnClose: true);
             store = new TsavoriteKV<int, int>
                 (128,
                 new LogSettings { LogDevice = log, MemorySizeBits = 17, PageSizeBits = 12 },

--- a/libs/storage/Tsavorite/cs/test/CheckpointManagerTests.cs
+++ b/libs/storage/Tsavorite/cs/test/CheckpointManagerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -38,10 +39,9 @@ namespace Tsavorite.test
                         $"{TestUtils.AzureTestContainer}/{TestUtils.AzureTestDirectory}"), false);
             }
 
-            var path = TestUtils.MethodTestDir + "/";
-            using (var log = Devices.CreateLogDevice(path + "hlog.log", deleteOnClose: true))
+            using (var log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "hlog.log"), deleteOnClose: true))
             {
-                TestUtils.RecreateDirectory(path);
+                TestUtils.RecreateDirectory(TestUtils.MethodTestDir);
 
                 using var store = new TsavoriteKV<long, long>
                 (1 << 10,
@@ -142,7 +142,7 @@ namespace Tsavorite.test
                 Assert.IsEmpty(checkpointManager.GetIndexCheckpointTokens());
             }
             checkpointManager.Dispose();
-            TestUtils.DeleteDirectory(path, wait: true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
         }
     }
 }

--- a/libs/storage/Tsavorite/cs/test/CompletePendingTests.cs
+++ b/libs/storage/Tsavorite/cs/test/CompletePendingTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Tsavorite.core;
@@ -20,7 +21,7 @@ namespace Tsavorite.test
             // Clean up log files from previous test runs in case they weren't cleaned up
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
 
-            log = Devices.CreateLogDevice($"{TestUtils.MethodTestDir}/CompletePendingTests.log", preallocateFile: true, deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "CompletePendingTests.log"), preallocateFile: true, deleteOnClose: true);
             store = new TsavoriteKV<KeyStruct, ValueStruct>(128, new LogSettings { LogDevice = log, MemorySizeBits = 29 });
         }
 

--- a/libs/storage/Tsavorite/cs/test/ComponentRecoveryTests.cs
+++ b/libs/storage/Tsavorite/cs/test/ComponentRecoveryTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Tsavorite.core;
@@ -17,7 +18,7 @@ namespace Tsavorite.test.recovery
 
             seed = 123;
             var rand1 = new Random(seed);
-            device = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/MallocFixedPageSizeRecoveryTest.dat", deleteOnClose: true);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "MallocFixedPageSizeRecoveryTest.dat"), deleteOnClose: true);
             var allocator = new MallocFixedPageSize<HashBucket>();
 
             //do something
@@ -98,8 +99,8 @@ namespace Tsavorite.test.recovery
             seed = 123;
             size = 1 << 16;
             numAdds = 1 << 18;
-            ht_device = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/TestFuzzyIndexRecoveryht.dat", deleteOnClose: true);
-            ofb_device = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/TestFuzzyIndexRecoveryofb.dat", deleteOnClose: true);
+            ht_device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "TestFuzzyIndexRecoveryht.dat"), deleteOnClose: true);
+            ofb_device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "TestFuzzyIndexRecoveryofb.dat"), deleteOnClose: true);
             hash_table1 = new TsavoriteBase();
             hash_table1.Initialize(size, 512);
 

--- a/libs/storage/Tsavorite/cs/test/DeltaLogTests.cs
+++ b/libs/storage/Tsavorite/cs/test/DeltaLogTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 
@@ -12,15 +13,12 @@ namespace Tsavorite.test
     {
         private TsavoriteLog log;
         private IDevice device;
-        private string path;
 
         [SetUp]
         public void Setup()
         {
-            path = TestUtils.MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
-            TestUtils.DeleteDirectory(path, wait: true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
         }
 
         [TearDown]
@@ -32,7 +30,7 @@ namespace Tsavorite.test
             device = null;
 
             // Clean up log files
-            TestUtils.DeleteDirectory(path, wait: true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
         }
 
         [Test]
@@ -41,8 +39,8 @@ namespace Tsavorite.test
         public void DeltaLogTest1([Values] TestUtils.DeviceType deviceType)
         {
             const int TotalCount = 200;
-            string filename = $"{path}delta_{deviceType}.log";
-            TestUtils.RecreateDirectory(path);
+            string filename = Path.Join(TestUtils.MethodTestDir, $"delta_{deviceType}.log");
+            TestUtils.RecreateDirectory(TestUtils.MethodTestDir);
 
             device = TestUtils.CreateTestDevice(deviceType, filename);
             device.Initialize(-1);

--- a/libs/storage/Tsavorite/cs/test/DeviceLogTests.cs
+++ b/libs/storage/Tsavorite/cs/test/DeviceLogTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -24,7 +25,7 @@ namespace Tsavorite.test
         public async ValueTask PageBlobTsavoriteLogTest1([Values] LogChecksumType logChecksum, [Values] TsavoriteLogTestBase.IteratorType iteratorType)
         {
             TestUtils.IgnoreIfNotRunningAzureTests();
-            var device = new AzureStorageDevice(TestUtils.AzureEmulatedStorageString, $"{TestUtils.AzureTestContainer}", TestUtils.AzureTestDirectory, "Tsavoritelog.log", deleteOnClose: true, logger: TestUtils.TestLoggerFactory.CreateLogger("asd"));
+            var device = new AzureStorageDevice(TestUtils.AzureEmulatedStorageString, TestUtils.AzureTestContainer, TestUtils.AzureTestDirectory, "Tsavoritelog.log", deleteOnClose: true, logger: TestUtils.TestLoggerFactory.CreateLogger("asd"));
             var checkpointManager = new DeviceLogCommitCheckpointManager(
                 new AzureStorageNamedDeviceFactory(TestUtils.AzureEmulatedStorageString),
                 new DefaultCheckpointNamingScheme($"{TestUtils.AzureTestContainer}/{TestUtils.AzureTestDirectory}"));
@@ -57,7 +58,7 @@ namespace Tsavorite.test
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
 
             // Create devices \ log for test for in memory device
-            using var device = new LocalMemoryDevice(1L << 28, 1L << 25, 2, latencyMs: 20, fileName: TestUtils.MethodTestDir + "/test.log");
+            using var device = new LocalMemoryDevice(1L << 28, 1L << 25, 2, latencyMs: 20, fileName: Path.Join(TestUtils.MethodTestDir, "test.log"));
             using var LocalMemorylog = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 80, MemorySizeBits = 20, GetMemory = null, SegmentSizeBits = 80, MutableFraction = 0.2, LogCommitManager = null });
 
             int entryLength = 10;

--- a/libs/storage/Tsavorite/cs/test/DeviceTests.cs
+++ b/libs/storage/Tsavorite/cs/test/DeviceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -16,14 +17,11 @@ namespace Tsavorite.test
         const int entryLength = 1024;
         SectorAlignedBufferPool bufferPool;
         readonly byte[] entry = new byte[entryLength];
-        string path;
         SemaphoreSlim semaphore;
 
         [SetUp]
         public void Setup()
         {
-            path = TestUtils.MethodTestDir + "/test.log";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
 
@@ -49,7 +47,7 @@ namespace Tsavorite.test
         public void NativeDeviceTest1()
         {
             // Create devices \ log for test for in memory device
-            using var device = new NativeStorageDevice(path, true); // Devices.CreateLogDevice(path, deleteOnClose: true)
+            using var device = new NativeStorageDevice(Path.Join(TestUtils.MethodTestDir, "test.log"), true); // Devices.CreateLogDevice(path, deleteOnClose: true)
 
             WriteInto(device, 0, entry, entryLength);
             ReadInto(device, 0, out var readEntry, entryLength);
@@ -74,7 +72,7 @@ namespace Tsavorite.test
                 var buffer = buffers[i];
                 IntPtr alignedBufferPtr = (IntPtr)(((long)Unsafe.AsPointer(ref buffer[0]) + (sector_size - 1)) & ~(sector_size - 1));
 
-                using var device = new NativeStorageDevice(path, true);
+                using var device = new NativeStorageDevice(Path.Join(TestUtils.MethodTestDir, "test.log"), true);
 
                 device.WriteAsync(alignedBufferPtr, 0, (uint)size, IOCallback, null);
                 semaphore.Wait();

--- a/libs/storage/Tsavorite/cs/test/DisposeTests.cs
+++ b/libs/storage/Tsavorite/cs/test/DisposeTests.cs
@@ -35,8 +35,8 @@ namespace Tsavorite.test.Dispose
             sutGate = new(0);
             otherGate = new(0);
 
-            log = Devices.CreateLogDevice(MethodTestDir + "/ObjectTests.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(MethodTestDir + "/ObjectTests.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "ObjectTests.log"), deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(Path.Join(MethodTestDir, "ObjectTests.obj.log"), deleteOnClose: true);
 
             LogSettings logSettings = new() { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 15, PageSizeBits = 10 };
             var concurrencyControlMode = ConcurrencyControlMode.None;

--- a/libs/storage/Tsavorite/cs/test/EnqueueAndWaitForCommit.cs
+++ b/libs/storage/Tsavorite/cs/test/EnqueueAndWaitForCommit.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Tsavorite.core;
@@ -17,7 +18,6 @@ namespace Tsavorite.test
         public IDevice device;
         static byte[] entry;
         static ReadOnlySpanBatch spanBatch;
-        private string path;
 
         public enum EnqueueIteratorType
         {
@@ -40,13 +40,11 @@ namespace Tsavorite.test
             entry = new byte[entryLength];
             spanBatch = new(numEntries);
 
-            path = TestUtils.MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
-            TestUtils.DeleteDirectory(path, wait: true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
 
             // Create devices \ log for test
-            device = Devices.CreateLogDevice(path + "EnqueueAndWaitForCommit.log", deleteOnClose: true);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "EnqueueAndWaitForCommit.log"), deleteOnClose: true);
             log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device });
         }
 
@@ -59,7 +57,7 @@ namespace Tsavorite.test
             device = null;
 
             // Clean up log files
-            TestUtils.DeleteDirectory(path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         [Test]

--- a/libs/storage/Tsavorite/cs/test/EnqueueTests.cs
+++ b/libs/storage/Tsavorite/cs/test/EnqueueTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,7 +17,6 @@ namespace Tsavorite.test
         private TsavoriteLog log;
         private IDevice device;
         static byte[] entry;
-        private string path;
 
         public enum EnqueueIteratorType
         {
@@ -48,10 +48,9 @@ namespace Tsavorite.test
         public void Setup()
         {
             entry = new byte[100];
-            path = TestUtils.MethodTestDir + "/";
 
             // Clean up log files from previous test runs in case they weren't cleaned up
-            TestUtils.DeleteDirectory(path, wait: true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
         }
 
         [TearDown]
@@ -63,7 +62,7 @@ namespace Tsavorite.test
             device = null;
 
             // Clean up log files
-            TestUtils.DeleteDirectory(path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         [Test]
@@ -76,9 +75,9 @@ namespace Tsavorite.test
             int numEntries = 500;
             int entryFlag = 9999;
 
-            string filename = path + "Enqueue" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "Enqueue" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
-            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = path }); // Needs to match what is set in TestUtils.CreateTestDevice 
+            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = TestUtils.MethodTestDir }); // Needs to match what is set in TestUtils.CreateTestDevice 
 
             // Reduce SpanBatch to make sure entry fits on page
             if (iteratorType == EnqueueIteratorType.SpanBatch)
@@ -170,9 +169,9 @@ namespace Tsavorite.test
 
             const int expectedEntryCount = 11;
 
-            string filename = path + "EnqueueAsyncBasic" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "EnqueueAsyncBasic" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
-            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = path });
+            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = TestUtils.MethodTestDir });
 
 #if WINDOWS
             if (deviceType == TestUtils.DeviceType.EmulatedAzure)

--- a/libs/storage/Tsavorite/cs/test/ExpirationTests.cs
+++ b/libs/storage/Tsavorite/cs/test/ExpirationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 using static Tsavorite.test.TestUtils;
@@ -510,7 +511,6 @@ namespace Tsavorite.test.Expiration
                 => SpanByteFunctions<Empty>.DoSafeCopy(ref src, ref dst, ref upsertInfo, ref recordInfo);
         }
 
-        private string path;
         IDevice log;
         ExpirationFunctions functions;
         TsavoriteKV<SpanByte, SpanByte> store;
@@ -519,10 +519,9 @@ namespace Tsavorite.test.Expiration
         [SetUp]
         public void Setup()
         {
-            path = MethodTestDir + "/";
             DeleteDirectory(MethodTestDir, wait: true);
 
-            log = Devices.CreateLogDevice(MethodTestDir + "/hlog.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "hlog.log"), deleteOnClose: true);
             store = new TsavoriteKV<SpanByte, SpanByte>
                 (128,
                 new LogSettings { LogDevice = log, MemorySizeBits = 19, PageSizeBits = 14 },
@@ -541,7 +540,7 @@ namespace Tsavorite.test.Expiration
             store = null;
             log?.Dispose();
             log = null;
-            DeleteDirectory(path);
+            DeleteDirectory(MethodTestDir);
         }
 
         private unsafe void Populate(Random rng)

--- a/libs/storage/Tsavorite/cs/test/FlakyDeviceTests.cs
+++ b/libs/storage/Tsavorite/cs/test/FlakyDeviceTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,7 +33,7 @@ namespace Tsavorite.test
                 writeTransientErrorRate = 0,
                 writePermanentErrorRate = 0.1,
             };
-            device = new SimulatedFlakyDevice(Devices.CreateLogDevice(path + "tsavoritelog.log", deleteOnClose: true),
+            device = new SimulatedFlakyDevice(Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "tsavoritelog.log"), deleteOnClose: true),
                 errorOptions);
             var logSettings = new TsavoriteLogSettings
             { LogDevice = device, LogChecksum = LogChecksumType.PerEntry, LogCommitManager = manager };
@@ -81,7 +82,7 @@ namespace Tsavorite.test
                 writeTransientErrorRate = 0,
                 writePermanentErrorRate = 0.05,
             };
-            device = new SimulatedFlakyDevice(Devices.CreateLogDevice(path + "tsavoritelog.log", deleteOnClose: true),
+            device = new SimulatedFlakyDevice(Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "tsavoritelog.log"), deleteOnClose: true),
                 errorOptions);
             var logSettings = new TsavoriteLogSettings
             { LogDevice = device, LogChecksum = LogChecksumType.PerEntry, LogCommitManager = manager };
@@ -147,7 +148,7 @@ namespace Tsavorite.test
                 writeTransientErrorRate = 0,
                 writePermanentErrorRate = 0.1,
             };
-            device = new SimulatedFlakyDevice(Devices.CreateLogDevice(path + "tsavoritelog.log", deleteOnClose: true),
+            device = new SimulatedFlakyDevice(Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "tsavoritelog.log"), deleteOnClose: true),
                 errorOptions);
             var logSettings = new TsavoriteLogSettings
             { LogDevice = device, LogChecksum = LogChecksumType.PerEntry, LogCommitManager = manager, TolerateDeviceFailure = true };

--- a/libs/storage/Tsavorite/cs/test/FunctionPerSessionTests.cs
+++ b/libs/storage/Tsavorite/cs/test/FunctionPerSessionTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -113,7 +114,7 @@ namespace Tsavorite.test
         public void Setup()
         {
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
-            _log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/FunctionPerSessionTests1.log", deleteOnClose: true);
+            _log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "FunctionPerSessionTests1.log"), deleteOnClose: true);
 
             _tsavorite = new TsavoriteKV<int, RefCountedValue>(128, new LogSettings()
             {

--- a/libs/storage/Tsavorite/cs/test/GenericByteArrayTests.cs
+++ b/libs/storage/Tsavorite/cs/test/GenericByteArrayTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using Tsavorite.core;
@@ -20,8 +21,8 @@ namespace Tsavorite.test
         public void Setup()
         {
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
-            log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/GenericStringTests.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/GenericStringTests.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "GenericStringTests.log"), deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "GenericStringTests.obj.log"), deleteOnClose: true);
 
             store = new TsavoriteKV<byte[], byte[]>(
                     1L << 20, // size of hash table in #cache lines; 64 bytes per cache line

--- a/libs/storage/Tsavorite/cs/test/GenericDiskDeleteTests.cs
+++ b/libs/storage/Tsavorite/cs/test/GenericDiskDeleteTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 using static Tsavorite.test.TestUtils;
@@ -18,8 +19,8 @@ namespace Tsavorite.test
         public void Setup()
         {
             DeleteDirectory(MethodTestDir, wait: true);
-            log = Devices.CreateLogDevice(MethodTestDir + "/GenericDiskDeleteTests.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(MethodTestDir + "/GenericDiskDeleteTests.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "GenericDiskDeleteTests.log"), deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(Path.Join(MethodTestDir, "GenericDiskDeleteTests.obj.log"), deleteOnClose: true);
 
             store = new TsavoriteKV<MyKey, MyValue>
                 (128,

--- a/libs/storage/Tsavorite/cs/test/GenericIterationTests.cs
+++ b/libs/storage/Tsavorite/cs/test/GenericIterationTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Tsavorite.core;
@@ -34,8 +35,8 @@ namespace Tsavorite.test
         private void InternalSetup(ConcurrencyControlMode concurrencyControlMode, bool largeMemory)
         {
             // Broke this out as we have different requirements by test.
-            log = Devices.CreateLogDevice(MethodTestDir + "/GenericIterationTests.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(MethodTestDir + "/GenericIterationTests.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "GenericIterationTests.log"), deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(Path.Join(MethodTestDir, "GenericIterationTests.obj.log"), deleteOnClose: true);
 
             store = new TsavoriteKV<MyKey, MyValue>
                 (128,

--- a/libs/storage/Tsavorite/cs/test/GenericLogCompactionTests.cs
+++ b/libs/storage/Tsavorite/cs/test/GenericLogCompactionTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 using static Tsavorite.test.TestUtils;
@@ -13,21 +14,18 @@ namespace Tsavorite.test
         private TsavoriteKV<MyKey, MyValue> store;
         private ClientSession<MyKey, MyValue, MyInput, MyOutput, int, MyFunctionsDelete> session;
         private IDevice log, objlog;
-        private string path;
 
         [SetUp]
         public void Setup()
         {
-            path = MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
-            DeleteDirectory(path, wait: true);
+            DeleteDirectory(MethodTestDir, wait: true);
 
             if (TestContext.CurrentContext.Test.Arguments.Length == 0)
             {
                 // Default log creation
-                log = Devices.CreateLogDevice(path + "/GenericLogCompactionTests.log", deleteOnClose: true);
-                objlog = Devices.CreateLogDevice(path + "/GenericLogCompactionTests.obj.log", deleteOnClose: true);
+                log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "GenericLogCompactionTests.log"), deleteOnClose: true);
+                objlog = Devices.CreateLogDevice(Path.Join(MethodTestDir, "GenericLogCompactionTests.obj.log"), deleteOnClose: true);
 
                 store = new TsavoriteKV<MyKey, MyValue>
                     (128,
@@ -41,8 +39,8 @@ namespace Tsavorite.test
                 // so for multi-parameter tests it is probably better to stay with the "separate SetUp method" approach.
                 var deviceType = (DeviceType)TestContext.CurrentContext.Test.Arguments[0];
 
-                log = CreateTestDevice(deviceType, $"{path}LogCompactBasicTest_{deviceType}.log");
-                objlog = CreateTestDevice(deviceType, $"{path}LogCompactBasicTest_{deviceType}.obj.log");
+                log = CreateTestDevice(deviceType, Path.Join(MethodTestDir, $"LogCompactBasicTest_{deviceType}.log"));
+                objlog = CreateTestDevice(deviceType, Path.Join(MethodTestDir, $"LogCompactBasicTest_{deviceType}.obj.log"));
 
                 store = new TsavoriteKV<MyKey, MyValue>
                     (128,
@@ -65,7 +63,7 @@ namespace Tsavorite.test
             objlog?.Dispose();
             objlog = null;
 
-            DeleteDirectory(path);
+            DeleteDirectory(MethodTestDir);
         }
 
         // Basic test that where shift begin address to untilAddress after compact

--- a/libs/storage/Tsavorite/cs/test/GenericLogScanTests.cs
+++ b/libs/storage/Tsavorite/cs/test/GenericLogScanTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 using static Tsavorite.test.TestUtils;
@@ -14,7 +15,6 @@ namespace Tsavorite.test
         private TsavoriteKV<MyKey, MyValue> store;
         private IDevice log, objlog;
         const int totalRecords = 250;
-        private string path;
 
         ITsavoriteEqualityComparer<MyKey> comparer = null;
 
@@ -37,10 +37,8 @@ namespace Tsavorite.test
         [SetUp]
         public void Setup()
         {
-            path = MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
-            DeleteDirectory(path, wait: true);
+            DeleteDirectory(TestUtils.MethodTestDir, wait: true);
 
             comparer = null;
             foreach (var arg in TestContext.CurrentContext.Test.Arguments)
@@ -63,7 +61,7 @@ namespace Tsavorite.test
             objlog?.Dispose();
             objlog = null;
 
-            DeleteDirectory(path);
+            DeleteDirectory(MethodTestDir);
         }
 
         internal struct GenericPushScanTestFunctions : IScanIteratorFunctions<MyKey, MyValue>
@@ -95,8 +93,8 @@ namespace Tsavorite.test
         [Category("Smoke")]
         public void DiskWriteScanBasicTest([Values] DeviceType deviceType, [Values] ScanIteratorType scanIteratorType)
         {
-            log = CreateTestDevice(deviceType, $"{path}DiskWriteScanBasicTest_{deviceType}.log");
-            objlog = CreateTestDevice(deviceType, $"{path}DiskWriteScanBasicTest_{deviceType}.obj.log");
+            log = CreateTestDevice(deviceType, Path.Join(MethodTestDir, $"DiskWriteScanBasicTest_{deviceType}.log"));
+            objlog = CreateTestDevice(deviceType, Path.Join(MethodTestDir, $"DiskWriteScanBasicTest_{deviceType}.obj.log"));
             store = new(128,
                       logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 15, PageSizeBits = 9, SegmentSizeBits = 22 },
                       serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() },
@@ -169,8 +167,8 @@ namespace Tsavorite.test
 
         public void BlittableScanJumpToBeginAddressTest()
         {
-            log = Devices.CreateLogDevice($"{MethodTestDir}/test.log");
-            objlog = Devices.CreateLogDevice($"{MethodTestDir}/test.obj.log");
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "test.log"));
+            objlog = Devices.CreateLogDevice(Path.Join(MethodTestDir, "test.obj.log"));
             store = new(128,
                       logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 20, PageSizeBits = 15, SegmentSizeBits = 18 },
                       serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() },
@@ -238,8 +236,8 @@ namespace Tsavorite.test
             const long PageSize = 1L << PageSizeBits;
             var recordSize = GenericAllocator<MyKey, MyValue>.RecordSize;
 
-            log = Devices.CreateLogDevice($"{MethodTestDir}/test.log");
-            objlog = Devices.CreateLogDevice($"{MethodTestDir}/test.obj.log");
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "test.log"));
+            objlog = Devices.CreateLogDevice(Path.Join(MethodTestDir, "test.obj.log"));
             store = new(128,
                       logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 20, PageSizeBits = 15, SegmentSizeBits = 18 },
                       serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() },
@@ -329,8 +327,8 @@ namespace Tsavorite.test
 
         public void GenericScanCursorFilterTest([Values(HashModulo.NoMod, HashModulo.Hundred)] HashModulo hashMod)
         {
-            log = Devices.CreateLogDevice($"{MethodTestDir}/test.log");
-            objlog = Devices.CreateLogDevice($"{MethodTestDir}/test.obj.log");
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "test.log"));
+            objlog = Devices.CreateLogDevice(Path.Join(MethodTestDir, "test.obj.log"));
             store = new(128,
                       logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 20, PageSizeBits = 15, SegmentSizeBits = 18 },
                       serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() },

--- a/libs/storage/Tsavorite/cs/test/GenericStringTests.cs
+++ b/libs/storage/Tsavorite/cs/test/GenericStringTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 using static Tsavorite.test.TestUtils;
@@ -13,15 +14,12 @@ namespace Tsavorite.test
         private TsavoriteKV<string, string> store;
         private ClientSession<string, string, string, string, Empty, MyFuncs> session;
         private IDevice log, objlog;
-        private string path;
 
         [SetUp]
         public void Setup()
         {
-            path = MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
-            DeleteDirectory(path, wait: true);
+            DeleteDirectory(MethodTestDir, wait: true);
         }
 
         [TearDown]
@@ -36,7 +34,7 @@ namespace Tsavorite.test
             objlog?.Dispose();
             objlog = null;
 
-            DeleteDirectory(path);
+            DeleteDirectory(MethodTestDir);
         }
 
         [Test]
@@ -44,8 +42,8 @@ namespace Tsavorite.test
         [Category("Smoke")]
         public void StringBasicTest([Values] DeviceType deviceType)
         {
-            string logfilename = path + "GenericStringTests" + deviceType.ToString() + ".log";
-            string objlogfilename = path + "GenericStringTests" + deviceType.ToString() + ".obj.log";
+            string logfilename = Path.Join(MethodTestDir, "GenericStringTests" + deviceType.ToString() + ".log");
+            string objlogfilename = Path.Join(MethodTestDir, "GenericStringTests" + deviceType.ToString() + ".obj.log");
 
             log = CreateTestDevice(deviceType, logfilename);
             objlog = CreateTestDevice(deviceType, objlogfilename);

--- a/libs/storage/Tsavorite/cs/test/LargeObjectTests.cs
+++ b/libs/storage/Tsavorite/cs/test/LargeObjectTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 
@@ -13,19 +14,17 @@ namespace Tsavorite.test.largeobjects
         private TsavoriteKV<MyKey, MyLargeValue> store1;
         private TsavoriteKV<MyKey, MyLargeValue> store2;
         private IDevice log, objlog;
-        private string test_path;
 
         [SetUp]
         public void Setup()
         {
-            test_path = TestUtils.MethodTestDir;
-            TestUtils.RecreateDirectory(test_path);
+            TestUtils.RecreateDirectory(TestUtils.MethodTestDir);
         }
 
         [TearDown]
         public void TearDown()
         {
-            TestUtils.DeleteDirectory(test_path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         [TestCase(CheckpointType.FoldOver)]
@@ -36,13 +35,13 @@ namespace Tsavorite.test.largeobjects
             MyInput input = default;
             MyLargeOutput output = new MyLargeOutput();
 
-            log = Devices.CreateLogDevice(test_path + "/LargeObjectTest.log");
-            objlog = Devices.CreateLogDevice(test_path + "/LargeObjectTest.obj.log");
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "LargeObjectTest.log"));
+            objlog = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "LargeObjectTest.obj.log"));
 
             store1 = new TsavoriteKV<MyKey, MyLargeValue>
                 (128,
                 new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 21, MemorySizeBits = 26 },
-                new CheckpointSettings { CheckpointDir = test_path },
+                new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir },
                 new SerializerSettings<MyKey, MyLargeValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyLargeValueSerializer() }
                 );
 
@@ -65,13 +64,13 @@ namespace Tsavorite.test.largeobjects
             log.Dispose();
             objlog.Dispose();
 
-            log = Devices.CreateLogDevice(test_path + "/LargeObjectTest.log");
-            objlog = Devices.CreateLogDevice(test_path + "/LargeObjectTest.obj.log");
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "LargeObjectTest.log"));
+            objlog = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "LargeObjectTest.obj.log"));
 
             store2 = new TsavoriteKV<MyKey, MyLargeValue>
                 (128,
                 new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 21, MemorySizeBits = 26 },
-                new CheckpointSettings { CheckpointDir = test_path },
+                new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir },
                 new SerializerSettings<MyKey, MyLargeValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyLargeValueSerializer() }
                 );
 

--- a/libs/storage/Tsavorite/cs/test/LogAndDeviceConfigTests.cs
+++ b/libs/storage/Tsavorite/cs/test/LogAndDeviceConfigTests.cs
@@ -17,19 +17,16 @@ namespace Tsavorite.test
     {
         private TsavoriteLog log;
         private IDevice device;
-        private string path;
         static readonly byte[] entry = new byte[100];
 
         [SetUp]
         public void Setup()
         {
-            path = TestUtils.MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
-            TestUtils.DeleteDirectory(path, wait: true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
 
             // Create devices \ log for test
-            device = Devices.CreateLogDevice(path + "DeviceConfig", deleteOnClose: true, recoverDevice: true, preallocateFile: true, capacity: 1 << 30);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "DeviceConfig"), deleteOnClose: true, recoverDevice: true, preallocateFile: true, capacity: 1 << 30);
             log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 80, MemorySizeBits = 20, GetMemory = null, SegmentSizeBits = 80, MutableFraction = 0.2, LogCommitManager = null });
         }
 
@@ -42,7 +39,7 @@ namespace Tsavorite.test
             device = null;
 
             // Clean up log files
-            TestUtils.DeleteDirectory(path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         [Test]
@@ -63,8 +60,8 @@ namespace Tsavorite.test
             log.Commit(true);
 
             // Verify  
-            Assert.IsTrue(File.Exists(path + "/log-commits/commit.1.0"));
-            Assert.IsTrue(File.Exists(path + "/DeviceConfig.0"));
+            Assert.IsTrue(File.Exists(Path.Join(TestUtils.MethodTestDir, "log-commits", "commit.1.0")));
+            Assert.IsTrue(File.Exists(Path.Join(TestUtils.MethodTestDir, "DeviceConfig.0")));
 
             // Read the log just to verify can actually read it
             int currentEntry = 0;

--- a/libs/storage/Tsavorite/cs/test/LogFastCommitTests.cs
+++ b/libs/storage/Tsavorite/cs/test/LogFastCommitTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using NUnit.Framework;
 using Tsavorite.core;
@@ -26,7 +27,7 @@ namespace Tsavorite.test
             var cookie = new byte[100];
             new Random().NextBytes(cookie);
 
-            var filename = path + "fastCommit" + deviceType.ToString() + ".log";
+            var filename = Path.Join(TestUtils.MethodTestDir, $"fastCommit{deviceType}.log");
             device = TestUtils.CreateTestDevice(deviceType, filename, deleteOnClose: true);
             var logSettings = new TsavoriteLogSettings { LogDevice = device, LogChecksum = LogChecksumType.PerEntry, LogCommitManager = manager, FastCommitMode = true, TryRecoverLatest = false, SegmentSizeBits = 26 };
             log = new TsavoriteLog(logSettings);
@@ -101,7 +102,7 @@ namespace Tsavorite.test
             var cookie = new byte[100];
             new Random().NextBytes(cookie);
 
-            var filename = path + "boundedGrowth" + deviceType.ToString() + ".log";
+            var filename = Path.Join(TestUtils.MethodTestDir, $"boundedGrowth{deviceType}.log");
             device = TestUtils.CreateTestDevice(deviceType, filename, deleteOnClose: true);
             var logSettings = new TsavoriteLogSettings { LogDevice = device, LogChecksum = LogChecksumType.PerEntry, LogCommitManager = manager, FastCommitMode = true, SegmentSizeBits = 26 };
             log = new TsavoriteLog(logSettings);

--- a/libs/storage/Tsavorite/cs/test/LogReadAsyncTests.cs
+++ b/libs/storage/Tsavorite/cs/test/LogReadAsyncTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Buffers;
+using System.IO;
 using System.Threading;
 using NUnit.Framework;
 using Tsavorite.core;
@@ -13,7 +14,6 @@ namespace Tsavorite.test
     {
         private TsavoriteLog log;
         private IDevice device;
-        private string path;
 
         public enum ParameterDefaultsIteratorType
         {
@@ -25,10 +25,8 @@ namespace Tsavorite.test
         [SetUp]
         public void Setup()
         {
-            path = TestUtils.MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
-            TestUtils.DeleteDirectory(path, wait: true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
 
         }
 
@@ -52,9 +50,9 @@ namespace Tsavorite.test
             int entryLength = 20;
             int numEntries = 500;
             int entryFlag = 9999;
-            string filename = path + "LogReadAsync" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, $"LogReadAsync{deviceType}.log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
-            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = path });
+            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = TestUtils.MethodTestDir });
 
             byte[] entry = new byte[entryLength];
 

--- a/libs/storage/Tsavorite/cs/test/LogRecoverReadOnlyTests.cs
+++ b/libs/storage/Tsavorite/cs/test/LogRecoverReadOnlyTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,7 +19,6 @@ namespace Tsavorite.test.recovery
         const int RestorePeriodMs = 5;
         const int NumElements = 100;
 
-        string path;
         string deviceName;
         CancellationTokenSource cts;
         SemaphoreSlim done;
@@ -26,11 +26,10 @@ namespace Tsavorite.test.recovery
         [SetUp]
         public void Setup()
         {
-            path = TestUtils.MethodTestDir + "/";
-            deviceName = path + "testlog";
+            deviceName = Path.Join(TestUtils.MethodTestDir, "testlog");
 
             // Clean up log files from previous test runs in case they weren't cleaned up
-            TestUtils.DeleteDirectory(path, wait: true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
 
             cts = new CancellationTokenSource();
             done = new SemaphoreSlim(0);
@@ -43,7 +42,7 @@ namespace Tsavorite.test.recovery
             cts = default;
             done?.Dispose();
             done = default;
-            TestUtils.DeleteDirectory(path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         [Test]

--- a/libs/storage/Tsavorite/cs/test/LogResumeTests.cs
+++ b/libs/storage/Tsavorite/cs/test/LogResumeTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,16 +15,13 @@ namespace Tsavorite.test
     internal class LogResumeTests
     {
         private IDevice device;
-        private string path;
 
         [SetUp]
         public void Setup()
         {
-            path = TestUtils.MethodTestDir + "/";
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
 
-            TestUtils.DeleteDirectory(path, wait: true);
-
-            device = Devices.CreateLogDevice(path + "Tsavoritelog.log", deleteOnClose: true);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "Tsavoritelog.log"), deleteOnClose: true);
         }
 
         [TearDown]
@@ -31,7 +29,7 @@ namespace Tsavorite.test
         {
             device?.Dispose();
             device = null;
-            TestUtils.DeleteDirectory(path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         [Test]
@@ -109,7 +107,7 @@ namespace Tsavorite.test
             var input3 = new byte[] { 11, 12 };
             string readerName = "abc";
 
-            using (var logCommitManager = new DeviceLogCommitCheckpointManager(new LocalStorageNamedDeviceFactory(), new DefaultCheckpointNamingScheme(path), removeOutdated))
+            using (var logCommitManager = new DeviceLogCommitCheckpointManager(new LocalStorageNamedDeviceFactory(), new DefaultCheckpointNamingScheme(TestUtils.MethodTestDir), removeOutdated))
             {
                 long originalCompleted;
 
@@ -152,7 +150,7 @@ namespace Tsavorite.test
             var input3 = new byte[] { 11, 12 };
             string readerName = "abcd";
 
-            using (var logCommitManager = new DeviceLogCommitCheckpointManager(new LocalStorageNamedDeviceFactory(), new DefaultCheckpointNamingScheme(path), removeOutdated))
+            using (var logCommitManager = new DeviceLogCommitCheckpointManager(new LocalStorageNamedDeviceFactory(), new DefaultCheckpointNamingScheme(TestUtils.MethodTestDir), removeOutdated))
             {
                 long originalCompleted;
 

--- a/libs/storage/Tsavorite/cs/test/LogScanTests.cs
+++ b/libs/storage/Tsavorite/cs/test/LogScanTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using System.Threading;
 using NUnit.Framework;
 using Tsavorite.core;
@@ -16,7 +17,6 @@ namespace Tsavorite.test
         private TsavoriteLog logUncommitted;
         private IDevice deviceUnCommitted;
 
-        private string path;
         static byte[] entry;
         const int entryLength = 100;
         const int numEntries = 1000;
@@ -27,10 +27,8 @@ namespace Tsavorite.test
         public void Setup()
         {
             entry = new byte[100];
-            path = TestUtils.MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
-            TestUtils.DeleteDirectory(path, wait: true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
         }
 
         [TearDown]
@@ -46,7 +44,7 @@ namespace Tsavorite.test
             logUncommitted = null;
 
             // Clean up log files
-            TestUtils.DeleteDirectory(path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         public void PopulateLog(TsavoriteLog log)
@@ -104,9 +102,9 @@ namespace Tsavorite.test
         public void ScanBasicDefaultTest([Values] TestUtils.DeviceType deviceType)
         {
             // Create log and device here (not in setup) because using DeviceType Enum which can't be used in Setup
-            string filename = path + "LogScanDefault" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "LogScanDefault" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
-            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = path });
+            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = TestUtils.MethodTestDir });
             PopulateLog(log);
 
             // Basic default scan from start to end 
@@ -137,9 +135,9 @@ namespace Tsavorite.test
         public void ScanBehindBeginAddressTest([Values] TestUtils.DeviceType deviceType)
         {
             // Create log and device here (not in setup) because using DeviceType Enum which can't be used in Setup
-            string filename = path + "LogScanDefault" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "LogScanDefault" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
-            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = path });
+            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = TestUtils.MethodTestDir });
             PopulateLog(log);
 
             // Basic default scan from start to end 
@@ -202,9 +200,9 @@ namespace Tsavorite.test
         public void ScanConsumerTest([Values] TestUtils.DeviceType deviceType)
         {
             // Create log and device here (not in setup) because using DeviceType Enum which can't be used in Setup
-            string filename = path + "LogScanDefault" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "LogScanDefault" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
-            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = path });
+            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = TestUtils.MethodTestDir });
             PopulateLog(log);
 
             // Basic default scan from start to end 
@@ -228,9 +226,9 @@ namespace Tsavorite.test
             // Test where all params are set just to make sure handles it ok
 
             // Create log and device here (not in setup) because using DeviceType Enum which can't be used in Setup
-            string filename = path + "LogScanNoDefault" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "LogScanNoDefault" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
-            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = path });
+            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = TestUtils.MethodTestDir });
             PopulateLog(log);
 
             // Read the log - Look for the flag so know each entry is unique
@@ -260,9 +258,9 @@ namespace Tsavorite.test
             //You can persist iterators(or more precisely, their CompletedUntilAddress) as part of a commit by simply naming them during their creation. 
 
             // Create log and device here (not in setup) because using DeviceType Enum which can't be used in Setup
-            string filename = path + "LogScanByName" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "LogScanByName" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
-            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = path });
+            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = TestUtils.MethodTestDir });
             PopulateLog(log);
 
             // Read the log - Look for the flag so know each entry is unique
@@ -292,9 +290,9 @@ namespace Tsavorite.test
             // You may also force an iterator to start at the specified begin address, i.e., without recovering: recover parameter = false
 
             // Create log and device here (not in setup) because using DeviceType Enum which can't be used in Setup
-            string filename = path + "LogScanWithoutRecover" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "LogScanWithoutRecover" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
-            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = path });
+            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = TestUtils.MethodTestDir });
             PopulateLog(log);
 
             // Read the log 
@@ -324,9 +322,9 @@ namespace Tsavorite.test
             // Same as default, but do it just to make sure have test in case default changes
 
             // Create log and device here (not in setup) because using DeviceType Enum which can't be used in Setup
-            string filename = path + "LogScanDoublePage" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "LogScanDoublePage" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
-            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = path });
+            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = TestUtils.MethodTestDir });
             PopulateLog(log);
 
             // Read the log - Look for the flag so know each entry is unique
@@ -354,9 +352,9 @@ namespace Tsavorite.test
         public void ScanBufferingModeSinglePageTest([Values] TestUtils.DeviceType deviceType)
         {
             // Create log and device here (not in setup) because using DeviceType Enum which can't be used in Setup
-            string filename = path + "LogScanSinglePage" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "LogScanSinglePage" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
-            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = path });
+            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = TestUtils.MethodTestDir });
             PopulateLog(log);
 
             // Read the log - Look for the flag so know each entry is unique
@@ -384,9 +382,9 @@ namespace Tsavorite.test
         public void ScanUncommittedTest([Values] TestUtils.DeviceType deviceType)
         {
             // Create log and device here (not in setup) because using DeviceType Enum which can't be used in Setup
-            string filename = path + "LogScan" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "LogScan" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
-            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = path, AutoRefreshSafeTailAddress = true });
+            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = TestUtils.MethodTestDir, AutoRefreshSafeTailAddress = true });
             PopulateUncommittedLog(log);
 
             // Setting scanUnCommitted to true is actual test here.

--- a/libs/storage/Tsavorite/cs/test/LogTests.cs
+++ b/libs/storage/Tsavorite/cs/test/LogTests.cs
@@ -21,16 +21,15 @@ namespace Tsavorite.test
         [Category("Smoke")]
         public void TestDisposeReleasesFileLocksWithCompletedCommit([Values] TestUtils.DeviceType deviceType)
         {
-            string path = TestUtils.MethodTestDir + "/";
-            string filename = path + "TestDisposeRelease" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "TestDisposeRelease" + deviceType.ToString() + ".log");
 
-            DirectoryInfo di = Directory.CreateDirectory(path);
+            DirectoryInfo di = Directory.CreateDirectory(TestUtils.MethodTestDir);
             IDevice device = TestUtils.CreateTestDevice(deviceType, filename);
             TsavoriteLog log = new TsavoriteLog(new TsavoriteLogSettings
             {
                 LogDevice = device,
                 SegmentSizeBits = 22,
-                LogCommitDir = path,
+                LogCommitDir = TestUtils.MethodTestDir,
                 LogChecksum = LogChecksumType.PerEntry
             });
 
@@ -61,7 +60,6 @@ namespace Tsavorite.test
         protected const int numSpanEntries = 500; // really slows down if go too many
         protected TsavoriteLog log;
         protected IDevice device;
-        protected string path;
         protected DeviceLogCommitCheckpointManager manager;
 
         protected static readonly byte[] entry = new byte[100];
@@ -79,14 +77,12 @@ namespace Tsavorite.test
 
         protected void BaseSetup(bool deleteOnClose = true)
         {
-            path = TestUtils.MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
-            TestUtils.DeleteDirectory(path, wait: true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
 
             manager = new DeviceLogCommitCheckpointManager(
                 new LocalStorageNamedDeviceFactory(deleteOnClose: deleteOnClose),
-                new DefaultCheckpointNamingScheme(path), false);
+                new DefaultCheckpointNamingScheme(TestUtils.MethodTestDir), false);
             this.deleteOnClose = deleteOnClose;
         }
 
@@ -101,7 +97,7 @@ namespace Tsavorite.test
             device?.Dispose();
             device = null;
 
-            TestUtils.DeleteDirectory(path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         internal class Counter
@@ -202,7 +198,7 @@ namespace Tsavorite.test
         [Category("TsavoriteLog")]
         public async ValueTask TsavoriteLogTest1([Values] LogChecksumType logChecksum, [Values] IteratorType iteratorType)
         {
-            device = Devices.CreateLogDevice(path + "Tsavoritelog.log", deleteOnClose: true);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "Tsavoritelog.log"), deleteOnClose: true);
             var logSettings = new TsavoriteLogSettings
             { LogDevice = device, LogChecksum = logChecksum, LogCommitManager = manager, TryRecoverLatest = false };
             log = IsAsync(iteratorType) ? await TsavoriteLog.CreateAsync(logSettings) : new TsavoriteLog(logSettings);
@@ -264,7 +260,7 @@ namespace Tsavorite.test
         {
             var iteratorType = IteratorType.Sync;
 
-            device = Devices.CreateLogDevice(path + "Tsavoritelog.log", deleteOnClose: true);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "Tsavoritelog.log"), deleteOnClose: true);
             var logSettings = new TsavoriteLogSettings
             { LogDevice = device, LogChecksum = logChecksum, LogCommitManager = manager, TryRecoverLatest = false };
             log = IsAsync(iteratorType) ? await TsavoriteLog.CreateAsync(logSettings) : new TsavoriteLog(logSettings);
@@ -346,7 +342,7 @@ namespace Tsavorite.test
         [Category("TsavoriteLog")]
         public void TsavoriteLogConsumerTest([Values] LogChecksumType logChecksum)
         {
-            device = Devices.CreateLogDevice(path + "Tsavoritelog.log", deleteOnClose: true);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "Tsavoritelog.log"), deleteOnClose: true);
             var logSettings = new TsavoriteLogSettings
             { LogDevice = device, LogChecksum = logChecksum, LogCommitManager = manager, TryRecoverLatest = false };
             log = new TsavoriteLog(logSettings);
@@ -377,7 +373,7 @@ namespace Tsavorite.test
         [Category("TsavoriteLog")]
         public async ValueTask TsavoriteLogAsyncConsumerTest([Values] LogChecksumType logChecksum)
         {
-            device = Devices.CreateLogDevice(path + "Tsavoritelog.log", deleteOnClose: true);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "Tsavoritelog.log"), deleteOnClose: true);
             var logSettings = new TsavoriteLogSettings
             { LogDevice = device, LogChecksum = logChecksum, LogCommitManager = manager, TryRecoverLatest = false };
             log = await TsavoriteLog.CreateAsync(logSettings);
@@ -419,7 +415,7 @@ namespace Tsavorite.test
             CancellationTokenSource cts = new CancellationTokenSource();
             CancellationToken token = cts.Token;
 
-            device = Devices.CreateLogDevice(path + "Tsavoritelog.log", deleteOnClose: true);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "Tsavoritelog.log"), deleteOnClose: true);
             var logSettings = new TsavoriteLogSettings
             { LogDevice = device, LogChecksum = logChecksum, LogCommitManager = manager, TryRecoverLatest = false };
             log = IsAsync(iteratorType) ? await TsavoriteLog.CreateAsync(logSettings) : new TsavoriteLog(logSettings);
@@ -470,7 +466,7 @@ namespace Tsavorite.test
         public async ValueTask TryEnqueue2([Values] LogChecksumType logChecksum, [Values] IteratorType iteratorType,
             [Values] TestUtils.DeviceType deviceType)
         {
-            string filename = path + "TryEnqueue2" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "TryEnqueue2" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
 
             var logSettings = new TsavoriteLogSettings
@@ -555,7 +551,7 @@ namespace Tsavorite.test
         public async ValueTask TruncateUntilBasic([Values] LogChecksumType logChecksum,
             [Values] IteratorType iteratorType, [Values] TestUtils.DeviceType deviceType)
         {
-            string filename = path + "TruncateUntilBasic" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "TruncateUntilBasic" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
 
             var logSettings = new TsavoriteLogSettings
@@ -615,7 +611,7 @@ namespace Tsavorite.test
 
             ReadOnlySpanBatch spanBatch = new ReadOnlySpanBatch(numSpanEntries);
 
-            string filename = path + "EnqueueAndWaitForCommitAsyncBasicTest" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "EnqueueAndWaitForCommitAsyncBasicTest" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
             log = new TsavoriteLog(new TsavoriteLogSettings
             {
@@ -672,7 +668,7 @@ namespace Tsavorite.test
         [Category("TsavoriteLog")]
         public async ValueTask TruncateUntil2([Values] LogChecksumType logChecksum, [Values] IteratorType iteratorType)
         {
-            device = Devices.CreateLogDevice(path + "tsavoritelog.log", deleteOnClose: true);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "tsavoritelog.log"), deleteOnClose: true);
             var logSettings = new TsavoriteLogSettings
             {
                 LogDevice = device,
@@ -748,7 +744,7 @@ namespace Tsavorite.test
         public async ValueTask TruncateUntilPageStart([Values] LogChecksumType logChecksum,
             [Values] IteratorType iteratorType)
         {
-            device = Devices.CreateLogDevice(path + "tsavoritelog.log", deleteOnClose: true);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "tsavoritelog.log"), deleteOnClose: true);
             log = new TsavoriteLog(new TsavoriteLogSettings
             {
                 LogDevice = device,
@@ -824,7 +820,7 @@ namespace Tsavorite.test
         [Category("Smoke")]
         public void CommitNoSpinWait([Values] TestUtils.DeviceType deviceType)
         {
-            string filename = path + "CommitNoSpinWait" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "CommitNoSpinWait" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
             log = new TsavoriteLog(new TsavoriteLogSettings
             { LogDevice = device, LogCommitManager = manager, SegmentSizeBits = 22 });
@@ -879,7 +875,7 @@ namespace Tsavorite.test
             CancellationTokenSource cts = new CancellationTokenSource();
             CancellationToken token = cts.Token;
 
-            string filename = $"{path}/CommitAsyncPrevTask_{deviceType}.log";
+            string filename = Path.Join(TestUtils.MethodTestDir, $"CommitAsyncPrevTask_{deviceType}.log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
             var logSettings = new TsavoriteLogSettings
             { LogDevice = device, LogCommitManager = manager, SegmentSizeBits = 22, TryRecoverLatest = false };
@@ -947,7 +943,7 @@ namespace Tsavorite.test
             CancellationTokenSource cts = new CancellationTokenSource();
             CancellationToken token = cts.Token;
 
-            string filename = path + "RefreshUncommittedAsyncTest" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "RefreshUncommittedAsyncTest" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
 
             log = new TsavoriteLog(new TsavoriteLogSettings
@@ -1036,7 +1032,7 @@ namespace Tsavorite.test
             var cookie = new byte[100];
             new Random().NextBytes(cookie);
 
-            device = Devices.CreateLogDevice(path + "SimpleCommitCookie" + fastCommit + ".log", deleteOnClose: true);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "SimpleCommitCookie" + fastCommit + ".log"), deleteOnClose: true);
             var logSettings = new TsavoriteLogSettings
             {
                 LogDevice = device,
@@ -1066,7 +1062,7 @@ namespace Tsavorite.test
         [Category("TsavoriteLog")]
         public void TsavoriteLogManualCommitTest()
         {
-            device = Devices.CreateLogDevice(path + "logManualCommitTest.log", deleteOnClose: true);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "logManualCommitTest.log"), deleteOnClose: true);
             var logSettings = new TsavoriteLogSettings
             {
                 LogDevice = device,
@@ -1145,7 +1141,7 @@ namespace Tsavorite.test
         [Category("TsavoriteLog")]
         public async ValueTask TsavoriteLogAsyncConsumerTestAfterDisposeIterator([Values] LogChecksumType logChecksum)
         {
-            device = Devices.CreateLogDevice(path + "tsavoritelog.log", deleteOnClose: true);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "tsavoritelog.log"), deleteOnClose: true);
             var logSettings = new TsavoriteLogSettings
             { LogDevice = device, LogChecksum = logChecksum, LogCommitManager = manager, TryRecoverLatest = false };
             log = await TsavoriteLog.CreateAsync(logSettings);

--- a/libs/storage/Tsavorite/cs/test/LowMemAsyncTests.cs
+++ b/libs/storage/Tsavorite/cs/test/LowMemAsyncTests.cs
@@ -14,19 +14,17 @@ namespace Tsavorite.test.async
         IDevice log;
         TsavoriteKV<long, long> store1;
         const int numOps = 2000;
-        string path;
 
         [SetUp]
         public void Setup()
         {
-            path = TestUtils.MethodTestDir;
-            TestUtils.DeleteDirectory(path, wait: true);
-            log = new LocalMemoryDevice(1L << 28, 1L << 25, 1, latencyMs: 20, fileName: path + "/test.log");
-            Directory.CreateDirectory(path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
+            log = new LocalMemoryDevice(1L << 28, 1L << 25, 1, latencyMs: 20, fileName: Path.Join(TestUtils.MethodTestDir, "test.log"));
+            Directory.CreateDirectory(TestUtils.MethodTestDir);
             store1 = new TsavoriteKV<long, long>
                 (1L << 10,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 12, SegmentSizeBits = 26 },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir }
                 );
         }
 
@@ -37,7 +35,7 @@ namespace Tsavorite.test.async
             store1 = null;
             log?.Dispose();
             log = null;
-            TestUtils.DeleteDirectory(path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         private static async Task Populate(ClientSession<long, long, long, long, Empty, SimpleFunctions<long, long>> s1)

--- a/libs/storage/Tsavorite/cs/test/ManagedLocalStorageTests.cs
+++ b/libs/storage/Tsavorite/cs/test/ManagedLocalStorageTests.cs
@@ -16,22 +16,19 @@ namespace Tsavorite.test
         private TsavoriteLog logFullParams;
         private IDevice deviceFullParams;
         static readonly byte[] entry = new byte[100];
-        private string path;
 
         [SetUp]
         public void Setup()
         {
-            path = TestUtils.MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
             // We loop to ensure clean-up as deleteOnClose does not always work for MLSD
-            TestUtils.DeleteDirectory(path, wait: true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
 
             // Create devices \ log for test
-            device = new ManagedLocalStorageDevice(path + "ManagedLocalStore.log", deleteOnClose: true);
+            device = new ManagedLocalStorageDevice(Path.Join(TestUtils.MethodTestDir, "ManagedLocalStore.log"), deleteOnClose: true);
             log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 12, MemorySizeBits = 14 });
 
-            deviceFullParams = new ManagedLocalStorageDevice(path + "ManagedLocalStoreFullParams.log", deleteOnClose: false, recoverDevice: true, preallocateFile: true, capacity: 1 << 30);
+            deviceFullParams = new ManagedLocalStorageDevice(Path.Join(TestUtils.MethodTestDir, "ManagedLocalStoreFullParams.log"), deleteOnClose: false, recoverDevice: true, preallocateFile: true, capacity: 1 << 30);
             logFullParams = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 12, MemorySizeBits = 14 });
         }
 
@@ -48,7 +45,7 @@ namespace Tsavorite.test
             deviceFullParams = null;
 
             // Clean up log 
-            TestUtils.DeleteDirectory(path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
 
@@ -149,7 +146,6 @@ namespace Tsavorite.test
         [Category("TsavoriteLog")]
         public void ManagedLocalStoreFullParamsTest()
         {
-
             int entryLength = 10;
 
             // Set Default entry data
@@ -163,8 +159,8 @@ namespace Tsavorite.test
             logFullParams.Commit(true);
 
             // Verify  
-            Assert.IsTrue(File.Exists(path + "/log-commits/commit.1.0"));
-            Assert.IsTrue(File.Exists(path + "/ManagedLocalStore.log.0"));
+            Assert.IsTrue(File.Exists(Path.Join(TestUtils.MethodTestDir, "log-commits", "commit.1.0")));
+            Assert.IsTrue(File.Exists(Path.Join(TestUtils.MethodTestDir, "ManagedLocalStore.log.0")));
 
             // Read the log just to verify can actually read it
             int currentEntry = 0;

--- a/libs/storage/Tsavorite/cs/test/MiscTests.cs
+++ b/libs/storage/Tsavorite/cs/test/MiscTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 using static Tsavorite.test.TestUtils;
@@ -18,8 +19,8 @@ namespace Tsavorite.test
         public void Setup()
         {
             DeleteDirectory(MethodTestDir, wait: true);
-            log = Devices.CreateLogDevice(MethodTestDir + "/MiscTests.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(MethodTestDir + "/MiscTests.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "MiscTests.log"), deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(Path.Join(MethodTestDir, "MiscTests.obj.log"), deleteOnClose: true);
 
             store = new TsavoriteKV<int, MyValue>
                 (128,
@@ -114,8 +115,8 @@ namespace Tsavorite.test
 
             try
             {
-                var checkpointDir = MethodTestDir + $"/checkpoints";
-                log = Devices.CreateLogDevice(MethodTestDir + "/hlog1.log", deleteOnClose: true);
+                var checkpointDir = Path.Join(MethodTestDir, "checkpoints");
+                log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "hlog1.log"), deleteOnClose: true);
                 store = new TsavoriteKV<KeyStruct, ValueStruct>
                     (128, new LogSettings { LogDevice = log, MemorySizeBits = 29 },
                     checkpointSettings: new CheckpointSettings { CheckpointDir = checkpointDir },

--- a/libs/storage/Tsavorite/cs/test/MoreLogCompactionTests.cs
+++ b/libs/storage/Tsavorite/cs/test/MoreLogCompactionTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 
@@ -16,7 +17,7 @@ namespace Tsavorite.test
         public void Setup()
         {
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
-            log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/MoreLogCompactionTests.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "MoreLogCompactionTests.log"), deleteOnClose: true);
             store = new TsavoriteKV<long, long>
                 (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 9 });
         }

--- a/libs/storage/Tsavorite/cs/test/NativeReadCacheTests.cs
+++ b/libs/storage/Tsavorite/cs/test/NativeReadCacheTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 
@@ -17,7 +18,7 @@ namespace Tsavorite.test.ReadCacheTests
         {
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
             var readCacheSettings = new ReadCacheSettings { MemorySizeBits = 15, PageSizeBits = 10 };
-            log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/NativeReadCacheTests.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "NativeReadCacheTests.log"), deleteOnClose: true);
             store = new TsavoriteKV<KeyStruct, ValueStruct>
                 (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 10, ReadCacheSettings = readCacheSettings });
         }

--- a/libs/storage/Tsavorite/cs/test/NeedCopyUpdateTests.cs
+++ b/libs/storage/Tsavorite/cs/test/NeedCopyUpdateTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 using static Tsavorite.test.TestUtils;
@@ -17,8 +18,8 @@ namespace Tsavorite.test
         public void Setup()
         {
             DeleteDirectory(MethodTestDir, wait: true);
-            log = Devices.CreateLogDevice(MethodTestDir + "/tests.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(MethodTestDir + "/tests.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "tests.log"), deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(Path.Join(MethodTestDir, "tests.obj.log"), deleteOnClose: true);
 
             store = new TsavoriteKV<int, RMWValue>
                 (128,
@@ -164,7 +165,7 @@ namespace Tsavorite.test
         public void Setup()
         {
             DeleteDirectory(MethodTestDir, wait: true);
-            log = Devices.CreateLogDevice(MethodTestDir + "/test.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "test.log"), deleteOnClose: true);
 
             store = new TsavoriteKV<long, long>(128,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = pageSizeBits, PageSizeBits = pageSizeBits });

--- a/libs/storage/Tsavorite/cs/test/ObjectReadCacheTests.cs
+++ b/libs/storage/Tsavorite/cs/test/ObjectReadCacheTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 
@@ -17,8 +18,8 @@ namespace Tsavorite.test.ReadCacheTests
         {
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
             var readCacheSettings = new ReadCacheSettings { MemorySizeBits = 15, PageSizeBits = 10 };
-            log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/ObjectReadCacheTests.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/ObjectReadCacheTests.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "ObjectReadCacheTests.log"), deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "ObjectReadCacheTests.obj.log"), deleteOnClose: true);
 
             store = new TsavoriteKV<MyKey, MyValue>
                 (128,

--- a/libs/storage/Tsavorite/cs/test/ObjectRecoveryTest.cs
+++ b/libs/storage/Tsavorite/cs/test/ObjectRecoveryTest.cs
@@ -24,7 +24,6 @@ namespace Tsavorite.test.recovery.objectstore
         const long completePendingInterval = (1L << 10);
         const long checkpointInterval = (1L << 16);
         private TsavoriteKV<AdId, NumClicks> store;
-        private string test_path;
         private Guid token;
         private IDevice log, objlog;
 
@@ -33,18 +32,17 @@ namespace Tsavorite.test.recovery.objectstore
 
         public void Setup(bool deleteDir)
         {
-            test_path = TestUtils.MethodTestDir;
             if (deleteDir)
-                TestUtils.RecreateDirectory(test_path);
+                TestUtils.RecreateDirectory(TestUtils.MethodTestDir);
 
-            log = Devices.CreateLogDevice(test_path + "/ObjectRecoveryTests.log", false);
-            objlog = Devices.CreateLogDevice(test_path + "/ObjectRecoveryTests.obj.log", false);
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "ObjectRecoveryTests.log"), false);
+            objlog = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "ObjectRecoveryTests.obj.log"), false);
 
             store = new TsavoriteKV<AdId, NumClicks>
                 (
                     keySpace,
                     new LogSettings { LogDevice = log, ObjectLogDevice = objlog },
-                    new CheckpointSettings { CheckpointDir = test_path },
+                    new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir },
                     new SerializerSettings<AdId, NumClicks> { keySerializer = () => new AdIdSerializer(), valueSerializer = () => new NumClicksSerializer() }
                     );
         }
@@ -62,7 +60,7 @@ namespace Tsavorite.test.recovery.objectstore
             objlog = null;
 
             if (deleteDir)
-                TestUtils.DeleteDirectory(test_path);
+                TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         private void PrepareToRecover()
@@ -173,7 +171,7 @@ namespace Tsavorite.test.recovery.objectstore
                 new DeviceLogCommitCheckpointManager(
                     new LocalStorageNamedDeviceFactory(),
                         new DefaultCheckpointNamingScheme(
-                          new DirectoryInfo(test_path).FullName)), null);
+                          new DirectoryInfo(TestUtils.MethodTestDir).FullName)), null);
 
             // Compute expected array
             long[] expected = new long[numUniqueKeys];

--- a/libs/storage/Tsavorite/cs/test/ObjectRecoveryTest2.cs
+++ b/libs/storage/Tsavorite/cs/test/ObjectRecoveryTest2.cs
@@ -13,19 +13,17 @@ namespace Tsavorite.test.recovery.objects
     public class ObjectRecoveryTests2
     {
         int iterations;
-        string TsavoriteFolderPath { get; set; }
 
         [SetUp]
         public void Setup()
         {
-            TsavoriteFolderPath = TestUtils.MethodTestDir;
-            TestUtils.RecreateDirectory(TsavoriteFolderPath);
+            TestUtils.RecreateDirectory(TestUtils.MethodTestDir);
         }
 
         [TearDown]
         public void TearDown()
         {
-            TestUtils.DeleteDirectory(TsavoriteFolderPath);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         [Test]
@@ -39,7 +37,7 @@ namespace Tsavorite.test.recovery.objects
             [Values] bool isAsync)
         {
             this.iterations = iterations;
-            Prepare(out _, out _, out IDevice log, out IDevice objlog, out TsavoriteKV<MyKey, MyValue> h, out MyContext context);
+            Prepare(out IDevice log, out IDevice objlog, out TsavoriteKV<MyKey, MyValue> h, out MyContext context);
 
             var session1 = h.NewSession<MyInput, MyOutput, MyContext, MyFunctions>(new MyFunctions());
             Write(session1, context, h, checkpointType);
@@ -51,7 +49,7 @@ namespace Tsavorite.test.recovery.objects
 
             Destroy(log, objlog, h);
 
-            Prepare(out _, out _, out log, out objlog, out h, out context);
+            Prepare(out log, out objlog, out h, out context);
 
             if (isAsync)
                 await h.RecoverAsync();
@@ -65,12 +63,10 @@ namespace Tsavorite.test.recovery.objects
             Destroy(log, objlog, h);
         }
 
-        private void Prepare(out string logPath, out string objPath, out IDevice log, out IDevice objlog, out TsavoriteKV<MyKey, MyValue> h, out MyContext context)
+        private void Prepare(out IDevice log, out IDevice objlog, out TsavoriteKV<MyKey, MyValue> h, out MyContext context)
         {
-            logPath = Path.Combine(TsavoriteFolderPath, $"RecoverTests.log");
-            objPath = Path.Combine(TsavoriteFolderPath, $"RecoverTests_HEAP.log");
-            log = Devices.CreateLogDevice(logPath);
-            objlog = Devices.CreateLogDevice(objPath);
+            log = Devices.CreateLogDevice(Path.Combine(TestUtils.MethodTestDir, "RecoverTests.log"));
+            objlog = Devices.CreateLogDevice(Path.Combine(TestUtils.MethodTestDir, "RecoverTests_HEAP.log"));
             h = new TsavoriteKV<MyKey, MyValue>
                 (1L << 20,
                 new LogSettings
@@ -83,7 +79,7 @@ namespace Tsavorite.test.recovery.objects
                 },
                 new CheckpointSettings()
                 {
-                    CheckpointDir = Path.Combine(TsavoriteFolderPath, "check-points")
+                    CheckpointDir = Path.Combine(TestUtils.MethodTestDir, "check-points")
                 },
                 new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() }
              );

--- a/libs/storage/Tsavorite/cs/test/ObjectRecoveryTest3.cs
+++ b/libs/storage/Tsavorite/cs/test/ObjectRecoveryTest3.cs
@@ -15,19 +15,17 @@ namespace Tsavorite.test.recovery.objects
     public class ObjectRecoveryTests3
     {
         int iterations;
-        string TsavoriteFolderPath { get; set; }
 
         [SetUp]
         public void Setup()
         {
-            TsavoriteFolderPath = TestUtils.MethodTestDir;
-            TestUtils.RecreateDirectory(TsavoriteFolderPath);
+            TestUtils.RecreateDirectory(TestUtils.MethodTestDir);
         }
 
         [TearDown]
         public void TearDown()
         {
-            TestUtils.DeleteDirectory(TsavoriteFolderPath);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         [Test]
@@ -38,7 +36,7 @@ namespace Tsavorite.test.recovery.objects
             [Values] bool isAsync)
         {
             this.iterations = iterations;
-            Prepare(out _, out _, out IDevice log, out IDevice objlog, out TsavoriteKV<MyKey, MyValue> h, out MyContext context);
+            Prepare(out IDevice log, out IDevice objlog, out TsavoriteKV<MyKey, MyValue> h, out MyContext context);
 
             var session1 = h.NewSession<MyInput, MyOutput, MyContext, MyFunctions>(new MyFunctions());
             var tokens = Write(session1, context, h, checkpointType);
@@ -52,7 +50,7 @@ namespace Tsavorite.test.recovery.objects
 
             foreach (var item in tokens)
             {
-                Prepare(out _, out _, out log, out objlog, out h, out context);
+                Prepare(out log, out objlog, out h, out context);
 
                 if (isAsync)
                     await h.RecoverAsync(default, item.Item2);
@@ -67,12 +65,10 @@ namespace Tsavorite.test.recovery.objects
             }
         }
 
-        private void Prepare(out string logPath, out string objPath, out IDevice log, out IDevice objlog, out TsavoriteKV<MyKey, MyValue> h, out MyContext context)
+        private void Prepare(out IDevice log, out IDevice objlog, out TsavoriteKV<MyKey, MyValue> h, out MyContext context)
         {
-            logPath = Path.Combine(TsavoriteFolderPath, $"RecoverTests.log");
-            objPath = Path.Combine(TsavoriteFolderPath, $"RecoverTests_HEAP.log");
-            log = Devices.CreateLogDevice(logPath);
-            objlog = Devices.CreateLogDevice(objPath);
+            log = Devices.CreateLogDevice(Path.Combine(TestUtils.MethodTestDir, "RecoverTests.log"));
+            objlog = Devices.CreateLogDevice(Path.Combine(TestUtils.MethodTestDir, "RecoverTests_HEAP.log"));
             h = new TsavoriteKV<MyKey, MyValue>
                 (1L << 20,
                 new LogSettings
@@ -85,7 +81,7 @@ namespace Tsavorite.test.recovery.objects
                 },
                 new CheckpointSettings()
                 {
-                    CheckpointDir = Path.Combine(TsavoriteFolderPath, "check-points")
+                    CheckpointDir = Path.Combine(TestUtils.MethodTestDir, "check-points")
                 },
                 new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() }
              );

--- a/libs/storage/Tsavorite/cs/test/ObjectTests.cs
+++ b/libs/storage/Tsavorite/cs/test/ObjectTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Tsavorite.core;
@@ -18,8 +19,8 @@ namespace Tsavorite.test
         public void Setup()
         {
             DeleteDirectory(MethodTestDir, wait: true);
-            log = Devices.CreateLogDevice(MethodTestDir + "/ObjectTests.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(MethodTestDir + "/ObjectTests.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "ObjectTests.log"), deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(Path.Join(MethodTestDir, "ObjectTests.obj.log"), deleteOnClose: true);
 
             store = new TsavoriteKV<MyKey, MyValue>
                 (128,

--- a/libs/storage/Tsavorite/cs/test/PostOperationsTests.cs
+++ b/libs/storage/Tsavorite/cs/test/PostOperationsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 
@@ -57,7 +58,7 @@ namespace Tsavorite.test
             // Clean up log files from previous test runs in case they weren't cleaned up
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
 
-            log = Devices.CreateLogDevice($"{TestUtils.MethodTestDir}/PostOperations.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "PostOperations.log"), deleteOnClose: true);
             store = new TsavoriteKV<int, int>
                        (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 10 });
             session = store.NewSession<int, int, Empty, PostFunctions>(new PostFunctions());

--- a/libs/storage/Tsavorite/cs/test/ReadAddressTests.cs
+++ b/libs/storage/Tsavorite/cs/test/ReadAddressTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Tsavorite.core;
@@ -144,16 +145,14 @@ namespace Tsavorite.test.readaddress
         {
             internal TsavoriteKV<Key, Value> store;
             internal IDevice logDevice;
-            internal string testDir;
             private readonly bool flush;
 
             internal long[] InsertAddresses = new long[numKeys];
 
             internal TestStore(bool useReadCache, ReadCopyOptions readCopyOptions, bool flush, ConcurrencyControlMode concurrencyControlMode)
             {
-                testDir = MethodTestDir;
-                DeleteDirectory(testDir, wait: true);
-                logDevice = Devices.CreateLogDevice($"{testDir}/hlog.log");
+                DeleteDirectory(MethodTestDir, wait: true);
+                logDevice = Devices.CreateLogDevice(Path.Join(MethodTestDir, "hlog.log"));
                 this.flush = flush;
 
                 var logSettings = new LogSettings
@@ -170,7 +169,7 @@ namespace Tsavorite.test.readaddress
                 store = new TsavoriteKV<Key, Value>(
                     size: 1L << 20,
                     logSettings: logSettings,
-                    checkpointSettings: new CheckpointSettings { CheckpointDir = $"{testDir}/chkpt" },
+                    checkpointSettings: new CheckpointSettings { CheckpointDir = Path.Join(MethodTestDir, "chkpt") },
                     serializerSettings: null,
                     comparer: new Key.Comparer(),
                     concurrencyControlMode: concurrencyControlMode
@@ -259,7 +258,7 @@ namespace Tsavorite.test.readaddress
                 store = null;
                 logDevice?.Dispose();
                 logDevice = null;
-                DeleteDirectory(testDir);
+                DeleteDirectory(MethodTestDir);
             }
         }
 

--- a/libs/storage/Tsavorite/cs/test/ReadCacheChainTests.cs
+++ b/libs/storage/Tsavorite/cs/test/ReadCacheChainTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -55,7 +56,7 @@ namespace Tsavorite.test.ReadCacheTests
         {
             DeleteDirectory(MethodTestDir, wait: true);
             var readCacheSettings = new ReadCacheSettings { MemorySizeBits = 15, PageSizeBits = 9 };
-            log = Devices.CreateLogDevice(MethodTestDir + "/NativeReadCacheTests.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "NativeReadCacheTests.log"), deleteOnClose: true);
 
             var concurrencyControlMode = ConcurrencyControlMode.None;
             foreach (var arg in TestContext.CurrentContext.Test.Arguments)
@@ -651,7 +652,7 @@ namespace Tsavorite.test.ReadCacheTests
         {
             DeleteDirectory(MethodTestDir, wait: true);
 
-            string filename = MethodTestDir + $"/{GetType().Name}.log";
+            string filename = Path.Join(MethodTestDir, $"{GetType().Name}.log");
             foreach (var arg in TestContext.CurrentContext.Test.Arguments)
             {
                 if (arg is DeviceType deviceType)
@@ -865,7 +866,7 @@ namespace Tsavorite.test.ReadCacheTests
         {
             DeleteDirectory(MethodTestDir, wait: true);
 
-            string filename = MethodTestDir + $"/{GetType().Name}.log";
+            string filename = Path.Join(MethodTestDir, $"{GetType().Name}.log");
             foreach (var arg in TestContext.CurrentContext.Test.Arguments)
             {
                 if (arg is DeviceType deviceType)

--- a/libs/storage/Tsavorite/cs/test/RecoverContinueTests.cs
+++ b/libs/storage/Tsavorite/cs/test/RecoverContinueTests.cs
@@ -18,14 +18,13 @@ namespace Tsavorite.test.recovery.sumstore.cntinue
         private TsavoriteKV<AdId, NumClicks> store3;
         private IDevice log;
         private int numOps;
-        private string checkpointDir;
 
         [SetUp]
         public void Setup()
         {
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
-            log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/test.log", deleteOnClose: true);
-            checkpointDir = TestUtils.MethodTestDir + "/checkpoints3";
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "test.log"), deleteOnClose: true);
+            string checkpointDir = Path.Join(TestUtils.MethodTestDir, "checkpoints3");
             Directory.CreateDirectory(checkpointDir);
 
             store1 = new TsavoriteKV<AdId, NumClicks>
@@ -61,7 +60,6 @@ namespace Tsavorite.test.recovery.sumstore.cntinue
             log?.Dispose();
             log = null;
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
-            TestUtils.DeleteDirectory(checkpointDir);
         }
 
         [Test]

--- a/libs/storage/Tsavorite/cs/test/RecoverReadOnlyTest.cs
+++ b/libs/storage/Tsavorite/cs/test/RecoverReadOnlyTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,22 +21,19 @@ namespace Tsavorite.test
         private TsavoriteLog logReadOnly;
         private IDevice deviceReadOnly;
 
-        private static string path;
         const int commitPeriodMs = 2000;
         const int restorePeriodMs = 1000;
 
         [SetUp]
         public void Setup()
         {
-            path = TestUtils.MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
-            TestUtils.DeleteDirectory(path, wait: true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
 
             // Create devices \ log for test
-            device = Devices.CreateLogDevice(path + "Recover", deleteOnClose: true);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "Recover"), deleteOnClose: true);
             log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, MemorySizeBits = 11, PageSizeBits = 9, MutableFraction = 0.5, SegmentSizeBits = 9 });
-            deviceReadOnly = Devices.CreateLogDevice(path + "RecoverReadOnly");
+            deviceReadOnly = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "RecoverReadOnly"));
             logReadOnly = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, ReadOnlyMode = true, PageSizeBits = 9, SegmentSizeBits = 9 });
         }
 
@@ -52,7 +50,7 @@ namespace Tsavorite.test
             deviceReadOnly = null;
 
             // Clean up log files
-            TestUtils.DeleteDirectory(path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
 

--- a/libs/storage/Tsavorite/cs/test/RecoveryChecks.cs
+++ b/libs/storage/Tsavorite/cs/test/RecoveryChecks.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -22,7 +23,6 @@ namespace Tsavorite.test.recovery
         protected IDevice log;
         protected const int numOps = 5000;
         protected AdId[] inputArray;
-        protected string path;
 
         protected void BaseSetup()
         {
@@ -32,16 +32,15 @@ namespace Tsavorite.test.recovery
                 inputArray[i].adId = i;
             }
 
-            path = TestUtils.MethodTestDir + "/";
-            log = Devices.CreateLogDevice(path + "hlog.log", deleteOnClose: false);
-            TestUtils.RecreateDirectory(path);
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "hlog.log"), deleteOnClose: false);
+            TestUtils.RecreateDirectory(TestUtils.MethodTestDir);
         }
 
         protected void BaseTearDown()
         {
             log?.Dispose();
             log = null;
-            TestUtils.DeleteDirectory(path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         public class MyFunctions : SimpleFunctions<long, long>
@@ -90,7 +89,7 @@ namespace Tsavorite.test.recovery
             using var store1 = new TsavoriteKV<long, long>
                 (size,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20, ReadCacheSettings = useReadCache ? new ReadCacheSettings() : null },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir }
                 );
 
             using var s1 = store1.NewSession<long, long, Empty, MyFunctions>(new MyFunctions());
@@ -120,7 +119,7 @@ namespace Tsavorite.test.recovery
             using var store2 = new TsavoriteKV<long, long>
                 (size,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20, ReadCacheSettings = useReadCache ? new ReadCacheSettings() : null },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir }
                 );
 
             if (isAsync)
@@ -170,7 +169,7 @@ namespace Tsavorite.test.recovery
             using var store1 = new TsavoriteKV<long, long>
                 (size,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20, ReadCacheSettings = useReadCache ? new ReadCacheSettings() : null },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir }
                 );
 
             using var s1 = store1.NewSession<long, long, Empty, SimpleFunctions<long, long>>(new SimpleFunctions<long, long>());
@@ -178,7 +177,7 @@ namespace Tsavorite.test.recovery
             using var store2 = new TsavoriteKV<long, long>
                 (size,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20, ReadCacheSettings = useReadCache ? new ReadCacheSettings() : null },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir }
                 );
 
             for (int i = 0; i < 5; i++)
@@ -247,7 +246,7 @@ namespace Tsavorite.test.recovery
                 using var store = new TsavoriteKV<long, long>
                     (128,
                     logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20 },
-                    checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                    checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir }
                     );
 
                 if (i > 0)
@@ -295,7 +294,7 @@ namespace Tsavorite.test.recovery
             using var store = new TsavoriteKV<long, long>
                 (128,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 11, SegmentSizeBits = 11 },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir }
                 );
 
             using var s1 = store.NewSession<long, long, Empty, SimpleFunctions<long, long>>(new SimpleFunctions<long, long>());
@@ -439,7 +438,7 @@ namespace Tsavorite.test.recovery
             using var store1 = new TsavoriteKV<long, long>
                 (size,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20, ReadCacheSettings = useReadCache ? new ReadCacheSettings() : null },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir }
                 );
 
             using var s1 = store1.NewSession<long, long, Empty, SimpleFunctions<long, long>>(new SimpleFunctions<long, long>());
@@ -447,7 +446,7 @@ namespace Tsavorite.test.recovery
             using var store2 = new TsavoriteKV<long, long>
                 (size,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20, ReadCacheSettings = useReadCache ? new ReadCacheSettings() : null },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir }
                 );
 
             for (int i = 0; i < 5; i++)
@@ -523,7 +522,7 @@ namespace Tsavorite.test.recovery
             using var store1 = new TsavoriteKV<long, long>
                 (size,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20, ReadCacheSettings = useReadCache ? new ReadCacheSettings() : null },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir }
                 );
 
             using var s1 = store1.NewSession<long, long, Empty, SimpleFunctions<long, long>>(new SimpleFunctions<long, long>());
@@ -531,7 +530,7 @@ namespace Tsavorite.test.recovery
             using var store2 = new TsavoriteKV<long, long>
                 (size,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20, ReadCacheSettings = useReadCache ? new ReadCacheSettings() : null },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir }
                 );
 
             for (int i = 0; i < 5; i++)
@@ -611,7 +610,7 @@ namespace Tsavorite.test.recovery
             using var store1 = new TsavoriteKV<long, long>
                 (size,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 14, ReadCacheSettings = useReadCache ? new ReadCacheSettings() : null },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = path },
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir },
                 concurrencyControlMode: ConcurrencyControlMode.RecordIsolation
                 );
 
@@ -656,7 +655,7 @@ namespace Tsavorite.test.recovery
             using var store2 = new TsavoriteKV<long, long>
                 (size,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20, ReadCacheSettings = useReadCache ? new ReadCacheSettings() : null },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir }
                 );
 
             if (isAsync)

--- a/libs/storage/Tsavorite/cs/test/RecoveryTests.cs
+++ b/libs/storage/Tsavorite/cs/test/RecoveryTests.cs
@@ -20,7 +20,6 @@ namespace Tsavorite.test.recovery.sumstore
         internal const long checkpointInterval = (1L << 14);
 
         private TsavoriteKV<AdId, NumClicks> store;
-        private string path;
         private readonly List<Guid> logTokens = new();
         private readonly List<Guid> indexTokens = new();
         private IDevice log;
@@ -28,20 +27,18 @@ namespace Tsavorite.test.recovery.sumstore
         [SetUp]
         public void Setup()
         {
-            path = TestUtils.MethodTestDir + "/";
-
             // Only clean these in the initial Setup, as tests use the other Setup() overload to recover
             logTokens.Clear();
             indexTokens.Clear();
-            TestUtils.DeleteDirectory(path, true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, true);
         }
 
         private void Setup(TestUtils.DeviceType deviceType)
         {
-            log = TestUtils.CreateTestDevice(deviceType, path + "Test.log");
+            log = TestUtils.CreateTestDevice(deviceType, Path.Join(TestUtils.MethodTestDir, "Test.log"));
             store = new TsavoriteKV<AdId, NumClicks>(keySpace,
                 new LogSettings { LogDevice = log, SegmentSizeBits = 25 }, //new LogSettings { LogDevice = log, MemorySizeBits = 14, PageSizeBits = 9 },  // locks ups at session.RMW line in Populate() for Local Memory
-                new CheckpointSettings { CheckpointDir = path }
+                new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir }
             );
         }
 
@@ -57,7 +54,7 @@ namespace Tsavorite.test.recovery.sumstore
 
             // Do NOT clean up here unless specified, as tests use this TearDown() to prepare for recovery
             if (deleteDir)
-                TestUtils.DeleteDirectory(path);
+                TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         private void PrepareToRecover(TestUtils.DeviceType deviceType)
@@ -203,7 +200,7 @@ namespace Tsavorite.test.recovery.sumstore
                 new DeviceLogCommitCheckpointManager(
                     new LocalStorageNamedDeviceFactory(),
                         new DefaultCheckpointNamingScheme(
-                          new DirectoryInfo(path).FullName)));
+                          new DirectoryInfo(TestUtils.MethodTestDir).FullName)));
 
             // Compute expected array
             long[] expected = new long[numUniqueKeys];
@@ -246,7 +243,6 @@ namespace Tsavorite.test.recovery.sumstore
         private static long ExpectedValue(int key) => expectedValueBase + key;
 
         private IDisposable storeDisp;
-        private string path;
         private Guid logToken;
         private Guid indexToken;
         private IDevice log;
@@ -262,24 +258,22 @@ namespace Tsavorite.test.recovery.sumstore
             smallSector = false;
             serializerSettingsObj = null;
 
-            path = TestUtils.MethodTestDir + "/";
-
             // Only clean these in the initial Setup, as tests use the other Setup() overload to recover
             logToken = Guid.Empty;
             indexToken = Guid.Empty;
-            TestUtils.DeleteDirectory(path, true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, true);
         }
 
         private TsavoriteKV<TData, TData> Setup<TData>()
         {
-            log = new LocalMemoryDevice(1L << 26, 1L << 22, 2, sector_size: smallSector ? 64 : (uint)512, fileName: $"{path}{typeof(TData).Name}.log");
+            log = new LocalMemoryDevice(1L << 26, 1L << 22, 2, sector_size: smallSector ? 64 : (uint)512, fileName: Path.Join(TestUtils.MethodTestDir, $"{typeof(TData).Name}.log"));
             objlog = serializerSettingsObj is null
                 ? null
-                : new LocalMemoryDevice(1L << 26, 1L << 22, 2, fileName: $"{path}{typeof(TData).Name}.obj.log");
+                : new LocalMemoryDevice(1L << 26, 1L << 22, 2, fileName: Path.Join(TestUtils.MethodTestDir, $"{typeof(TData).Name}.obj.log"));
 
             var result = new TsavoriteKV<TData, TData>(DeviceTypeRecoveryTests.keySpace,
                 new LogSettings { LogDevice = log, ObjectLogDevice = objlog, SegmentSizeBits = 25 },
-                new CheckpointSettings { CheckpointDir = path },
+                new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir },
                 serializerSettingsObj as SerializerSettings<TData, TData>
             );
 
@@ -301,7 +295,7 @@ namespace Tsavorite.test.recovery.sumstore
 
             // Do NOT clean up here unless specified, as tests use this TearDown() to prepare for recovery
             if (deleteDir)
-                TestUtils.DeleteDirectory(path);
+                TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         private TsavoriteKV<TData, TData> PrepareToRecover<TData>()

--- a/libs/storage/Tsavorite/cs/test/ReproReadCacheTest.cs
+++ b/libs/storage/Tsavorite/cs/test/ReproReadCacheTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -62,7 +63,7 @@ namespace Tsavorite.test.ReadCacheTests
             DeleteDirectory(MethodTestDir, wait: true);
 
             ReadCacheSettings readCacheSettings = default;
-            string filename = MethodTestDir + "/BasicTests.log";
+            string filename = Path.Join(MethodTestDir, "BasicTests.log");
 
             var concurrencyControlMode = ConcurrencyControlMode.None;
             foreach (var arg in TestContext.CurrentContext.Test.Arguments)

--- a/libs/storage/Tsavorite/cs/test/SessionTests.cs
+++ b/libs/storage/Tsavorite/cs/test/SessionTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Tsavorite.core;
@@ -18,7 +19,7 @@ namespace Tsavorite.test.async
         public void Setup()
         {
             DeleteDirectory(MethodTestDir, wait: true);
-            log = Devices.CreateLogDevice(MethodTestDir + "/hlog1.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "hlog1.log"), deleteOnClose: true);
             store = new TsavoriteKV<KeyStruct, ValueStruct>
                 (128, new LogSettings { LogDevice = log, MemorySizeBits = 29 });
         }

--- a/libs/storage/Tsavorite/cs/test/SharedDirectoryTests.cs
+++ b/libs/storage/Tsavorite/cs/test/SharedDirectoryTests.cs
@@ -21,7 +21,6 @@ namespace Tsavorite.test.recovery.sumstore
         const long keySpace = (1L << 5);
         const long numOps = (1L << 10);
         const long completePendingInterval = (1L << 10);
-        private string rootPath;
         private string sharedLogDirectory;
         TsavoriteTestInstance original;
         TsavoriteTestInstance clone;
@@ -29,9 +28,8 @@ namespace Tsavorite.test.recovery.sumstore
         [SetUp]
         public void Setup()
         {
-            rootPath = TestUtils.MethodTestDir;
-            TestUtils.RecreateDirectory(rootPath);
-            sharedLogDirectory = $"{rootPath}/SharedLogs";
+            TestUtils.RecreateDirectory(TestUtils.MethodTestDir);
+            sharedLogDirectory = Path.Join(TestUtils.MethodTestDir, "SharedLogs");
             Directory.CreateDirectory(sharedLogDirectory);
 
             original = new TsavoriteTestInstance();
@@ -43,7 +41,7 @@ namespace Tsavorite.test.recovery.sumstore
         {
             original.TearDown();
             clone.TearDown();
-            TestUtils.DeleteDirectory(rootPath);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         [Test]
@@ -52,7 +50,7 @@ namespace Tsavorite.test.recovery.sumstore
         [Category("Smoke")]
         public async ValueTask SharedLogDirectory([Values] bool isAsync)
         {
-            original.Initialize($"{rootPath}/OriginalCheckpoint", sharedLogDirectory);
+            original.Initialize(Path.Join(TestUtils.MethodTestDir, "OriginalCheckpoint"), sharedLogDirectory);
             Assert.IsTrue(IsDirectoryEmpty(sharedLogDirectory)); // sanity check
             Populate(original.Store);
 
@@ -65,7 +63,7 @@ namespace Tsavorite.test.recovery.sumstore
             Test(original, checkpointGuid);
 
             // Copy checkpoint directory
-            var cloneCheckpointDirectory = $"{rootPath}/CloneCheckpoint";
+            var cloneCheckpointDirectory = Path.Join(TestUtils.MethodTestDir, "CloneCheckpoint");
             CopyDirectory(new DirectoryInfo(original.CheckpointDirectory), new DirectoryInfo(cloneCheckpointDirectory));
 
             // Recover from original checkpoint
@@ -112,7 +110,7 @@ namespace Tsavorite.test.recovery.sumstore
                 LogDirectory = logDirectory;
 
                 string logFileName = "log";
-                string deviceFileName = $"{LogDirectory}/{logFileName}";
+                string deviceFileName = Path.Join(LogDirectory, logFileName);
                 KeyValuePair<int, SafeFileHandle>[] initialHandles = null;
                 if (populateLogHandles)
                 {

--- a/libs/storage/Tsavorite/cs/test/SimpleAsyncTests.cs
+++ b/libs/storage/Tsavorite/cs/test/SimpleAsyncTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -16,7 +17,6 @@ namespace Tsavorite.test.async
         TsavoriteKV<long, long> store;
         const int numOps = 5000;
         AdId[] inputArray;
-        string path;
 
         [SetUp]
         public void Setup()
@@ -27,13 +27,12 @@ namespace Tsavorite.test.async
                 inputArray[i].adId = i;
             }
 
-            path = TestUtils.MethodTestDir + "/";
-            TestUtils.RecreateDirectory(path);
-            log = Devices.CreateLogDevice(path + "Async.log", deleteOnClose: true);
+            TestUtils.RecreateDirectory(TestUtils.MethodTestDir);
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "Async.log"), deleteOnClose: true);
             store = new TsavoriteKV<long, long>
                 (1L << 10,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 15 },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir }
                 );
         }
 
@@ -44,7 +43,7 @@ namespace Tsavorite.test.async
             store = null;
             log?.Dispose();
             log = null;
-            TestUtils.DeleteDirectory(path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         // Test that does .ReadAsync with minimum parameters (ref key)

--- a/libs/storage/Tsavorite/cs/test/SimpleRecoveryTest.cs
+++ b/libs/storage/Tsavorite/cs/test/SimpleRecoveryTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -72,7 +73,7 @@ namespace Tsavorite.test.recovery.sumstore.simple
         {
             checkpointManager = new DeviceLogCommitCheckpointManager(
                 new LocalStorageNamedDeviceFactory(),
-                new DefaultCheckpointNamingScheme($"{TestUtils.MethodTestDir}/chkpt"));
+                new DefaultCheckpointNamingScheme(Path.Join(TestUtils.MethodTestDir, "chkpt")));
             await SimpleRecoveryTest1_Worker(checkpointType, isAsync, testCommitCookie);
             checkpointManager.PurgeAll();
         }
@@ -93,9 +94,9 @@ namespace Tsavorite.test.recovery.sumstore.simple
             }
 
             if (checkpointManager is null)
-                checkpointDir = TestUtils.MethodTestDir + $"/checkpoints";
+                checkpointDir = Path.Join(TestUtils.MethodTestDir, "checkpoints");
 
-            log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/SimpleRecoveryTest1.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "SimpleRecoveryTest1.log"), deleteOnClose: true);
 
             store1 = new TsavoriteKV<AdId, NumClicks>(128,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },
@@ -160,8 +161,8 @@ namespace Tsavorite.test.recovery.sumstore.simple
         [Category("TsavoriteKV"), Category("CheckpointRestore")]
         public async ValueTask SimpleRecoveryTest2([Values] CheckpointType checkpointType, [Values] bool isAsync)
         {
-            checkpointManager = new DeviceLogCommitCheckpointManager(new LocalStorageNamedDeviceFactory(), new DefaultCheckpointNamingScheme(TestUtils.MethodTestDir + "/checkpoints4"), false);
-            log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/SimpleRecoveryTest2.log", deleteOnClose: true);
+            checkpointManager = new DeviceLogCommitCheckpointManager(new LocalStorageNamedDeviceFactory(), new DefaultCheckpointNamingScheme(Path.Join(TestUtils.MethodTestDir, "checkpoints4")), false);
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "SimpleRecoveryTest2.log"), deleteOnClose: true);
 
             store1 = new TsavoriteKV<AdId, NumClicks>(128,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },
@@ -212,8 +213,8 @@ namespace Tsavorite.test.recovery.sumstore.simple
         [Category("TsavoriteKV"), Category("CheckpointRestore")]
         public async ValueTask ShouldRecoverBeginAddress([Values] bool isAsync)
         {
-            log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/SimpleRecoveryTest2.log", deleteOnClose: true);
-            checkpointDir = TestUtils.MethodTestDir + "/checkpoints6";
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "SimpleRecoveryTest2.log"), deleteOnClose: true);
+            checkpointDir = Path.Join(TestUtils.MethodTestDir, "checkpoints6");
 
             store1 = new TsavoriteKV<AdId, NumClicks>(128,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },
@@ -256,8 +257,8 @@ namespace Tsavorite.test.recovery.sumstore.simple
         [Category("TsavoriteKV"), Category("CheckpointRestore")]
         public void SimpleReadAndUpdateInfoTest()
         {
-            checkpointManager = new DeviceLogCommitCheckpointManager(new LocalStorageNamedDeviceFactory(), new DefaultCheckpointNamingScheme(TestUtils.MethodTestDir + "/checkpoints"), false);
-            log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/SimpleReadAndUpdateInfoTest.log", deleteOnClose: true);
+            checkpointManager = new DeviceLogCommitCheckpointManager(new LocalStorageNamedDeviceFactory(), new DefaultCheckpointNamingScheme(Path.Join(TestUtils.MethodTestDir, "checkpoints")), false);
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "SimpleReadAndUpdateInfoTest.log"), deleteOnClose: true);
 
             store1 = new TsavoriteKV<AdId, NumClicks>(128,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },

--- a/libs/storage/Tsavorite/cs/test/SpanByteIterationTests.cs
+++ b/libs/storage/Tsavorite/cs/test/SpanByteIterationTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Tsavorite.core;
@@ -15,7 +16,6 @@ namespace Tsavorite.test
     {
         private TsavoriteKV<SpanByte, SpanByte> store;
         private IDevice log;
-        private string path;
 
         // Note: We always set value.length to 2, which includes both VLValue members; we are not exercising the "Variable Length" aspect here.
         private const int ValueLength = 2;
@@ -23,10 +23,8 @@ namespace Tsavorite.test
         [SetUp]
         public void Setup()
         {
-            path = MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
-            DeleteDirectory(path, wait: true);
+            DeleteDirectory(TestUtils.MethodTestDir, wait: true);
         }
 
         [TearDown]
@@ -36,7 +34,7 @@ namespace Tsavorite.test
             store = null;
             log?.Dispose();
             log = null;
-            DeleteDirectory(path);
+            DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         internal struct SpanBytePushIterationTestFunctions : IScanIteratorFunctions<SpanByte, SpanByte>
@@ -70,7 +68,7 @@ namespace Tsavorite.test
         [Category(SmokeTestCategory)]
         public unsafe void SpanByteIterationBasicTest([Values] DeviceType deviceType, [Values] ScanIteratorType scanIteratorType)
         {
-            log = CreateTestDevice(deviceType, $"{path}{deviceType}.log");
+            log = CreateTestDevice(deviceType, $"{MethodTestDir}{deviceType}.log");
             store = new TsavoriteKV<SpanByte, SpanByte>
                  (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 9, SegmentSizeBits = 22 },
                  concurrencyControlMode: scanIteratorType == ScanIteratorType.Pull ? ConcurrencyControlMode.None : ConcurrencyControlMode.LockTable);
@@ -160,7 +158,7 @@ namespace Tsavorite.test
         [Category(SmokeTestCategory)]
         public void SpanByteIterationPushStopTest([Values] DeviceType deviceType)
         {
-            log = CreateTestDevice(deviceType, $"{path}{deviceType}.log");
+            log = CreateTestDevice(deviceType, Path.Join(MethodTestDir, $"{deviceType}.log"));
             store = new TsavoriteKV<SpanByte, SpanByte>
                  (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 9, SegmentSizeBits = 22 });
 
@@ -204,7 +202,7 @@ namespace Tsavorite.test
         [Category(SmokeTestCategory)]
         public unsafe void SpanByteIterationPushLockTest([Values(1, 4)] int scanThreads, [Values(1, 4)] int updateThreads, [Values] ScanMode scanMode)
         {
-            log = Devices.CreateLogDevice($"{path}lock_test.log");
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "lock_test.log"));
             // Must be large enough to contain all records in memory to exercise locking
             store = new TsavoriteKV<SpanByte, SpanByte>
                  (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 25, PageSizeBits = 19, SegmentSizeBits = 22 });

--- a/libs/storage/Tsavorite/cs/test/SpanByteLogScanTests.cs
+++ b/libs/storage/Tsavorite/cs/test/SpanByteLogScanTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -49,7 +50,7 @@ namespace Tsavorite.test
             }
 
             DeleteDirectory(MethodTestDir, wait: true);
-            log = Devices.CreateLogDevice(MethodTestDir + "/test.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "test.log"), deleteOnClose: true);
             store = new TsavoriteKV<SpanByte, SpanByte>
                 (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 25, PageSizeBits = PageSizeBits }, concurrencyControlMode: ConcurrencyControlMode.None, comparer: comparer);
         }
@@ -366,7 +367,7 @@ namespace Tsavorite.test
         public unsafe void SpanByteJumpToBeginAddressTest()
         {
             DeleteDirectory(MethodTestDir, wait: true);
-            using var log = Devices.CreateLogDevice(MethodTestDir + "/test.log", deleteOnClose: true);
+            using var log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "test.log"), deleteOnClose: true);
             using var store = new TsavoriteKV<SpanByte, SpanByte>
                 (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 20, PageSizeBits = 15 }, concurrencyControlMode: ConcurrencyControlMode.None);
             using var session = store.NewSession<SpanByte, SpanByteAndMemory, Empty, SpanByteFunctions<Empty>>(new SpanByteFunctions<Empty>());

--- a/libs/storage/Tsavorite/cs/test/SpanByteTests.cs
+++ b/libs/storage/Tsavorite/cs/test/SpanByteTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using NUnit.Framework;
@@ -25,7 +26,7 @@ namespace Tsavorite.test
 
             try
             {
-                using var log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/hlog1.log", deleteOnClose: true);
+                using var log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "hlog1.log"), deleteOnClose: true);
                 using var store = new TsavoriteKV<SpanByte, SpanByte>
                     (128, new LogSettings { LogDevice = log, MemorySizeBits = 17, PageSizeBits = 12 });
                 using var s = store.NewSession<SpanByte, SpanByteAndMemory, Empty, SpanByteFunctions<Empty>>(new SpanByteFunctions<Empty>());
@@ -79,7 +80,7 @@ namespace Tsavorite.test
 
             try
             {
-                using var log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/test.log", deleteOnClose: true);
+                using var log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "test.log"), deleteOnClose: true);
                 using var store = new TsavoriteKV<SpanByte, SpanByte>(
                     size: 1L << 10,
                     new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 12 });
@@ -203,7 +204,7 @@ namespace Tsavorite.test
         {
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
 
-            using var log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/vl-iter.log", deleteOnClose: true);
+            using var log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "vl-iter.log"), deleteOnClose: true);
             using var store = new TsavoriteKV<SpanByte, SpanByte>
                 (128,
                 new LogSettings { LogDevice = log, MemorySizeBits = 17, PageSizeBits = 10 }, // 1KB page

--- a/libs/storage/Tsavorite/cs/test/SpanByteVLVectorTests.cs
+++ b/libs/storage/Tsavorite/cs/test/SpanByteVLVectorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 using static Tsavorite.test.TestUtils;
@@ -22,7 +23,7 @@ namespace Tsavorite.test
         {
             DeleteDirectory(MethodTestDir, wait: true);
 
-            var log = Devices.CreateLogDevice(MethodTestDir + "/hlog1.log", deleteOnClose: true);
+            var log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "hlog1.log"), deleteOnClose: true);
             var store = new TsavoriteKV<SpanByte, SpanByte>
                 (128,
                 new LogSettings { LogDevice = log, MemorySizeBits = 17, PageSizeBits = 12 },
@@ -82,7 +83,7 @@ namespace Tsavorite.test
         {
             DeleteDirectory(MethodTestDir, wait: true);
 
-            var log = Devices.CreateLogDevice(MethodTestDir + "/hlog1.log", deleteOnClose: true);
+            var log = Devices.CreateLogDevice(Path.Join(MethodTestDir, "hlog1.log"), deleteOnClose: true);
             var store = new TsavoriteKV<SpanByte, SpanByte>
                 (128,
                 new LogSettings { LogDevice = log, MemorySizeBits = 17, PageSizeBits = 12 },

--- a/libs/storage/Tsavorite/cs/test/StateMachineBarrierTests.cs
+++ b/libs/storage/Tsavorite/cs/test/StateMachineBarrierTests.cs
@@ -25,8 +25,8 @@ namespace Tsavorite.test.statemachine
                 inputArray[i].adId = i;
             }
 
-            log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/StateMachineTest1.log", deleteOnClose: true);
-            string checkpointDir = TestUtils.MethodTestDir + "/statemachinetest";
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "StateMachineTest1.log"), deleteOnClose: true);
+            string checkpointDir = Path.Join(TestUtils.MethodTestDir, "statemachinetest");
             Directory.CreateDirectory(checkpointDir);
             store = new TsavoriteKV<AdId, NumClicks>
                 (128,
@@ -151,7 +151,7 @@ namespace Tsavorite.test.statemachine
             var store = new TsavoriteKV<AdId, NumClicks>
                 (128,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, PageSizeBits = 10, MemorySizeBits = 13 },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir + "/statemachinetest" }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = Path.Join(TestUtils.MethodTestDir, "statemachinetest") }
                 );
 
             store.Recover(); // sync, does not require session

--- a/libs/storage/Tsavorite/cs/test/StateMachineTests.cs
+++ b/libs/storage/Tsavorite/cs/test/StateMachineTests.cs
@@ -27,8 +27,8 @@ namespace Tsavorite.test.statemachine
                 inputArray[i].adId = i;
             }
 
-            log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/StateMachineTest1.log", deleteOnClose: true);
-            string checkpointDir = TestUtils.MethodTestDir + "/statemachinetest";
+            log = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "StateMachineTest1.log"), deleteOnClose: true);
+            string checkpointDir = Path.Join(TestUtils.MethodTestDir, "statemachinetest");
             Directory.CreateDirectory(checkpointDir);
             store = new TsavoriteKV<AdId, NumClicks>
                 (128,
@@ -689,7 +689,7 @@ namespace Tsavorite.test.statemachine
             var store = new TsavoriteKV<AdId, NumClicks>
                 (128,
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, PageSizeBits = 10, MemorySizeBits = 13 },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = TestUtils.MethodTestDir + "/statemachinetest" }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = Path.Join(TestUtils.MethodTestDir, "statemachinetest") }
                 );
 
             store.Recover(); // sync, does not require session

--- a/libs/storage/Tsavorite/cs/test/TryEnqueueBasicTests.cs
+++ b/libs/storage/Tsavorite/cs/test/TryEnqueueBasicTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 using NUnit.Framework;
 using Tsavorite.core;
 
@@ -15,7 +16,6 @@ namespace Tsavorite.test
     {
         private TsavoriteLog log;
         private IDevice device;
-        private string path;
         static readonly byte[] entry = new byte[100];
 
         public enum TryEnqueueIteratorType
@@ -36,10 +36,8 @@ namespace Tsavorite.test
         [SetUp]
         public void Setup()
         {
-            path = TestUtils.MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
-            TestUtils.DeleteDirectory(path, wait: true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
         }
 
         [TearDown]
@@ -51,7 +49,7 @@ namespace Tsavorite.test
             device = null;
 
             // Clean up log files
-            TestUtils.DeleteDirectory(path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
 
@@ -65,9 +63,9 @@ namespace Tsavorite.test
             int entryFlag = 9999;
 
             // Create devices \ log for test
-            string filename = path + "TryEnqueue" + deviceType.ToString() + ".log";
+            string filename = Path.Join(TestUtils.MethodTestDir, "TryEnqueue" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
-            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = path });
+            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = TestUtils.MethodTestDir });
 
 #if WINDOWS
             // Issue with Non Async Commit and Emulated Azure so don't run it - at least put after device creation to see if crashes doing that simple thing

--- a/libs/storage/Tsavorite/cs/test/UnsafeContextTests.cs
+++ b/libs/storage/Tsavorite/cs/test/UnsafeContextTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -20,21 +21,18 @@ namespace Tsavorite.test.UnsafeContext
         private ClientSession<KeyStruct, ValueStruct, InputStruct, OutputStruct, Empty, Functions> fullSession;
         private UnsafeContext<KeyStruct, ValueStruct, InputStruct, OutputStruct, Empty, Functions> uContext;
         private IDevice log;
-        private string path;
         DeviceType deviceType;
 
         [SetUp]
         public void Setup()
         {
-            path = MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
-            DeleteDirectory(path, wait: true);
+            DeleteDirectory(MethodTestDir, wait: true);
         }
 
         private void Setup(long size, LogSettings logSettings, DeviceType deviceType)
         {
-            string filename = path + TestContext.CurrentContext.Test.Name + deviceType.ToString() + ".log";
+            string filename = Path.Join(MethodTestDir, TestContext.CurrentContext.Test.Name + deviceType.ToString() + ".log");
             log = CreateTestDevice(deviceType, filename);
             logSettings.LogDevice = log;
             store = new TsavoriteKV<KeyStruct, ValueStruct>(size, logSettings);
@@ -52,7 +50,7 @@ namespace Tsavorite.test.UnsafeContext
             store = null;
             log?.Dispose();
             log = null;
-            DeleteDirectory(path);
+            DeleteDirectory(MethodTestDir);
         }
 
         private void AssertCompleted(Status expected, Status actual)

--- a/libs/storage/Tsavorite/cs/test/WaitForCommit.cs
+++ b/libs/storage/Tsavorite/cs/test/WaitForCommit.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using System.Threading;
 using NUnit.Framework;
 using Tsavorite.core;
@@ -12,7 +13,6 @@ namespace Tsavorite.test
     {
         static TsavoriteLog log;
         public IDevice device;
-        private string path;
         static readonly byte[] entry = new byte[10];
         static readonly AutoResetEvent ev = new(false);
         static readonly AutoResetEvent done = new(false);
@@ -20,13 +20,11 @@ namespace Tsavorite.test
         [SetUp]
         public void Setup()
         {
-            path = TestUtils.MethodTestDir + "/";
-
             // Clean up log files from previous test runs in case they weren't cleaned up
-            TestUtils.DeleteDirectory(path, wait: true);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
 
             // Create devices \ log for test
-            device = Devices.CreateLogDevice(path + "WaitForCommit", deleteOnClose: true);
+            device = Devices.CreateLogDevice(Path.Join(TestUtils.MethodTestDir, "WaitForCommit"), deleteOnClose: true);
             log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device });
         }
 
@@ -39,7 +37,7 @@ namespace Tsavorite.test
             device = null;
 
             // Clean up log files
-            TestUtils.DeleteDirectory(path);
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
         [TestCase("Sync")]  // use string here instead of Bool so shows up in Test Explorer with more descriptive name


### PR DESCRIPTION
Use `System.IO.Path.Join` to construct paths in Tsavorite tests.

Split off from #306 