### PR TITLE
Restore $(Platform) to Tsavorite binary OutputPaths

### DIFF
--- a/libs/storage/Tsavorite/cs/benchmark/Tsavorite.benchmark.csproj
+++ b/libs/storage/Tsavorite/cs/benchmark/Tsavorite.benchmark.csproj
@@ -12,6 +12,7 @@
     <AssemblyOriginatorKeyFile>../../../../../Garnet.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
     <SignAssembly>true</SignAssembly>
+    <OutputPath>bin\$(Platform)\$(Configuration)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libs/storage/Tsavorite/cs/src/core/Tsavorite.core.csproj
+++ b/libs/storage/Tsavorite/cs/src/core/Tsavorite.core.csproj
@@ -12,7 +12,8 @@
     <OutputType>Library</OutputType>
     <AssemblyOriginatorKeyFile>../../../../../../Garnet.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-	<EmbedUntrackedSources>true</EmbedUntrackedSources>
+	  <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <OutputPath>bin\$(Platform)\$(Configuration)</OutputPath>
     <DocumentationFile>bin\$(Platform)\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 

--- a/libs/storage/Tsavorite/cs/src/devices/AzureStorageDevice/Tsavorite.devices.AzureStorageDevice.csproj
+++ b/libs/storage/Tsavorite/cs/src/devices/AzureStorageDevice/Tsavorite.devices.AzureStorageDevice.csproj
@@ -13,7 +13,8 @@
     <OutputType>Library</OutputType>
     <AssemblyOriginatorKeyFile>../../../../../../../Garnet.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-	<EmbedUntrackedSources>true</EmbedUntrackedSources>
+  	<EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <OutputPath>bin\$(Platform)\$(Configuration)</OutputPath>
     <DocumentationFile>bin\$(Platform)\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 

--- a/libs/storage/Tsavorite/cs/test/Tsavorite.test.csproj
+++ b/libs/storage/Tsavorite/cs/test/Tsavorite.test.csproj
@@ -13,6 +13,7 @@
     <OutputType>Library</OutputType>
     <AssemblyOriginatorKeyFile>../../../../../Garnet.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
+    <OutputPath>bin\$(Platform)\$(Configuration)</OutputPath>
     <DocumentationFile>bin\$(Platform)\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   	


### PR DESCRIPTION
@PaulusParssinen #297 used the default for OutputPath which does not include $(Platform) and Garnet.nuspec was not updated.

Let's stay with:
    <OutputPath>bin\$(Platform)\$(Configuration)</OutputPath>
I'll add a comment to #317 for this