### PR TITLE
Fix CLUSTER REPLICATE error handling

### DIFF
--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaReceiveCheckpoint.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaReceiveCheckpoint.cs
@@ -58,7 +58,7 @@ namespace Garnet.cluster
             {
                 replicateLock.WriteUnlock();
             }
-            return true;
+            return false;
         }
 
         /// <summary>

--- a/test/Garnet.test.cluster/ClusterReplicationTests.cs
+++ b/test/Garnet.test.cluster/ClusterReplicationTests.cs
@@ -1009,7 +1009,7 @@ namespace Garnet.test.cluster
 
         [Test, Order(21)]
         [Category("REPLICATION")]
-        public void FailedReplication()
+        public void ClusterReplicateFails()
         {
             const string UserName = "temp-user";
             const string Password = "temp-password";

--- a/test/Garnet.test.cluster/ClusterReplicationTests.cs
+++ b/test/Garnet.test.cluster/ClusterReplicationTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -1004,6 +1005,41 @@ namespace Garnet.test.cluster
                 context.ValidateKVCollectionAgainstReplica(ref context.kvPairs, replicaIndex: replicaIndex, primaryIndex: newPrimaryIndex);
             else
                 context.ValidateNodeObjects(ref context.kvPairsObj, nodeIndex: newPrimaryIndex, set: set);
+        }
+
+        [Test, Order(21)]
+        [Category("REPLICATION")]
+        public void FailedReplication()
+        {
+            const string UserName = "temp-user";
+            const string Password = "temp-password";
+
+            const string ClusterUserName = "cluster-user";
+            const string ClusterPassword = "cluster-password";
+
+            // setup a cluster (mimicing the style in which this bug was first found)
+            ServerCredential clusterCreds = new(ClusterUserName, ClusterPassword, IsAdmin: true, UsedForClusterAuth: true, IsClearText: true);
+            ServerCredential userCreds = new(UserName, Password, IsAdmin: true, UsedForClusterAuth: false, IsClearText: true);
+
+            context.GenerateCredentials([userCreds, clusterCreds]);
+            context.CreateInstances(2, disableObjects: true, disablePubSub: true, enableAOF: true, clusterCreds: clusterCreds, useAcl: true, MainMemoryReplication: true, CommitFrequencyMs: -1);
+            var primaryEndpoint = (IPEndPoint)context.endpoints.First();
+            var replicaEndpoint = (IPEndPoint)context.endpoints.Last();
+
+            Assert.AreNotEqual(primaryEndpoint, replicaEndpoint, "Should have different endpoints for nodes");
+
+            using var primaryConnection = ConnectionMultiplexer.Connect($"{primaryEndpoint.Address}:{primaryEndpoint.Port},user={UserName},password={Password}");
+            var primaryServer = primaryConnection.GetServer(primaryEndpoint);
+
+            Assert.AreEqual("OK", (string)primaryServer.Execute("CLUSTER", ["ADDSLOTSRANGE", "0", "16383"], flags: CommandFlags.NoRedirect));
+            Assert.AreEqual("OK", (string)primaryServer.Execute("CLUSTER", ["MEET", replicaEndpoint.Address.ToString(), replicaEndpoint.Port.ToString()], flags: CommandFlags.NoRedirect));
+
+            using var replicaConnection = ConnectionMultiplexer.Connect($"{replicaEndpoint.Address}:{replicaEndpoint.Port},user={UserName},password={Password}");
+            var replicaServer = replicaConnection.GetServer(replicaEndpoint);
+
+            // try to replicate from a server that doesn't exist
+            var exc = Assert.Throws<RedisServerException>(() => replicaServer.Execute("CLUSTER", ["REPLICATE", Guid.NewGuid().ToString()], flags: CommandFlags.NoRedirect));
+            Assert.IsTrue(exc.Message.StartsWith("ERR I don't know about node "));
         }
     }
 }

--- a/test/Garnet.test.cluster/ClusterReplicationTests.cs
+++ b/test/Garnet.test.cluster/ClusterReplicationTests.cs
@@ -1017,7 +1017,7 @@ namespace Garnet.test.cluster
             const string ClusterUserName = "cluster-user";
             const string ClusterPassword = "cluster-password";
 
-            // setup a cluster (mimicing the style in which this bug was first found)
+            // Setup a cluster (mimicking the style in which this bug was first found)
             ServerCredential clusterCreds = new(ClusterUserName, ClusterPassword, IsAdmin: true, UsedForClusterAuth: true, IsClearText: true);
             ServerCredential userCreds = new(UserName, Password, IsAdmin: true, UsedForClusterAuth: false, IsClearText: true);
 
@@ -1037,7 +1037,7 @@ namespace Garnet.test.cluster
             using var replicaConnection = ConnectionMultiplexer.Connect($"{replicaEndpoint.Address}:{replicaEndpoint.Port},user={UserName},password={Password}");
             var replicaServer = replicaConnection.GetServer(replicaEndpoint);
 
-            // try to replicate from a server that doesn't exist
+            // Try to replicate from a server that doesn't exist
             var exc = Assert.Throws<RedisServerException>(() => replicaServer.Execute("CLUSTER", ["REPLICATE", Guid.NewGuid().ToString()], flags: CommandFlags.NoRedirect));
             Assert.IsTrue(exc.Message.StartsWith("ERR I don't know about node "));
         }

--- a/test/Garnet.test.cluster/ClusterTestContext.cs
+++ b/test/Garnet.test.cluster/ClusterTestContext.cs
@@ -104,12 +104,13 @@ namespace Garnet.test.cluster
             bool useAcl = false,
             X509CertificateCollection certificates = null,
             ServerCredential clusterCreds = new ServerCredential(),
-            AadAuthenticationSettings authenticationSettings = null)
+            AadAuthenticationSettings authenticationSettings = null,
+            bool disablePubSub = true)
         {
             endpoints = TestUtils.GetEndPoints(shards, 7000);
             nodes = TestUtils.CreateGarnetCluster(
                 TestFolder,
-                disablePubSub: true,
+                disablePubSub: disablePubSub,
                 disableObjects: disableObjects,
                 endpoints: endpoints,
                 enableAOF: enableAOF,


### PR DESCRIPTION
`CLUSTER REPLICATE` would return `+OK` even if an error was encountered.

Adds a test for the failure, which replicates the conditions under which it was found (scripting spinning up a two node cluster).