### PR TITLE
Clear input header field (flags) for object store RMW operations

### DIFF
--- a/libs/server/Resp/Objects/HashCommands.cs
+++ b/libs/server/Resp/Objects/HashCommands.cs
@@ -69,6 +69,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.Hash;
+                inputPtr->header.flags = 0;
                 inputPtr->header.HashOp = hop;
                 inputPtr->count = inputCount;
                 inputPtr->done = hashOpsCount;
@@ -152,6 +153,7 @@ namespace Garnet.server
                 int inputCount = op == HashOperation.HGETALL ? 0 : (op == HashOperation.HRANDFIELD ? count + 1 : count - 1);
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.Hash;
+                inputPtr->header.flags = 0;
                 inputPtr->header.HashOp = op;
                 inputPtr->count = inputCount;
                 inputPtr->done = hashItemsDoneCount;
@@ -253,6 +255,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.Hash;
+                inputPtr->header.flags = 0;
                 inputPtr->header.HashOp = HashOperation.HLEN;
                 inputPtr->count = 1;
                 inputPtr->done = 0;
@@ -323,6 +326,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.Hash;
+                inputPtr->header.flags = 0;
                 inputPtr->header.HashOp = HashOperation.HSTRLEN;
                 inputPtr->count = 1;
                 inputPtr->done = 0;
@@ -397,6 +401,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.Hash;
+                inputPtr->header.flags = 0;
                 inputPtr->header.HashOp = HashOperation.HDEL;
                 inputPtr->count = inputCount;
                 inputPtr->done = hashItemsDoneCount;
@@ -474,6 +479,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.Hash;
+                inputPtr->header.flags = 0;
                 inputPtr->header.HashOp = HashOperation.HEXISTS;
                 inputPtr->count = 1;
                 inputPtr->done = 0;
@@ -546,6 +552,7 @@ namespace Garnet.server
 
             // Prepare header in input buffer
             inputPtr->header.type = GarnetObjectType.Hash;
+            inputPtr->header.flags = 0;
             inputPtr->header.HashOp = op;
             inputPtr->count = count - 1;
             inputPtr->done = hashOpsCount;
@@ -634,6 +641,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.Hash;
+                inputPtr->header.flags = 0;
                 inputPtr->header.HashOp = op;
                 inputPtr->count = count + 1;
                 inputPtr->done = 0;

--- a/libs/server/Resp/Objects/ListCommands.cs
+++ b/libs/server/Resp/Objects/ListCommands.cs
@@ -61,6 +61,7 @@ namespace Garnet.server
 
             // Prepare header in input buffer
             inputPtr->header.type = GarnetObjectType.List;
+            inputPtr->header.flags = 0;
             inputPtr->header.ListOp = lop;
             inputPtr->count = inputCount;
             inputPtr->done = listItemsDoneCount;
@@ -157,6 +158,7 @@ namespace Garnet.server
 
             // Prepare header in input buffer
             inputPtr->header.type = GarnetObjectType.List;
+            inputPtr->header.flags = 0;
             inputPtr->header.ListOp = lop;
             inputPtr->done = 0;
             inputPtr->count = popCount;
@@ -230,6 +232,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.List;
+                inputPtr->header.flags = 0;
                 inputPtr->header.ListOp = ListOperation.LLEN;
                 inputPtr->count = count;
                 inputPtr->done = 0;
@@ -307,6 +310,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.List;
+                inputPtr->header.flags = 0;
                 inputPtr->header.ListOp = ListOperation.LTRIM;
                 inputPtr->count = start;
                 inputPtr->done = stop;
@@ -375,6 +379,7 @@ namespace Garnet.server
                 var inputLength = (int)(recvBufferPtr + bytesRead - (byte*)inputPtr);
 
                 inputPtr->header.type = GarnetObjectType.List;
+                inputPtr->header.flags = 0;
                 inputPtr->header.ListOp = ListOperation.LRANGE;
                 inputPtr->count = start;
                 inputPtr->done = end;
@@ -449,6 +454,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.List;
+                inputPtr->header.flags = 0;
                 inputPtr->header.ListOp = ListOperation.LINDEX;
                 inputPtr->count = index;
                 inputPtr->done = 0;
@@ -524,6 +530,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.List;
+                inputPtr->header.flags = 0;
                 inputPtr->header.ListOp = ListOperation.LINSERT;
                 inputPtr->done = 0;
                 inputPtr->count = 0;
@@ -610,6 +617,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.List;
+                inputPtr->header.flags = 0;
                 inputPtr->header.ListOp = ListOperation.LREM;
                 inputPtr->count = nCount;
                 inputPtr->done = 0;
@@ -818,6 +826,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.List;
+                inputPtr->header.flags = 0;
                 inputPtr->header.ListOp = ListOperation.LSET;
                 inputPtr->count = 0;
                 inputPtr->done = 0;

--- a/libs/server/Resp/Objects/SetCommands.cs
+++ b/libs/server/Resp/Objects/SetCommands.cs
@@ -67,6 +67,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.Set;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SetOp = SetOperation.SADD;
                 inputPtr->count = inputCount;
                 inputPtr->done = setOpsCount;
@@ -249,6 +250,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.Set;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SetOp = SetOperation.SREM;
                 inputPtr->count = inputCount;
                 inputPtr->done = setItemsDoneCount;
@@ -329,6 +331,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.Set;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SetOp = SetOperation.SCARD;
                 inputPtr->count = 1;
                 inputPtr->done = 0;
@@ -396,6 +399,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.Set;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SetOp = SetOperation.SMEMBERS;
                 inputPtr->count = count;
                 inputPtr->done = setItemsDoneCount;
@@ -466,6 +470,7 @@ namespace Garnet.server
 
             // Prepare header in input buffer
             inputPtr->header.type = GarnetObjectType.Set;
+            inputPtr->header.flags = 0;
             inputPtr->header.SetOp = SetOperation.SISMEMBER;
             inputPtr->count = count - 2;
             inputPtr->done = 0;
@@ -543,6 +548,7 @@ namespace Garnet.server
 
             // Prepare header in input buffer
             inputPtr->header.type = GarnetObjectType.Set;
+            inputPtr->header.flags = 0;
             inputPtr->header.SetOp = SetOperation.SPOP;
             inputPtr->count = int.MinValue;
 
@@ -726,6 +732,7 @@ namespace Garnet.server
 
             // Prepare header in input buffer
             inputPtr->header.type = GarnetObjectType.Set;
+            inputPtr->header.flags = 0;
             inputPtr->header.SetOp = SetOperation.SRANDMEMBER;
             inputPtr->count = Int32.MinValue;
 

--- a/libs/server/Resp/Objects/SharedObjectCommands.cs
+++ b/libs/server/Resp/Objects/SharedObjectCommands.cs
@@ -68,6 +68,7 @@ namespace Garnet.server
 
                 // ObjectInputHeader
                 (*(ObjectInputHeader*)(pcurr)).header.type = objectType;
+                (*(ObjectInputHeader*)(pcurr)).header.flags = 0;
 
                 switch (objectType)
                 {

--- a/libs/server/Resp/Objects/SortedSetCommands.cs
+++ b/libs/server/Resp/Objects/SortedSetCommands.cs
@@ -74,6 +74,7 @@ namespace Garnet.server
 
             // Prepare header in input buffer
             inputPtr->header.type = GarnetObjectType.SortedSet;
+            inputPtr->header.flags = 0;
             inputPtr->header.SortedSetOp = SortedSetOperation.ZADD;
             inputPtr->count = inputCount;
             inputPtr->done = zaddDoneCount;
@@ -143,6 +144,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 rmwInput->header.type = GarnetObjectType.SortedSet;
+                rmwInput->header.flags = 0;
                 rmwInput->header.SortedSetOp = SortedSetOperation.ZREM;
                 rmwInput->count = inputCount;
                 rmwInput->done = zaddDoneCount;
@@ -226,6 +228,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.SortedSet;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SortedSetOp = SortedSetOperation.ZCARD;
                 inputPtr->count = 1;
                 inputPtr->done = 0;
@@ -312,6 +315,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.SortedSet;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SortedSetOp = op;
                 inputPtr->count = count - 1;
                 inputPtr->done = 0;
@@ -411,6 +415,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.SortedSet;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SortedSetOp = SortedSetOperation.ZSCORE;
                 inputPtr->count = scoreKeySize;
                 inputPtr->done = 0;
@@ -485,6 +490,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.SortedSet;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SortedSetOp = SortedSetOperation.ZMSCORE;
                 inputPtr->count = inputCount;
                 inputPtr->done = 0;
@@ -572,6 +578,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.SortedSet;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SortedSetOp = op;
                 inputPtr->count = popCount;
                 inputPtr->done = zaddDoneCount;
@@ -649,6 +656,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.SortedSet;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SortedSetOp = SortedSetOperation.ZCOUNT;
                 inputPtr->count = 0;
                 inputPtr->done = 0;
@@ -739,6 +747,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.SortedSet;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SortedSetOp = op;
                 inputPtr->count = 0;
                 inputPtr->done = 0;
@@ -823,6 +832,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.SortedSet;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SortedSetOp = SortedSetOperation.ZINCRBY;
                 inputPtr->count = count - 1;
                 inputPtr->done = 0;
@@ -925,6 +935,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.SortedSet;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SortedSetOp = op;
                 inputPtr->count = memberSize;
                 inputPtr->done = 0;
@@ -997,6 +1008,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.SortedSet;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SortedSetOp = op;
                 inputPtr->count = 0;
                 inputPtr->done = 0;
@@ -1101,6 +1113,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.SortedSet;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SortedSetOp = SortedSetOperation.ZRANDMEMBER;
                 inputPtr->count = count == 1 ? 1 : paramCount;
                 inputPtr->done = withScoresSpan.SequenceEqual(includeWithScores) ? 1 : 0;

--- a/libs/server/Resp/Objects/SortedSetGeoCommands.cs
+++ b/libs/server/Resp/Objects/SortedSetGeoCommands.cs
@@ -53,6 +53,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.SortedSet;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SortedSetOp = SortedSetOperation.GEOADD;
                 inputPtr->count = inputCount;
                 inputPtr->done = zaddDoneCount;
@@ -154,6 +155,7 @@ namespace Garnet.server
 
                 // Prepare header in input buffer
                 inputPtr->header.type = GarnetObjectType.SortedSet;
+                inputPtr->header.flags = 0;
                 inputPtr->header.SortedSetOp = op;
                 inputPtr->count = inputCount;
 

--- a/libs/server/Storage/Session/ObjectStore/HashOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/HashOps.cs
@@ -41,6 +41,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)input.ptr;
             rmwInput->header.type = GarnetObjectType.Hash;
+            rmwInput->header.flags = 0;
             rmwInput->header.HashOp = nx ? HashOperation.HSETNX : HashOperation.HSET;
             rmwInput->count = 1;
             rmwInput->done = 0;
@@ -73,6 +74,7 @@ namespace Garnet.server
             // Prepare header in buffer
             var rmwInput = (ObjectInputHeader*)scratchBufferManager.CreateArgSlice(ObjectInputHeader.Size).ptr;
             rmwInput->header.type = GarnetObjectType.Hash;
+            rmwInput->header.flags = 0;
             rmwInput->header.HashOp = HashOperation.HSET;
             rmwInput->count = elements.Length;
             rmwInput->done = 0;
@@ -127,6 +129,7 @@ namespace Garnet.server
             // Prepare header in buffer
             var rmwInput = (ObjectInputHeader*)scratchBufferManager.CreateArgSlice(ObjectInputHeader.Size).ptr;
             rmwInput->header.type = GarnetObjectType.Hash;
+            rmwInput->header.flags = 0;
             rmwInput->header.HashOp = HashOperation.HDEL;
             rmwInput->count = fields.Length;
             rmwInput->done = 0;
@@ -197,6 +200,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)scratchBufferManager.CreateArgSlice(ObjectInputHeader.Size).ptr;
             rmwInput->header.type = GarnetObjectType.Hash;
+            rmwInput->header.flags = 0;
             rmwInput->header.HashOp = fields == default ? HashOperation.HGETALL : HashOperation.HGET;
             rmwInput->count = fields == default ? 0 : fields.Length;
             rmwInput->done = 0;
@@ -247,6 +251,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)input.ptr;
             rmwInput->header.type = GarnetObjectType.Hash;
+            rmwInput->header.flags = 0;
             rmwInput->header.HashOp = HashOperation.HLEN;
             rmwInput->count = 1;
             rmwInput->done = 0;
@@ -278,6 +283,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)input.ptr;
             rmwInput->header.type = GarnetObjectType.Hash;
+            rmwInput->header.flags = 0;
             rmwInput->header.HashOp = HashOperation.HEXISTS;
             rmwInput->count = 1;
             rmwInput->done = 0;
@@ -308,6 +314,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)scratchBufferManager.CreateArgSlice(ObjectInputHeader.Size).ptr;
             rmwInput->header.type = GarnetObjectType.Hash;
+            rmwInput->header.flags = 0;
             rmwInput->header.HashOp = HashOperation.HRANDFIELD;
             rmwInput->count = 2;
             rmwInput->done = 0;
@@ -350,6 +357,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)scratchBufferManager.CreateArgSlice(ObjectInputHeader.Size).ptr;
             rmwInput->header.type = GarnetObjectType.Hash;
+            rmwInput->header.flags = 0;
             rmwInput->header.HashOp = HashOperation.HRANDFIELD;
             rmwInput->count = 4;
             rmwInput->done = 0;
@@ -417,6 +425,7 @@ namespace Garnet.server
             var inputSize = ObjectInputHeader.Size + sizeof(int);
             var rmwInput = scratchBufferManager.CreateArgSlice(inputSize).ptr;
             ((ObjectInputHeader*)rmwInput)->header.type = GarnetObjectType.Hash;
+            ((ObjectInputHeader*)rmwInput)->header.flags = 0;
             ((ObjectInputHeader*)rmwInput)->header.HashOp = HashOperation.HSCAN;
 
             // Number of tokens in the input after the header (match, value, count, value)

--- a/libs/server/Storage/Session/ObjectStore/ListOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/ListOps.cs
@@ -33,6 +33,7 @@ namespace Garnet.server
             // Prepare header in buffer
             var rmwInput = (ObjectInputHeader*)scratchBufferManager.CreateArgSlice(ObjectInputHeader.Size).ptr;
             rmwInput->header.type = GarnetObjectType.List;
+            rmwInput->header.flags = 0;
             rmwInput->header.ListOp = lop;
             rmwInput->count = elements.Length;
             rmwInput->done = 0;
@@ -75,6 +76,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)input.ptr;
             rmwInput->header.type = GarnetObjectType.List;
+            rmwInput->header.flags = 0;
             rmwInput->header.ListOp = lop;
             rmwInput->count = 1;
             rmwInput->done = 0;
@@ -126,6 +128,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)input.ptr;
             rmwInput->header.type = GarnetObjectType.List;
+            rmwInput->header.flags = 0;
             rmwInput->header.ListOp = lop;
             rmwInput->count = count;
             rmwInput->done = 0;
@@ -163,6 +166,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)input.ptr;
             rmwInput->header.type = GarnetObjectType.List;
+            rmwInput->header.flags = 0;
             rmwInput->header.ListOp = ListOperation.LLEN;
             rmwInput->count = count;
             rmwInput->done = 0;
@@ -298,6 +302,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)input.ptr;
             rmwInput->header.type = GarnetObjectType.List;
+            rmwInput->header.flags = 0;
             rmwInput->header.ListOp = ListOperation.LTRIM;
             rmwInput->count = start;
             rmwInput->done = stop;

--- a/libs/server/Storage/Session/ObjectStore/SetOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/SetOps.cs
@@ -36,6 +36,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)input.ptr;
             rmwInput->header.type = GarnetObjectType.Set;
+            rmwInput->header.flags = 0;
             rmwInput->header.SetOp = SetOperation.SADD;
             rmwInput->count = 1;
             rmwInput->done = 0;
@@ -68,6 +69,7 @@ namespace Garnet.server
             // Prepare header in buffer
             var rmwInput = (ObjectInputHeader*)scratchBufferManager.CreateArgSlice(ObjectInputHeader.Size).ptr;
             rmwInput->header.type = GarnetObjectType.Set;
+            rmwInput->header.flags = 0;
             rmwInput->header.SetOp = SetOperation.SADD;
             rmwInput->count = members.Length;
             rmwInput->done = 0;
@@ -108,6 +110,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)input.ptr;
             rmwInput->header.type = GarnetObjectType.Set;
+            rmwInput->header.flags = 0;
             rmwInput->header.SetOp = SetOperation.SREM;
             rmwInput->count = 1;
             rmwInput->done = 0;
@@ -141,6 +144,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)scratchBufferManager.CreateArgSlice(ObjectInputHeader.Size).ptr;
             rmwInput->header.type = GarnetObjectType.Set;
+            rmwInput->header.flags = 0;
             rmwInput->header.SetOp = SetOperation.SREM;
             rmwInput->count = members.Length;
             rmwInput->done = 0;
@@ -180,6 +184,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)input.ptr;
             rmwInput->header.type = GarnetObjectType.Set;
+            rmwInput->header.flags = 0;
             rmwInput->header.SetOp = SetOperation.SCARD;
             rmwInput->count = 1;
             rmwInput->done = 0;
@@ -210,6 +215,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)input.ptr;
             rmwInput->header.type = GarnetObjectType.Set;
+            rmwInput->header.flags = 0;
             rmwInput->header.SetOp = SetOperation.SMEMBERS;
             rmwInput->count = 1;
             rmwInput->done = 0;
@@ -266,6 +272,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)input.ptr;
             rmwInput->header.type = GarnetObjectType.Set;
+            rmwInput->header.flags = 0;
             rmwInput->header.SetOp = SetOperation.SPOP;
             rmwInput->count = count;
             rmwInput->done = 0;
@@ -308,6 +315,7 @@ namespace Garnet.server
             var inputSize = ObjectInputHeader.Size + sizeof(int);
             var rmwInput = scratchBufferManager.CreateArgSlice(inputSize).ptr;
             ((ObjectInputHeader*)rmwInput)->header.type = GarnetObjectType.Set;
+            ((ObjectInputHeader*)rmwInput)->header.flags = 0;
             ((ObjectInputHeader*)rmwInput)->header.SetOp = SetOperation.SSCAN;
 
             // Number of tokens in the input after the header (match, value, count, value)

--- a/libs/server/Storage/Session/ObjectStore/SortedSetOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/SortedSetOps.cs
@@ -37,6 +37,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)input.ptr;
             rmwInput->header.type = GarnetObjectType.SortedSet;
+            rmwInput->header.flags = 0;
             rmwInput->header.SortedSetOp = SortedSetOperation.ZADD;
             rmwInput->count = 1;
             rmwInput->done = 0;
@@ -68,6 +69,7 @@ namespace Garnet.server
             // Prepare header in buffer
             var rmwInput = (ObjectInputHeader*)scratchBufferManager.CreateArgSlice(ObjectInputHeader.Size).ptr;
             rmwInput->header.type = GarnetObjectType.SortedSet;
+            rmwInput->header.flags = 0;
             rmwInput->header.SortedSetOp = SortedSetOperation.ZADD;
             rmwInput->count = inputs.Length;
             rmwInput->done = 0;
@@ -109,6 +111,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)_inputSlice.ptr;
             rmwInput->header.type = GarnetObjectType.SortedSet;
+            rmwInput->header.flags = 0;
             rmwInput->header.SortedSetOp = SortedSetOperation.ZREM;
             rmwInput->count = 1;
             rmwInput->done = 0;
@@ -140,6 +143,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)scratchBufferManager.CreateArgSlice(ObjectInputHeader.Size).ptr;
             rmwInput->header.type = GarnetObjectType.SortedSet;
+            rmwInput->header.flags = 0;
             rmwInput->header.SortedSetOp = SortedSetOperation.ZREM;
             rmwInput->count = members.Length;
             rmwInput->done = 0;
@@ -190,6 +194,7 @@ namespace Garnet.server
                     // Prepare header in input buffer
                     var rmwInput = (ObjectInputHeader*)_inputSlice.ptr;
                     rmwInput->header.type = GarnetObjectType.SortedSet;
+                    rmwInput->header.flags = 0;
                     rmwInput->header.SortedSetOp = SortedSetOperation.ZREMRANGEBYLEX;
                     rmwInput->count = 3;
                     rmwInput->done = 0;
@@ -234,6 +239,7 @@ namespace Garnet.server
                     // Prepare header in input buffer
                     var rmwInput = (ObjectInputHeader*)_inputSlice.ptr;
                     rmwInput->header.type = GarnetObjectType.SortedSet;
+                    rmwInput->header.flags = 0;
                     rmwInput->header.SortedSetOp = SortedSetOperation.ZREMRANGEBYSCORE;
                     rmwInput->count = 3;
                     rmwInput->done = 0;
@@ -278,6 +284,7 @@ namespace Garnet.server
                     // Prepare header in input buffer
                     var rmwInput = (ObjectInputHeader*)_inputSlice.ptr;
                     rmwInput->header.type = GarnetObjectType.SortedSet;
+                    rmwInput->header.flags = 0;
                     rmwInput->header.SortedSetOp = SortedSetOperation.ZREMRANGEBYRANK;
                     rmwInput->count = 3;
                     rmwInput->done = 0;
@@ -312,6 +319,7 @@ namespace Garnet.server
 
             var inputPtr = (ObjectInputHeader*)input.ptr;
             inputPtr->header.type = GarnetObjectType.SortedSet;
+            inputPtr->header.flags = 0;
             inputPtr->header.SortedSetOp = lowScoresFirst ? SortedSetOperation.ZPOPMIN : SortedSetOperation.ZPOPMAX;
             inputPtr->count = count;
             inputPtr->done = 0;
@@ -357,6 +365,7 @@ namespace Garnet.server
                 // Prepare header in input buffer
                 var rmwInput = (ObjectInputHeader*)_inputSlice.ptr;
                 rmwInput->header.type = GarnetObjectType.SortedSet;
+                rmwInput->header.flags = 0;
                 rmwInput->header.SortedSetOp = SortedSetOperation.ZINCRBY;
                 rmwInput->count = 3;
                 rmwInput->done = 0;
@@ -400,6 +409,7 @@ namespace Garnet.server
             // Prepare header in input buffer
             var rmwInput = (ObjectInputHeader*)input.ptr;
             rmwInput->header.type = GarnetObjectType.SortedSet;
+            rmwInput->header.flags = 0;
             rmwInput->header.SortedSetOp = SortedSetOperation.ZCARD;
             rmwInput->count = 1;
             rmwInput->done = 0;
@@ -464,6 +474,7 @@ namespace Garnet.server
             var inputPtr = (ObjectInputHeader*)scratchBufferManager.CreateArgSlice(ObjectInputHeader.Size).ptr;
             inputPtr->header.SortedSetOp = sortedOperation;
             inputPtr->header.type = GarnetObjectType.SortedSet;
+            inputPtr->header.flags = 0;
             inputPtr->count = 2 + (operation != default ? 1 : 0) + (sortedOperation != SortedSetOperation.ZREVRANGE && reverse ? 1 : 0) + (limit != default ? 3 : 0);
             inputPtr->done = 0;
 
@@ -616,6 +627,7 @@ namespace Garnet.server
             var inputSize = ObjectInputHeader.Size + sizeof(int);
             var rmwInput = scratchBufferManager.CreateArgSlice(inputSize).ptr;
             ((ObjectInputHeader*)rmwInput)->header.type = GarnetObjectType.SortedSet;
+            ((ObjectInputHeader*)rmwInput)->header.flags = 0;
             ((ObjectInputHeader*)rmwInput)->header.SortedSetOp = SortedSetOperation.ZSCAN;
 
             // Number of tokens in the input after the header (match, value, count, value)


### PR DESCRIPTION
When preparing input for the object store RMW operations, we need to set the flag field to 0, as the buffer being used to create the input may not be zero'ed out.

Fixes https://github.com/microsoft/garnet/issues/342