### PR TITLE
Example - Adding parseState to ObjectInput

### DIFF
--- a/libs/server/API/GarnetApiObjectCommands.cs
+++ b/libs/server/API/GarnetApiObjectCommands.cs
@@ -17,14 +17,6 @@ namespace Garnet.server
         #region SortedSet Methods
 
         /// <inheritdoc />
-        public GarnetStatus SortedSetAdd(byte[] key, ref ObjectInput input, out int zaddCount)
-        {
-            var status = storageSession.SortedSetAdd(key, ref input, out var output, ref objectContext);
-            zaddCount = output.result1;
-            return status;
-        }
-
-        /// <inheritdoc />
         public GarnetStatus SortedSetAdd(ArgSlice key, ArgSlice score, ArgSlice member, out int zaddCount)
             => storageSession.SortedSetAdd(key, score, member, out zaddCount, ref objectContext);
 
@@ -33,8 +25,8 @@ namespace Garnet.server
             => storageSession.SortedSetAdd(key, inputs, out zaddCount, ref objectContext);
 
         /// <inheritdoc />
-        public GarnetStatus SortedSetAdd(byte[] key, ref ObjectInput input, out ObjectOutputHeader output)
-            => storageSession.SortedSetAdd(key, ref input, out output, ref objectContext);
+        public GarnetStatus SortedSetAdd(byte[] key, ref ObjectInput input, ref GarnetObjectStoreOutput output)
+            => storageSession.SortedSetAdd(key, ref input, ref output, ref objectContext);
 
         /// <inheritdoc />
         public GarnetStatus SortedSetRemove(ArgSlice key, ArgSlice member, out int zremCount)

--- a/libs/server/API/IGarnetApi.cs
+++ b/libs/server/API/IGarnetApi.cs
@@ -278,16 +278,6 @@ namespace Garnet.server
         #region SortedSet Methods
 
         /// <summary>
-        /// Adds all the specified members with the specified scores to the sorted set stored at key.
-        /// Current members get the score updated and reordered.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <param name="input">Formatted input arguments with header [ObjectInputHeader][RESP score][RESP member]...</param>
-        /// <param name="zaddCount">Number of adds performed</param>
-        /// <returns></returns>
-        GarnetStatus SortedSetAdd(byte[] key, ref ObjectInput input, out int zaddCount);
-
-        /// <summary>
         /// Adds the specified member with the specified score to the sorted set stored at key.
         /// </summary>
         /// <param name="key">Key</param>
@@ -315,7 +305,7 @@ namespace Garnet.server
         /// <param name="input"></param>
         /// <param name="output"></param>
         /// <returns></returns>
-        GarnetStatus SortedSetAdd(byte[] key, ref ObjectInput input, out ObjectOutputHeader output);
+        GarnetStatus SortedSetAdd(byte[] key, ref ObjectInput input, ref GarnetObjectStoreOutput output);
 
         /// <summary>
         /// Removes the specified member from the sorted set stored at key.

--- a/libs/server/InputHeader.cs
+++ b/libs/server/InputHeader.cs
@@ -127,24 +127,24 @@ namespace Garnet.server
         /// </summary>
         internal unsafe bool CheckSetGetFlag()
             => (flags & RespInputFlags.SetGet) != 0;
+
+        public unsafe byte* ToPointer()
+            => (byte*)Unsafe.AsPointer(ref cmd);
     }
 
-    [StructLayout(LayoutKind.Explicit, Size = Size)]
     public struct ObjectInput
     {
         public const int Size = RespInputHeader.Size + 2 * sizeof(int) + ArgSlice.Size;
 
-        [FieldOffset(0)]
         public RespInputHeader header;
 
-        [FieldOffset(RespInputHeader.Size)]
         public int arg1;
 
-        [FieldOffset(RespInputHeader.Size + sizeof(int))]
         public int arg2;
 
-        [FieldOffset(RespInputHeader.Size + sizeof(int) + sizeof(int))]
         public ArgSlice payload;
+
+        public SessionParseState parseState;
 
         public unsafe byte* ToPointer()
             => (byte*)Unsafe.AsPointer(ref header);

--- a/libs/server/Objects/SortedSet/SortedSetObject.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObject.cs
@@ -180,8 +180,6 @@ namespace Garnet.server
         /// <inheritdoc />
         public override unsafe bool Operate(ref ObjectInput input, ref SpanByteAndMemory output, out long sizeChange, out bool removeKey)
         {
-            byte* _input = null;
-
             fixed (byte* outputSpan = output.SpanByte.AsSpan())
             {
                 var header = input.header;
@@ -198,7 +196,7 @@ namespace Garnet.server
                 switch (header.SortedSetOp)
                 {
                     case SortedSetOperation.ZADD:
-                        SortedSetAdd(ref input, outputSpan);
+                        SortedSetAdd(ref input, ref output);
                         break;
                     case SortedSetOperation.ZREM:
                         SortedSetRemove(ref input, outputSpan);

--- a/libs/server/Resp/Parser/ParseUtils.cs
+++ b/libs/server/Resp/Parser/ParseUtils.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Buffers.Text;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Garnet.common;
@@ -71,6 +72,36 @@ namespace Garnet.server
             var ptr = slice.ptr;
             return RespReadUtils.TryReadLong(ref ptr, slice.ptr + slice.length, out number, out var bytesRead)
                    || ((int)bytesRead != slice.length);
+        }
+
+        /// <summary>
+        /// Read a signed 64-bit double from a given ArgSlice.
+        /// </summary>
+        /// <returns>
+        /// Parsed double
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double ReadDouble(ref ArgSlice slice)
+        {
+            if (!TryReadDouble(ref slice, out var number))
+            {
+                RespParsingException.ThrowNotANumber(slice.ptr, slice.length);
+            }
+            return number;
+        }
+
+        /// <summary>
+        /// Try to read a signed 64-bit double from a given ArgSlice.
+        /// </summary>
+        /// <returns>
+        /// True if double parsed successfully
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadDouble(ref ArgSlice slice, out double number)
+        {
+            var sbNumber = slice.ReadOnlySpan;
+            return Utf8Parser.TryParse(sbNumber, out number, out var bytesConsumed) &&
+                            bytesConsumed == sbNumber.Length; ;
         }
 
         /// <summary>

--- a/libs/server/Resp/Parser/SessionParseState.cs
+++ b/libs/server/Resp/Parser/SessionParseState.cs
@@ -59,7 +59,7 @@ namespace Garnet.server
         {
             this.count = count;
 
-            if (count <= MinParams || count <= buffer.Length)
+            if (count <= MinParams || (buffer != null && count <= buffer.Length))
                 return;
 
             buffer = GC.AllocateArray<ArgSlice>(count, true);
@@ -150,6 +150,28 @@ namespace Garnet.server
         {
             Debug.Assert(i < count);
             return ParseUtils.TryReadLong(ref Unsafe.AsRef<ArgSlice>(bufferPtr + i), out value);
+        }
+
+        /// <summary>
+        /// Get double argument at the given index
+        /// </summary>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double GetDouble(int i)
+        {
+            Debug.Assert(i < count);
+            return ParseUtils.ReadDouble(ref Unsafe.AsRef<ArgSlice>(bufferPtr + i));
+        }
+
+        /// <summary>
+        /// Try to get double argument at the given index
+        /// </summary>
+        /// <returns>True if double parsed successfully</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryGetDouble(int i, out double value)
+        {
+            Debug.Assert(i < count);
+            return ParseUtils.TryReadDouble(ref Unsafe.AsRef<ArgSlice>(bufferPtr + i), out value);
         }
 
         /// <summary>

--- a/libs/server/Storage/Session/ObjectStore/SortedSetOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/SortedSetOps.cs
@@ -812,9 +812,9 @@ namespace Garnet.server
         /// <param name="output"></param>
         /// <param name="objectStoreContext"></param>
         /// <returns></returns>
-        public GarnetStatus SortedSetAdd<TObjectContext>(byte[] key, ref ObjectInput input, out ObjectOutputHeader output, ref TObjectContext objectStoreContext)
+        public GarnetStatus SortedSetAdd<TObjectContext>(byte[] key, ref ObjectInput input, ref GarnetObjectStoreOutput output, ref TObjectContext objectStoreContext)
         where TObjectContext : ITsavoriteContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectStoreFunctions>
-        => RMWObjectStoreOperation(key, ref input, out output, ref objectStoreContext);
+        => RMWObjectStoreOperationWithOutput(key, ref input, ref objectStoreContext, ref output);
 
         /// <summary>
         /// Removes the specified members from the sorted set stored at key.

--- a/test/Garnet.test/RespSortedSetTests.cs
+++ b/test/Garnet.test/RespSortedSetTests.cs
@@ -2204,27 +2204,14 @@ namespace Garnet.test
 
 
         [Test]
-        public void CanContinueOnInvalidInput()
+        public void CanDoZaddWithInvalidInput()
         {
             using var lightClientRequest = TestUtils.CreateRequest();
             var key = "zset1";
             var response = lightClientRequest.SendCommand($"ZADD {key} 1 uno 2 due 3 tre 4 quattro 5 cinque foo bar");
-            var expectedResponse = ":5\r\n";
+            var expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_NOT_VALID_FLOAT)}\r\n";
             var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
             Assert.AreEqual(expectedResponse, actualValue);
-
-            key = "zset2";
-            response = lightClientRequest.SendCommand($"ZADD {key} 1 uno 2 due 3 tre foo bar 4 quattro 5 cinque");
-            expectedResponse = ":5\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            Assert.AreEqual(expectedResponse, actualValue);
-
-            key = "zset3";
-            response = lightClientRequest.SendCommand($"ZADD {key} foo bar 1 uno 2 due 3 tre 4 quattro 5 cinque");
-            expectedResponse = ":5\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            Assert.AreEqual(expectedResponse, actualValue);
-
         }
 
         [Test]


### PR DESCRIPTION
This is a work in progress.

- Adding parseState to ObjectInput 
- Updating AOF recovery (only RMW)
- Using parseState in ZADD implementation