### PR TITLE
Empty collection key deletion - continued

### DIFF
--- a/libs/server/Storage/Session/ObjectStore/ListOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/ListOps.cs
@@ -192,8 +192,8 @@ namespace Garnet.server
             element = default;
             var objectLockableContext = txnManager.ObjectStoreLockableContext;
 
-            //If source and destination are the same, the operation is equivalent to removing the last element from the list
-            //and pushing it as first element of the list, so it can be considered as a list rotation command.
+            // If source and destination are the same, the operation is equivalent to removing the last element from the list
+            // and pushing it as first element of the list, so it can be considered as a list rotation command.
             bool sameKey = sourceKey.ReadOnlySpan.SequenceEqual(destinationKey.ReadOnlySpan);
 
             bool createTransaction = false;
@@ -209,7 +209,7 @@ namespace Garnet.server
 
             try
             {
-                // get the source key
+                // Get the source key
                 var statusOp = GET(sourceKey.ToArray(), out var sourceList, ref objectLockableContext);
 
                 if (statusOp == GarnetStatus.NOTFOUND)
@@ -227,7 +227,7 @@ namespace Garnet.server
                     ListObject dstListObject = default;
                     if (!sameKey)
                     {
-                        // read destination key
+                        // Read destination key
                         var arrDestKey = destinationKey.ToArray();
                         statusOp = GET(arrDestKey, out var destinationList, ref objectStoreLockableContext);
 
@@ -242,7 +242,7 @@ namespace Garnet.server
                         dstListObject = listObject;
                     }
 
-                    // right pop (removelast) from source
+                    // Right pop (removelast) from source
                     if (sourceDirection == OperationDirection.Right)
                     {
                         element = srcListObject.LnkList.Last.Value;
@@ -250,19 +250,22 @@ namespace Garnet.server
                     }
                     else
                     {
-                        // left pop (removefirst) from source
+                        // Left pop (removefirst) from source
                         element = srcListObject.LnkList.First.Value;
                         srcListObject.LnkList.RemoveFirst();
                     }
                     srcListObject.UpdateSize(element, false);
 
-                    //update sourcelist
-                    SET(sourceKey.ToArray(), srcListObject, ref objectStoreLockableContext);
-
                     IGarnetObject newListValue = null;
                     if (!sameKey)
                     {
-                        //left push (addfirst) to destination
+                        if (srcListObject.LnkList.Count == 0)
+                        {
+                            _ = EXPIRE(sourceKey, TimeSpan.Zero, out _, StoreType.Object, ExpireOption.None,
+                                ref lockableContext, ref objectLockableContext);
+                        }
+
+                        // Left push (addfirst) to destination
                         if (destinationDirection == OperationDirection.Left)
                             dstListObject.LnkList.AddFirst(element);
                         else
@@ -270,10 +273,13 @@ namespace Garnet.server
 
                         dstListObject.UpdateSize(element);
                         newListValue = new ListObject(dstListObject.LnkList, dstListObject.Expiration, dstListObject.Size);
+
+                        // Upsert
+                        SET(destinationKey.ToArray(), newListValue, ref objectStoreLockableContext);
                     }
                     else
                     {
-                        // when the source and the destination key is the same the operation is done only in the sourceList
+                        // When the source and the destination key is the same the operation is done only in the sourceList
                         if (sourceDirection == OperationDirection.Right && destinationDirection == OperationDirection.Left)
                             srcListObject.LnkList.AddFirst(element);
                         else if (sourceDirection == OperationDirection.Left && destinationDirection == OperationDirection.Right)
@@ -281,9 +287,6 @@ namespace Garnet.server
                         newListValue = srcListObject;
                         ((ListObject)newListValue).UpdateSize(element);
                     }
-
-                    // upsert
-                    SET(destinationKey.ToArray(), newListValue, ref objectStoreLockableContext);
                 }
             }
             finally

--- a/libs/server/Storage/Session/ObjectStore/SetOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/SetOps.cs
@@ -718,7 +718,7 @@ namespace Garnet.server
                         _ = EXPIRE(destination, TimeSpan.Zero, out _, StoreType.Object, ExpireOption.None,
                             ref lockableContext, ref setObjectStoreLockableContext);
                     }
-                    
+
                     count = members.Count;
                 }
 
@@ -947,7 +947,7 @@ namespace Garnet.server
                         _ = EXPIRE(destination, TimeSpan.Zero, out _, StoreType.Object, ExpireOption.None,
                             ref lockableContext, ref setObjectStoreLockableContext);
                     }
-                    
+
                     count = diffSet.Count;
                 }
 

--- a/libs/server/Storage/Session/ObjectStore/SetOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/SetOps.cs
@@ -429,6 +429,12 @@ namespace Garnet.server
 
                 srcSetObject.UpdateSize(arrMember, false);
 
+                if (srcSetObject.Set.Count == 0)
+                {
+                    _ = EXPIRE(sourceKey, TimeSpan.Zero, out _, StoreType.Object, ExpireOption.None,
+                        ref lockableContext, ref objectLockableContext);
+                }
+
                 dstSetObject.Set.Add(arrMember);
                 dstSetObject.UpdateSize(arrMember);
 
@@ -532,13 +538,23 @@ namespace Garnet.server
 
                 if (status == GarnetStatus.OK)
                 {
-                    var newSetObject = new SetObject();
-                    foreach (var item in members)
+                    if (members.Count > 0)
                     {
-                        _ = newSetObject.Set.Add(item);
-                        newSetObject.UpdateSize(item);
+                        var newSetObject = new SetObject();
+                        foreach (var item in members)
+                        {
+                            _ = newSetObject.Set.Add(item);
+                            newSetObject.UpdateSize(item);
+                        }
+
+                        _ = SET(key, newSetObject, ref setObjectStoreLockableContext);
                     }
-                    _ = SET(key, newSetObject, ref setObjectStoreLockableContext);
+                    else
+                    {
+                        _ = EXPIRE(destination, TimeSpan.Zero, out _, StoreType.Object, ExpireOption.None,
+                            ref lockableContext, ref setObjectStoreLockableContext);
+                    }
+
                     count = members.Count;
                 }
 
@@ -686,13 +702,23 @@ namespace Garnet.server
 
                 if (status == GarnetStatus.OK)
                 {
-                    var newSetObject = new SetObject();
-                    foreach (var item in members)
+                    if (members.Count > 0)
                     {
-                        _ = newSetObject.Set.Add(item);
-                        newSetObject.UpdateSize(item);
+                        var newSetObject = new SetObject();
+                        foreach (var item in members)
+                        {
+                            _ = newSetObject.Set.Add(item);
+                            newSetObject.UpdateSize(item);
+                        }
+
+                        _ = SET(key, newSetObject, ref setObjectStoreLockableContext);
                     }
-                    _ = SET(key, newSetObject, ref setObjectStoreLockableContext);
+                    else
+                    {
+                        _ = EXPIRE(destination, TimeSpan.Zero, out _, StoreType.Object, ExpireOption.None,
+                            ref lockableContext, ref setObjectStoreLockableContext);
+                    }
+                    
                     count = members.Count;
                 }
 
@@ -906,13 +932,22 @@ namespace Garnet.server
 
                 if (status == GarnetStatus.OK)
                 {
-                    var newSetObject = new SetObject();
-                    foreach (var item in diffSet)
+                    if (diffSet.Count > 0)
                     {
-                        _ = newSetObject.Set.Add(item);
-                        newSetObject.UpdateSize(item);
+                        var newSetObject = new SetObject();
+                        foreach (var item in diffSet)
+                        {
+                            _ = newSetObject.Set.Add(item);
+                            newSetObject.UpdateSize(item);
+                        }
+                        _ = SET(key, newSetObject, ref setObjectStoreLockableContext);
                     }
-                    _ = SET(key, newSetObject, ref setObjectStoreLockableContext);
+                    else
+                    {
+                        _ = EXPIRE(destination, TimeSpan.Zero, out _, StoreType.Object, ExpireOption.None,
+                            ref lockableContext, ref setObjectStoreLockableContext);
+                    }
+                    
                     count = diffSet.Count;
                 }
 

--- a/test/Garnet.test/RespHashTests.cs
+++ b/test/Garnet.test/RespHashTests.cs
@@ -39,6 +39,16 @@ namespace Garnet.test
         #region SEClientTests
 
         [Test]
+        public void CanSetEmpty()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+            db.HashSet("user:user1", []);
+            var exists = db.KeyExists("user:user1");
+            Assert.IsFalse(exists);
+        }
+
+        [Test]
         public void CanSetAndGetOnePair()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
@@ -109,7 +119,7 @@ namespace Garnet.test
 
 
         [Test]
-        public void CanDeleleteMultipleFields()
+        public void CanDeleteMultipleFields()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = redis.GetDatabase(0);
@@ -117,10 +127,15 @@ namespace Garnet.test
             var result = db.HashDelete(new RedisKey("user:user1"), [new RedisValue("Title"), new RedisValue("Year")]);
             string resultGet = db.HashGet("user:user1", "Example");
             Assert.AreEqual("One", resultGet);
+
+            result = db.HashDelete(new RedisKey("user:user1"), [new RedisValue("Example")]);
+            Assert.AreEqual(1, result);
+            var exists = db.KeyExists("user:user1");
+            Assert.IsFalse(exists);
         }
 
         [Test]
-        public void CanDeleleteMultipleFieldsWithNonExistingField()
+        public void CanDeleteMultipleFieldsWithNonExistingField()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = redis.GetDatabase(0);

--- a/test/Garnet.test/RespSetTest.cs
+++ b/test/Garnet.test/RespSetTest.cs
@@ -50,6 +50,13 @@ namespace Garnet.test
 
             result = db.SetAdd(key, "World");
             Assert.IsFalse(result);
+
+            var emptySetKey = $"{key}_empty";
+            var added = db.SetAdd(key, []);
+            Assert.AreEqual(0, added);
+
+            result = db.KeyExists(emptySetKey);
+            Assert.IsFalse(result);
         }
 
         [Test]
@@ -166,10 +173,11 @@ namespace Garnet.test
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = redis.GetDatabase(0);
-            var result = db.SetAdd(new RedisKey("user1:set"), ["ItemOne", "ItemTwo", "ItemThree", "ItemFour"]);
+            var key = new RedisKey("user1:set");
+            var result = db.SetAdd(key, ["ItemOne", "ItemTwo", "ItemThree", "ItemFour"]);
             Assert.AreEqual(4, result);
 
-            var existingMemberExists = db.SetContains(new RedisKey("user1:set"), "ItemOne");
+            var existingMemberExists = db.SetContains(key, "ItemOne");
             Assert.IsTrue(existingMemberExists, "Existing member 'ItemOne' does not exist in the set.");
 
             var memresponse = db.Execute("MEMORY", "USAGE", "user1:set");
@@ -177,7 +185,7 @@ namespace Garnet.test
             var expectedResponse = 424;
             Assert.AreEqual(expectedResponse, actualValue);
 
-            var response = db.SetRemove(new RedisKey("user1:set"), new RedisValue("ItemOne"));
+            var response = db.SetRemove(key, new RedisValue("ItemOne"));
             Assert.AreEqual(true, response);
 
             memresponse = db.Execute("MEMORY", "USAGE", "user1:set");
@@ -185,7 +193,7 @@ namespace Garnet.test
             expectedResponse = 352;
             Assert.AreEqual(expectedResponse, actualValue);
 
-            response = db.SetRemove(new RedisKey("user1:set"), new RedisValue("ItemFive"));
+            response = db.SetRemove(key, new RedisValue("ItemFive"));
             Assert.AreEqual(false, response);
 
             memresponse = db.Execute("MEMORY", "USAGE", "user1:set");
@@ -193,7 +201,7 @@ namespace Garnet.test
             expectedResponse = 352;
             Assert.AreEqual(expectedResponse, actualValue);
 
-            var longResponse = db.SetRemove(new RedisKey("user1:set"), ["ItemTwo", "ItemThree"]);
+            var longResponse = db.SetRemove(key, ["ItemTwo", "ItemThree"]);
             Assert.AreEqual(2, longResponse);
 
             memresponse = db.Execute("MEMORY", "USAGE", "user1:set");
@@ -201,8 +209,14 @@ namespace Garnet.test
             expectedResponse = 200;
             Assert.AreEqual(expectedResponse, actualValue);
 
-            var members = db.SetMembers(new RedisKey("user1:set"));
+            var members = db.SetMembers(key);
             Assert.AreEqual(1, members.Length);
+
+            response = db.SetRemove(key, new RedisValue("ItemFour"));
+            Assert.IsTrue(response);
+
+            var exists = db.KeyExists(key);
+            Assert.IsFalse(exists);
         }
 
         [Test]
@@ -397,12 +411,22 @@ namespace Garnet.test
             var key2 = "key2";
             var key2Value = new RedisValue[] { "c", "d", "e" };
 
+            var key3 = "key3";
+            var key3Value = new RedisValue[] { };
+
+            var key4 = "key4";
+            var key4Value = new RedisValue[] { };
+
             var addResult = db.SetAdd(key1, key1Value);
             Assert.AreEqual(3, addResult);
             addResult = db.SetAdd(key2, key2Value);
             Assert.AreEqual(3, addResult);
+            addResult = db.SetAdd(key3, key3Value);
+            Assert.AreEqual(0, addResult);
+            addResult = db.SetAdd(key4, key4Value);
+            Assert.AreEqual(0, addResult);
 
-            var result = (int)db.Execute("SUNIONSTORE", key, key1, key2);
+            var result = db.SetCombineAndStore(SetOperation.Union, key, key1, key2);
             Assert.AreEqual(5, result);
 
             var membersResult = db.SetMembers(key);
@@ -410,6 +434,12 @@ namespace Garnet.test
             var strResult = membersResult.Select(m => m.ToString()).ToArray();
             var expectedResult = new[] { "a", "b", "c", "d", "e" };
             Assert.IsTrue(expectedResult.OrderBy(t => t).SequenceEqual(strResult.OrderBy(t => t)));
+
+            result = db.SetCombineAndStore(SetOperation.Union, key, key3, key4);
+            Assert.AreEqual(0, result);
+
+            var exists = db.KeyExists(key);
+            Assert.IsFalse(exists);
         }
 
 
@@ -465,12 +495,17 @@ namespace Garnet.test
             var key2 = "key2";
             var key2Value = new RedisValue[] { "c", "d", "e" };
 
+            var key3 = "key3";
+            var key3Value = new RedisValue[] { "d", "e" };
+
             var addResult = db.SetAdd(key1, key1Value);
             Assert.AreEqual(key1Value.Length, addResult);
             addResult = db.SetAdd(key2, key2Value);
             Assert.AreEqual(key2Value.Length, addResult);
+            addResult = db.SetAdd(key3, key3Value);
+            Assert.AreEqual(key3Value.Length, addResult);
 
-            var result = (int)db.Execute("SINTERSTORE", key, key1, key2);
+            var result = db.SetCombineAndStore(SetOperation.Intersect, key, key1, key2);
             Assert.AreEqual(1, result);
 
             var membersResult = db.SetMembers(key);
@@ -478,6 +513,12 @@ namespace Garnet.test
             var strResult = membersResult.Select(m => m.ToString()).ToArray();
             var expectedResult = new[] { "c" };
             Assert.IsTrue(expectedResult.SequenceEqual(strResult));
+
+            result = db.SetCombineAndStore(SetOperation.Intersect, key, key1, key3);
+            Assert.AreEqual(0, result);
+
+            var exists = db.KeyExists(key);
+            Assert.IsFalse(exists);
         }
 
 
@@ -499,7 +540,7 @@ namespace Garnet.test
             addResult = db.SetAdd(key2, key2Value);
             Assert.AreEqual(1, addResult);
 
-            var result = (RedisResult[])db.Execute("SDIFF", key1, key2);
+            var result = db.SetCombine(SetOperation.Difference, key1, key2);
             Assert.AreEqual(3, result.Length);
             var strResult = result.Select(r => r.ToString()).ToArray();
             var expectedResult = new[] { "a", "b", "d" };
@@ -512,7 +553,7 @@ namespace Garnet.test
             addResult = db.SetAdd(key3, key3Value);
             Assert.AreEqual(3, addResult);
 
-            result = (RedisResult[])db.Execute("SDIFF", key1, key2, key3);
+            result = db.SetCombine(SetOperation.Difference, new [] { new RedisKey(key1), new RedisKey(key2), new RedisKey(key3)});
             Assert.AreEqual(2, result.Length);
             strResult = result.Select(r => r.ToString()).ToArray();
             expectedResult = ["b", "d"];
@@ -541,7 +582,7 @@ namespace Garnet.test
             addResult = db.SetAdd(key2, key2Value);
             Assert.AreEqual(1, addResult);
 
-            var result = db.Execute("SDIFFSTORE", key, key1, key2);
+            var result = db.SetCombineAndStore(SetOperation.Difference, key, key1, key2);
             Assert.AreEqual(3, int.Parse(result.ToString()));
 
             var membersResult = db.SetMembers("key");
@@ -561,12 +602,24 @@ namespace Garnet.test
             addResult = db.SetAdd(key4, key4Value);
             Assert.AreEqual(2, addResult);
 
-            result = db.Execute("SDIFFSTORE", key, key3, key4);
+            result = db.SetCombineAndStore(SetOperation.Difference, key, key3, key4);
             Assert.AreEqual(1, (int)result);
 
             membersResult = db.SetMembers("key");
             Assert.AreEqual(1, membersResult.Length);
             Assert.IsTrue(Array.Exists(membersResult, t => t.ToString().Equals("c")));
+
+            var key5 = "key5";
+            var key5Value = new RedisValue[] { "a", "b", "c" };
+
+            addResult = db.SetAdd(key5, key5Value);
+            Assert.AreEqual(3, addResult);
+
+            result = db.SetCombineAndStore(SetOperation.Difference, key, key3, key5);
+            Assert.AreEqual(0, (int)result);
+
+            var exists = db.KeyExists(key);
+            Assert.IsFalse(exists);
         }
 
         [Test]
@@ -599,6 +652,17 @@ namespace Garnet.test
             membersResult = db.SetMembers(destination);
             strResult = membersResult.Select(r => r.ToString()).ToArray();
             expectedResult = ["three", "two"];
+            Assert.IsTrue(expectedResult.OrderBy(t => t).SequenceEqual(strResult.OrderBy(t => t)));
+
+            result = db.SetMove(source, destination, "one");
+            Assert.IsTrue(result);
+
+            var exists = db.KeyExists(source);
+            Assert.IsFalse(exists);
+
+            membersResult = db.SetMembers(destination);
+            strResult = membersResult.Select(r => r.ToString()).ToArray();
+            expectedResult = ["three", "two", "one"];
             Assert.IsTrue(expectedResult.OrderBy(t => t).SequenceEqual(strResult.OrderBy(t => t)));
         }
         #endregion
@@ -1312,15 +1376,16 @@ namespace Garnet.test
             // SUNION
             RespTestsUtils.CheckCommandOnWrongTypeObjectSE(() => db.SetCombine(SetOperation.Union, keys[0], keys[1]));
             // SUNIONSTORE
-            RespTestsUtils.CheckCommandOnWrongTypeObjectSE(() => db.Execute("SUNIONSTORE", keys[0], keys[1]));
+            RespTestsUtils.CheckCommandOnWrongTypeObjectSE(() => db.SetCombineAndStore(SetOperation.Union, keys[0], new[] {keys[1]}));
             // SDIFF
             RespTestsUtils.CheckCommandOnWrongTypeObjectSE(() => db.SetCombine(SetOperation.Difference, keys[0], keys[1]));
             // SDIFFSTORE
-            RespTestsUtils.CheckCommandOnWrongTypeObjectSE(() => db.Execute("SDIFFSTORE", keys[0], keys[1]));
+            RespTestsUtils.CheckCommandOnWrongTypeObjectSE(() =>
+                db.SetCombineAndStore(SetOperation.Difference, keys[0], new[] { keys[1] }));
             // SINTER
             RespTestsUtils.CheckCommandOnWrongTypeObjectSE(() => db.SetCombine(SetOperation.Intersect, keys[0], keys[1]));
             // SINTERSTORE
-            RespTestsUtils.CheckCommandOnWrongTypeObjectSE(() => db.Execute("SINTERSTORE", keys[0], keys[1]));
+            RespTestsUtils.CheckCommandOnWrongTypeObjectSE(() => db.SetCombineAndStore(SetOperation.Intersect, keys[0], new[] { keys[1] }));
         }
 
         #endregion

--- a/test/Garnet.test/RespSetTest.cs
+++ b/test/Garnet.test/RespSetTest.cs
@@ -553,7 +553,7 @@ namespace Garnet.test
             addResult = db.SetAdd(key3, key3Value);
             Assert.AreEqual(3, addResult);
 
-            result = db.SetCombine(SetOperation.Difference, new [] { new RedisKey(key1), new RedisKey(key2), new RedisKey(key3)});
+            result = db.SetCombine(SetOperation.Difference, new[] { new RedisKey(key1), new RedisKey(key2), new RedisKey(key3) });
             Assert.AreEqual(2, result.Length);
             strResult = result.Select(r => r.ToString()).ToArray();
             expectedResult = ["b", "d"];
@@ -1376,7 +1376,7 @@ namespace Garnet.test
             // SUNION
             RespTestsUtils.CheckCommandOnWrongTypeObjectSE(() => db.SetCombine(SetOperation.Union, keys[0], keys[1]));
             // SUNIONSTORE
-            RespTestsUtils.CheckCommandOnWrongTypeObjectSE(() => db.SetCombineAndStore(SetOperation.Union, keys[0], new[] {keys[1]}));
+            RespTestsUtils.CheckCommandOnWrongTypeObjectSE(() => db.SetCombineAndStore(SetOperation.Union, keys[0], new[] { keys[1] }));
             // SDIFF
             RespTestsUtils.CheckCommandOnWrongTypeObjectSE(() => db.SetCombine(SetOperation.Difference, keys[0], keys[1]));
             // SDIFFSTORE

--- a/test/Garnet.test/RespSortedSetTests.cs
+++ b/test/Garnet.test/RespSortedSetTests.cs
@@ -307,7 +307,7 @@ namespace Garnet.test
             Assert.AreEqual(2, result);
 
             var members = db.SortedSetRangeByRank(key);
-            Assert.AreEqual(new[] {new RedisValue("c"), new RedisValue("d"), new RedisValue("h")}, members);
+            Assert.AreEqual(new[] { new RedisValue("c"), new RedisValue("d"), new RedisValue("h") }, members);
 
             result = db.SortedSetRemoveRangeByRank(key, 0, 2);
             Assert.AreEqual(3, result);

--- a/test/Garnet.test/RespSortedSetTests.cs
+++ b/test/Garnet.test/RespSortedSetTests.cs
@@ -133,6 +133,15 @@ namespace Garnet.test
             actualValue = ResultType.Integer == response.Resp2Type ? Int32.Parse(response.ToString()) : -1;
             expectedResponse = 1952;
             Assert.AreEqual(expectedResponse, actualValue);
+
+            var deleted = db.KeyDelete(key);
+            Assert.IsTrue(deleted);
+
+            added = db.SortedSetAdd(key, []);
+            Assert.AreEqual(0, added);
+
+            var exists = db.KeyExists(key);
+            Assert.IsFalse(exists);
         }
 
 
@@ -274,6 +283,55 @@ namespace Garnet.test
 
             response = db.Execute("MEMORY", "USAGE", key);
             Assert.IsTrue(response.IsNull);
+        }
+
+        [Test]
+        public void AddRemoveBy()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            var key = "SortedSet_AddRemoveBy";
+
+            // 10 entries are added
+            var added = db.SortedSetAdd(key, entries);
+            Assert.AreEqual(entries.Length, added);
+
+            var result = db.SortedSetRemoveRangeByValue(key, new RedisValue("e"), new RedisValue("g"));
+            Assert.AreEqual(3, result);
+
+            result = db.SortedSetRemoveRangeByScore(key, 9, 10);
+            Assert.AreEqual(2, result);
+
+            result = db.SortedSetRemoveRangeByRank(key, 0, 1);
+            Assert.AreEqual(2, result);
+
+            var members = db.SortedSetRangeByRank(key);
+            Assert.AreEqual(new[] {new RedisValue("c"), new RedisValue("d"), new RedisValue("h")}, members);
+
+            result = db.SortedSetRemoveRangeByRank(key, 0, 2);
+            Assert.AreEqual(3, result);
+
+            var exists = db.KeyExists(key);
+            Assert.IsFalse(exists);
+
+            added = db.SortedSetAdd(key, entries);
+            Assert.AreEqual(entries.Length, added);
+
+            result = db.SortedSetRemoveRangeByScore(key, 0, 10);
+            Assert.AreEqual(10, result);
+
+            exists = db.KeyExists(key);
+            Assert.IsFalse(exists);
+
+            added = db.SortedSetAdd(key, entries);
+            Assert.AreEqual(entries.Length, added);
+
+            result = db.SortedSetRemoveRangeByValue(key, "a", "j");
+            Assert.AreEqual(10, result);
+
+            exists = db.KeyExists(key);
+            Assert.IsFalse(exists);
         }
 
         [Test]


### PR DESCRIPTION
* Implemented key deletion for emptied collection when RMW is not called (and underlying object is directly altered)
* Extended tests to test that keys are being removed for each command that may empty the object collection

(Continues the fixes introduced in PR #443)