### PR TITLE
Cache stateless comparers

### DIFF
--- a/libs/server/Objects/Hash/HashObject.cs
+++ b/libs/server/Objects/Hash/HashObject.cs
@@ -49,7 +49,7 @@ namespace Garnet.server
         public HashObject(long expiration = 0)
             : base(expiration, MemoryUtils.DictionaryOverhead)
         {
-            hash = new Dictionary<byte[], byte[]>(new ByteArrayComparer());
+            hash = new Dictionary<byte[], byte[]>(ByteArrayComparer.Instance);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Garnet.server
         public HashObject(BinaryReader reader)
             : base(reader, MemoryUtils.DictionaryOverhead)
         {
-            hash = new Dictionary<byte[], byte[]>(new ByteArrayComparer());
+            hash = new Dictionary<byte[], byte[]>(ByteArrayComparer.Instance);
 
             int count = reader.ReadInt32();
             for (int i = 0; i < count; i++)

--- a/libs/server/Objects/Set/SetObject.cs
+++ b/libs/server/Objects/Set/SetObject.cs
@@ -46,7 +46,7 @@ namespace Garnet.server
         public SetObject(long expiration = 0)
             : base(expiration, MemoryUtils.HashSetOverhead)
         {
-            set = new HashSet<byte[]>(new ByteArrayComparer());
+            set = new HashSet<byte[]>(ByteArrayComparer.Instance);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Garnet.server
         public SetObject(BinaryReader reader)
             : base(reader, MemoryUtils.HashSetOverhead)
         {
-            set = new HashSet<byte[]>(new ByteArrayComparer());
+            set = new HashSet<byte[]>(ByteArrayComparer.Instance);
 
             int count = reader.ReadInt32();
             for (int i = 0; i < count; i++)

--- a/libs/server/Objects/SortedSet/SortedSetObject.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObject.cs
@@ -72,11 +72,8 @@ namespace Garnet.server
     /// </summary>
     public partial class SortedSetObject : GarnetObjectBase
     {
-        readonly SortedSet<(double, byte[])> sortedSet;
-        readonly Dictionary<byte[], double> sortedSetDict;
-
-        static readonly SortedSetComparer sortedSetComparer = new();
-        static readonly ByteArrayComparer byteArrayComparer = new();
+        private readonly SortedSet<(double, byte[])> sortedSet;
+        private readonly Dictionary<byte[], double> sortedSetDict;
 
         /// <summary>
         /// Constructor
@@ -84,8 +81,8 @@ namespace Garnet.server
         public SortedSetObject(long expiration = 0)
             : base(expiration, MemoryUtils.SortedSetOverhead + MemoryUtils.DictionaryOverhead)
         {
-            sortedSet = new(sortedSetComparer);
-            sortedSetDict = new Dictionary<byte[], double>(byteArrayComparer);
+            sortedSet = new(SortedSetComparer.Instance);
+            sortedSetDict = new Dictionary<byte[], double>(ByteArrayComparer.Instance);
         }
 
         /// <summary>
@@ -94,8 +91,8 @@ namespace Garnet.server
         public SortedSetObject(BinaryReader reader)
             : base(reader, MemoryUtils.SortedSetOverhead + MemoryUtils.DictionaryOverhead)
         {
-            sortedSet = new(sortedSetComparer);
-            sortedSetDict = new Dictionary<byte[], double>(byteArrayComparer);
+            sortedSet = new(SortedSetComparer.Instance);
+            sortedSetDict = new Dictionary<byte[], double>(ByteArrayComparer.Instance);
 
             int count = reader.ReadInt32();
             for (int i = 0; i < count; i++)

--- a/libs/server/Objects/SortedSetComparer.cs
+++ b/libs/server/Objects/SortedSetComparer.cs
@@ -6,8 +6,15 @@ using System.Collections.Generic;
 
 namespace Garnet.server
 {
-    class SortedSetComparer : IComparer<(double, byte[])>
+    public sealed class SortedSetComparer : IComparer<(double, byte[])>
     {
+        /// <summary>
+        /// The default instance.
+        /// </summary>
+        /// <remarks>Used to avoid allocating new comparers.</remarks>
+        public static readonly SortedSetComparer Instance = new();
+
+        /// <inheritdoc/>
         public int Compare((double, byte[]) x, (double, byte[]) y)
         {
             var ret = x.Item1.CompareTo(y.Item1);

--- a/libs/server/PubSub/SubscribeBroker.cs
+++ b/libs/server/PubSub/SubscribeBroker.cs
@@ -132,7 +132,7 @@ namespace Garnet.server
         {
             try
             {
-                var uniqueKeys = new Dictionary<byte[], (byte[], byte[])>(new ByteArrayComparer());
+                var uniqueKeys = new Dictionary<byte[], (byte[], byte[])>(ByteArrayComparer.Instance);
                 long truncateUntilAddress = log.BeginAddress;
 
                 while (true)
@@ -215,8 +215,8 @@ namespace Garnet.server
             if (Interlocked.CompareExchange(ref publishQueue, new AsyncQueue<(byte[], byte[])>(), null) == null)
             {
                 done.Reset();
-                subscriptions = new ConcurrentDictionary<byte[], ConcurrentDictionary<int, ServerSessionBase>>(new ByteArrayComparer());
-                prefixSubscriptions = new ConcurrentDictionary<byte[], (bool, ConcurrentDictionary<int, ServerSessionBase>)>(new ByteArrayComparer());
+                subscriptions = new ConcurrentDictionary<byte[], ConcurrentDictionary<int, ServerSessionBase>>(ByteArrayComparer.Instance);
+                prefixSubscriptions = new ConcurrentDictionary<byte[], (bool, ConcurrentDictionary<int, ServerSessionBase>)>(ByteArrayComparer.Instance);
                 Task.Run(() => Start(cts.Token));
             }
             else
@@ -245,8 +245,8 @@ namespace Garnet.server
             if (Interlocked.CompareExchange(ref publishQueue, new AsyncQueue<(byte[], byte[])>(), null) == null)
             {
                 done.Reset();
-                subscriptions = new ConcurrentDictionary<byte[], ConcurrentDictionary<int, ServerSessionBase>>(new ByteArrayComparer());
-                prefixSubscriptions = new ConcurrentDictionary<byte[], (bool, ConcurrentDictionary<int, ServerSessionBase>)>(new ByteArrayComparer());
+                subscriptions = new ConcurrentDictionary<byte[], ConcurrentDictionary<int, ServerSessionBase>>(ByteArrayComparer.Instance);
+                prefixSubscriptions = new ConcurrentDictionary<byte[], (bool, ConcurrentDictionary<int, ServerSessionBase>)>(ByteArrayComparer.Instance);
                 Task.Run(() => Start(cts.Token));
             }
             else

--- a/libs/server/Resp/ByteArrayComparer.cs
+++ b/libs/server/Resp/ByteArrayComparer.cs
@@ -10,22 +10,19 @@ namespace Garnet.server
     /// <summary>
     /// Byte array equality comparer
     /// </summary>
-    public class ByteArrayComparer : IEqualityComparer<byte[]>
+    public sealed class ByteArrayComparer : IEqualityComparer<byte[]>
     {
         /// <summary>
-        /// Equals
+        /// The default instance.
         /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <remarks>Used to avoid allocating new comparers.</remarks>
+        public static readonly ByteArrayComparer Instance = new();
+
+        /// <inheritdoc />
         public bool Equals(byte[] left, byte[] right)
             => new ReadOnlySpan<byte>(left).SequenceEqual(new ReadOnlySpan<byte>(right));
 
-        /// <summary>
-        /// Get hash code
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public unsafe int GetHashCode(byte[] key)
         {
             fixed (byte* k = key)

--- a/libs/server/Storage/Session/ObjectStore/SetOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/SetOps.cs
@@ -431,7 +431,7 @@ namespace Garnet.server
         /// <returns></returns>
         public GarnetStatus SetUnion(ArgSlice[] keys, out HashSet<byte[]> output)
         {
-            output = new HashSet<byte[]>(new ByteArrayComparer());
+            output = new HashSet<byte[]>(ByteArrayComparer.Instance);
 
             if (keys.Length == 0)
                 return GarnetStatus.OK;
@@ -517,7 +517,7 @@ namespace Garnet.server
         private HashSet<byte[]> SetUnion<TObjectContext>(ArgSlice[] keys, ref TObjectContext objectContext)
             where TObjectContext : ITsavoriteContext<byte[], IGarnetObject, SpanByte, GarnetObjectStoreOutput, long>
         {
-            var result = new HashSet<byte[]>(new ByteArrayComparer());
+            var result = new HashSet<byte[]>(ByteArrayComparer.Instance);
             if (keys.Length == 0)
             {
                 return result;
@@ -742,7 +742,7 @@ namespace Garnet.server
             {
                 if (first.garnetObject is SetObject firstObject)
                 {
-                    result = new HashSet<byte[]>(firstObject.Set, new ByteArrayComparer());
+                    result = new HashSet<byte[]>(firstObject.Set, ByteArrayComparer.Instance);
                 }
             }
             else

--- a/libs/storage/Tsavorite/cs/src/core/Index/Interfaces/ITsavoriteEqualityComparer.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Interfaces/ITsavoriteEqualityComparer.cs
@@ -1,26 +1,27 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
+
 namespace Tsavorite.core
 {
     /// <summary>
-    /// Key interface
+    /// Defines methods to support the comparison of Tsavorite keys for equality.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">The type of keys to compare.</typeparam>
+    /// <remarks>This comparer differs from the built-in <see cref="IEqualityComparer{T}"/> in that it implements a 64-bit hash code</remarks>
     public interface ITsavoriteEqualityComparer<T>
     {
         /// <summary>
         /// Get 64-bit hash code
         /// </summary>
-        /// <returns></returns>
-        long GetHashCode64(ref T k);
+        long GetHashCode64(ref T key);
 
         /// <summary>
         /// Equality comparison
         /// </summary>
         /// <param name="k1">Left side</param>
         /// <param name="k2">Right side</param>
-        /// <returns></returns>
         bool Equals(ref T k1, ref T k2);
     }
 }

--- a/libs/storage/Tsavorite/cs/src/core/Index/Interfaces/TsavoriteEqualityComparer.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Interfaces/TsavoriteEqualityComparer.cs
@@ -11,19 +11,18 @@ namespace Tsavorite.core
     {
         public static ITsavoriteEqualityComparer<T> Get<T>()
         {
-            var t = typeof(T);
-            if (t == typeof(string))
-                return new StringTsavoriteEqualityComparer() as ITsavoriteEqualityComparer<T>;
-            else if (t == typeof(byte[]))
-                return new ByteArrayTsavoriteEqualityComparer() as ITsavoriteEqualityComparer<T>;
-            else if (t == typeof(long))
-                return new LongTsavoriteEqualityComparer() as ITsavoriteEqualityComparer<T>;
-            else if (t == typeof(int))
-                return new IntTsavoriteEqualityComparer() as ITsavoriteEqualityComparer<T>;
-            else if (t == typeof(Guid))
-                return new GuidTsavoriteEqualityComparer() as ITsavoriteEqualityComparer<T>;
-            else if (t == typeof(SpanByte))
-                return new SpanByteComparer() as ITsavoriteEqualityComparer<T>;
+            if (typeof(T) == typeof(string))
+                return (ITsavoriteEqualityComparer<T>)(object)new StringTsavoriteEqualityComparer();
+            else if (typeof(T) == typeof(byte[]))
+                return (ITsavoriteEqualityComparer<T>)(object)new ByteArrayTsavoriteEqualityComparer();
+            else if (typeof(T) == typeof(long))
+                return (ITsavoriteEqualityComparer<T>)(object)new LongTsavoriteEqualityComparer();
+            else if (typeof(T) == typeof(int))
+                return (ITsavoriteEqualityComparer<T>)(object)new IntTsavoriteEqualityComparer();
+            else if (typeof(T) == typeof(Guid))
+                return (ITsavoriteEqualityComparer<T>)(object)new GuidTsavoriteEqualityComparer();
+            else if (typeof(T) == typeof(SpanByte))
+                return (ITsavoriteEqualityComparer<T>)(object)new SpanByteComparer();
             else
             {
                 Debug.WriteLine("***WARNING*** Creating default Tsavorite key equality comparer based on potentially slow EqualityComparer<Key>.Default."

--- a/libs/storage/Tsavorite/cs/src/core/Index/Interfaces/TsavoriteEqualityComparer.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Interfaces/TsavoriteEqualityComparer.cs
@@ -12,22 +12,22 @@ namespace Tsavorite.core
         public static ITsavoriteEqualityComparer<T> Get<T>()
         {
             if (typeof(T) == typeof(string))
-                return (ITsavoriteEqualityComparer<T>)(object)new StringTsavoriteEqualityComparer();
+                return (ITsavoriteEqualityComparer<T>)(object)StringTsavoriteEqualityComparer.Instance;
             else if (typeof(T) == typeof(byte[]))
-                return (ITsavoriteEqualityComparer<T>)(object)new ByteArrayTsavoriteEqualityComparer();
+                return (ITsavoriteEqualityComparer<T>)(object)ByteArrayTsavoriteEqualityComparer.Instance;
             else if (typeof(T) == typeof(long))
-                return (ITsavoriteEqualityComparer<T>)(object)new LongTsavoriteEqualityComparer();
+                return (ITsavoriteEqualityComparer<T>)(object)LongTsavoriteEqualityComparer.Instance;
             else if (typeof(T) == typeof(int))
-                return (ITsavoriteEqualityComparer<T>)(object)new IntTsavoriteEqualityComparer();
+                return (ITsavoriteEqualityComparer<T>)(object)IntTsavoriteEqualityComparer.Instance;
             else if (typeof(T) == typeof(Guid))
-                return (ITsavoriteEqualityComparer<T>)(object)new GuidTsavoriteEqualityComparer();
+                return (ITsavoriteEqualityComparer<T>)(object)GuidTsavoriteEqualityComparer.Instance;
             else if (typeof(T) == typeof(SpanByte))
-                return (ITsavoriteEqualityComparer<T>)(object)new SpanByteComparer();
+                return (ITsavoriteEqualityComparer<T>)(object)SpanByteComparer.Instance;
             else
             {
                 Debug.WriteLine("***WARNING*** Creating default Tsavorite key equality comparer based on potentially slow EqualityComparer<Key>.Default."
                                + "To avoid this, provide a comparer (ITsavoriteEqualityComparer<Key>) as an argument to Tsavorite's constructor, or make Key implement the interface ITsavoriteEqualityComparer<Key>");
-                return DefaultTsavoriteEqualityComparer<T>.Default;
+                return DefaultTsavoriteEqualityComparer<T>.Instance;
             }
         }
     }
@@ -38,11 +38,12 @@ namespace Tsavorite.core
     public sealed class StringTsavoriteEqualityComparer : ITsavoriteEqualityComparer<string>
     {
         /// <summary>
-        /// Equals
+        /// The default instance.
         /// </summary>
-        /// <param name="key1"></param>
-        /// <param name="key2"></param>
-        /// <returns></returns>
+        /// <remarks>Used to avoid allocating new comparers.</remarks>
+        public static readonly StringTsavoriteEqualityComparer Instance = new();
+
+        /// <inheritdoc />
         public bool Equals(ref string key1, ref string key2)
         {
             // Use locals in case the record space is cleared.
@@ -50,11 +51,7 @@ namespace Tsavorite.core
             return (k1 is null || k2 is null) ? false : k1 == k2;
         }
 
-        /// <summary>
-        /// GetHashCode64
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public unsafe long GetHashCode64(ref string key)
         {
             // Use locals in case the record space is cleared.
@@ -75,18 +72,15 @@ namespace Tsavorite.core
     public sealed class LongTsavoriteEqualityComparer : ITsavoriteEqualityComparer<long>
     {
         /// <summary>
-        /// Equals
+        /// The default instance.
         /// </summary>
-        /// <param name="k1"></param>
-        /// <param name="k2"></param>
-        /// <returns></returns>
+        /// <remarks>Used to avoid allocating new comparers.</remarks>
+        public static readonly LongTsavoriteEqualityComparer Instance = new();
+
+        /// <inheritdoc />
         public bool Equals(ref long k1, ref long k2) => k1 == k2;
 
-        /// <summary>
-        /// GetHashCode64
-        /// </summary>
-        /// <param name="k"></param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public long GetHashCode64(ref long k) => Utility.GetHashCode(k);
     }
 
@@ -96,18 +90,15 @@ namespace Tsavorite.core
     public sealed class IntTsavoriteEqualityComparer : ITsavoriteEqualityComparer<int>
     {
         /// <summary>
-        /// Equals
+        /// The default instance.
         /// </summary>
-        /// <param name="k1"></param>
-        /// <param name="k2"></param>
-        /// <returns></returns>
+        /// <remarks>Used to avoid allocating new comparers.</remarks>
+        public static readonly IntTsavoriteEqualityComparer Instance = new();
+
+        /// <inheritdoc />
         public bool Equals(ref int k1, ref int k2) => k1 == k2;
 
-        /// <summary>
-        /// GetHashCode64
-        /// </summary>
-        /// <param name="k"></param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public long GetHashCode64(ref int k) => Utility.GetHashCode(k);
     }
 
@@ -117,18 +108,15 @@ namespace Tsavorite.core
     public sealed class GuidTsavoriteEqualityComparer : ITsavoriteEqualityComparer<Guid>
     {
         /// <summary>
-        /// Equals
+        /// The default instance.
         /// </summary>
-        /// <param name="k1"></param>
-        /// <param name="k2"></param>
-        /// <returns></returns>
+        /// <remarks>Used to avoid allocating new comparers.</remarks>
+        public static readonly GuidTsavoriteEqualityComparer Instance = new();
+
+        /// <inheritdoc />
         public bool Equals(ref Guid k1, ref Guid k2) => k1 == k2;
 
-        /// <summary>
-        /// GetHashCode64
-        /// </summary>
-        /// <param name="k"></param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public unsafe long GetHashCode64(ref Guid k)
         {
             var _k = k;
@@ -143,18 +131,15 @@ namespace Tsavorite.core
     public sealed class ByteArrayTsavoriteEqualityComparer : ITsavoriteEqualityComparer<byte[]>
     {
         /// <summary>
-        /// Equals
+        /// The default instance.
         /// </summary>
-        /// <param name="key1"></param>
-        /// <param name="key2"></param>
-        /// <returns></returns>
+        /// <remarks>Used to avoid allocating new comparers.</remarks>
+        public static readonly ByteArrayTsavoriteEqualityComparer Instance = new();
+
+        /// <inheritdoc />
         public bool Equals(ref byte[] key1, ref byte[] key2) => key1.AsSpan().SequenceEqual(key2);
 
-        /// <summary>
-        /// GetHashCode64
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public unsafe long GetHashCode64(ref byte[] key)
         {
             // Use locals in case the record space is cleared.
@@ -175,18 +160,18 @@ namespace Tsavorite.core
     /// <typeparam name="T"></typeparam>
     internal sealed class DefaultTsavoriteEqualityComparer<T> : ITsavoriteEqualityComparer<T>
     {
-        public static readonly DefaultTsavoriteEqualityComparer<T> Default = new DefaultTsavoriteEqualityComparer<T>();
+        /// <summary>
+        /// The default instance.
+        /// </summary>
+        /// <remarks>Used to avoid allocating new comparers.</remarks>
+        public static readonly DefaultTsavoriteEqualityComparer<T> Instance = new();
 
         private static readonly EqualityComparer<T> DefaultEC = EqualityComparer<T>.Default;
 
-        public bool Equals(ref T k1, ref T k2)
-        {
-            return DefaultEC.Equals(k1, k2);
-        }
+        /// <inheritdoc />
+        public bool Equals(ref T k1, ref T k2) => DefaultEC.Equals(k1, k2);
 
-        public long GetHashCode64(ref T k)
-        {
-            return Utility.GetHashCode(DefaultEC.GetHashCode(k));
-        }
+        /// <inheritdoc />
+        public long GetHashCode64(ref T k) => Utility.GetHashCode(DefaultEC.GetHashCode(k));
     }
 }

--- a/libs/storage/Tsavorite/cs/src/core/VarLen/SpanByteComparer.cs
+++ b/libs/storage/Tsavorite/cs/src/core/VarLen/SpanByteComparer.cs
@@ -11,6 +11,12 @@ namespace Tsavorite.core
     /// </summary>
     public struct SpanByteComparer : ITsavoriteEqualityComparer<SpanByte>
     {
+        /// <summary>
+        /// The default instance.
+        /// </summary>
+        /// <remarks>Used to avoid allocating new comparers.</remarks>
+        public static readonly SpanByteComparer Instance = new();
+
         /// <inheritdoc />
         public unsafe long GetHashCode64(ref SpanByte spanByte) => StaticGetHashCode64(ref spanByte);
 

--- a/main/GarnetServer/Extensions/MyDictObject.cs
+++ b/main/GarnetServer/Extensions/MyDictObject.cs
@@ -27,13 +27,13 @@ namespace Garnet
         public MyDict(byte type)
             : base(type, 0, MemoryUtils.DictionaryOverhead)
         {
-            dict = new(new ByteArrayComparer());
+            dict = new(ByteArrayComparer.Instance);
         }
 
         public MyDict(byte type, BinaryReader reader)
             : base(type, reader, MemoryUtils.DictionaryOverhead)
         {
-            dict = new(new ByteArrayComparer());
+            dict = new(ByteArrayComparer.Instance);
 
             int count = reader.ReadInt32();
             for (int i = 0; i < count; i++)


### PR DESCRIPTION
This PR optimizes the usage of stateless `ITsavoriteEqualityComparer` and other comparer implementations.

### Commits
* [Use ldtoken + castclass instead of ldtoken + isinst in ``TsavoriteEqualityComparer.Get<T>()``](https://github.com/microsoft/garnet/pull/340/commits/751364281d4d54b2e68777c78d229fc221923da2)
* [Cache key comparers in Tsavorite](https://github.com/microsoft/garnet/pull/340/commits/f422150fb5282c09fa41dd107b70cfe1a23b1e19)
* [Cache stateless comparers in Garnet](https://github.com/microsoft/garnet/pull/340/commits/a1ec942c3644fbb1a0380bdeaaad98eaf98d6a35)