### PR TITLE
Validate ZRANGE indexes

### DIFF
--- a/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
@@ -449,14 +449,27 @@ namespace Garnet.server
                                 maxIndex = sortedSetDict.Count - 1;
                             }
 
-                            // calculate number of elements
-                            int n = maxIndex - minIndex + 1;
+                            // No elements to return if both indexes fall outside the range or min is higher than max
+                            if ((minIndex < 0 && maxIndex < 0) || (minIndex > maxIndex))
+                            {
+                                while (!RespWriteUtils.WriteEmptyArray(ref curr, end))
+                                    ObjectUtils.ReallocateOutput(ref output, ref isMemory, ref ptr, ref ptrHandle, ref curr, ref end);
+                                countDone = _input->arg1;
+                                count = 0;
+                            }
+                            else
+                            {
+                                // Clamp minIndex to 0, if it is beyond the number of elements
+                                minIndex = Math.Max(0, minIndex);
 
-                            var iterator = options.Reverse ? sortedSet.Reverse() : sortedSet;
-                            iterator = iterator.Skip(minIndex).Take(n);
+                                // calculate number of elements
+                                int n = maxIndex - minIndex + 1;
+                                var iterator = options.Reverse ? sortedSet.Reverse() : sortedSet;
+                                iterator = iterator.Skip(minIndex).Take(n);
 
-                            WriteSortedSetResult(options.WithScores, n, respProtocolVersion, iterator, ref output, ref isMemory, ref ptr, ref ptrHandle, ref curr, ref end);
-                            countDone = _input->arg1;
+                                WriteSortedSetResult(options.WithScores, n, respProtocolVersion, iterator, ref output, ref isMemory, ref ptr, ref ptrHandle, ref curr, ref end);
+                                countDone = _input->arg1;
+                            }
                         }
                     }
                 }

--- a/test/Garnet.test/RespSortedSetTests.cs
+++ b/test/Garnet.test/RespSortedSetTests.cs
@@ -882,9 +882,9 @@ namespace Garnet.test
         }
 
         [Test]
-        //[TestCase(10)]
-        //[TestCase(30)]
-        [TestCase(1000)]
+        [TestCase(10)]
+        [TestCase(30)]
+        [TestCase(100)]
         public void CanDoZRangeByIndexLC(int bytesSent)
         {
             //ZRANGE key min max [BYSCORE|BYLEX] [REV] [LIMIT offset count] [WITHSCORES]

--- a/test/Garnet.test/RespSortedSetTests.cs
+++ b/test/Garnet.test/RespSortedSetTests.cs
@@ -882,9 +882,9 @@ namespace Garnet.test
         }
 
         [Test]
-        [TestCase(10)]
-        [TestCase(30)]
-        [TestCase(100)]
+        //[TestCase(10)]
+        //[TestCase(30)]
+        [TestCase(1000)]
         public void CanDoZRangeByIndexLC(int bytesSent)
         {
             //ZRANGE key min max [BYSCORE|BYLEX] [REV] [LIMIT offset count] [WITHSCORES]
@@ -916,6 +916,31 @@ namespace Garnet.test
 
             response = lightClientRequest.SendCommand("ZRANGE board -2 -1 WITHSCORES", 5);
             expectedResponse = "*4\r\n$3\r\ntwo\r\n$1\r\n2\r\n$5\r\nthree\r\n$1\r\n3\r\n";
+            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
+            Assert.AreEqual(expectedResponse, actualValue);
+
+            response = lightClientRequest.SendCommand("ZRANGE board -50 -1 WITHSCORES", 7);
+            expectedResponse = "*6\r\n$3\r\none\r\n$1\r\n1\r\n$3\r\ntwo\r\n$1\r\n2\r\n$5\r\nthree\r\n$1\r\n3\r\n";
+            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
+            Assert.AreEqual(expectedResponse, actualValue);
+
+            response = lightClientRequest.SendCommand("ZRANGE board -50 -10 WITHSCORES", 1);
+            expectedResponse = "*0\r\n";
+            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
+            Assert.AreEqual(expectedResponse, actualValue);
+
+            response = lightClientRequest.SendCommand("ZRANGE board 2 1 WITHSCORES", 1);
+            expectedResponse = "*0\r\n";
+            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
+            Assert.AreEqual(expectedResponse, actualValue);
+
+            response = lightClientRequest.SendCommand("ZRANGE board -1 -2 WITHSCORES", 1);
+            expectedResponse = "*0\r\n";
+            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
+            Assert.AreEqual(expectedResponse, actualValue);
+
+            response = lightClientRequest.SendCommand("ZRANGE board 50 60 WITHSCORES", 1);
+            expectedResponse = "*0\r\n";
             actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
             Assert.AreEqual(expectedResponse, actualValue);
 


### PR DESCRIPTION
Fixes #505 

ZRANGE processing is currently missing validations on min and max index values if they fall beyond the range of the number of elements present in the sorted set. This change fixes that.
