### PR TITLE
Garnet Epoch Protection Fix & Misc

### DIFF
--- a/libs/cluster/Server/ClusterProvider.cs
+++ b/libs/cluster/Server/ClusterProvider.cs
@@ -287,7 +287,7 @@ namespace Garnet.cluster
                 foreach (var s in sessions)
                 {
                     var entryEpoch = s.LocalCurrentEpoch;
-                    if (entryEpoch != 0 && entryEpoch >= currentEpoch)
+                    if (entryEpoch != 0 && entryEpoch < currentEpoch)
                         goto retry;
                 }
                 break;

--- a/libs/cluster/Server/Replication/CheckpointEntry.cs
+++ b/libs/cluster/Server/Replication/CheckpointEntry.cs
@@ -43,7 +43,7 @@ namespace Garnet.cluster
         }
 
         public long GetMinAofCoveredAddress()
-            => Math.Min(storeCheckpointCoveredAofAddress, objectCheckpointCoveredAofAddress);
+            => Math.Max(Math.Min(storeCheckpointCoveredAofAddress, objectCheckpointCoveredAofAddress), 64);
 
         /// <summary>
         /// Indicate addition of new reader by trying to increment reader counter

--- a/libs/cluster/Server/Replication/PrimaryOps/ReplicaSyncSession.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/ReplicaSyncSession.cs
@@ -47,6 +47,7 @@ namespace Garnet.cluster
         public async Task<bool> SendCheckpoint()
         {
             errorMsg = default;
+            var retryCount = 0;
             var storeCkptManager = clusterProvider.GetReplicationLogCheckpointManager(StoreType.Main);
             var objectStoreCkptManager = clusterProvider.GetReplicationLogCheckpointManager(StoreType.Object);
             var current = clusterProvider.clusterManager.CurrentConfig;
@@ -96,6 +97,8 @@ namespace Garnet.cluster
                     {
                         localEntry.RemoveReader();
                         _ = Thread.Yield();
+                        if (retryCount++ > 10)
+                            throw new GarnetException("Attaching replica maximum retry count reached!");
                         goto retry;
                     }
                 }
@@ -110,6 +113,8 @@ namespace Garnet.cluster
                     {
                         localEntry.RemoveReader();
                         _ = Thread.Yield();
+                        if (retryCount++ > 10)
+                            throw new GarnetException("Attaching replica maximum retry count reached!");
                         goto retry;
                     }
                 }

--- a/libs/cluster/Server/Replication/PrimaryOps/ReplicaSyncSession.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/ReplicaSyncSession.cs
@@ -192,7 +192,7 @@ namespace Garnet.cluster
                 var beginAddress = RecoveredReplicationOffset;
                 if (!recoverFromRemote)
                 {
-                    //If replica is ahead of this primary it will force itself to forget and start syncing from RecoveredReplicationOffset
+                    // If replica is ahead of this primary it will force itself to forget and start syncing from RecoveredReplicationOffset
                     if (replicaAofBeginAddress > ReplicationManager.kFirstValidAofAddress && replicaAofBeginAddress > RecoveredReplicationOffset)
                     {
                         logger?.LogInformation(

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -220,7 +220,8 @@ namespace Garnet.server
             {
                 storeVersion = !recoverMainStoreFromToken ? store.Recover() : store.Recover(storeIndexToken, storeHlogToken);
                 if (objectStore != null) objectStoreVersion = !recoverObjectStoreFromToken ? objectStore.Recover() : objectStore.Recover(objectStoreIndexToken, objectStoreHlogToken);
-                lastSaveTime = DateTimeOffset.UtcNow;
+                if (storeVersion > 0 || objectStoreVersion > 0)
+                    lastSaveTime = DateTimeOffset.UtcNow;
             }
             catch (Exception ex)
             {
@@ -269,8 +270,8 @@ namespace Garnet.server
             long replicationOffset = 0;
             try
             {
-                //When replaying AOF we do not want to write record again to AOF.
-                //So initialize local AofProcessor with recordToAof: false.
+                // When replaying AOF we do not want to write record again to AOF.
+                // So initialize local AofProcessor with recordToAof: false.
                 var aofProcessor = new AofProcessor(this, recordToAof: false, logger);
                 aofProcessor.Recover(untilAddress);
                 aofProcessor.Dispose();
@@ -578,22 +579,22 @@ namespace Garnet.server
         /// <summary>
         /// Take a checkpoint if no checkpoint was taken after the provided time offset
         /// </summary>
-        /// <param name="afterTime"></param>
+        /// <param name="entryTime"></param>
         /// <returns></returns>
-        public async Task TakeOnDemandCheckpoint(DateTimeOffset afterTime)
+        public async Task TakeOnDemandCheckpoint(DateTimeOffset entryTime)
         {
-            //Take lock to ensure not other task will be taking a checkpoint
+            // Take lock to ensure no other task will be taking a checkpoint
             while (!StartCheckpoint())
                 await Task.Yield();
 
-            //If an external task has taken a checkpoint after the provided afterTime return
-            if (this.lastSaveTime > afterTime)
+            // If an external task has taken a checkpoint beyond the provided entryTime return
+            if (this.lastSaveTime > entryTime)
             {
                 CompleteCheckpoint();
                 return;
             }
 
-            //If no newer checkpoint was taken compared to the provided afterTime take a checkpoint
+            // Necessary to take a checkpoint because the latest checkpoint is before entryTime
             await CheckpointTask(StoreType.All, logger: logger);
         }
 

--- a/test/Garnet.test.cluster/ClusterReplicationTests.cs
+++ b/test/Garnet.test.cluster/ClusterReplicationTests.cs
@@ -236,6 +236,9 @@ namespace Garnet.test.cluster
                 context.PopulatePrimary(ref context.kvPairs, keyLength, kvpairCount, 0);
             else
                 context.PopulatePrimaryRMW(ref context.kvPairs, keyLength, kvpairCount, 0, addCount);
+
+            var primaryLastSaveTime = context.clusterTestUtils.LastSave(0, logger: context.logger);
+            var replicaLastSaveTime = context.clusterTestUtils.LastSave(1, logger: context.logger);
             context.clusterTestUtils.Checkpoint(0, logger: context.logger);
 
             // Populate Primary
@@ -243,8 +246,8 @@ namespace Garnet.test.cluster
             context.ValidateKVCollectionAgainstReplica(ref context.kvPairs, 1);
 
             context.clusterTestUtils.WaitForReplicaAofSync(0, 1, context.logger);
-            context.clusterTestUtils.WaitFirstCheckpoint(0, context.logger);
-            context.clusterTestUtils.WaitFirstCheckpoint(1, context.logger);
+            context.clusterTestUtils.WaitCheckpoint(0, primaryLastSaveTime, logger: context.logger);
+            context.clusterTestUtils.WaitCheckpoint(1, replicaLastSaveTime, logger: context.logger);
 
             // Shutdown secondary
             context.nodes[1].Store.CommitAOF(true);
@@ -599,9 +602,11 @@ namespace Garnet.test.cluster
 
             if (checkpoint)
             {
+                var primaryLastSaveTime = context.clusterTestUtils.LastSave(0, logger: context.logger);
+                var replicaLastSaveTime = context.clusterTestUtils.LastSave(1, logger: context.logger);
                 context.clusterTestUtils.Checkpoint(0);
-                context.clusterTestUtils.WaitFirstCheckpoint(0, logger: context.logger);
-                context.clusterTestUtils.WaitFirstCheckpoint(1, logger: context.logger);
+                context.clusterTestUtils.WaitCheckpoint(0, primaryLastSaveTime, logger: context.logger);
+                context.clusterTestUtils.WaitCheckpoint(1, replicaLastSaveTime, logger: context.logger);
             }
 
             #region InitiateFailover
@@ -667,8 +672,9 @@ namespace Garnet.test.cluster
 
             if (takePrimaryCheckpoint)
             {
+                var primaryLastSaveTime = context.clusterTestUtils.LastSave(0, logger: context.logger);
                 context.clusterTestUtils.Checkpoint(0, logger: context.logger);
-                context.clusterTestUtils.WaitFirstCheckpoint(0, logger: context.logger);
+                context.clusterTestUtils.WaitCheckpoint(0, primaryLastSaveTime, logger: context.logger);
             }
 
             // Wait for replication offsets to synchronize
@@ -692,8 +698,9 @@ namespace Garnet.test.cluster
 
             if (takeNewPrimaryCheckpoint)
             {
+                var newPrimaryLastSaveTime = context.clusterTestUtils.LastSave(1, logger: context.logger);
                 context.clusterTestUtils.Checkpoint(1, logger: context.logger);
-                context.clusterTestUtils.WaitFirstCheckpoint(1, logger: context.logger);
+                context.clusterTestUtils.WaitCheckpoint(1, newPrimaryLastSaveTime, logger: context.logger);
             }
             context.clusterTestUtils.WaitForReplicaAofSync(1, 2, context.logger);
 
@@ -912,11 +919,19 @@ namespace Garnet.test.cluster
             }
             else context.PopulatePrimaryWithObjects(ref context.kvPairsObj, keyLength, kvpairCount, primaryIndex: oldPrimaryIndex, set: set);
 
-            if (ckptBeforeDivergence) context.clusterTestUtils.Checkpoint(oldPrimaryIndex, logger: context.logger);
+            if (ckptBeforeDivergence)
+            {
+                var oldPrimaryLastSaveTime = context.clusterTestUtils.LastSave(oldPrimaryIndex, logger: context.logger);
+                var newPrimaryLastSaveTime = context.clusterTestUtils.LastSave(newPrimaryIndex, logger: context.logger);
+                var replicaLastSaveTime = context.clusterTestUtils.LastSave(replicaIndex, logger: context.logger);
+                context.clusterTestUtils.Checkpoint(oldPrimaryIndex, logger: context.logger);
+                context.clusterTestUtils.WaitCheckpoint(oldPrimaryIndex, oldPrimaryLastSaveTime, logger: context.logger);
+                context.clusterTestUtils.WaitCheckpoint(newPrimaryIndex, newPrimaryLastSaveTime, logger: context.logger);
+                context.clusterTestUtils.WaitCheckpoint(replicaIndex, replicaLastSaveTime, logger: context.logger);
+            }
+
             context.clusterTestUtils.WaitForReplicaAofSync(oldPrimaryIndex, newPrimaryIndex, context.logger);
             context.clusterTestUtils.WaitForReplicaAofSync(oldPrimaryIndex, replicaIndex, context.logger);
-            context.clusterTestUtils.WaitFirstCheckpoint(newPrimaryIndex, logger: context.logger);
-            context.clusterTestUtils.WaitFirstCheckpoint(replicaIndex, logger: context.logger);
 
             // Make this replica of no-one
             _ = context.clusterTestUtils.ReplicaOf(1, logger: context.logger);

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -2673,9 +2673,13 @@ namespace Garnet.test.cluster
             try
             {
                 var server = redis.GetServer(endPoint);
-
-                while (server.LastSave() < time)
+                while (true)
+                {
+                    var lastSaveTime = server.LastSave();
+                    if (lastSaveTime >= time)
+                        break;
                     BackOff();
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fix the following bugs/issues

1. Ensure WaitForConfigTransition spin-waits for epoch transition of all sessions to next epoch before continuing.
2. Set a max retry for metadata acquisition on SendCheckpoint stage of replica attach.
3. Make sure AOF begin sync address is calculated correctly.
