### PR TITLE
Fix SortedSetPop to return popped elements.

### DIFF
--- a/libs/server/Storage/Session/ObjectStore/Common.cs
+++ b/libs/server/Storage/Session/ObjectStore/Common.cs
@@ -102,7 +102,7 @@ namespace Garnet.server
         }
 
         /// <summary>
-        /// Converts an array of result in RESP format to ArgSlice[] type
+        /// Converts an array of elements in RESP format to ArgSlice[] type
         /// </summary>
         /// <param name="outputFooter">The RESP format output object</param>
         /// <param name="error">A description of the error, if there is any</param>
@@ -113,7 +113,7 @@ namespace Garnet.server
             ArgSlice[] elements = default;
             error = default;
 
-            // For reading the result in the outputFooter
+            // For reading the elements in the outputFooter
             byte* element = null;
             int len = 0;
 
@@ -135,7 +135,7 @@ namespace Garnet.server
                     {
                         if (isScanOutput)
                         {
-                            // Read the first two result
+                            // Read the first two elements
                             if (!RespReadUtils.ReadUnsignedArrayLength(out var outerArraySize, ref refPtr, outputPtr + outputSpan.Length))
                                 return default;
 
@@ -146,7 +146,7 @@ namespace Garnet.server
                                 return default;
                         }
 
-                        // Get the number of result
+                        // Get the number of elements
                         if (!RespReadUtils.ReadUnsignedArrayLength(out var arraySize, ref refPtr, outputPtr + outputSpan.Length))
                             return default;
 

--- a/libs/server/Storage/Session/ObjectStore/SortedSetOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/SortedSetOps.cs
@@ -323,8 +323,8 @@ namespace Garnet.server
             var status = RMWObjectStoreOperationWithOutput(key.ToArray(), input, ref objectStoreContext, ref outputFooter);
 
             //process output
-            //if (status == GarnetStatus.OK)
-            ProcessRespArrayOutput(outputFooter, out _);
+            if (status == GarnetStatus.OK)
+                pairs = ProcessRespArrayOutputAsPairs(outputFooter, out _);
 
             return status;
         }

--- a/test/Garnet.test/Garnet.test.csproj
+++ b/test/Garnet.test/Garnet.test.csproj
@@ -21,6 +21,7 @@
     <Compile Include="..\..\main\GarnetServer\Extensions\SampleDeleteTxn.cs" Link="SampleDeleteTxn.cs" />
     <Compile Include="..\..\main\GarnetServer\Extensions\SetIfPM.cs" Link="SetIfPM.cs" />
     <Compile Include="..\..\main\GarnetServer\Extensions\SetWPIfPGT.cs" Link="SetWPIFPGT.cs" />
+    <Compile Include="..\..\playground\Embedded.perftest\DummyNetworkSender.cs" Link="DummyNetworkSender.cs" />
   </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Fixes #514 

Fixed SortedSetPop operation to parse the output buffer array and extract pairs of elements as scores & member information to be returned to the caller.

