### PR TITLE
Fix SafeAofAddress

### DIFF
--- a/libs/cluster/Server/Replication/ReplicationManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationManager.cs
@@ -75,14 +75,14 @@ namespace Garnet.cluster
         public long GetRecoveredSafeAofAddress()
         {
             var storeAofAddress = clusterProvider.replicationManager.GetCkptManager(StoreType.Main).RecoveredSafeAofAddress;
-            var objectStoreAofAddress = clusterProvider.serverOptions.DisableObjects ? clusterProvider.replicationManager.GetCkptManager(StoreType.Main).RecoveredSafeAofAddress : long.MaxValue;
+            var objectStoreAofAddress = clusterProvider.serverOptions.DisableObjects ? long.MaxValue : clusterProvider.replicationManager.GetCkptManager(StoreType.Object).RecoveredSafeAofAddress;
             return Math.Min(storeAofAddress, objectStoreAofAddress);
         }
 
         public long GetCurrentSafeAofAddress()
         {
             var storeAofAddress = clusterProvider.replicationManager.GetCkptManager(StoreType.Main).CurrentSafeAofAddress;
-            var objectStoreAofAddress = clusterProvider.serverOptions.DisableObjects ? clusterProvider.replicationManager.GetCkptManager(StoreType.Main).CurrentSafeAofAddress : long.MaxValue;
+            var objectStoreAofAddress = clusterProvider.serverOptions.DisableObjects ? long.MaxValue : clusterProvider.replicationManager.GetCkptManager(StoreType.Object).CurrentSafeAofAddress;
             return Math.Min(storeAofAddress, objectStoreAofAddress);
         }
 


### PR DESCRIPTION
1. Fix the typo: get `SafeAofAddress` from the right store type `StoreType.Object`.
2. Fix the conditional logic of `DisableObjects`.