### PR TITLE
Fix null reference exception in commit task

### DIFF
--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -317,7 +317,7 @@ namespace Garnet.server
                     if (token.IsCancellationRequested) break;
 
                     // if we are replica and in auto-commit - do not commit as it will clobber the AOF addresses
-                    if (serverOptions.EnableFastCommit && clusterProvider.IsReplica())
+                    if (serverOptions.EnableFastCommit && (clusterProvider?.IsReplica() ?? false))
                     {
                         await Task.Delay(commitFrequencyMs, token);
                     }

--- a/test/Garnet.test/RespAofTests.cs
+++ b/test/Garnet.test/RespAofTests.cs
@@ -99,6 +99,36 @@ namespace Garnet.test
         }
 
         [Test]
+        [Timeout(10_000)]
+        public void AofUpsertStoreCommitTaskRecoverTest()
+        {
+            server.Dispose(false);
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, tryRecover: false, enableAOF: true, commitFrequencyMs: 100);
+            server.Start();
+
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
+            {
+                var db = redis.GetDatabase(0);
+                db.StringSet("SeAofUpsertRecoverTestKey1", "SeAofUpsertRecoverTestValue1");
+                db.StringSet("SeAofUpsertRecoverTestKey2", "SeAofUpsertRecoverTestValue2");
+            }
+
+            server.Store.WaitForCommit();
+            server.Dispose(false);
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, tryRecover: true, enableAOF: true);
+            server.Start();
+
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
+            {
+                var db = redis.GetDatabase(0);
+                var recoveredValue = db.StringGet("SeAofUpsertRecoverTestKey1");
+                Assert.AreEqual("SeAofUpsertRecoverTestValue1", recoveredValue.ToString());
+                recoveredValue = db.StringGet("SeAofUpsertRecoverTestKey2");
+                Assert.AreEqual("SeAofUpsertRecoverTestValue2", recoveredValue.ToString());
+            }
+        }
+
+        [Test]
         public void AofUpsertStoreAutoCommitCommitWaitRecoverTest()
         {
             server.Dispose(false);


### PR DESCRIPTION
Fixes #537 

Recurring commit task execution has a bug that causes a null reference exception when ClusterProvider is not initialized in standalone mode. This change fixes that and adds a test to verify commit task execution.