### PR TITLE
Fix TTL on objects, issue #337

### DIFF
--- a/libs/server/Storage/Session/MainStore/MainStoreOps.cs
+++ b/libs/server/Storage/Session/MainStore/MainStoreOps.cs
@@ -271,7 +271,7 @@ namespace Garnet.server
 
             if ((storeType == StoreType.Object || storeType == StoreType.All) && objectStoreSession != null)
             {
-                (*(RespInputHeader*)pcurr).type = GarnetObjectType.Ttl;
+                (*(RespInputHeader*)pcurr).type = milliseconds ? GarnetObjectType.PTtl : GarnetObjectType.Ttl;
 
                 var keyBA = key.ToByteArray();
                 var objO = new GarnetObjectStoreOutput { spanByteAndMemory = output };


### PR DESCRIPTION
Use `GarnetObjectType.PTtl` or `GarnetObjectType.Ttl` depending on the flag `milliseconds`.
This fixes #337 