### PR TITLE
Cleanup of the release pipeline:  removed a task that didn't work and a switch in Nuget Pack that wasn't used 

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -158,8 +158,7 @@ jobs:
 
   - task: GitHubRelease@0
     displayName: 'Create the GitHub release'
-# Debug - set to True after done testing
-    enabled: False
+    enabled: True
     inputs:
       action: 'create'
       gitHubConnection: ADO_to_Github_ServiceConnection
@@ -184,8 +183,7 @@ jobs:
 
   - task: NuGetCommand@2
     displayName: 'Push to NuGet.org'
-# Debug - set to True after done testing
-    enabled: False
+    enabled: True
     inputs:
       command: push
       packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'

--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -104,19 +104,12 @@ jobs:
             }
         ]
 
-  - task: CopyFiles@2
-    displayName: 'Copy Files for Nuget package to Artifacts dir: $(build.artifactstagingdirectory)'
-    enabled: True
-    inputs:
-      Contents: '**/bin/AnyCPU/$(BuildConfiguration)/**/*'
-      TargetFolder: $(build.artifactstagingdirectory)
-
   - task: NuGetCommand@2
     displayName: nuget pack Garnet
     enabled: True
     inputs:
       command: custom
-      arguments: pack Garnet.nuspec -OutputDirectory $(Build.ArtifactStagingDirectory) -Properties Configuration=$(BuildConfiguration) -Symbols -SymbolPackageFormat snupkg -version $(Build.BuildNumber) -Verbosity Detailed
+      arguments: pack Garnet.nuspec -OutputDirectory $(Build.ArtifactStagingDirectory) -Symbols -SymbolPackageFormat snupkg -version $(Build.BuildNumber) -Verbosity Detailed
 
   # Do after Nuget Pack so not part of Nuget Pack
   - task: PowerShell@2
@@ -165,7 +158,8 @@ jobs:
 
   - task: GitHubRelease@0
     displayName: 'Create the GitHub release'
-    enabled: True
+# Debug - set to True after done testing
+    enabled: False
     inputs:
       action: 'create'
       gitHubConnection: ADO_to_Github_ServiceConnection
@@ -190,7 +184,8 @@ jobs:
 
   - task: NuGetCommand@2
     displayName: 'Push to NuGet.org'
-    enabled: True
+# Debug - set to True after done testing
+    enabled: False
     inputs:
       command: push
       packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'


### PR DESCRIPTION
This is what we found when testing csproj PR.  The "Copy Files for Nuget package ..." task and the "$(BuildConfiguration)" setting in the pack task are not needed and were removed.  In both cases it is because they used the variable $(BuildConfiguration) and it isn't used anywhere else.