### PR TITLE
Fix disposal of migration sessions.

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -3,7 +3,7 @@
 #      1) update the name: string below (line 6)     -- this is the version for the nuget package (e.g. 1.0.0)
 #      2) update \libs\host\GarnetServer.cs readonly string version  (~line 45)   -- NOTE - these two values need to be the same 
 ###################################### 
-name: 1.0.15
+name: 1.0.16
 trigger:
   branches:
     include:

--- a/libs/cluster/Server/Migration/MigrateSessionTaskStore.cs
+++ b/libs/cluster/Server/Migration/MigrateSessionTaskStore.cs
@@ -174,11 +174,12 @@ namespace Garnet.cluster
                     }
                 }
 
-                if (mSessions == null)
-                    return false;
+                if (mSessions != null)
+                {
+                    foreach (var session in mSessions)
+                        session.Dispose();
+                }
 
-                foreach (var session in mSessions)
-                    session.Dispose();
                 return true;
             }
             catch (Exception ex)

--- a/libs/cluster/Server/Migration/MigrationManager.cs
+++ b/libs/cluster/Server/Migration/MigrationManager.cs
@@ -82,7 +82,7 @@ namespace Garnet.cluster
         /// <param name="mSession"></param>
         /// <returns></returns>
         public bool TryRemoveMigrationTask(MigrateSession mSession)
-            => migrationTaskStore.TryRemove(mSession.GetTargetNodeId);
+            => migrationTaskStore.TryRemove(mSession);
 
         /// <summary>
         /// Remove migration task associated with provided target nodeId 

--- a/libs/cluster/Session/MigrateCommand.cs
+++ b/libs/cluster/Session/MigrateCommand.cs
@@ -182,6 +182,8 @@ namespace Garnet.cluster
                         // Add pointer of current parsed key
                         if (!keys.TryAdd(new ArgSlice(keyPtr, ksize), KeyMigrationStatus.QUEUED))
                             logger?.LogWarning($"Failed to add {{key}}", Encoding.ASCII.GetString(keyPtr, ksize));
+                        else
+                            _ = slots.Add(slot);
                     }
                 }
                 else if (option.Equals("SLOTS", StringComparison.OrdinalIgnoreCase))

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -43,7 +43,7 @@ namespace Garnet
         protected StoreWrapper storeWrapper;
 
         // IMPORTANT: Keep the version in sync with .azure\pipelines\azure-pipelines-external-release.yml line ~6.
-        readonly string version = "1.0.15";
+        readonly string version = "1.0.16";
 
         /// <summary>
         /// Resp protocol version


### PR DESCRIPTION
**Problem**
When using KEYS option for slot migration, the migration session removal isn't disposing the session object. This leads to an out of memory exception when migrating a large number of keys.

**Fix**
- [x] Set slots correctly for the migrate operation. This helps to ensure the slots are correctly reset on removal of migration session.
- [x] Also, removal of multiple outstanding session objects when node is removed for the FORGET command, will dispose each of those session objects.