### PR TITLE
Only truncate AOF if all active stores are checkpointed

### DIFF
--- a/libs/cluster/Server/ClusterProvider.cs
+++ b/libs/cluster/Server/ClusterProvider.cs
@@ -156,6 +156,10 @@ namespace Garnet.cluster
             // Used to delete old checkpoints and cleanup and also cleanup during attachment to new primary
             replicationManager.AddCheckpointEntry(entry, storeType, full);
 
+            // Only truncate AOF if 1) both stores were checkpointed OR 2) only Main was checkpointed but Object was not enabled
+            if (storeType != StoreType.All && !(storeType == StoreType.Main && serverOptions.DisableObjects))
+                return;
+
             if (clusterManager.CurrentConfig.LocalNodeRole == NodeRole.PRIMARY)
                 _ = replicationManager.SafeTruncateAof(CheckpointCoveredAofAddress);
             else

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -719,15 +719,19 @@ namespace Garnet.server
                     objectStoreCheckpointResult = await objectStore.TakeHybridLogCheckpointAsync(checkpointType, tryIncremental);
             }
 
-            // If cluster is enabled the replication manager is responsible for truncating AOF
-            if (serverOptions.EnableCluster && serverOptions.EnableAOF)
+            // Only truncate AOF if both stores are checkpointed
+            if (storeType == StoreType.All)
             {
-                clusterProvider.SafeTruncateAOF(storeType, full, CheckpointCoveredAofAddress, storeCheckpointResult.token, objectStoreCheckpointResult.token);
-            }
-            else
-            {
-                appendOnlyFile?.TruncateUntil(CheckpointCoveredAofAddress);
-                appendOnlyFile?.Commit();
+                // If cluster is enabled the replication manager is responsible for truncating AOF
+                if (serverOptions.EnableCluster && serverOptions.EnableAOF)
+                {
+                    clusterProvider.SafeTruncateAOF(storeType, full, CheckpointCoveredAofAddress, storeCheckpointResult.token, objectStoreCheckpointResult.token);
+                }
+                else
+                {
+                    appendOnlyFile?.TruncateUntil(CheckpointCoveredAofAddress);
+                    appendOnlyFile?.Commit();
+                }
             }
 
             if (objectStore != null)

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -719,8 +719,6 @@ namespace Garnet.server
                     objectStoreCheckpointResult = await objectStore.TakeHybridLogCheckpointAsync(checkpointType, tryIncremental);
             }
 
-            // Only truncate AOF if both stores are checkpointed
-            if (storeType == StoreType.All)
             {
                 // If cluster is enabled the replication manager is responsible for truncating AOF
                 if (serverOptions.EnableCluster && serverOptions.EnableAOF)
@@ -729,8 +727,11 @@ namespace Garnet.server
                 }
                 else
                 {
-                    appendOnlyFile?.TruncateUntil(CheckpointCoveredAofAddress);
-                    appendOnlyFile?.Commit();
+                    if (storeType == StoreType.All || (storeType == StoreType.Main && serverOptions.DisableObjects))
+                    {
+                        appendOnlyFile?.TruncateUntil(CheckpointCoveredAofAddress);
+                        appendOnlyFile?.Commit();
+                    }
                 }
             }
 


### PR DESCRIPTION
AOF is truncated after checkpointing. However, truncation should only happen if both stores are checkpointed, since they share the same AOF. The current implementation can lose data if `storeType` is not `StoreType.All`.

This bug so far is not triggered because every caller is using `StoreType.All`.