### PR TITLE
Updated SCAN output cursor value as bulk string

### DIFF
--- a/libs/server/Resp/ArrayCommands.cs
+++ b/libs/server/Resp/ArrayCommands.cs
@@ -469,22 +469,9 @@ namespace Garnet.server
         private void WriteOutputForScan(long cursorValue, List<byte[]> keys, ref byte* curr, byte* end)
         {
             // The output is an array of two elements: cursor value and an array of keys
-            // Note the cursor value should be formatted as a simple string ('+')
+            // Note the cursor value should be formatted as bulk string ('$')
             while (!RespWriteUtils.WriteIntegerAsBulkString(cursorValue, ref curr, end, out _))
                 SendAndReset();
-
-            if (keys.Count == 0)
-            {
-                // Cursor value
-                while (!RespWriteUtils.WriteIntegerAsBulkString(0, ref curr, end))
-                    SendAndReset();
-
-                // Empty array
-                while (!RespWriteUtils.WriteEmptyArray(ref curr, end))
-                    SendAndReset();
-
-                return;
-            }
 
             // Write size of the array
             while (!RespWriteUtils.WriteArrayLength(keys.Count, ref curr, end))

--- a/libs/server/Resp/ArrayCommands.cs
+++ b/libs/server/Resp/ArrayCommands.cs
@@ -408,7 +408,7 @@ namespace Garnet.server
                     SendAndReset();
 
                 // Number of keys "0"
-                while (!RespWriteUtils.WriteLongAsSimpleString(0, ref dcurr, dend))
+                while (!RespWriteUtils.WriteIntegerAsBulkString(0, ref dcurr, dend))
                     SendAndReset();
 
                 // Empty array
@@ -470,13 +470,13 @@ namespace Garnet.server
         {
             // The output is an array of two elements: cursor value and an array of keys
             // Note the cursor value should be formatted as a simple string ('+')
-            while (!RespWriteUtils.WriteLongAsSimpleString(cursorValue, ref curr, end))
+            while (!RespWriteUtils.WriteIntegerAsBulkString(cursorValue, ref curr, end, out _))
                 SendAndReset();
 
             if (keys.Count == 0)
             {
                 // Cursor value
-                while (!RespWriteUtils.WriteLongAsSimpleString(0, ref curr, end))
+                while (!RespWriteUtils.WriteIntegerAsBulkString(0, ref curr, end))
                     SendAndReset();
 
                 // Empty array

--- a/test/Garnet.test/RespScanCommandsTests.cs
+++ b/test/Garnet.test/RespScanCommandsTests.cs
@@ -300,6 +300,7 @@ namespace Garnet.test
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = redis.GetDatabase(0);
             var result = db.Execute("SCAN", "0");
+            Assert.AreEqual(ResultType.BulkString, result[0].Resp2Type);
             _ = int.TryParse(((RedisValue[])((RedisResult[])result!)[0])[0], out var cursor);
             RedisValue[] keysMatch = ((RedisValue[])((RedisResult[])result!)[1]);
             Assert.IsTrue(cursor == 0);
@@ -315,7 +316,8 @@ namespace Garnet.test
             db.StringSet(new RedisKey("hello"), new RedisValue("keyvalueone"));
             db.StringSet(new RedisKey("foo"), new RedisValue("keyvaluetwo"));
             var result = db.Execute("SCAN", "0", "MATCH", "*o*", "COUNT", "1000");
-            RedisValue[] keysMatch = ((RedisValue[])((RedisResult[])result!)[1]);
+            Assert.AreEqual(ResultType.BulkString, result[0].Resp2Type);
+            RedisValue[] keysMatch = (RedisValue[])((RedisResult[])result!)[1];
             Assert.True(keysMatch.Contains("foo") && keysMatch.Contains("hello"));
         }
 
@@ -336,6 +338,7 @@ namespace Garnet.test
             do
             {
                 var result = db.Execute("SCAN", cursor.ToString());
+                Assert.AreEqual(ResultType.BulkString, result[0].Resp2Type);
                 _ = int.TryParse(((RedisValue[])((RedisResult[])result!)[0])[0], out cursor);
                 RedisValue[] keysMatch = ((RedisValue[])((RedisResult[])result!)[1]);
                 recordsReturned += keysMatch.Length;


### PR DESCRIPTION
SCAN output includes the cursor value that could be used for subsequent SCAN calls.
It is currently encoded as simple string which should have been a bulk string. This is fixed as part of this change.

Fixes #517 
