### PR TITLE
Optimize PreviousPowerOf2

### DIFF
--- a/libs/client/Utility.cs
+++ b/libs/client/Utility.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -63,17 +64,11 @@ namespace Garnet.client
         /// <summary>
         /// Previous power of 2
         /// </summary>
-        /// <param name="v"></param>
-        /// <returns></returns>
         public static long PreviousPowerOf2(long v)
         {
-            v |= v >> 1;
-            v |= v >> 2;
-            v |= v >> 4;
-            v |= v >> 8;
-            v |= v >> 16;
-            v |= v >> 32;
-            return v - (v >> 1);
+            // Adjusted from BitOperations.RoundUpToPowerOf2
+            int shift = 63 - BitOperations.LeadingZeroCount((ulong)v);
+            return (long)(1UL ^ (ulong)(shift >> 6)) << shift;
         }
 
         /// <summary>

--- a/libs/server/Servers/ServerOptions.cs
+++ b/libs/server/Servers/ServerOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Numerics;
 using Microsoft.Extensions.Logging;
 using Tsavorite.core;
 
@@ -290,17 +291,11 @@ namespace Garnet.server
         /// <summary>
         /// Previous power of 2
         /// </summary>
-        /// <param name="v"></param>
-        /// <returns></returns>
         protected static long PreviousPowerOf2(long v)
         {
-            v |= v >> 1;
-            v |= v >> 2;
-            v |= v >> 4;
-            v |= v >> 8;
-            v |= v >> 16;
-            v |= v >> 32;
-            return v - (v >> 1);
+            // Adjusted from BitOperations.RoundUpToPowerOf2
+            int shift = 63 - BitOperations.LeadingZeroCount((ulong)v);
+            return (long)(1UL ^ (ulong)(shift >> 6)) << shift;
         }
     }
 }

--- a/libs/storage/Tsavorite/cs/src/core/Utilities/Utility.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Utilities/Utility.cs
@@ -75,17 +75,11 @@ namespace Tsavorite.core
         /// <summary>
         /// Previous power of 2
         /// </summary>
-        /// <param name="v"></param>
-        /// <returns></returns>
         internal static long PreviousPowerOf2(long v)
         {
-            v |= v >> 1;
-            v |= v >> 2;
-            v |= v >> 4;
-            v |= v >> 8;
-            v |= v >> 16;
-            v |= v >> 32;
-            return v - (v >> 1);
+            // Adjusted from BitOperations.RoundUpToPowerOf2
+            int shift = 63 - BitOperations.LeadingZeroCount((ulong)v);
+            return (long)(1UL ^ (ulong)(shift >> 6)) << shift;
         }
 
         /// <summary>


### PR DESCRIPTION
Note: there's difference in behaviour for negative values. Do we care?

I don't feel strongly about this one as it isn't really in hot-paths. Might not be worth it.

### Diff
```diff
 ; Assembly listing for method Garnet.client.Utility:PreviousPowerOf2(long):long (FullOpts)
 ; Emitting BLENDED_CODE for X64 with AVX - Windows
 ; FullOpts code
 ; optimized code
 ; rsp based frame
 ; partially interruptible
 ; No PGO data
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] ( 22, 22   )    long  ->  rcx        
-;# V01 OutArgs      [V01    ] (  1,  1   )  struct ( 0) [rsp+0x00]  do-not-enreg[XS] addr-exposed "OutgoingArgSpace"
+;  V00 arg0         [V00,T00] (  3,  3   )    long  ->  rcx         single-def
+;  V01 loc0         [V01,T01] (  3,  3   )     int  ->  rax         single-def
+;# V02 OutArgs      [V02    ] (  1,  1   )  struct ( 0) [rsp+0x00]  do-not-enreg[XS] addr-exposed "OutgoingArgSpace"
 ;
 ; Lcl frame size = 0
 
 G_M63292_IG01:  ;; offset=0x0000
 						;; size=0 bbWeight=1 PerfScore 0.00
 G_M63292_IG02:  ;; offset=0x0000
-       mov      rax, rcx
-       sar      rax, 1
-       or       rcx, rax
-       mov      rax, rcx
-       sar      rax, 2
-       or       rcx, rax
-       mov      rax, rcx
-       sar      rax, 4
-       or       rcx, rax
-       mov      rax, rcx
-       sar      rax, 8
-       or       rcx, rax
-       mov      rax, rcx
-       sar      rax, 16
-       or       rcx, rax
-       mov      rax, rcx
-       sar      rax, 32
-       or       rcx, rax
-       mov      rax, rcx
-       sar      rax, 1
-       sub      rcx, rax
-       mov      rax, rcx
-						;; size=71 bbWeight=1 PerfScore 7.25
-G_M63292_IG03:  ;; offset=0x0047
+       xor      eax, eax
+       lzcnt    rax, rcx
+       neg      eax
+       add      eax, 63
+       mov      ecx, eax
+       sar      ecx, 6
+       movsxd   rcx, ecx
+       xor      rcx, 1
+       shlx     rax, rcx, rax
+						;; size=29 bbWeight=1 PerfScore 4.50
+G_M63292_IG03:  ;; offset=0x001D
        ret      
 						;; size=1 bbWeight=1 PerfScore 1.00
 
-; Total bytes of code 72, prolog size 0, PerfScore 8.25, instruction count 23, allocated bytes for code 72 (MethodHash=a07108c3) for method Garnet.client.Utility:PreviousPowerOf2(long):long (FullOpts)
+; Total bytes of code 30, prolog size 0, PerfScore 5.50, instruction count 10, allocated bytes for code 30 (MethodHash=a07108c3) for method Garnet.client.Utility:PreviousPowerOf2(long):long (FullOpts)
 ; ============================================================
```