### PR TITLE
Fix nuget dependencies for Garnet package

### DIFF
--- a/Garnet.nuspec
+++ b/Garnet.nuspec
@@ -21,8 +21,9 @@
       <dependency id="Microsoft.Extensions.Logging.Console" version="8.0.0" />
       <dependency id="Newtonsoft.Json" version="13.0.3" />
       <dependency id="CommandLineParser" version="2.9.1" />
-      <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.28.1" />
-      <dependency id="System.IdentityModel.Tokens.Jwt" version="6.34.0" />
+      <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="7.5.1" />
+      <dependency id="System.IdentityModel.Tokens.Jwt" version="7.5.1" />
+	  <dependency id="Microsoft.IdentityModel.Validators" version="7.5.1" />
       <dependency id="Azure.Storage.Blobs" version="12.14.1" />
     </dependencies>
     <readme>README.md</readme>

--- a/Garnet.nuspec
+++ b/Garnet.nuspec
@@ -23,7 +23,7 @@
       <dependency id="CommandLineParser" version="2.9.1" />
       <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="7.5.1" />
       <dependency id="System.IdentityModel.Tokens.Jwt" version="7.5.1" />
-	  <dependency id="Microsoft.IdentityModel.Validators" version="7.5.1" />
+	    <dependency id="Microsoft.IdentityModel.Validators" version="7.5.1" />
       <dependency id="Azure.Storage.Blobs" version="12.14.1" />
     </dependencies>
     <readme>README.md</readme>


### PR DESCRIPTION
in #372, there was Microsoft.IdentityModel.Validators introduced and added as a dependency of project. This works when Garnet is built from source as dlls get copied, however consuming the Nuget yields a dll not found exception on runtime. Adding the dependency to Nuget and updating version as per Directory.Packages.props