### PR TITLE
[bug fix] The bin path is null caused the program startup failure

### DIFF
--- a/main/GarnetServer/Program.cs
+++ b/main/GarnetServer/Program.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Threading;
 using Garnet.common;
 using Garnet.server;
@@ -49,7 +48,7 @@ namespace Garnet
         /// </summary>
         static bool TryRegisterExtensions(GarnetServer server)
         {
-            var binPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var binPath = AppContext.BaseDirectory;
 
             if (!TryGetRespCommandsInfo(Path.Combine(binPath!, CustomRespCommandInfoJsonFileName), out var customCommandsInfo))
                 return false;


### PR DESCRIPTION
Version 1.0.9 uses `Assembly.GetExecutingAssembly().Location` to get the directory where Garnet is located, but it return an empty string in SingleFile mode ([source link](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assembly.location#remarks)), leading to program startup failure with the error: `Unable to initialize server due to exception: Value cannot be null. (Parameter 'path1')`. Using `AppContext.BaseDirectory` works well.

> `Assembly.Location Property`: In .NET 5 and later versions, for bundled assemblies, the value returned is an empty string. ([source link](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assembly.location#remarks))

The test code is as follows:
```cs
var binPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
Console.WriteLine($"AppContext.BaseDirectory:{AppContext.BaseDirectory}, is null:{AppContext.BaseDirectory is null}");
Console.WriteLine($"Assembly.GetExecutingAssembly().Location:{Assembly.GetExecutingAssembly().Location}, is null:{Assembly.GetExecutingAssembly().Location is null}");
Console.WriteLine($"binPath:{binPath}, is null:{binPath is null}");
```

The output is as follows:
```
PS D:\tmp\test\bb> \code\tmp\garnet\main\GarnetServer\bin\Release\net8.0\publish\linux-arm64\GarnetServer.exe
    _________
   /_||___||_\      Garnet 1.0.9 64 bit; standalone mode
   '. \   / .'      Port: 3278
     '.\ /.'        https://aka.ms/GetGarnet
       '.'

AppContext.BaseDirectory:D:\code\tmp\garnet\main\GarnetServer\bin\Release\net8.0\publish\linux-arm64\, is null:False
Assembly.GetExecutingAssembly().Location:, is null:False
binPath:, is null:True
Unable to initialize server due to exception: Value cannot be null. (Parameter 'path1')
PS D:\tmp\test\bb>
```

