### PR TITLE
BDN for parsing + ACL

### DIFF
--- a/benchmark/BDN.benchmark/Resp/RespParseStress.cs
+++ b/benchmark/BDN.benchmark/Resp/RespParseStress.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using Embedded.perftest;
+using Garnet.server;
+
+namespace BDN.benchmark.Resp
+{
+    public unsafe class RespParseStress
+    {
+        EmbeddedRespServer server;
+        RespServerSession session;
+        byte[] batchBuffer;
+        byte* batchBufferPtr;
+
+        static ReadOnlySpan<byte> INLINE_PING => "PING\r\n"u8;
+        static readonly int batchSize = 128;
+        static readonly Random rand = new Random();
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            var opt = new GarnetServerOptions
+            {
+                QuietMode = true
+            };
+            server = new EmbeddedRespServer(opt);
+            session = server.GetRespSession();
+
+            batchBuffer = GC.AllocateArray<byte>(INLINE_PING.Length * batchSize, pinned: true);
+            batchBufferPtr = (byte*)Unsafe.AsPointer(ref batchBuffer[0]);
+            var batchBufferSpan = new Span<byte>(batchBuffer);
+
+            int batchBufferLength = 0;
+            for (int i = 0; i < batchSize; i++)
+            {
+                INLINE_PING.CopyTo(batchBufferSpan.Slice(batchBufferLength));
+                batchBufferLength += INLINE_PING.Length;
+            }
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            session.Dispose();
+            server.Dispose();
+        }
+
+        [Benchmark]
+        public void InlinePing()
+        {
+            _ = session.TryConsumeMessages(batchBufferPtr, batchBuffer.Length);
+        }
+    }
+}

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -38,12 +38,11 @@ namespace Garnet.server
             if (NetworkSingleKeySlotVerify(keyPtr, ksize, true))
                 return true;
 
-            keyPtr -= sizeof(int); // length header
-            *(int*)keyPtr = ksize;
+            var key = new SpanByte(ksize, (nint)keyPtr);
 
             var o = new SpanByteAndMemory(dcurr, (int)(dend - dcurr));
             SpanByte input = default;
-            var status = storageApi.GET(ref Unsafe.AsRef<SpanByte>(keyPtr), ref input, ref o);
+            var status = storageApi.GET(ref key, ref input, ref o);
 
             switch (status)
             {
@@ -311,12 +310,10 @@ namespace Garnet.server
             if (NetworkSingleKeySlotVerify(keyPtr, ksize, false))
                 return true;
 
-            keyPtr -= sizeof(int);
-            valPtr -= sizeof(int);
-            *(int*)keyPtr = ksize;
-            *(int*)valPtr = vsize;
+            var key = new SpanByte(ksize, (nint)keyPtr);
+            var value = new SpanByte(vsize, (nint)valPtr);
+            var status = storageApi.SET(ref key, ref value);
 
-            var status = storageApi.SET(ref Unsafe.AsRef<SpanByte>(keyPtr), ref Unsafe.AsRef<SpanByte>(valPtr));
             while (!RespWriteUtils.WriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
                 SendAndReset();
 


### PR DESCRIPTION
Uses a batch size of 128 commands per BDN call invocation.
Also: change GET/SET to not clobber input buffer in order to work correctly with BDN + it is a cleaner design.
