### PR TITLE
Support HMSET command within a transaction

### DIFF
--- a/libs/server/Transaction/TxnKeyManager.cs
+++ b/libs/server/Transaction/TxnKeyManager.cs
@@ -109,6 +109,7 @@ namespace Garnet.server
                 RespCommand.HKEYS => HashObjectKeys((byte)HashOperation.HKEYS),
                 RespCommand.HLEN => HashObjectKeys((byte)HashOperation.HLEN),
                 RespCommand.HMGET => HashObjectKeys((byte)HashOperation.HMGET),
+                RespCommand.HMSET => HashObjectKeys((byte)HashOperation.HMSET),
                 RespCommand.HRANDFIELD => HashObjectKeys((byte)HashOperation.HRANDFIELD),
                 RespCommand.HSCAN => HashObjectKeys((byte)HashOperation.HSCAN),
                 RespCommand.HSET => HashObjectKeys((byte)HashOperation.HSET),

--- a/test/Garnet.test/RespHashTests.cs
+++ b/test/Garnet.test/RespHashTests.cs
@@ -1,6 +1,4 @@
 ﻿// Copyright (c) Microsoft Corporation.
-// // Copyright (c) Microsoft Corporation.
-// // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
 using System;
@@ -1090,6 +1088,20 @@ namespace Garnet.test
             // This should commit
             res = lightClientRequest.SendCommand("EXEC", 2);
             expectedResponse = "*1\r\n:1\r\n";
+            Assert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+
+            // HMSET within MULTI/EXEC
+            res = lightClientRequest.SendCommand("MULTI");
+            expectedResponse = "+OK\r\n";
+            Assert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+
+            res = lightClientRequest.SendCommand($"HMSET {key} field4 4");
+            expectedResponse = "+QUEUED\r\n";
+            Assert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+
+            // This should commit
+            res = lightClientRequest.SendCommand("EXEC", 2);
+            expectedResponse = "*1\r\n+OK\r\n";
             Assert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
         }
 


### PR DESCRIPTION
HMSET command invocation was missing within the GetKeys call within a transaction.
This fixes that.

Fixes #513 