### PR TITLE
Fix ACL enforcement when transaction active

### DIFF
--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -312,13 +312,19 @@ namespace Garnet.server
                         {
                             success = ProcessBasicCommands(cmd, count, ptr, ref lockableGarnetApi);
                         }
-                        else success = cmd switch
+                        else
                         {
-                            RespCommand.EXEC => NetworkEXEC(ptr),
-                            RespCommand.MULTI => NetworkMULTI(ptr),
-                            RespCommand.DISCARD => NetworkDISCARD(),
-                            _ => NetworkSKIP(cmd, count),
-                        };
+                            if (CheckACLPermissions(cmd, ptr, count, out success))
+                            {
+                                success = cmd switch
+                                {
+                                    RespCommand.EXEC => NetworkEXEC(ptr),
+                                    RespCommand.MULTI => NetworkMULTI(ptr),
+                                    RespCommand.DISCARD => NetworkDISCARD(),
+                                    _ => NetworkSKIP(cmd, count),
+                                };
+                            }
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
`ProcessBasicCommands` is not (currently) called if a transaction is pending.  This allowed commands to bypass ACLs when queuing commands.

Fixed that, which revealed a bug in the MultiACLs test (I assumed `DISCARD` was available if `MULTI` was) which is also fixed.