### PR TITLE
[PubSub] Fix overriding exisiting session subscriptions

### DIFF
--- a/libs/server/PubSub/SubscribeBroker.cs
+++ b/libs/server/PubSub/SubscribeBroker.cs
@@ -226,7 +226,7 @@ namespace Garnet.server
             var subscriptionKey = new Span<byte>(start, (int)(key - start)).ToArray();
             subscriptions.TryAdd(subscriptionKey, new ConcurrentDictionary<int, ServerSessionBase>());
             if (subscriptions.TryGetValue(subscriptionKey, out var val))
-                val.TryAdd(sid, session);
+                val.TryAdd(id, session);
             return id;
         }
 
@@ -256,7 +256,7 @@ namespace Garnet.server
             var subscriptionPrefix = new Span<byte>(start, (int)(prefix - start)).ToArray();
             prefixSubscriptions.TryAdd(subscriptionPrefix, (ascii, new ConcurrentDictionary<int, ServerSessionBase>()));
             if (prefixSubscriptions.TryGetValue(subscriptionPrefix, out var val))
-                val.Item2.TryAdd(sid, session);
+                val.Item2.TryAdd(id, session);
             return id;
         }
 


### PR DESCRIPTION
There is a race condition where the server can override session subscription to a channel when a different session tries to subscribe at the same time
