### PR TITLE
Additional Checks for MIGRATE KEYS

### DIFF
--- a/libs/cluster/CmdStrings.cs
+++ b/libs/cluster/CmdStrings.cs
@@ -126,6 +126,7 @@ namespace Garnet.cluster
         /// </summary>
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_MIGRATE_TO_MYSELF => "ERR Can't MIGRATE to myself"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_INCOMPLETESLOTSRANGE => "ERR incomplete slotrange"u8;
+        public static ReadOnlySpan<byte> RESP_ERR_GENERIC_SLOTNOTMIGRATING => "ERR slot state not set to MIGRATING state"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_PARSING => "ERR Parsing error"u8;
 
         /// <summary>

--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -391,6 +391,22 @@ namespace Garnet.cluster
         #region GetFromSlot
 
         /// <summary>
+        /// Check if slot is set as IMPORTING
+        /// </summary>
+        /// <param name="slot">Slot number.</param>
+        /// <returns>True if slot is in IMPORTING state, false otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsImportingSlot(ushort slot) => slotMap[slot]._state == SlotState.IMPORTING;
+
+        /// <summary>
+        /// Check if slot is set as MIGRATING
+        /// </summary>
+        /// <param name="slot">Slot number.</param>
+        /// <returns>True if slot is in MIGRATING state, false otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsMigratingSlot(ushort slot) => slotMap[slot]._state == SlotState.MIGRATING;
+
+        /// <summary>
         /// Get slot state
         /// </summary>
         /// <param name="slot">Slot number.</param>

--- a/libs/cluster/Server/ClusterManagerSlotState.cs
+++ b/libs/cluster/Server/ClusterManagerSlotState.cs
@@ -158,21 +158,21 @@ namespace Garnet.cluster
                 var current = currentConfig;
                 var migratingWorkerId = current.GetWorkerIdFromNodeId(nodeid);
 
-                //Check migrating worker is a known valid worker
+                // Check migrating worker is a known valid worker
                 if (migratingWorkerId == 0)
                 {
                     errorMessage = Encoding.ASCII.GetBytes($"ERR I don't know about node {nodeid}");
                     return false;
                 }
 
-                //Check if nodeid is different from local node
+                // Check if node-id is different from local node
                 if (current.LocalNodeId.Equals(nodeid, StringComparison.OrdinalIgnoreCase))
                 {
                     errorMessage = CmdStrings.RESP_ERR_GENERIC_MIGRATE_TO_MYSELF;
                     return false;
                 }
 
-                //Check if local node is primary
+                // Check if local node is primary
                 if (current.GetNodeRoleFromNodeId(nodeid) != NodeRole.PRIMARY)
                 {
                     errorMessage = Encoding.ASCII.GetBytes($"ERR Target node {nodeid} is not a master node.");
@@ -181,14 +181,14 @@ namespace Garnet.cluster
 
                 foreach (var slot in slots)
                 {
-                    //Check if slot is owned by local node
+                    // Check if slot is owned by local node
                     if (!current.IsLocal((ushort)slot))
                     {
                         errorMessage = Encoding.ASCII.GetBytes($"ERR I'm not the owner of hash slot {slot}");
                         return false;
                     }
 
-                    //Check node state is stable
+                    // Check node state is stable
                     if (current.GetState((ushort)slot) != SlotState.STABLE)
                     {
                         var _migratingNodeId = current.GetNodeIdFromSlot((ushort)slot);
@@ -243,7 +243,7 @@ namespace Garnet.cluster
                     return false;
                 }
 
-                string sourceNodeId = current.GetNodeIdFromSlot((ushort)slot);
+                var sourceNodeId = current.GetNodeIdFromSlot((ushort)slot);
                 if (sourceNodeId == null || !sourceNodeId.Equals(nodeid, StringComparison.OrdinalIgnoreCase))
                 {
                     errorMessage = Encoding.ASCII.GetBytes($"ERR Slot {slot} is not owned by {nodeid}");
@@ -460,7 +460,7 @@ namespace Garnet.cluster
         public static unsafe void DeleteKeysInSlotsFromMainStore(BasicGarnetApi BasicGarnetApi, HashSet<int> slots)
         {
             using var iter = BasicGarnetApi.IterateMainStore();
-            while (iter.GetNext(out var recordInfo))
+            while (iter.GetNext(out _))
             {
                 ref SpanByte key = ref iter.GetKey();
                 var s = NumUtils.HashSlot(key.ToPointer(), key.Length);
@@ -477,7 +477,7 @@ namespace Garnet.cluster
         public static unsafe void DeleteKeysInSlotsFromObjectStore(BasicGarnetApi BasicGarnetApi, HashSet<int> slots)
         {
             using var iterObject = BasicGarnetApi.IterateObjectStore();
-            while (iterObject.GetNext(out var recordInfo))
+            while (iterObject.GetNext(out _))
             {
                 ref var key = ref iterObject.GetKey();
                 ref var value = ref iterObject.GetValue();

--- a/libs/cluster/Server/ClusterManagerSlotState.cs
+++ b/libs/cluster/Server/ClusterManagerSlotState.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using Garnet.common;
@@ -452,14 +451,6 @@ namespace Garnet.cluster
                 ResetSlotState(slot);
             }
         }
-
-        /// <summary>
-        /// Check if slot is in importing state.
-        /// </summary>
-        /// <param name="slot">Slot to check state</param>
-        /// <returns>True if slot is in Importing state, false otherwise</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool IsImporting(ushort slot) => currentConfig.GetState(slot) == SlotState.IMPORTING;
 
         /// <summary>
         /// Methods used to cleanup keys for given slot collection in main store

--- a/libs/cluster/Server/Migration/MigrateSession.cs
+++ b/libs/cluster/Server/Migration/MigrateSession.cs
@@ -260,7 +260,7 @@ namespace Garnet.cluster
             if (!clusterProvider.clusterManager.TryPrepareSlotsForMigration(_sslots, _targetNodeId, out var resp))
             {
                 Status = MigrateState.FAIL;
-                logger?.LogError(Encoding.ASCII.GetString(resp));
+                logger?.LogError("{errorMsg}", Encoding.ASCII.GetString(resp));
                 return false;
             }
             return true;
@@ -286,7 +286,10 @@ namespace Garnet.cluster
             // Set slot at target to stable state when migrate slots fails
             // This issues a SETSLOTRANGE STABLE for the slots of the failed migration task
             if (!TrySetSlotRanges(null, MigrateState.STABLE))
+            {
+                logger?.LogError("MigrateSession.RecoverFromFailure failed to make slots STABLE");
                 return false;
+            }
 
             // Set slots at source node to their original state when migrate fails
             // This will execute the equivalent of SETSLOTRANGE STABLE for the slots of the failed migration task

--- a/libs/cluster/Server/Migration/MigrateSessionKeys.cs
+++ b/libs/cluster/Server/Migration/MigrateSessionKeys.cs
@@ -33,25 +33,25 @@ namespace Garnet.cluster
                 // 1 byte RespCommand
                 // 1 byte RespInputFlags
                 var inputSize = sizeof(int) + RespInputHeader.Size;
-                byte* pbCmdInput = stackalloc byte[inputSize];
+                var pbCmdInput = stackalloc byte[inputSize];
 
                 ////////////////
                 // Build Input//
                 ////////////////
-                byte* pcurr = pbCmdInput;
+                var pcurr = pbCmdInput;
                 *(int*)pcurr = inputSize - sizeof(int);
                 pcurr += sizeof(int);
                 // 1. Header
                 ((RespInputHeader*)(pcurr))->SetHeader(RespCommandAccessor.MIGRATE, 0);
 
-                byte* bufPtr = buffer.GetValidPointer();
-                byte* bufPtrEnd = bufPtr + bufferSize;
-                for (int i = 0; i < keysWithSize.Count; i++)
+                var bufPtr = buffer.GetValidPointer();
+                var bufPtrEnd = bufPtr + bufferSize;
+                for (var i = 0; i < keysWithSize.Count; i++)
                 {
                     // 1. Prepare key pointers
                     var tuple = keysWithSize[i];
-                    byte* keyPtr = (byte*)((IntPtr)tuple.Item1).ToPointer();
-                    int ksize = (int)tuple.Item2;
+                    var keyPtr = (byte*)((IntPtr)tuple.Item1).ToPointer();
+                    var ksize = (int)tuple.Item2;
                     keyPtr -= sizeof(int);
                     *(int*)keyPtr = ksize;
 
@@ -69,7 +69,7 @@ namespace Garnet.cluster
 
                     //4. Make value SpanByte
                     keyPtr = (byte*)((IntPtr)tuple.Item1).ToPointer();
-                    SpanByte key = SpanByte.FromPinnedPointer(keyPtr, ksize);
+                    var key = SpanByte.FromPinnedPointer(keyPtr, ksize);
                     SpanByte value;
                     MemoryHandle memoryHandle = default;
                     if (!o.IsSpanByte)
@@ -109,13 +109,13 @@ namespace Garnet.cluster
         /// <returns>True on success, false otherwise</returns>
         private bool MigrateKeysFromObjectStore(ref List<(long, long)> objectStoreKeys)
         {
-            for (int i = 0; i < objectStoreKeys.Count; i++)
+            for (var i = 0; i < objectStoreKeys.Count; i++)
             {
                 var tuple = objectStoreKeys[i];
-                byte* keyPtr = (byte*)((IntPtr)tuple.Item1).ToPointer();
-                int ksize = (int)tuple.Item2;
+                var keyPtr = (byte*)((IntPtr)tuple.Item1).ToPointer();
+                var ksize = (int)tuple.Item2;
 
-                byte[] key = new byte[ksize];
+                var key = new byte[ksize];
                 Marshal.Copy((IntPtr)keyPtr, key, 0, ksize);
 
                 SpanByte input = default;
@@ -126,7 +126,7 @@ namespace Garnet.cluster
 
                 if (!ClusterSession.Expired(ref value.garnetObject))
                 {
-                    byte[] objectData = GarnetObjectSerializer.Serialize(value.garnetObject);
+                    var objectData = GarnetObjectSerializer.Serialize(value.garnetObject);
 
                     if (!WriteOrSendObjectStoreKeyValuePair(key, objectData, value.garnetObject.Expiration))
                         return false;
@@ -148,7 +148,8 @@ namespace Garnet.cluster
             var keysWithSize = _keysWithSize;
             try
             {
-                CheckConnection();
+                if (!CheckConnection())
+                    return false;
                 _gcs.InitMigrateBuffer();
                 if (!MigrateKeysFromMainStore(ref keysWithSize, out var objectStoreKeys))
                     return false;
@@ -175,11 +176,11 @@ namespace Garnet.cluster
             if (_copyOption)
                 return;
 
-            for (int i = 0; i < keysWithSize.Count; i++)
+            for (var i = 0; i < keysWithSize.Count; i++)
             {
                 var tuple = keysWithSize[i];
-                byte* keyPtr = (byte*)((IntPtr)tuple.Item1).ToPointer();
-                int ksize = (int)tuple.Item2;
+                var keyPtr = (byte*)((IntPtr)tuple.Item1).ToPointer();
+                var ksize = (int)tuple.Item2;
                 keyPtr -= sizeof(int);
                 *(int*)keyPtr = ksize;
                 localServerSession.BasicGarnetApi.DELETE(ref Unsafe.AsRef<SpanByte>(keyPtr));

--- a/libs/cluster/Server/Migration/MigrateSessionKeys.cs
+++ b/libs/cluster/Server/Migration/MigrateSessionKeys.cs
@@ -23,16 +23,16 @@ namespace Garnet.cluster
         /// <returns>True on success, false otherwise</returns>
         private bool MigrateKeysFromMainStore(ref List<(long, long)> keysWithSize, out List<(long, long)> objectStoreKeys)
         {
-            int bufferSize = 1 << 10;
+            var bufferSize = 1 << 10;
             SectorAlignedMemory buffer = new(bufferSize, 1);
-            objectStoreKeys = new();
+            objectStoreKeys = [];
 
             try
             {
                 // 4 byte length of input
                 // 1 byte RespCommand
                 // 1 byte RespInputFlags
-                int inputSize = sizeof(int) + RespInputHeader.Size;
+                var inputSize = sizeof(int) + RespInputHeader.Size;
                 byte* pbCmdInput = stackalloc byte[inputSize];
 
                 ////////////////

--- a/libs/cluster/Server/Migration/MigrateSessionSend.cs
+++ b/libs/cluster/Server/Migration/MigrateSessionSend.cs
@@ -70,7 +70,7 @@ namespace Garnet.cluster
             {
                 try
                 {
-                    bool status = task.ContinueWith(resp =>
+                    _ = task.ContinueWith(resp =>
                     {
                         // Check if setslotsrange executed correctly
                         if (!resp.Result.Equals("OK", StringComparison.Ordinal))
@@ -85,6 +85,7 @@ namespace Garnet.cluster
                 catch (Exception ex)
                 {
                     logger?.LogError(ex, "An error has occurred");
+                    Status = MigrateState.FAIL;
                     return false;
                 }
             }

--- a/libs/cluster/Session/MigrateCommand.cs
+++ b/libs/cluster/Session/MigrateCommand.cs
@@ -238,7 +238,7 @@ namespace Garnet.cluster
                             // Skip if previous error encountered
                             if (pstate != MigrateCmdParseState.SUCCESS) continue;
 
-                            for (int slot = slotStart; slot <= slotEnd; slot++)
+                            for (var slot = slotStart; slot <= slotEnd; slot++)
                             {
                                 // Check if slot is in valid range
                                 if (ClusterConfig.OutOfRange(slot))

--- a/libs/cluster/Session/MigrateCommand.cs
+++ b/libs/cluster/Session/MigrateCommand.cs
@@ -28,7 +28,8 @@ namespace Garnet.cluster
             CROSSSLOT,
             TARGETNODENOTMASTER,
             INCOMPLETESLOTSRANGE,
-            SLOTOUTOFRANGE
+            SLOTOUTOFRANGE,
+            NOTMIGRATING,
         }
 
         private bool HandleCommandParsingErrors(MigrateCmdParseState mpState, string targetAddress, int targetPort, int slotMultiRef)
@@ -46,7 +47,7 @@ namespace Garnet.cluster
                 MigrateCmdParseState.TARGETNODENOTMASTER => Encoding.ASCII.GetBytes($"ERR Cannot initiate migration, target node ({targetAddress}:{targetPort}) is not a primary."),
                 MigrateCmdParseState.INCOMPLETESLOTSRANGE => CmdStrings.RESP_ERR_GENERIC_INCOMPLETESLOTSRANGE,
                 MigrateCmdParseState.SLOTOUTOFRANGE => Encoding.ASCII.GetBytes($"ERR Slot {slotMultiRef} out of range."),
-
+                MigrateCmdParseState.NOTMIGRATING => CmdStrings.RESP_ERR_GENERIC_SLOTNOTMIGRATING,
                 _ => CmdStrings.RESP_ERR_GENERIC_PARSING,
             };
             while (!RespWriteUtils.WriteError(errorMessage, ref dcurr, dend))
@@ -103,7 +104,7 @@ namespace Garnet.cluster
                 if (targetNodeId == null) pstate = MigrateCmdParseState.UNKNOWNTARGET;
             }
 
-            //Add single key if specified
+            // Add single key if specified
             if (sksize > 0)
             {
                 keysWithSize = [];
@@ -151,7 +152,7 @@ namespace Garnet.cluster
 
                         // Check if all keys are local R/W because we migrate keys and need to be able to delete them
                         var slot = NumUtils.HashSlot(keyPtr, ksize);
-                        if (!current.IsLocal((ushort)slot, readCommand: false))
+                        if (!current.IsLocal(slot, readCommand: false))
                         {
                             pstate = MigrateCmdParseState.SLOTNOTLOCAL;
                             continue;
@@ -161,6 +162,13 @@ namespace Garnet.cluster
                         if (!slots.Contains(slot) && slots.Count > 0)
                         {
                             pstate = MigrateCmdParseState.CROSSSLOT;
+                            continue;
+                        }
+
+                        // Check if slot is not set as MIGRATING
+                        if (!current.IsMigratingSlot(slot))
+                        {
+                            pstate = MigrateCmdParseState.NOTMIGRATING;
                             continue;
                         }
 


### PR DESCRIPTION
Add check to validate slot is in MIGRATING state when migrate with keys option is called.
Fix validity check for data migrate command a target when slot not in IMPORTING state.
Misc code cleanup