### PR TITLE
Helm Chart: Add support for configuration from a secret

### DIFF
--- a/charts/garnet/templates/secret.yaml
+++ b/charts/garnet/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.garnet.existingSecret }}
+{{- if .Values.garnet.config }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "garnet.fullname" . }}-config
+  labels:
+    {{- include "garnet.labels" . | nindent 4 }}
+type: Opaque
+data:
+  garnet.conf: {{ .Values.garnet.config | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/garnet/templates/statefulset.yaml
+++ b/charts/garnet/templates/statefulset.yaml
@@ -42,10 +42,14 @@ spec:
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["./GarnetServer"]
-          {{- if .Values.containers.args }}
+          {{- if or .Values.containers.args .Values.garnet.config .Values.garnet.existingSecret }}
           args:
           {{- range .Values.containers.args }}
           - {{ . | quote }}
+          {{- end }}
+          {{- if or .Values.garnet.existingSecret .Values.garnet.config }}
+          - "--config-import-path"
+          - "/config"
           {{- end }}
           {{- end }}
           ports:
@@ -65,6 +69,11 @@ spec:
           volumeMounts:
           - name: data
             mountPath: /data
+          {{- if or .Values.garnet.existingSecret .Values.garnet.config }}
+          - name: config-volume
+            mountPath: /config
+            subPath: garnet.conf
+          {{- end }}
           {{- with .Values.extraVolumeMounts }}
           {{- toYaml . | nindent 10}}
           {{- end }}
@@ -94,6 +103,11 @@ spec:
       {{- if (eq .Values.persistence.enabled false) }}
         - emptyDir: {}
           name: data
+      {{- end }}
+      {{- if or .Values.garnet.existingSecret .Values.garnet.config }}
+        - name: config-volume
+          secret: 
+            secretName: {{ if .Values.garnet.existingSecret }}{{ .Values.garnet.existingSecret }}{{ else }}{{ include "garnet.fullname" . }}-config{{ end }}
       {{- end }}
       {{- with .Values.extraVolumes }}
       {{- toYaml . | nindent 6}}

--- a/charts/garnet/values.yaml
+++ b/charts/garnet/values.yaml
@@ -49,6 +49,18 @@ containers:
   # -- Containers livenessProbe
   readinessProbe: {}
 
+# -- Garnet
+garnet:
+  # -- Garnet secret (if you want to use an existing secret)
+  existingSecret: ""
+  # -- Garnet config
+  config: ""
+  # config: |
+  #   {
+  #     "AuthenticationMode": "Password",
+  #     "Password": ""
+  #   }
+
 # -- Init containers
 initContainers: []
 


### PR DESCRIPTION
Hi,

I noticed there's no support for using garnet.conf instead of command line arguments. This aims to fix that by adding support for a secret or using an existingSecret.

If you configure Auth and Passwords currently you can't really store the values.yaml in version control since it would contain the password in clear text. This will allow you to add sensitive information (password) to a secret, you could store it using SealedSecrets or something similar in git and apply that secret alongside the helm chart for example.

Hopefully this is appreciated :)