### PR TITLE
Fix Dockerfile entrypoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ USER $APP_UID
 EXPOSE 6379
 
 # Run GarnetServer with an index size of 128MB
-ENTRYPOINT ["./GarnetServer", "-i", "128m", "--port", "6379"]
+ENTRYPOINT ["/app/GarnetServer", "-i", "128m", "--port", "6379"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -39,4 +39,4 @@ USER $APP_UID
 EXPOSE 6379
 
 # Run GarnetServer with an index size of 128MB
-ENTRYPOINT ["./GarnetServer", "-i", "128m", "--port", "6379"]
+ENTRYPOINT ["/app/GarnetServer", "-i", "128m", "--port", "6379"]

--- a/Dockerfile.cbl-mariner
+++ b/Dockerfile.cbl-mariner
@@ -39,4 +39,4 @@ USER $APP_UID
 EXPOSE 6379
 
 # Run GarnetServer with an index size of 128MB
-ENTRYPOINT ["./GarnetServer", "-i", "128m", "--port", "6379"]
+ENTRYPOINT ["/app/GarnetServer", "-i", "128m", "--port", "6379"]

--- a/Dockerfile.chiseled
+++ b/Dockerfile.chiseled
@@ -36,4 +36,4 @@ COPY --from=build /app .
 EXPOSE 6379
 
 # Run GarnetServer with an index size of 128MB
-ENTRYPOINT ["./GarnetServer", "-i", "128m", "--port", "6379"]
+ENTRYPOINT ["/app/GarnetServer", "-i", "128m", "--port", "6379"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -39,4 +39,4 @@ USER $APP_UID
 EXPOSE 6379
 
 # Run GarnetServer with an index size of 128MB
-ENTRYPOINT ["./GarnetServer", "-i", "128m", "--port", "6379"]
+ENTRYPOINT ["/app/GarnetServer", "-i", "128m", "--port", "6379"]


### PR DESCRIPTION
Fixes a regression introduced in #224;

entrypoints containing relative paths are incompatible with the usage of custom working directories.

This causes unexpected failures particularly in CI (GitHub, Gitea, Forgejo actions), where the repository is often mounted and set as the working directory - notably, when garnet is used as a `service`.

***

## Workaround for end users

Manually set the entrypoint to `["/app/GarnetServer", "-i", "128m", "--port", "6379"]` when invoking the container.

The docs for doing this with GH Actions `service`s are [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idservicesservice_idoptions). **The workaround must be altered, and is not complete;** the `--entrypoint` option does not accept array syntax, so only `--entrypoint /app/GarnetServer` may be specified. Note then that Garnet's default port is 3278, and one must change their application behaviour accordingly.

This workaround does not work for the main container of a job (under `container`), as it [does not support `--entrypoint`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontaineroptions).

***

This cropped up during the prelim stages of adding garnet support to Forgejo, and cost a fair bit of time to troubleshoot, as it was such an unexpected error. I would expect this to cause problems for integration testing in general, which may limit the adoption of garnet.

See also [these docs](https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#entrypoint) as a side note. I've also seen a couple of StackOverflow posts claiming relative entrypoints don't behave well on Ansible.