### PR TITLE
Remove `Worker.ReplicationOffset` in `ClusterConfig`

### DIFF
--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -575,7 +575,7 @@ namespace Garnet.cluster
 
         private string CreateFormattedNodeInfo(int workerId)
         {
-            var nodeInfo = "*12\r\n";
+            var nodeInfo = "*10\r\n";
             nodeInfo += "$2\r\nid\r\n";
             nodeInfo += $"$40\r\n{workers[workerId].Nodeid}\r\n";
             nodeInfo += "$4\r\nport\r\n";

--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -58,7 +58,6 @@ namespace Garnet.cluster
             workers[0].ConfigEpoch = 0;
             workers[0].Role = NodeRole.UNASSIGNED;
             workers[0].ReplicaOfNodeId = null;
-            workers[0].ReplicationOffset = 0;
             workers[0].hostname = null;
         }
 
@@ -110,7 +109,6 @@ namespace Garnet.cluster
             newWorkers[1].ConfigEpoch = configEpoch;
             newWorkers[1].Role = role;
             newWorkers[1].ReplicaOfNodeId = replicaOfNodeId;
-            newWorkers[1].ReplicationOffset = 0;
             newWorkers[1].hostname = hostname;
             return new ClusterConfig(slotMap, newWorkers);
         }
@@ -586,8 +584,6 @@ namespace Garnet.cluster
             nodeInfo += $"${workers[workerId].Address.Length}\r\n{workers[workerId].Address}\r\n";
             nodeInfo += "$4\r\nrole\r\n";
             nodeInfo += $"${workers[workerId].Role.ToString().Length}\r\n{workers[workerId].Role}\r\n";
-            nodeInfo += "$18\r\nreplication-offset\r\n";
-            nodeInfo += $":{workers[workerId].ReplicationOffset}\r\n";
             nodeInfo += "$6\r\nhealth\r\n";
             nodeInfo += $"$6\r\nonline\r\n";
             return nodeInfo;
@@ -849,13 +845,6 @@ namespace Garnet.cluster
             }
             return null;
         }
-
-        /// <summary>
-        /// Update replication offset lazily.
-        /// </summary>
-        /// <param name="newReplicationOffset">Long of new replication offset.</param>
-        public void LazyUpdateLocalReplicationOffset(long newReplicationOffset)
-            => workers[1].ReplicationOffset = newReplicationOffset;
 
         /// <summary>
         /// Merging incoming configuration from gossip with local configuration copy.

--- a/libs/cluster/Server/ClusterConfigSerializer.cs
+++ b/libs/cluster/Server/ClusterConfigSerializer.cs
@@ -42,8 +42,6 @@ namespace Garnet.cluster
                     //40 bytes
                     writer.Write(worker.ReplicaOfNodeId);
 
-                //4 bytes
-                writer.Write(worker.ReplicationOffset);
                 //1 byte
                 writer.Write(worker.hostname == null ? (byte)0 : (byte)1);
                 if (worker.hostname != null)
@@ -123,8 +121,6 @@ namespace Garnet.cluster
                 byte isNull = reader.ReadByte();
                 if (isNull > 0)
                     newWorkers[i].ReplicaOfNodeId = reader.ReadString();
-
-                newWorkers[i].ReplicationOffset = reader.ReadInt64();
 
                 isNull = reader.ReadByte();
                 if (isNull > 0)

--- a/libs/cluster/Server/GarnetServerNode.cs
+++ b/libs/cluster/Server/GarnetServerNode.cs
@@ -142,7 +142,6 @@ namespace Garnet.cluster
             byte[] byteArray;
             if (conf != lastConfig)
             {
-                if (clusterProvider.replicationManager != null) conf.LazyUpdateLocalReplicationOffset(clusterProvider.replicationManager.ReplicationOffset);
                 byteArray = conf.ToByteArray();
                 lastConfig = conf;
             }

--- a/libs/cluster/Server/Worker.cs
+++ b/libs/cluster/Server/Worker.cs
@@ -58,11 +58,6 @@ namespace Garnet.cluster
         public string ReplicaOfNodeId;
 
         /// <summary>
-        /// Replication offset (readonly value for information only)
-        /// </summary>
-        public long ReplicationOffset;
-
-        /// <summary>
         /// Hostname of this instance
         /// </summary>
         public string hostname;

--- a/test/Garnet.test.cluster/ClientClusterConfig.cs
+++ b/test/Garnet.test.cluster/ClientClusterConfig.cs
@@ -137,7 +137,6 @@ namespace GarnetClusterManagement
             workers[0].ConfigEpoch = 0;
             workers[0].Role = NodeRole.UNASSIGNED;
             workers[0].ReplicaOfNodeId = string.Empty;
-            workers[0].ReplicationOffset = 0;
             workers[0].hostname = null;
         }
 

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -75,7 +75,6 @@ namespace Garnet.test.cluster
         public string address;
         public int port;
         public Role role;
-        public long replicationOffset;
     }
 
     public struct ShardInfo
@@ -370,8 +369,7 @@ namespace Garnet.test.cluster
                                     nodeid = GetNodeIdFromNode(i, logger),
                                     address = endpoint.Address.ToString(),
                                     port = endpoint.Port,
-                                    role = Role.PRIMARY,
-                                    replicationOffset = 0
+                                    role = Role.PRIMARY
                                 }
                             }
                     };
@@ -434,8 +432,7 @@ namespace Garnet.test.cluster
                             nodeid = GetNodeIdFromNode(i, logger),
                             address = GetAddressFromNodeIndex(i),
                             port = GetPortFromNodeIndex(i),
-                            role = Role.REPLICA,
-                            replicationOffset = 0
+                            role = Role.REPLICA
                         }
                     );
                     j = (j + 1) % primary_count;
@@ -2008,15 +2005,14 @@ namespace Garnet.test.cluster
                     shardInfo.nodes = [];
                     foreach (var node in nodes.Select(v => (RedisResult[])v))
                     {
-                        Assert.AreEqual(12, node.Length);
+                        Assert.AreEqual(10, node.Length);
                         NodeInfo nodeInfo = new()
                         {
                             nodeIndex = GetNodeIndexFromPort((int)node[3]),
                             nodeid = (string)node[1],
                             port = (int)node[3],
                             address = (string)node[5],
-                            role = Enum.Parse<Role>((string)node[7]),
-                            replicationOffset = (long)node[9]
+                            role = Enum.Parse<Role>((string)node[7])
                         };
                         shardInfo.nodes.Add(nodeInfo);
                     }


### PR DESCRIPTION
Remove the field `ReplicationOffset` from `struct Worker` for the following reasons:
1. It is barely used: Only the local worker (`ClusterConfig.workers[1]`) carries a meaningful replication offset, other workers have `ReplicationOffset = 0` upon initialization but never being updated later (this field is not updated during gossip).
2. It is redundant: the local replication offset is already available in replication info (by command `INFO`).
3. Most importantly, it does not match the semantics of `ClusterConfig`: the cluster configuration is not expected to be updated in a steady state (i.e., no cluster membership changes) while replication offset can change rapidly as long as there is new data. The cluster epoch should not be updated simply because there is new data being replicated.