### PR TITLE
Add secondary OS (ubuntu and Windows) to be ran at night 

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest ]
+        os: [ ubuntu-22.04, ubuntu-20.04, windows-2022, windows-2019 ]
         framework: [ 'net6.0', 'net8.0' ]
         configuration: [ 'Debug', 'Release' ]
         test: [ 'Garnet.test', 'Garnet.test.cluster' ]
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest ]
+        os: [ ubuntu-22.04, ubuntu-20.04, windows-2022, windows-2019 ]
         framework: [ 'net6.0', 'net8.0' ]
         configuration: [ 'Debug', 'Release' ]
     steps:


### PR DESCRIPTION
This is for extra coverage for now of "second tier" OS configurations. We can always add more (MacOS etc) if we see fit and we want to fix issues \ support it.

One note - our CI's do "latest" so they probably won't be that much different than the Ubuntu 22.04 and Windows 2022, but "latest" will continue advancing where these two will be set.