### PR TITLE
Fixed calculation of operations per second in server metrics

### DIFF
--- a/libs/server/Metrics/GarnetServerMonitor.cs
+++ b/libs/server/Metrics/GarnetServerMonitor.cs
@@ -114,11 +114,11 @@ namespace Garnet.server
                 var elapsedSec = TimeSpan.FromTicks(currTimestamp - startTimestamp).TotalSeconds;
                 globalMetrics.instantaneous_net_input_tpt = (globalMetrics.globalSessionMetrics.get_total_net_input_bytes() - instant_input_net_bytes) / (elapsedSec * GarnetServerMetrics.byteUnit);
                 globalMetrics.instantaneous_net_output_tpt = (globalMetrics.globalSessionMetrics.get_total_net_output_bytes() - instant_output_net_bytes) / (elapsedSec * GarnetServerMetrics.byteUnit);
-                globalMetrics.instantaneous_cmd_per_sec = (globalMetrics.globalSessionMetrics.get_total_commands_processed() - instant_commands_processed) / (elapsedSec * GarnetServerMetrics.byteUnit);
+                globalMetrics.instantaneous_cmd_per_sec = (globalMetrics.globalSessionMetrics.get_total_commands_processed() - instant_commands_processed) / elapsedSec;
 
                 globalMetrics.instantaneous_net_input_tpt = Math.Round(globalMetrics.instantaneous_net_input_tpt, 2);
                 globalMetrics.instantaneous_net_output_tpt = Math.Round(globalMetrics.instantaneous_net_output_tpt, 2);
-                globalMetrics.instantaneous_cmd_per_sec = Math.Round(globalMetrics.instantaneous_cmd_per_sec, 2);
+                globalMetrics.instantaneous_cmd_per_sec = Math.Round(globalMetrics.instantaneous_cmd_per_sec);
 
                 startTimestamp = currTimestamp;
                 instant_input_net_bytes = globalMetrics.globalSessionMetrics.get_total_net_input_bytes();


### PR DESCRIPTION
This commit corrects the calculation of the instantaneous operations per second in the server metrics. The previous calculation was incorrectly using the `byteUnit` for conversion, which is not appropriate for operations per second. The corrected calculation now accurately reflects the number of operations processed per second.