### PR TITLE
Immediately process QUIT if in a transaction

### DIFF
--- a/libs/server/Resp/AdminCommands.cs
+++ b/libs/server/Resp/AdminCommands.cs
@@ -351,10 +351,7 @@ namespace Garnet.server
             }
             else if (command == RespCommand.QUIT)
             {
-                while (!RespWriteUtils.WriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
-                    SendAndReset();
-
-                toDispose = true;
+                return NetworkQUIT();
             }
             else if (command == RespCommand.SAVE)
             {

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -346,6 +346,7 @@ namespace Garnet.server
                             RespCommand.EXEC => NetworkEXEC(),
                             RespCommand.MULTI => NetworkMULTI(),
                             RespCommand.DISCARD => NetworkDISCARD(),
+                            RespCommand.QUIT => NetworkQUIT(),
                             _ => NetworkSKIP(cmd),
                         };
                     }


### PR DESCRIPTION
Before we'd respond with an `-ERR` as quit was not expected in a transaction.  Now it is processed immediately.

DRY'd up the quit code slightly too, since we had two copies of it.