### PR TITLE
Guard against multiple recovery tasks

### DIFF
--- a/libs/cluster/CmdStrings.cs
+++ b/libs/cluster/CmdStrings.cs
@@ -89,6 +89,7 @@ namespace Garnet.cluster
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_UNKNOWN_ENDPOINT => "ERR Unknown endpoint"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_CANNOT_MAKE_REPLICA_WITH_ASSIGNED_SLOTS => "ERR Primary has been assigned slots and cannot be a replica"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_CANNOT_ACQUIRE_RECOVERY_LOCK => "ERR Recovery in progress, could not acquire recoverLock"u8;
+        public static ReadOnlySpan<byte> RESP_ERR_GENERIC_CANNOT_TAKEOVER_FROM_PRIMARY => "ERR Could not take over from primary"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_CANNOT_REPLICATE_SELF => "ERR Can't replicate myself"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_NOT_ASSIGNED_PRIMARY_ERROR => "ERR Don't have primary"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_WORKERS_NOT_INITIALIZED => "ERR workers not initialized"u8;

--- a/libs/cluster/CmdStrings.cs
+++ b/libs/cluster/CmdStrings.cs
@@ -88,6 +88,7 @@ namespace Garnet.cluster
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_CANNOT_FAILOVER_FROM_NON_MASTER => "ERR Cannot failover a non-master node"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_UNKNOWN_ENDPOINT => "ERR Unknown endpoint"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_CANNOT_MAKE_REPLICA_WITH_ASSIGNED_SLOTS => "ERR Primary has been assigned slots and cannot be a replica"u8;
+        public static ReadOnlySpan<byte> RESP_ERR_GENERIC_CANNOT_ACQUIRE_RECOVERY_LOCK => "ERR Recovery in progress, could not acquire recoverLock"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_CANNOT_REPLICATE_SELF => "ERR Can't replicate myself"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_NOT_ASSIGNED_PRIMARY_ERROR => "ERR Don't have primary"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_WORKERS_NOT_INITIALIZED => "ERR workers not initialized"u8;

--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -264,13 +264,17 @@ namespace Garnet.cluster
         public List<int> GetLocalPrimarySlots()
         {
             var primaryId = LocalNodePrimaryId;
-            List<int> result = new();
-            for (int i = 0; i < MAX_HASH_SLOT_VALUE; i++)
+            List<int> slots = [];
+
+            if (primaryId != null)
             {
-                if (workers[slotMap[i].workerId].Nodeid.Equals(primaryId, StringComparison.OrdinalIgnoreCase))
-                    result.Add(i);
+                for (var i = 0; i < MAX_HASH_SLOT_VALUE; i++)
+                {
+                    if (slotMap[i].workerId > 0 && workers[slotMap[i].workerId].Nodeid.Equals(primaryId, StringComparison.OrdinalIgnoreCase))
+                        slots.Add(i);
+                }
             }
-            return result;
+            return slots;
         }
 
         /// <summary>

--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -1014,7 +1014,7 @@ namespace Garnet.cluster
             var slots = GetLocalPrimarySlots();
             var newSlotMap = new HashSlot[MAX_HASH_SLOT_VALUE];
             Array.Copy(slotMap, newSlotMap, slotMap.Length);
-            foreach (int slot in slots)
+            foreach (var slot in slots)
             {
                 newSlotMap[slot]._workerId = 1;
                 newSlotMap[slot]._state = SlotState.STABLE;

--- a/libs/cluster/Server/ClusterManager.cs
+++ b/libs/cluster/Server/ClusterManager.cs
@@ -280,7 +280,7 @@ namespace Garnet.cluster
                 if (Interlocked.CompareExchange(ref currentConfig, newConfig, current) == current)
                     break;
             }
-            clusterProvider.replicationManager.Reset();
+            clusterProvider.replicationManager.SuspendRecovery();
             FlushConfig();
         }
 

--- a/libs/cluster/Server/ClusterManager.cs
+++ b/libs/cluster/Server/ClusterManager.cs
@@ -302,17 +302,21 @@ namespace Garnet.cluster
         /// <summary>
         /// Takeover as new primary but forcefully claim ownership of old primary's slots.
         /// </summary>
-        public void TryTakeOverForPrimary()
+        public bool TryTakeOverForPrimary()
         {
             while (true)
             {
                 var current = currentConfig;
-                var newConfig = current.TakeOverFromPrimary();
-                newConfig = newConfig.BumpLocalNodeConfigEpoch();
+
+                if (!current.IsReplica || current.LocalNodePrimaryId == null)
+                    return false;
+
+                var newConfig = current.TakeOverFromPrimary().BumpLocalNodeConfigEpoch();
                 if (Interlocked.CompareExchange(ref currentConfig, newConfig, current) == current)
                     break;
             }
             FlushConfig();
+            return true;
         }
     }
 }

--- a/libs/cluster/Server/ClusterManager.cs
+++ b/libs/cluster/Server/ClusterManager.cs
@@ -280,7 +280,6 @@ namespace Garnet.cluster
                 if (Interlocked.CompareExchange(ref currentConfig, newConfig, current) == current)
                     break;
             }
-            clusterProvider.replicationManager.SuspendRecovery();
             FlushConfig();
         }
 

--- a/libs/cluster/Server/ClusterManagerWorkerState.cs
+++ b/libs/cluster/Server/ClusterManagerWorkerState.cs
@@ -138,10 +138,9 @@ namespace Garnet.cluster
         /// </summary>
         /// <param name="nodeid"></param>
         /// <param name="force">Check if node is clean (i.e. is PRIMARY without any assigned nodes)</param>
-        /// <param name="recovering"></param>
         /// <param name="errorMessage">The ASCII encoded error response if the method returned <see langword="false"/>; otherwise <see langword="default"/></param>
         /// <param name="logger"></param>
-        public bool TryAddReplica(string nodeid, bool force, ref bool recovering, out ReadOnlySpan<byte> errorMessage, ILogger logger = null)
+        public bool TryAddReplica(string nodeid, bool force, out ReadOnlySpan<byte> errorMessage, ILogger logger = null)
         {
             errorMessage = default;
             while (true)
@@ -183,7 +182,9 @@ namespace Garnet.cluster
                     return false;
                 }
 
-                recovering = true;
+                // Transition to recovering state
+                clusterProvider.replicationManager.StartRecovery();
+
                 var newConfig = currentConfig.MakeReplicaOf(nodeid);
                 newConfig = newConfig.BumpLocalNodeConfigEpoch();
                 if (Interlocked.CompareExchange(ref currentConfig, newConfig, current) == current)

--- a/libs/cluster/Server/ClusterProvider.cs
+++ b/libs/cluster/Server/ClusterProvider.cs
@@ -112,7 +112,7 @@ namespace Garnet.cluster
 
         /// <inheritdoc />
         public bool IsReplica()
-            => clusterManager?.CurrentConfig.LocalNodeRole == NodeRole.REPLICA || replicationManager?.recovering == true;
+            => clusterManager?.CurrentConfig.LocalNodeRole == NodeRole.REPLICA || replicationManager?.Recovering == true;
 
         /// <inheritdoc />
         public void ResetGossipStats()
@@ -218,7 +218,7 @@ namespace Garnet.cluster
                     replicationInfo.Add(new("master_port", port.ToString()));
                     replicationInfo.Add(primaryLinkStatus[0]);
                     replicationInfo.Add(primaryLinkStatus[1]);
-                    replicationInfo.Add(new("master_sync_in_progress", replicationManager.recovering.ToString()));
+                    replicationInfo.Add(new("master_sync_in_progress", replicationManager.Recovering.ToString()));
                     replicationInfo.Add(new("slave_read_repl_offset", replication_offset));
                     replicationInfo.Add(new("slave_priority", "100"));
                     replicationInfo.Add(new("slave_read_only", "1"));

--- a/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
+++ b/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
@@ -158,7 +158,7 @@ namespace Garnet.cluster
             status = FailoverStatus.TAKING_OVER_AS_PRIMARY;
 
             // Make replica syncing unavailable by setting recovery flag
-            clusterProvider.replicationManager.recovering = true;
+            clusterProvider.replicationManager.StartRecovery();
             _ = clusterProvider.WaitForConfigTransition();
 
             // Update replicationIds and replicationOffset2
@@ -170,7 +170,7 @@ namespace Garnet.cluster
             _ = clusterProvider.WaitForConfigTransition();
 
             // Disable recovering as now we have become a primary
-            clusterProvider.replicationManager.recovering = false;
+            clusterProvider.replicationManager.SuspendRecovery();
         }
 
         /// <summary>

--- a/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
+++ b/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
@@ -122,7 +122,7 @@ namespace Garnet.cluster
                     return false;
                 }
 
-                // Cachec connection for use with next operations
+                // Cache connection for use with next operations
                 primaryClient = client;
 
                 // Issue stop writes to the primary

--- a/libs/cluster/Server/GarnetClientExtensions.cs
+++ b/libs/cluster/Server/GarnetClientExtensions.cs
@@ -23,7 +23,7 @@ namespace Garnet.cluster
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public static Task<MemoryResult<byte>> Gossip(this GarnetClient client, Memory<byte> data, CancellationToken cancellationToken = default)
-            => client.ExecuteForMemoryResultWithCancellationAsync(GarnetClient.CLUSTER, new Memory<byte>[] { GOSSIP, data }, cancellationToken);
+            => client.ExecuteForMemoryResultWithCancellationAsync(GarnetClient.CLUSTER, [GOSSIP, data], cancellationToken);
 
         /// <summary>
         /// Send config
@@ -33,7 +33,7 @@ namespace Garnet.cluster
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public static Task<MemoryResult<byte>> GossipWithMeet(this GarnetClient client, Memory<byte> data, CancellationToken cancellationToken = default)
-            => client.ExecuteForMemoryResultWithCancellationAsync(GarnetClient.CLUSTER, new Memory<byte>[] { GOSSIP, WITHMEET, data }, cancellationToken);
+            => client.ExecuteForMemoryResultWithCancellationAsync(GarnetClient.CLUSTER, [GOSSIP, WITHMEET, data], cancellationToken);
 
         /// <summary>
         /// Send stop writes to primary
@@ -43,7 +43,7 @@ namespace Garnet.cluster
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public static async Task<long> failstopwrites(this GarnetClient client, Memory<byte> nodeid, CancellationToken cancellationToken = default)
-            => await client.ExecuteForLongResultWithCancellationAsync(GarnetClient.CLUSTER, new Memory<byte>[] { CmdStrings.failstopwrites.ToArray(), nodeid }, cancellationToken).ConfigureAwait(false);
+            => await client.ExecuteForLongResultWithCancellationAsync(GarnetClient.CLUSTER, [CmdStrings.failstopwrites.ToArray(), nodeid], cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Send request to await for replication offset sync with replica

--- a/libs/cluster/Server/GarnetServerNode.cs
+++ b/libs/cluster/Server/GarnetServerNode.cs
@@ -123,7 +123,7 @@ namespace Garnet.cluster
             {
                 _ = meetLock.TryWriteLock();
                 UpdateGossipSend();
-                var resp = gc.GossipWithMeet(configByteArray).WaitAsync(clusterProvider.clusterManager.gossipDelay, cts.Token).GetAwaiter().GetResult();
+                var resp = gc.GossipWithMeet(configByteArray).WaitAsync(clusterProvider.clusterManager.clusterTimeout, cts.Token).GetAwaiter().GetResult();
                 return resp;
             }
             finally

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaReceiveCheckpoint.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaReceiveCheckpoint.cs
@@ -160,6 +160,7 @@ namespace Garnet.cluster
             {
                 logger?.LogError(ex, "An error occurred at ReplicationManager.RetrieveStoreCheckpoint");
                 clusterProvider.clusterManager.TryResetReplica();
+                clusterProvider.replicationManager.SuspendRecovery();
                 return ex.Message;
             }
             finally

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaReceiveCheckpoint.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaReceiveCheckpoint.cs
@@ -44,12 +44,12 @@ namespace Garnet.cluster
                 logger?.LogTrace("CLUSTER REPLICATE {nodeid}", nodeid);
 
                 // TryAddReplica will set the recovering boolean
-                if (clusterProvider.clusterManager.TryAddReplica(nodeid, force: force, ref recovering, out errorMessage))
+                if (clusterProvider.clusterManager.TryAddReplica(nodeid, force: force, out errorMessage))
                 {
                     // Wait for threads to agree
                     session.UnsafeWaitForConfigTransition();
 
-                    //TODO: We should not be resetting this, need to decide where to start syncing from
+                    // Resetting here to decide later when to sync from
                     clusterProvider.replicationManager.ReplicationOffset = 0;
                     return clusterProvider.replicationManager.TryReplicateFromPrimary(out errorMessage, background);
                 }
@@ -68,7 +68,7 @@ namespace Garnet.cluster
         public bool TryReplicateFromPrimary(out ReadOnlySpan<byte> errorMessage, bool background = false)
         {
             errorMessage = default;
-            Debug.Assert(recovering);
+            Debug.Assert(Recovering);
 
             // The caller should have stopped accepting AOF records from old primary at this point
             // (TryREPLICAOF -> TryAddReplica -> UnsafeWaitForConfigTransition)
@@ -303,7 +303,7 @@ namespace Garnet.cluster
             storeWrapper.appendOnlyFile.Initialize(beginAddress, recoveredReplicationOffset);
 
             // Done with recovery at this point
-            recovering = false;
+            SuspendRecovery();
 
             // Finally, advertise that we are caught up to the replication offset
             ReplicationOffset = recoveredReplicationOffset;

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicationReplicaAofSync.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicationReplicaAofSync.cs
@@ -23,7 +23,7 @@ namespace Garnet.cluster
             var currentConfig = clusterProvider.clusterManager.CurrentConfig;
             try
             {
-                if (clusterProvider.replicationManager.recovering)
+                if (clusterProvider.replicationManager.Recovering)
                 {
                     logger?.LogWarning("Replica is recovering cannot sync AOF");
                     throw new Exception("Replica is recovering cannot sync AOF");

--- a/libs/cluster/Session/ClusterSlotVerify.cs
+++ b/libs/cluster/Session/ClusterSlotVerify.cs
@@ -30,7 +30,7 @@ namespace Garnet.cluster
             if (IsLocal)
             {
                 // TODO: make sure other Read locations add this new logic
-                if (clusterProvider.replicationManager.recovering)
+                if (clusterProvider.replicationManager.Recovering)
                 {
                     // If we are a replica, let primary handle the request
                     if (config.LocalNodeRole == NodeRole.REPLICA)

--- a/libs/cluster/Session/RespClusterFailoverCommands.cs
+++ b/libs/cluster/Session/RespClusterFailoverCommands.cs
@@ -71,8 +71,8 @@ namespace Garnet.cluster
                 else
                 {
                     var current = clusterProvider.clusterManager.CurrentConfig;
-                    var nodeRole = current.LocalNodeRole;
-                    if (nodeRole == NodeRole.REPLICA)
+                    // Make local node configuration indicates that this a replica with a configured primary
+                    if (current.IsReplica && current.LocalNodePrimaryId != null)
                     {
                         if (!clusterProvider.failoverManager.TryStartReplicaFailover(failoverOption, failoverTimeout))
                         {
@@ -83,7 +83,7 @@ namespace Garnet.cluster
                     }
                     else
                     {
-                        while (!RespWriteUtils.WriteError($"ERR Node is not a {NodeRole.REPLICA} ~{nodeRole}~", ref dcurr, dend))
+                        while (!RespWriteUtils.WriteError($"ERR Node is not configured as a {NodeRole.REPLICA}", ref dcurr, dend))
                             SendAndReset();
                         return true;
                     }

--- a/libs/common/GarnetException.cs
+++ b/libs/common/GarnetException.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 
 namespace Garnet.common
 {
@@ -12,18 +13,25 @@ namespace Garnet.common
     public class GarnetException : Exception
     {
         /// <summary>
+        /// LogLevel for this exception
+        /// </summary>
+        public LogLevel LogLevel { get; } = LogLevel.Trace;
+
+        /// <summary>
         /// Throw Garnet exception
         /// </summary>
-        public GarnetException()
+        public GarnetException(LogLevel logLevel = LogLevel.Trace)
         {
+            LogLevel = logLevel;
         }
 
         /// <summary>
         /// Throw Garnet exception with message
         /// </summary>
         /// <param name="message"></param>
-        public GarnetException(string message) : base(message)
+        public GarnetException(string message, LogLevel logLevel = LogLevel.Trace) : base(message)
         {
+            LogLevel = logLevel;
         }
 
         /// <summary>
@@ -31,8 +39,9 @@ namespace Garnet.common
         /// </summary>
         /// <param name="message"></param>
         /// <param name="innerException"></param>
-        public GarnetException(string message, Exception innerException) : base(message, innerException)
+        public GarnetException(string message, Exception innerException, LogLevel logLevel = LogLevel.Trace) : base(message, innerException)
         {
+            LogLevel = logLevel;
         }
 
         /// <summary>
@@ -40,7 +49,7 @@ namespace Garnet.common
         /// </summary>
         /// <param name="message">Exception message.</param>
         [DoesNotReturn]
-        public static void Throw(string message) =>
-            throw new GarnetException(message);
+        public static void Throw(string message, LogLevel logLevel = LogLevel.Trace) =>
+            throw new GarnetException(message, logLevel);
     }
 }

--- a/libs/common/Parsing/RespParsingException.cs
+++ b/libs/common/Parsing/RespParsingException.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace Garnet.common.Parsing
 {
@@ -15,7 +16,8 @@ namespace Garnet.common.Parsing
         /// Construct a new RESP parsing exception with the given message.
         /// </summary>
         /// <param name="message">Message that described the exception that has occurred.</param>
-        RespParsingException(string message) : base(message)
+        /// <param name="logLevel">Logging level for the exception that occurred</param>
+        RespParsingException(string message, LogLevel logLevel = LogLevel.Critical) : base(message, logLevel)
         {
             // Nothing...
         }
@@ -78,8 +80,9 @@ namespace Garnet.common.Parsing
         /// Throw helper that throws a RespParsingException.
         /// </summary>
         /// <param name="message">Exception message.</param>
+        /// <param name="logLevel">LogLevel for exception.</param>
         [DoesNotReturn]
-        public static new void Throw(string message) =>
-            throw new RespParsingException(message);
+        public static new void Throw(string message, LogLevel logLevel = LogLevel.Critical) =>
+            throw new RespParsingException(message, logLevel);
     }
 }

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -231,8 +231,7 @@ namespace Garnet.server
             catch (RespParsingException ex)
             {
                 sessionMetrics?.incr_total_number_resp_server_session_exceptions(1);
-                logger?.LogCritical($"Aborting open session due to RESP parsing error: {ex.Message}");
-                logger?.LogDebug(ex, "RespParsingException in ProcessMessages:");
+                logger.Log(ex.LogLevel, ex, "Aborting open session due to RESP parsing error");
 
                 // Forward parsing error as RESP error
                 while (!RespWriteUtils.WriteError($"ERR Protocol Error: {ex.Message}", ref dcurr, dend))
@@ -243,10 +242,17 @@ namespace Garnet.server
                     Send(networkSender.GetResponseObjectHead());
                 networkSender.Dispose();
             }
+            catch (GarnetException ex)
+            {
+                sessionMetrics?.incr_total_number_resp_server_session_exceptions(1);
+                logger.Log(ex.LogLevel, ex, "ProcessMessages threw a GarnetException:");
+                // The session is no longer usable, dispose it
+                networkSender.Dispose();
+            }
             catch (Exception ex)
             {
                 sessionMetrics?.incr_total_number_resp_server_session_exceptions(1);
-                logger?.LogCritical(ex, "ProcessMessages threw exception:");
+                logger?.LogCritical(ex, "ProcessMessages threw an exception:");
                 // The session is no longer usable, dispose it
                 networkSender.Dispose();
             }
@@ -806,7 +812,7 @@ namespace Garnet.server
                 // Reaching here means that we retried SendAndReset without the RespWriteUtils.Write*
                 // method making any progress. This should only happen when the message being written is
                 // too large to fit in the response buffer.
-                GarnetException.Throw("Failed to write to response buffer");
+                GarnetException.Throw("Failed to write to response buffer", LogLevel.Critical);
             }
         }
 

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -254,7 +254,6 @@ namespace Garnet.server
             {
                 networkSender.ExitAndReturnResponseObject();
                 clusterSession?.ReleaseCurrentEpoch();
-
             }
 
             if (txnManager.IsSkippingOperations())

--- a/test/Garnet.test.cluster/ClusterReplicationTests.cs
+++ b/test/Garnet.test.cluster/ClusterReplicationTests.cs
@@ -1007,59 +1007,5 @@ namespace Garnet.test.cluster
             else
                 context.ValidateNodeObjects(ref context.kvPairsObj, nodeIndex: newPrimaryIndex, set: set);
         }
-
-        [Test, Order(21)]
-        [Category("REPLICATION")]
-        public void ClusterMultipleConsecutiveFailoversTest()
-        {
-            context.CreateInstances(2, tryRecover: true, disableObjects: true, enableAOF: true, useTLS: useTLS);
-            context.CreateConnection(useTLS: useTLS);
-
-            context.clusterTestUtils.SetConfigEpoch(0, 1, logger: context.logger);
-            var resp = context.clusterTestUtils.AddSlotsRange(0, [(0, 16383)], logger: context.logger);
-            Assert.AreEqual("OK", resp);
-
-            var keyLength = 32;
-            var kvpairCount = keyCount;
-            context.kvPairs = [];
-            context.PopulatePrimary(ref context.kvPairs, keyLength, kvpairCount, 0);
-
-            var primaryIndex = 0;
-            var replicaIndex = 1;
-            var iterations = 10;
-            while (iterations-- > 0)
-            {
-                // Introduce nodes
-                context.clusterTestUtils.Meet(primaryIndex, replicaIndex, logger: context.logger);
-                context.clusterTestUtils.WaitUntilNodeIsKnown(replicaIndex, primaryIndex, logger: context.logger);
-
-                // Attach replica
-                resp = context.clusterTestUtils.ClusterReplicate(replicaIndex, primaryIndex, logger: context.logger);
-                Assert.AreEqual("OK", resp);
-
-                context.clusterTestUtils.WaitForReplicaRecovery(replicaIndex);
-                context.ValidateKVCollectionAgainstReplica(ref context.kvPairs, primaryIndex);
-                context.nodes[primaryIndex].Dispose(deleteDir: true);
-
-                resp = context.clusterTestUtils.ClusterFailover(replicaIndex, "TAKEOVER", logger: context.logger);
-                Assert.AreEqual("OK", resp);
-
-                // Restart failed node
-                context.nodes[primaryIndex] = context.CreateInstance(
-                    context.clusterTestUtils.GetEndPoint(primaryIndex).Port,
-                    disableObjects: true,
-                    tryRecover: false,
-                    enableAOF: true,
-                    timeout: timeout,
-                    useTLS: useTLS,
-                    cleanClusterConfig: true);
-                context.nodes[primaryIndex].Start();
-                context.CreateConnection(useTLS: useTLS);
-
-                // Swap indices
-                (replicaIndex, primaryIndex) = (primaryIndex, replicaIndex);
-            }
-
-        }
     }
 }

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -1099,7 +1099,7 @@ namespace Garnet.test.cluster
             }
             catch (Exception ex)
             {
-                logger?.LogError(ex, "An error has occured");
+                logger?.LogError(ex, "An error has occurred");
                 Assert.Fail(ex.Message);
             }
         }
@@ -1117,7 +1117,7 @@ namespace Garnet.test.cluster
             }
             catch (Exception ex)
             {
-                logger?.LogError(ex, "An error has occured");
+                logger?.LogError(ex, "An error has occurred");
                 Assert.Fail(ex.Message);
             }
         }
@@ -1135,7 +1135,7 @@ namespace Garnet.test.cluster
             }
             catch (Exception ex)
             {
-                logger?.LogError(ex, "An error has occured");
+                logger?.LogError(ex, "An error has occurred");
                 Assert.Fail(ex.Message);
                 return null;
             }

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -1767,10 +1767,16 @@ namespace Garnet.test.cluster
             }
             catch (Exception ex)
             {
-                logger?.LogError(ex, "An error has occured; ClusterSlots");
+                logger?.LogError(ex, "An error has occurred; ClusterSlots");
                 Assert.Fail(ex.Message);
                 return null;
             }
+        }
+
+        public string ClusterReplicate(int replicaNodeIndex, int primaryNodeIndex, ILogger logger = null)
+        {
+            var primaryId = ClusterMyId(primaryNodeIndex, logger: logger);
+            return ClusterReplicate(replicaNodeIndex, primaryId, logger: logger);
         }
 
         public string ClusterReplicate(int sourceNodeIndex, string primaryNodeId, bool async = false, bool failEx = true, ILogger logger = null)


### PR DESCRIPTION
This PR introduces a recovery lock in place of the recovery bool variable in ReplicationManager.
Using the lock, we allow only one recover operation to happen at any given point in time.
A node enters and exits recovery in the following cases:

1.  Node receives a CLUSTER REPLICATE/REPLICAOF request and enters recovery after succeeding to update the local configuration. The node will exit recovery if it succeeds to recover from a remote or local checkpoint. If the attach/recovery the recoveryLock is released
2. When a replica is taking over for its primary, it will try to enter recovering state to break the AOF sync stream. It will exit said state when after succeeding in taking over. 
3. When a node restarts as a replica, the node will acquire the recover lock and attempt to attach to their primary before restart. It will release it on success or after failure.

Additional fixes improvements as follows:
1. Add LogLevel parameter to GarnetException to avoid logging every exception as critical.
2. Perform additional checks to ensure there is no race condition when transitioning a replica to the role of a primary during a failover.