### PR TITLE
Ensure Read/Write Safety During Recovery

### DIFF
--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -130,7 +130,6 @@ namespace Garnet.cluster
             return false;
         }
 
-
         /// <summary>
         /// Check if the provided  slot is local from the perspective of the local config.
         /// 1. Local slots are assigned to workerId = 1

--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -102,7 +102,7 @@ namespace Garnet.cluster
             string replicaOfNodeId,
             string hostname)
         {
-            Worker[] newWorkers = new Worker[workers.Length];
+            var newWorkers = new Worker[workers.Length];
             Array.Copy(workers, newWorkers, workers.Length);
             newWorkers[1].Address = address;
             newWorkers[1].Port = port;
@@ -145,9 +145,20 @@ namespace Garnet.cluster
         public bool IsLocal(ushort slot, bool readCommand = true)
             => slotMap[slot].workerId == 1 || IsLocalExpensive(slot, readCommand);
 
+        /// <summary>
+        /// If slot in MIGRATE state then it must have been set by original owner, so we keep treating it like a local slot and serve requests if the key has not yet migrated.
+        /// If it is a read command and this is a replica the associated slot should be assigned to this node's primary in order for the read request to be served.
+        /// </summary>
+        /// <param name="slot"></param>
+        /// <param name="readCommand"></param>
+        /// <returns></returns>
         private bool IsLocalExpensive(ushort slot, bool readCommand)
-            => (readCommand && workers[1].Role == NodeRole.REPLICA && workers[slotMap[slot]._workerId].Nodeid.Equals(LocalNodePrimaryId, StringComparison.OrdinalIgnoreCase)) ||
-            slotMap[slot]._state == SlotState.MIGRATING;
+            => slotMap[slot]._state == SlotState.MIGRATING ||
+            (readCommand &&
+            workers[1].Role == NodeRole.REPLICA &&
+            slotMap[slot]._workerId > 1 &&
+            LocalNodePrimaryId != null &&
+            workers[slotMap[slot]._workerId].Nodeid.Equals(LocalNodePrimaryId, StringComparison.OrdinalIgnoreCase));
 
         /// <summary>
         /// Check if specified node-id belongs to a node in our local config.
@@ -156,7 +167,7 @@ namespace Garnet.cluster
         /// <returns>True if node-id in worker list, false otherwise.</returns>
         public bool IsKnown(string nodeid)
         {
-            for (int i = 1; i <= NumWorkers; i++)
+            for (var i = 1; i <= NumWorkers; i++)
                 if (workers[i].Nodeid.Equals(nodeid, StringComparison.OrdinalIgnoreCase))
                     return true;
             return false;
@@ -468,7 +479,7 @@ namespace Garnet.cluster
         /// <returns>Formatted string.</returns>
         public string GetClusterInfo()
         {
-            string nodes = "";
+            var nodes = "";
             for (ushort i = 1; i <= NumWorkers; i++)
                 nodes += GetNodeInfo(i);
             return nodes;
@@ -507,8 +518,8 @@ namespace Garnet.cluster
         {
             // Only print special states for local node
             if (workerId != 1) return "";
-            string specialStates = "";
-            for (int slot = 0; slot < slotMap.Length; slot++)
+            var specialStates = "";
+            for (var slot = 0; slot < slotMap.Length; slot++)
             {
                 if (slotMap[slot]._state == SlotState.MIGRATING)
                 {
@@ -531,7 +542,7 @@ namespace Garnet.cluster
         public List<(ushort, ushort)> GetShardRanges(int workerId)
         {
             List<(ushort, ushort)> ranges = new();
-            ushort startRange = ushort.MaxValue;
+            var startRange = ushort.MaxValue;
             ushort endRange;
             for (ushort i = 0; i < MAX_HASH_SLOT_VALUE + 1; i++)
             {
@@ -555,10 +566,10 @@ namespace Garnet.cluster
         public List<int> GetWorkerReplicas(int workerId)
         {
             var primaryId = workers[workerId].Nodeid;
-            List<int> replicaWorkerIds = new();
+            List<int> replicaWorkerIds = [];
             for (ushort i = 1; i <= NumWorkers; i++)
             {
-                string replicaOf = workers[i].ReplicaOfNodeId;
+                var replicaOf = workers[i].ReplicaOfNodeId;
                 if (replicaOf != null && replicaOf.Equals(primaryId, StringComparison.OrdinalIgnoreCase))
                     replicaWorkerIds.Add(i);
             }
@@ -721,8 +732,8 @@ namespace Garnet.cluster
 
         private List<int> GetSlotList(ushort workerId)
         {
-            List<int> result = new();
-            for (int i = 0; i < MAX_HASH_SLOT_VALUE; i++)
+            List<int> result = [];
+            for (var i = 0; i < MAX_HASH_SLOT_VALUE; i++)
                 if (slotMap[i].workerId == workerId) result.Add(i);
             return result;
         }
@@ -734,10 +745,10 @@ namespace Garnet.cluster
         /// <returns></returns>
         public List<string> GetReplicas(string nodeid)
         {
-            List<string> replicas = new();
+            List<string> replicas = [];
             for (ushort i = 1; i < workers.Length; i++)
             {
-                string replicaOf = workers[i].ReplicaOfNodeId;
+                var replicaOf = workers[i].ReplicaOfNodeId;
                 if (replicaOf != null && replicaOf.Equals(nodeid, StringComparison.OrdinalIgnoreCase))
                     replicas.Add(GetNodeInfo(i));
             }
@@ -751,10 +762,10 @@ namespace Garnet.cluster
         /// <returns></returns>
         public List<string> GetReplicaIds(string nodeid)
         {
-            List<string> replicas = new();
+            List<string> replicas = [];
             for (ushort i = 1; i < workers.Length; i++)
             {
-                string replicaOf = workers[i].ReplicaOfNodeId;
+                var replicaOf = workers[i].ReplicaOfNodeId;
                 if (replicaOf != null && replicaOf.Equals(nodeid, StringComparison.OrdinalIgnoreCase))
                     replicas.Add(workers[i].Nodeid);
             }
@@ -763,10 +774,10 @@ namespace Garnet.cluster
 
         public List<(string, int)> GetReplicaEndpoints(string nodeid)
         {
-            List<(string, int)> replicaEndpoints = new();
+            List<(string, int)> replicaEndpoints = [];
             for (ushort i = 1; i < workers.Length; i++)
             {
-                string replicaOf = workers[i].ReplicaOfNodeId;
+                var replicaOf = workers[i].ReplicaOfNodeId;
                 if (replicaOf != null && replicaOf.Equals(nodeid, StringComparison.OrdinalIgnoreCase))
                     replicaEndpoints.Add(new(workers[i].Address, workers[i].Port));
             }
@@ -789,8 +800,8 @@ namespace Garnet.cluster
         /// <returns>List of triplets.</returns>
         public List<(string, string, int)> GetWorkerInfoForGossip()
         {
-            List<(string, string, int)> result = new();
-            for (int i = 2; i < workers.Length; i++)
+            List<(string, string, int)> result = [];
+            for (var i = 2; i < workers.Length; i++)
                 result.Add((workers[i].Nodeid, workers[i].Address, workers[i].Port));
             return result;
         }
@@ -802,8 +813,8 @@ namespace Garnet.cluster
         /// <returns>Integer representing count of slots in given state.</returns>
         public int GetSlotCountForState(SlotState slotState)
         {
-            int count = 0;
-            for (int i = 0; i < slotMap.Length; i++)
+            var count = 0;
+            for (var i = 0; i < slotMap.Length; i++)
                 count += slotMap[i]._state == slotState ? 1 : 0;
             return count;
         }
@@ -814,7 +825,7 @@ namespace Garnet.cluster
         /// <returns>Integer representing number of primary nodes.</returns>
         public int GetPrimaryCount()
         {
-            int count = 0;
+            var count = 0;
             for (ushort i = 1; i <= NumWorkers; i++)
             {
                 var w = workers[i];
@@ -890,7 +901,7 @@ namespace Garnet.cluster
             List<int> slots)
         {
             ushort workerId = 0;
-            for (int i = 1; i < workers.Length; i++)
+            for (var i = 1; i < workers.Length; i++)
             {
                 if (workers[i].Nodeid.Equals(nodeid, StringComparison.OrdinalIgnoreCase))
                 {
@@ -902,7 +913,7 @@ namespace Garnet.cluster
                 }
             }
 
-            Worker[] newWorkers = this.workers;
+            var newWorkers = workers;
             if (workerId == 0)
             {
                 newWorkers = new Worker[workers.Length + 1];
@@ -918,7 +929,7 @@ namespace Garnet.cluster
             newWorkers[workerId].ReplicaOfNodeId = replicaOfNodeId;
             newWorkers[workerId].hostname = hostname;
 
-            var newSlotMap = this.slotMap;
+            var newSlotMap = slotMap;
             if (slots != null)
             {
                 foreach (int slot in slots)
@@ -939,7 +950,7 @@ namespace Garnet.cluster
         public ClusterConfig RemoveWorker(string nodeid)
         {
             ushort workerId = 0;
-            for (int i = 1; i < workers.Length; i++)
+            for (var i = 1; i < workers.Length; i++)
             {
                 if (workers[i].Nodeid.Equals(nodeid, StringComparison.OrdinalIgnoreCase))
                 {
@@ -950,7 +961,7 @@ namespace Garnet.cluster
 
             var newSlotMap = new HashSlot[MAX_HASH_SLOT_VALUE];
             Array.Copy(slotMap, newSlotMap, slotMap.Length);
-            for (int i = 0; i < newSlotMap.Length; i++)
+            for (var i = 0; i < newSlotMap.Length; i++)
             {
                 if (newSlotMap[i].workerId == workerId)
                 {
@@ -963,7 +974,7 @@ namespace Garnet.cluster
                 }
             }
 
-            Worker[] newWorkers = new Worker[workers.Length - 1];
+            var newWorkers = new Worker[workers.Length - 1];
             Array.Copy(workers, 0, newWorkers, 0, workerId);
             if (workers.Length - 1 != workerId)
                 Array.Copy(workers, workerId + 1, newWorkers, workerId, workers.Length - workerId - 1);
@@ -1040,7 +1051,7 @@ namespace Garnet.cluster
             Array.Copy(slotMap, newSlotMap, slotMap.Length);
             if (slots != null)
             {
-                foreach (int slot in slots)
+                foreach (var slot in slots)
                 {
                     if (newSlotMap[slot].workerId != 0)
                     {
@@ -1072,7 +1083,7 @@ namespace Garnet.cluster
             Array.Copy(slotMap, newSlotMap, slotMap.Length);
             if (slots != null)
             {
-                foreach (int slot in slots)
+                foreach (var slot in slots)
                 {
                     if (newSlotMap[slot].workerId == 0)
                     {
@@ -1152,7 +1163,7 @@ namespace Garnet.cluster
         /// <returns>ClusterConfig object with updates.</returns>
         public ClusterConfig BumpLocalNodeConfigEpoch()
         {
-            long maxConfigEpoch = GetMaxConfigEpoch();
+            var maxConfigEpoch = GetMaxConfigEpoch();
             var newWorkers = new Worker[workers.Length];
             Array.Copy(workers, newWorkers, workers.Length);
             newWorkers[1].ConfigEpoch = maxConfigEpoch + 1;

--- a/libs/cluster/Server/ClusterManagerWorkerState.cs
+++ b/libs/cluster/Server/ClusterManagerWorkerState.cs
@@ -190,8 +190,7 @@ namespace Garnet.cluster
                     return false;
                 }
 
-                var newConfig = currentConfig.MakeReplicaOf(nodeid);
-                newConfig = newConfig.BumpLocalNodeConfigEpoch();
+                var newConfig = currentConfig.MakeReplicaOf(nodeid).BumpLocalNodeConfigEpoch();
                 if (Interlocked.CompareExchange(ref currentConfig, newConfig, current) == current)
                     break;
             }

--- a/libs/cluster/Server/ClusterManagerWorkerState.cs
+++ b/libs/cluster/Server/ClusterManagerWorkerState.cs
@@ -183,6 +183,7 @@ namespace Garnet.cluster
                 }
 
                 // Transition to recovering state
+                // Only one caller will succeed in becoming a replica for the provided node-id
                 if (!clusterProvider.replicationManager.StartRecovery())
                 {
                     logger?.LogError($"{nameof(TryAddReplica)}: {{logMessage}}", Encoding.ASCII.GetString(CmdStrings.RESP_ERR_GENERIC_CANNOT_ACQUIRE_RECOVERY_LOCK));

--- a/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
+++ b/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
@@ -335,7 +335,7 @@ namespace Garnet.cluster
                 if (!TakeOverAsPrimary())
                 {
                     // Request primary to be reset to original state only if DEFAULT option was used
-                    if(primaryClient != null)
+                    if (primaryClient != null)
                         _ = await primaryClient?.failstopwrites(Array.Empty<byte>()).WaitAsync(failoverTimeout, cts.Token);
                     return false;
                 }

--- a/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
+++ b/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
@@ -163,7 +163,7 @@ namespace Garnet.cluster
             // Make replica syncing unavailable by setting recovery flag
             if (!clusterProvider.replicationManager.StartRecovery())
             {
-                logger?.LogError($"{nameof(TakeOverAsPrimary)}: {{logMessage}}", Encoding.ASCII.GetString(CmdStrings.RESP_ERR_GENERIC_CANNOT_ACQUIRE_RECOVERY_LOCK));
+                logger?.LogWarning($"{nameof(TakeOverAsPrimary)}: {{logMessage}}", Encoding.ASCII.GetString(CmdStrings.RESP_ERR_GENERIC_CANNOT_ACQUIRE_RECOVERY_LOCK));
                 return false;
             }
             _ = clusterProvider.WaitForConfigTransition();
@@ -173,7 +173,7 @@ namespace Garnet.cluster
                 // Take over slots from old primary
                 if (!clusterProvider.clusterManager.TryTakeOverForPrimary())
                 {
-                    logger?.LogError($"{nameof(TakeOverAsPrimary)}: {{logMessage}}", Encoding.ASCII.GetString(CmdStrings.RESP_ERR_GENERIC_CANNOT_TAKEOVER_FROM_PRIMARY));
+                    logger?.LogWarning($"{nameof(TakeOverAsPrimary)}: {{logMessage}}", Encoding.ASCII.GetString(CmdStrings.RESP_ERR_GENERIC_CANNOT_TAKEOVER_FROM_PRIMARY));
                     return false;
                 }
 
@@ -335,7 +335,8 @@ namespace Garnet.cluster
                 if (!TakeOverAsPrimary())
                 {
                     // Request primary to be reset to original state only if DEFAULT option was used
-                    _ = await primaryClient?.failstopwrites(Array.Empty<byte>()).WaitAsync(failoverTimeout, cts.Token);
+                    if(primaryClient != null)
+                        _ = await primaryClient?.failstopwrites(Array.Empty<byte>()).WaitAsync(failoverTimeout, cts.Token);
                     return false;
                 }
 

--- a/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
+++ b/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
@@ -166,6 +166,7 @@ namespace Garnet.cluster
                 logger?.LogWarning($"{nameof(TakeOverAsPrimary)}: {{logMessage}}", Encoding.ASCII.GetString(CmdStrings.RESP_ERR_GENERIC_CANNOT_ACQUIRE_RECOVERY_LOCK));
                 return false;
             }
+            // Wait for all threads to observe recovery state
             _ = clusterProvider.WaitForConfigTransition();
 
             try
@@ -182,6 +183,8 @@ namespace Garnet.cluster
 
                 // Initialize checkpoint history
                 clusterProvider.replicationManager.InitializeCheckpointStore();
+
+                // Wait for all threads to observe configuration transition to primary
                 _ = clusterProvider.WaitForConfigTransition();
             }
             finally

--- a/libs/cluster/Server/Replication/CheckpointStore.cs
+++ b/libs/cluster/Server/Replication/CheckpointStore.cs
@@ -44,7 +44,7 @@ namespace Garnet.cluster
 
             //This purge does not check for active readers
             //1. If primary is initializing then we will not have any active readers since not connections are established at recovery
-            //2. If replica is initializing during failover we dot this before allowing other replicas to attach.
+            //2. If replica is initializing during failover we do this before allowing other replicas to attach.
             if (safelyRemoveOutdated)
                 PurgeAllCheckpointsExceptEntry(tail);
         }

--- a/libs/cluster/Server/Replication/PrimaryOps/ReplicaSyncSession.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/ReplicaSyncSession.cs
@@ -356,6 +356,7 @@ namespace Garnet.cluster
 
         private async Task SendCheckpointMetadata(GarnetClientSession gcs, ReplicationLogCheckpointManager ckptManager, CheckpointFileType fileType, Guid fileToken)
         {
+            logger?.LogInformation("<Begin sending checkpoint metadata {fileToken} {fileType}", fileToken, fileType);
             var checkpointMetadata = Array.Empty<byte>();
             if (fileToken != default)
             {
@@ -393,6 +394,8 @@ namespace Garnet.cluster
                 logger?.LogError("Primary error at SendCheckpointMetadata {resp}", resp);
                 throw new Exception($"Primary error at SendCheckpointMetadata {resp}");
             }
+
+            logger?.LogInformation("<Complete sending checkpoint metadata {fileToken} {fileType}", fileToken, fileType);
         }
 
         private async Task SendFileSegments(GarnetClientSession gcs, Guid token, CheckpointFileType type, long startAddress, long endAddress, int batchSize = 1 << 17)
@@ -440,6 +443,7 @@ namespace Garnet.cluster
             {
                 device.Dispose();
             }
+            logger?.LogInformation("<Complete sending checkpoint file segments {guid} {type} {startAddress} {endAddress}", token, type, startAddress, endAddress);
         }
 
         private async Task SendObjectFiles(GarnetClientSession gcs, Guid token, CheckpointFileType type, int segmentCount, int batchSize = 1 << 17)

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaReceiveCheckpoint.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaReceiveCheckpoint.cs
@@ -308,6 +308,8 @@ namespace Garnet.cluster
             try
             {
                 UpdateLastPrimarySyncTime();
+
+                logger?.LogInformation("Initiating Checkpoint Recovery at replica {sIndexToken} {sHlogToken} {oIndexToken} {oHlogToken}", remoteCheckpoint.storeIndexToken, remoteCheckpoint.storeHlogToken, remoteCheckpoint.objectStoreIndexToken, remoteCheckpoint.objectStoreHlogToken);
                 storeWrapper.RecoverCheckpoint(recoverMainStoreFromToken, recoverObjectStoreFromToken,
                     remoteCheckpoint.storeIndexToken, remoteCheckpoint.storeHlogToken, remoteCheckpoint.objectStoreIndexToken, remoteCheckpoint.objectStoreHlogToken);
 
@@ -317,6 +319,7 @@ namespace Garnet.cluster
                     recoveredReplicationOffset = storeWrapper.ReplayAOF(recoveredReplicationOffset);
                 }
 
+                logger?.LogInformation("Initializing AOF");
                 storeWrapper.appendOnlyFile.Initialize(beginAddress, recoveredReplicationOffset);
 
                 // Finally, advertise that we are caught up to the replication offset
@@ -339,9 +342,11 @@ namespace Garnet.cluster
                 checkpointStore.PurgeAllCheckpointsExceptEntry(cEntry);
 
                 // Initialize in-memory checkpoint store and delete outdated checkpoint entries
+                logger?.LogInformation("Initializing CheckpointStore");
                 InitializeCheckpointStore();
 
                 // Update replicationId to mark any subsequent checkpoints as part of this history
+                logger?.LogInformation("Updating ReplicationId");
                 TryUpdateMyPrimaryReplId(primaryReplicationId);
 
                 return ReplicationOffset;

--- a/libs/cluster/Server/Replication/ReplicationManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationManager.cs
@@ -137,8 +137,32 @@ namespace Garnet.cluster
             storeWrapper.EnqueueCommit(isMainStore, newVersion);
         }
 
-        public bool StartRecovery() => recoverLock.TryWriteLock();
-        public void SuspendRecovery() => recoverLock.WriteUnlock();
+        /// <summary>
+        /// Acquire recovery and checkpoint locks to prevent checkpoints and parallel recovery tasks
+        /// </summary>
+        public bool StartRecovery()
+        {
+            if (!clusterProvider.storeWrapper.TryPauseCheckpoints())
+                return false;
+
+            if (!recoverLock.TryWriteLock())
+            {
+                // If failed to acquire recoverLock re-enable checkpoint taking
+                clusterProvider.storeWrapper.ResumeCheckpoints();
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Release recovery and checkpoint locks
+        /// </summary>
+        public void SuspendRecovery()
+        {
+            recoverLock.WriteUnlock();
+            clusterProvider.storeWrapper.ResumeCheckpoints();
+        }
 
         public void Dispose()
         {

--- a/libs/cluster/Server/Replication/ReplicationManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationManager.cs
@@ -246,7 +246,7 @@ namespace Garnet.cluster
                     if (clusterProvider.replicationManager.TryAddReplicationTask(replicaId, 0, out var aofSyncTaskInfo))
                     {
                         if (!TryConnectToReplica(replicaId, 0, aofSyncTaskInfo, out var errorMessage))
-                            logger?.LogError(Encoding.ASCII.GetString(errorMessage));
+                            logger?.LogError($"{{errorMessage}}", Encoding.ASCII.GetString(errorMessage));
                     }
                 }
             }

--- a/libs/cluster/Session/ClusterCommands.cs
+++ b/libs/cluster/Session/ClusterCommands.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using Garnet.common;
 using Garnet.server;
@@ -133,6 +134,8 @@ namespace Garnet.cluster
         /// </summary>
         public void UnsafeWaitForConfigTransition()
         {
+            // Ensure that we are under epoch protection when calling this method
+            Debug.Assert(_localCurrentEpoch != 0);
             ReleaseCurrentEpoch();
             clusterProvider.WaitForConfigTransition();
             AcquireCurrentEpoch();

--- a/libs/cluster/Session/ClusterSlotCheck.cs
+++ b/libs/cluster/Session/ClusterSlotCheck.cs
@@ -12,15 +12,6 @@ namespace Garnet.cluster
 {
     internal sealed unsafe partial class ClusterSession : IClusterSession
     {
-        private bool CheckIfKeyExists(byte[] key)
-        {
-            fixed (byte* keyPtr = key)
-                return CheckIfKeyExists(new ArgSlice(keyPtr, key.Length));
-        }
-
-        private bool CheckIfKeyExists(ArgSlice keySlice)
-            => basicGarnetApi.EXISTS(keySlice, StoreType.All) == GarnetStatus.OK;
-
         /// <summary>
         /// Redirect message for readonly operation COUNTKEYS GETKEYSINSLOT
         /// </summary>

--- a/libs/cluster/Session/RespClusterReplicationCommands.cs
+++ b/libs/cluster/Session/RespClusterReplicationCommands.cs
@@ -91,7 +91,7 @@ namespace Garnet.cluster
             }
             else
             {
-                if (!clusterProvider.replicationManager.TryBeginReplicate(this, nodeid, background, false, out var errorMessage))
+                if (!clusterProvider.replicationManager.TryBeginReplicate(this, nodeid, background: background, force: false, out var errorMessage))
                 {
                     while (!RespWriteUtils.WriteError(errorMessage, ref dcurr, dend))
                         SendAndReset();

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -569,13 +569,13 @@ namespace Garnet.server
         /// Mark the beginning of a checkpoint by taking and a lock to avoid concurrent checkpoint tasks
         /// </summary>
         /// <returns></returns>
-        bool StartCheckpoint()
+        public bool TryPauseCheckpoints()
             => _checkpointTaskLock.TryWriteLock();
 
         /// <summary>
         /// Release checkpoint task lock
         /// </summary>
-        void CompleteCheckpoint()
+        public void ResumeCheckpoints()
             => _checkpointTaskLock.WriteUnlock();
 
         /// <summary>
@@ -586,13 +586,13 @@ namespace Garnet.server
         public async Task TakeOnDemandCheckpoint(DateTimeOffset entryTime)
         {
             // Take lock to ensure no other task will be taking a checkpoint
-            while (!StartCheckpoint())
+            while (!TryPauseCheckpoints())
                 await Task.Yield();
 
             // If an external task has taken a checkpoint beyond the provided entryTime return
             if (this.lastSaveTime > entryTime)
             {
-                CompleteCheckpoint();
+                ResumeCheckpoints();
                 return;
             }
 
@@ -609,7 +609,8 @@ namespace Garnet.server
         /// <returns></returns>
         public bool TakeCheckpoint(bool background, StoreType storeType = StoreType.All, ILogger logger = null)
         {
-            if (!StartCheckpoint()) return false;
+            // Prevent parallel checkpoint
+            if (!TryPauseCheckpoints()) return false;
             if (background)
                 Task.Run(async () => await CheckpointTask(storeType, logger));
             else
@@ -654,7 +655,7 @@ namespace Garnet.server
             }
             finally
             {
-                CompleteCheckpoint();
+                ResumeCheckpoints();
             }
         }
 

--- a/test/Garnet.test.cluster/ClusterReplicationTests.cs
+++ b/test/Garnet.test.cluster/ClusterReplicationTests.cs
@@ -143,7 +143,7 @@ namespace Garnet.test.cluster
         {
             var replica_count = 1;// Per primary
             var primary_count = 1;
-            var nodes_count = primary_count + primary_count * replica_count;
+            var nodes_count = primary_count + (primary_count * replica_count);
             Assert.IsTrue(primary_count > 0);
             context.CreateInstances(nodes_count, disableObjects: disableObjects, enableAOF: true, useTLS: useTLS);
             context.CreateConnection(useTLS: useTLS);
@@ -209,7 +209,7 @@ namespace Garnet.test.cluster
         {
             var replica_count = 1;// Per primary
             var primary_count = 1;
-            var nodes_count = primary_count + primary_count * replica_count;
+            var nodes_count = primary_count + (primary_count * replica_count);
             Assert.IsTrue(primary_count > 0);
             context.CreateInstances(nodes_count, disableObjects: disableObjects, enableAOF: true, useTLS: useTLS);
             context.CreateConnection(useTLS: useTLS);
@@ -401,7 +401,7 @@ namespace Garnet.test.cluster
             var kvpairCount = keyCount;
             var addCount = 5;
             context.kvPairs = [];
-            context.kvPairsObj = new Dictionary<string, List<int>>();
+            context.kvPairsObj = [];
 
             // Populate Primary
             if (disableObjects)
@@ -437,7 +437,7 @@ namespace Garnet.test.cluster
         {
             var replica_count = 1;// Per primary
             var primary_count = 1;
-            var nodes_count = primary_count + primary_count * replica_count;
+            var nodes_count = primary_count + (primary_count * replica_count);
             Assert.IsTrue(primary_count > 0);
             context.CreateInstances(nodes_count, tryRecover: true, disableObjects: disableObjects, enableAOF: true, useTLS: useTLS);
             context.CreateConnection(useTLS: useTLS);
@@ -503,7 +503,7 @@ namespace Garnet.test.cluster
         {
             var replica_count = 1;// Per primary
             var primary_count = 1;
-            var nodes_count = primary_count + primary_count * replica_count;
+            var nodes_count = primary_count + (primary_count * replica_count);
             Assert.IsTrue(primary_count > 0);
             context.CreateInstances(nodes_count, enableAOF: true, useTLS: useTLS);
             context.CreateConnection(useTLS: useTLS);
@@ -567,7 +567,7 @@ namespace Garnet.test.cluster
         {
             var replica_count = 1;// Per primary
             var primary_count = 1;
-            var nodes_count = primary_count + primary_count * replica_count;
+            var nodes_count = primary_count + (primary_count * replica_count);
             Assert.IsTrue(primary_count > 0);
             context.CreateInstances(nodes_count, disableObjects: true, enableAOF: true, useTLS: useTLS);
             context.CreateConnection(useTLS: useTLS);
@@ -636,7 +636,7 @@ namespace Garnet.test.cluster
         {
             var replica_count = 2; // Per primary
             var primary_count = 1;
-            var nodes_count = primary_count + primary_count * replica_count;
+            var nodes_count = primary_count + (primary_count * replica_count);
             Assert.IsTrue(primary_count > 0);
             context.CreateInstances(nodes_count, disableObjects: true, EnableIncrementalSnapshots: enableIncrementalSnapshots, enableAOF: true, useTLS: useTLS);
             context.CreateConnection(useTLS: useTLS);
@@ -749,7 +749,7 @@ namespace Garnet.test.cluster
         {
             var replica_count = 2; // Per primary
             var primary_count = 1;
-            var nodes_count = primary_count + primary_count * replica_count;
+            var nodes_count = primary_count + (primary_count * replica_count);
             Assert.IsTrue(primary_count > 0);
             context.CreateInstances(nodes_count, disableObjects: true, MainMemoryReplication: true, OnDemandCheckpoint: true, CommitFrequencyMs: -1, enableAOF: true, useTLS: useTLS);
             context.CreateConnection(useTLS: useTLS);
@@ -793,7 +793,7 @@ namespace Garnet.test.cluster
         {
             var replica_count = 1;// Per primary
             var primary_count = 1;
-            var nodes_count = primary_count + primary_count * replica_count;
+            var nodes_count = primary_count + (primary_count * replica_count);
             Assert.IsTrue(primary_count > 0);
             context.CreateInstances(nodes_count, disableObjects: true, MainMemoryReplication: MainMemoryReplication, OnDemandCheckpoint: onDemandCheckpoint, CommitFrequencyMs: -1, enableAOF: true, useTLS: useTLS);
             context.CreateConnection(useTLS: useTLS);
@@ -892,7 +892,7 @@ namespace Garnet.test.cluster
             var set = false;
             var replica_count = 2;// Per primary
             var primary_count = 1;
-            var nodes_count = primary_count + primary_count * replica_count;
+            var nodes_count = primary_count + (primary_count * replica_count);
             Assert.IsTrue(primary_count > 0);
             context.CreateInstances(nodes_count, disableObjects: disableObjects, MainMemoryReplication: mainMemoryReplication, CommitFrequencyMs: mainMemoryReplication ? -1 : 0, OnDemandCheckpoint: mainMemoryReplication, FastCommit: fastCommit, enableAOF: true, useTLS: useTLS);
             context.CreateConnection(useTLS: useTLS);

--- a/test/Garnet.test.cluster/ClusterTestContext.cs
+++ b/test/Garnet.test.cluster/ClusterTestContext.cs
@@ -416,7 +416,7 @@ namespace Garnet.test.cluster
                 }
 
                 var retVal = clusterTestUtils.GetKey(replicaIndex, keyBytes, out var _, out var _, out var _, out var responseState, logger: logger);
-                while (retVal == null || (value != int.Parse(retVal)))
+                while (responseState != ResponseState.OK || retVal == null || (value != int.Parse(retVal)))
                 {
                     retVal = clusterTestUtils.GetKey(replicaIndex, keyBytes, out var _, out var _, out var _, out responseState, logger: logger);
                     ClusterTestUtils.BackOff();
@@ -465,7 +465,7 @@ namespace Garnet.test.cluster
                 clusterTestUtils.WaitForReplicaAofSync(primaryIndex, replicaIndex);
 
                 var retVal = clusterTestUtils.GetKey(replicaIndex, keyBytes, out int _, out string _, out int _, out ResponseState responseState, logger: logger);
-                while (retVal == null || (value != int.Parse(retVal)))
+                while (responseState != ResponseState.OK || retVal == null || (value != int.Parse(retVal)))
                 {
                     retVal = clusterTestUtils.GetKey(replicaIndex, keyBytes, out int _, out string _, out int _, out responseState, logger: logger);
                     ClusterTestUtils.BackOff();


### PR DESCRIPTION
This PR contains the following enchantments:

- [x] Added validity checks on nodeId and workerId at IsLocalExpensive.
- [x]  Add nullptr check to prevent object nullptr ref for concurrent failover and recovery operations.
- [x]  Propagate RESP errors back to the client at CLUSTER REPLICATE.
- [x]  Ensure SuspendRecovery happens at the end of BeginRecover.
- [x]  Prevent start of recovery if there is an ongoing failover.
- [x]  Refactor and simplify SingleKeyVerify validation.
- [x]  Add recovery check at SingleKeyReadWriteVerify to prevent writes while replica is taking over.