### PR TITLE
Remove unused useHandlesForPin

### DIFF
--- a/libs/common/Memory/LimitedFixedBufferPool.cs
+++ b/libs/common/Memory/LimitedFixedBufferPool.cs
@@ -20,7 +20,6 @@ namespace Garnet.common
     {
         readonly PoolLevel[] pool;
         readonly int numLevels, minAllocationSize, maxEntriesPerLevel;
-        readonly bool useHandlesForPin;
         readonly ILogger logger;
 
         /// <summary>
@@ -33,12 +32,11 @@ namespace Garnet.common
         /// <summary>
         /// Constructor
         /// </summary>
-        public LimitedFixedBufferPool(int minAllocationSize, int maxEntriesPerLevel = 16, int numLevels = 4, bool useHandlesForPin = false, ILogger logger = null)
+        public LimitedFixedBufferPool(int minAllocationSize, int maxEntriesPerLevel = 16, int numLevels = 4, ILogger logger = null)
         {
             this.minAllocationSize = minAllocationSize;
             this.maxEntriesPerLevel = maxEntriesPerLevel;
             this.numLevels = numLevels;
-            this.useHandlesForPin = useHandlesForPin;
             this.logger = logger;
             pool = new PoolLevel[numLevels];
         }
@@ -97,7 +95,7 @@ namespace Garnet.common
                     return page;
                 }
             }
-            return new PoolEntry(size, this, useHandlesForPin);
+            return new PoolEntry(size, this);
         }
 
         /// <summary>

--- a/libs/common/Memory/PoolEntry.cs
+++ b/libs/common/Memory/PoolEntry.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace Garnet.common
 {
@@ -23,7 +22,6 @@ namespace Garnet.common
         /// </summary>
         public byte* entryPtr;
 
-        GCHandle handle;
         readonly LimitedFixedBufferPool pool;
         bool disposed;
 


### PR DESCRIPTION
This PR resolves issue #460 by removing useHandlesForPin option.
This option is not actively being used. Instead, we rely on GC.AllocateArray to pin memory.