### PR TITLE
Validate arguments of public methods#CA1062

### DIFF
--- a/Garnet.sln
+++ b/Garnet.sln
@@ -1,5 +1,5 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
+# 17
 VisualStudioVersion = 17.0.31808.319
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmark", "benchmark", "{346A5A53-51E4-4A75-B7E6-491D950382CE}"
@@ -94,6 +94,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommandInfoUpdater", "playground\CommandInfoUpdater\CommandInfoUpdater.csproj", "{9BE474A2-1547-43AC-B4F2-FB48A01FA995}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleModule", "playground\SampleModule\SampleModule.csproj", "{A8CA619E-8F13-4EF8-943F-2D5E3FEBFB3F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Garnet.test.client", "test\Garnet.test.client\Garnet.test.client.csproj", "{2B0DBD77-4122-4585-9C03-F2256AD4A119}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -279,6 +281,14 @@ Global
 		{A8CA619E-8F13-4EF8-943F-2D5E3FEBFB3F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A8CA619E-8F13-4EF8-943F-2D5E3FEBFB3F}.Release|x64.ActiveCfg = Release|Any CPU
 		{A8CA619E-8F13-4EF8-943F-2D5E3FEBFB3F}.Release|x64.Build.0 = Release|Any CPU
+		{2B0DBD77-4122-4585-9C03-F2256AD4A119}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B0DBD77-4122-4585-9C03-F2256AD4A119}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B0DBD77-4122-4585-9C03-F2256AD4A119}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2B0DBD77-4122-4585-9C03-F2256AD4A119}.Debug|x64.Build.0 = Debug|Any CPU
+		{2B0DBD77-4122-4585-9C03-F2256AD4A119}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B0DBD77-4122-4585-9C03-F2256AD4A119}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B0DBD77-4122-4585-9C03-F2256AD4A119}.Release|x64.ActiveCfg = Release|Any CPU
+		{2B0DBD77-4122-4585-9C03-F2256AD4A119}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -308,6 +318,7 @@ Global
 		{9F6E4734-6341-4A9C-A7FF-636A39D8BEAD} = {346A5A53-51E4-4A75-B7E6-491D950382CE}
 		{9BE474A2-1547-43AC-B4F2-FB48A01FA995} = {69A71E2C-00E3-42F3-854E-BE157A24834E}
 		{A8CA619E-8F13-4EF8-943F-2D5E3FEBFB3F} = {69A71E2C-00E3-42F3-854E-BE157A24834E}
+		{2B0DBD77-4122-4585-9C03-F2256AD4A119} = {9A03717A-4E0B-49CA-8579-A02A4C1D003F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2C02C405-4798-41CA-AF98-61EDFEF6772E}

--- a/libs/client/GarnetClientAPI/GarnetClientAdminCommands.cs
+++ b/libs/client/GarnetClientAPI/GarnetClientAdminCommands.cs
@@ -30,7 +30,11 @@ namespace Garnet.client
         /// <param name="callback"></param>
         /// <param name="context"></param>
         public void Save(Action<long, string> callback, long context = 0)
-            => ExecuteForStringResult(callback, context, SAVE, default(string));
+        {
+            ArgumentNullException.ThrowIfNull(callback);
+
+            ExecuteForStringResult(callback, context, SAVE, default(string));
+        }
 
         /// <summary>
         /// Return information and statistics of the server from the corresponding section
@@ -50,6 +54,8 @@ namespace Garnet.client
         /// <returns></returns>
         public async Task<string> ReplicaOf(string address, int port, CancellationToken cancellationToken = default)
         {
+            ArgumentNullException.ThrowIfNull(address);
+
             List<Memory<byte>> args = new List<Memory<byte>>()
             {
                 Encoding.ASCII.GetBytes(address),

--- a/libs/client/GarnetClientAPI/GarnetClientBasicRespCommands.cs
+++ b/libs/client/GarnetClientAPI/GarnetClientBasicRespCommands.cs
@@ -29,7 +29,12 @@ namespace Garnet.client
         /// </summary>
         /// <returns></returns>
         public void Quit(Action<long, string> callback, long context = 0)
-            => ExecuteForStringResult(callback, context, QUIT, default(string));
+        {
+            ArgumentNullException.ThrowIfNull(callback);
+
+            ExecuteForStringResult(callback, context, QUIT, default(string));
+        }
+
         #endregion
 
         #region pingCMD
@@ -50,7 +55,12 @@ namespace Garnet.client
         /// </summary>
         /// <returns></returns>
         public void Ping(Action<long, string> callback, long context = 0)
-            => ExecuteForStringResult(callback, context, PING, default(string));
+        {
+            ArgumentNullException.ThrowIfNull(callback);
+
+            ExecuteForStringResult(callback, context, PING, default(string));
+        }
+
         #endregion
 
         #region getCMD
@@ -59,7 +69,12 @@ namespace Garnet.client
         /// </summary>
         /// <param name="key">Key</param>
         /// <returns></returns>
-        public Task<string> StringGetAsync(string key) => ExecuteForStringResultAsync(GET, key);
+        public Task<string> StringGetAsync(string key)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+
+            return ExecuteForStringResultAsync(GET, key);
+        }
 
         /// <summary>
         /// Get value for given key
@@ -67,14 +82,24 @@ namespace Garnet.client
         /// <param name="key"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        public Task<string> StringGetAsync(string key, CancellationToken token) => ExecuteForStringResultWithCancellationAsync(GET, key, null, token);
+        public Task<string> StringGetAsync(string key, CancellationToken token)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+
+            return ExecuteForStringResultWithCancellationAsync(GET, key, null, token);
+        }
 
         /// <summary>
         /// Get value for given key
         /// </summary>
         /// <param name="key">Key</param>
         /// <returns></returns>
-        public Task<MemoryResult<byte>> StringGetAsMemoryAsync(string key) => ExecuteForMemoryResultAsync(GET, key);
+        public Task<MemoryResult<byte>> StringGetAsMemoryAsync(string key)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+
+            return ExecuteForMemoryResultAsync(GET, key);
+        }
 
         /// <summary>
         /// Get value for given key
@@ -82,14 +107,20 @@ namespace Garnet.client
         /// <param name="key">Key</param>
         /// <param name="token"></param>
         /// <returns></returns>
-        public Task<MemoryResult<byte>> StringGetAsMemoryAsync(string key, CancellationToken token) => ExecuteForMemoryResultWithCancellationAsync(GET, key, null, token);
+        public Task<MemoryResult<byte>> StringGetAsMemoryAsync(string key, CancellationToken token)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+
+            return ExecuteForMemoryResultWithCancellationAsync(GET, key, null, token);
+        }
 
         /// <summary>
         /// Get value for given key
         /// </summary>
         /// <param name="key">Key</param>
         /// <returns></returns>
-        public Task<MemoryResult<byte>> StringGetAsMemoryAsync(Memory<byte> key) => ExecuteForMemoryResultAsync(GET, key);
+        public Task<MemoryResult<byte>> StringGetAsMemoryAsync(Memory<byte> key)
+            => ExecuteForMemoryResultAsync(GET, key);
 
         /// <summary>
         /// Get value for given key
@@ -97,7 +128,8 @@ namespace Garnet.client
         /// <param name="key">Key</param>
         /// <param name="token"></param>
         /// <returns></returns>
-        public Task<MemoryResult<byte>> StringGetAsMemoryAsync(Memory<byte> key, CancellationToken token) => ExecuteForMemoryResultWithCancellationAsync(GET, key, null, token);
+        public Task<MemoryResult<byte>> StringGetAsMemoryAsync(Memory<byte> key, CancellationToken token)
+            => ExecuteForMemoryResultWithCancellationAsync(GET, key, null, token);
 
         /// <summary>
         /// Get value for given key
@@ -107,7 +139,12 @@ namespace Garnet.client
         /// <param name="context">Optional context to correlate request to callback</param>
         /// <returns></returns>
         public void StringGet(string key, Action<long, string> callback, long context = 0)
-            => ExecuteForStringResult(callback, context, GET, key);
+        {
+            ArgumentNullException.ThrowIfNull(key);
+            ArgumentNullException.ThrowIfNull(callback);
+
+            ExecuteForStringResult(callback, context, GET, key);
+        }
 
         /// <summary>
         /// Get value for given key
@@ -129,7 +166,12 @@ namespace Garnet.client
         /// <param name="callback"></param>
         /// <param name="context"></param>
         public void StringGet(string[] keys, Action<long, string[], string> callback, long context = 0)
-            => ExecuteForStringArrayResult(callback, context, "MGET", keys);
+        {
+            ArgumentNullException.ThrowIfNull(keys);
+            ArgumentNullException.ThrowIfNull(callback);
+
+            ExecuteForStringArrayResult(callback, context, "MGET", keys);
+        }
 
         /// <summary>
         /// Get for multiple keys with Memory array type

--- a/libs/client/GarnetClientAPI/GarnetClientExecuteAPI.cs
+++ b/libs/client/GarnetClientAPI/GarnetClientExecuteAPI.cs
@@ -53,6 +53,8 @@ namespace Garnet.client
         /// <returns></returns>
         public Task<string> ExecuteForStringResultAsync(string op, ICollection<string> args = null)
         {
+            ArgumentNullException.ThrowIfNull(op);
+
             var tcs = new TcsWrapper { taskType = TaskType.StringAsync, stringTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously) };
             var _ = InternalExecuteAsync(tcs, op, args);
             return tcs.stringTcs.Task;

--- a/libs/client/GarnetClientAPI/GarnetClientListCommands.cs
+++ b/libs/client/GarnetClientAPI/GarnetClientListCommands.cs
@@ -24,6 +24,10 @@ namespace Garnet.client
         /// <param name="context">An optional context to correlate request to callback.</param>
         public void ListLeftPush(string key, string element, Action<long, long, string> callback, long context = 0)
         {
+            ArgumentNullException.ThrowIfNull(key);
+            ArgumentNullException.ThrowIfNull(element);
+            ArgumentNullException.ThrowIfNull(callback);
+
             ListLeftPush(key, new[] { element }, callback, context);
         }
 

--- a/libs/client/GarnetClientAPI/GarnetClientSortedSetCommands.cs
+++ b/libs/client/GarnetClientAPI/GarnetClientSortedSetCommands.cs
@@ -26,6 +26,10 @@ namespace Garnet.client
         /// <param name="context"></param>
         public void SortedSetAdd(string key, string member, double score, Action<long, long, string> callback, long context = 0)
         {
+            ArgumentNullException.ThrowIfNull(key);
+            ArgumentNullException.ThrowIfNull(member);
+            ArgumentNullException.ThrowIfNull(callback);
+
             var parameters = new List<Memory<byte>>
             {
                 Encoding.ASCII.GetBytes(key),

--- a/libs/client/GarnetClientAPI/SortedSetPairCollection.cs
+++ b/libs/client/GarnetClientAPI/SortedSetPairCollection.cs
@@ -29,6 +29,8 @@ namespace Garnet.client.GarnetClientAPI
         /// <param name="score"></param>
         public void AddSortedSetEntry(byte[] member, double score)
         {
+            ArgumentNullException.ThrowIfNull(member);
+
             elements.Add(Encoding.ASCII.GetBytes(score.ToString()));
             elements.Add((Memory<byte>)member);
         }

--- a/test/Garnet.test.client/Garnet.test.client.csproj
+++ b/test/Garnet.test.client/Garnet.test.client.csproj
@@ -1,0 +1,42 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../../Garnet.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\testcerts\testcert.pfx" Link="testcert.pfx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="Microsoft.CodeAnalysis" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StackExchange.Redis" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\libs\client\Garnet.client.csproj" />
+   </ItemGroup>
+
+  <ItemGroup>
+    <None Update="redis.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/test/Garnet.test.client/GarnetClientAPI/GarnetClientAdminCommandsTests.cs
+++ b/test/Garnet.test.client/GarnetClientAPI/GarnetClientAdminCommandsTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Threading;
+using Garnet.client;
+using NUnit.Framework;
+
+namespace Garnet.test.client.GarnetClientAPI;
+
+[TestFixture]
+internal class GarnetClientAdminCommandsTests
+{
+    private GarnetClient context;
+
+    [SetUp]
+    public void Setup()
+    {
+        context = new GarnetClient("garnet", 9999);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        context.Dispose();
+    }
+
+    [Test]
+    public void ShouldThrowArgumentNullExceptionForSaveWhenCallbackIsNull()
+    {
+        const Action<long, string> callback = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => context.Save(callback, 0));
+
+        Assert.AreEqual(nameof(callback), exception!.ParamName);
+    }
+
+    [Test]
+    public void ShouldThrowArgumentNullExceptionForReplicaOfWhenAddressIsNull()
+    {
+        const string address = null!;
+        var port = 100;
+
+        var exception = Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await context.ReplicaOf(address, port, default(CancellationToken)));
+
+        Assert.AreEqual(nameof(address), exception!.ParamName);
+    }
+}

--- a/test/Garnet.test.client/GarnetClientAPI/GarnetClientBasicRespCommandsTests.cs
+++ b/test/Garnet.test.client/GarnetClientAPI/GarnetClientBasicRespCommandsTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Threading;
+using Garnet.client;
+using NUnit.Framework;
+
+namespace Garnet.test.client.GarnetClientAPI;
+
+[TestFixture]
+internal class GarnetClientBasicRespCommandsTests
+{
+    private GarnetClient context;
+
+    [SetUp]
+    public void Setup()
+    {
+        context = new GarnetClient("garnet", 9999);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        context.Dispose();
+    }
+
+    [Test]
+    public void ShouldThrowArgumentNullExceptionForQuitWhenCallbackIsNull()
+    {
+        const Action<long, string> callback = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => context.Quit(callback, 0));
+
+        Assert.AreEqual(nameof(callback), exception!.ParamName);
+    }
+}

--- a/test/Garnet.test.client/GarnetClientAPI/GarnetClientExecuteAPITests.cs
+++ b/test/Garnet.test.client/GarnetClientAPI/GarnetClientExecuteAPITests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Garnet.client;
+using NUnit.Framework;
+
+namespace Garnet.test.client.GarnetClientAPI;
+
+[TestFixture]
+internal class GarnetClientExecuteAPITests
+{
+    private GarnetClient context;
+
+    [SetUp]
+    public void Setup()
+    {
+        context = new GarnetClient("garnet", 9999);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        context.Dispose();
+    }
+
+    [Test]
+    public void ShouldThrowArgumentNullExceptionForExecuteForStringResultAsyncWhenOpIsNull()
+    {
+        const string op = null!;
+
+        var exception = Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await context.ExecuteForStringResultAsync(op, default(ICollection<string>)));
+
+        Assert.AreEqual(nameof(op), exception!.ParamName);
+    }
+}

--- a/test/Garnet.test.client/GarnetClientAPI/GarnetClientListCommandsTests.cs
+++ b/test/Garnet.test.client/GarnetClientAPI/GarnetClientListCommandsTests.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using Garnet.client;
+using NUnit.Framework;
+
+namespace Garnet.test.client.GarnetClientAPI;
+
+[TestFixture]
+internal class GarnetClientListCommandsTests
+{
+    private GarnetClient context;
+
+    [SetUp]
+    public void Setup()
+    {
+        context = new GarnetClient("garnet", 9999);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        context.Dispose();
+    }
+
+    [Test]
+    public void ShouldThrowArgumentNullExceptionForListLeftPushWhenKeyIsNull()
+    {
+        const string key = null!;
+        const string element = nameof(element);
+        Action<long, long, string> callback = (_, _, _) => { };
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => context.ListLeftPush(key, element, callback, 0));
+
+        Assert.AreEqual(nameof(key), exception!.ParamName);
+    }
+
+    [Test]
+    public void ShouldThrowArgumentNullExceptionForListLeftPushWhenElementIsNull()
+    {
+        const string key = nameof(key);
+        const string element = null!;
+        Action<long, long, string> callback = (_, _, _) => { };
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => context.ListLeftPush(key, element, callback, 0));
+
+        Assert.AreEqual(nameof(element), exception!.ParamName);
+    }
+
+    [Test]
+    public void ShouldThrowArgumentNullExceptionForListLeftPushWhenCallbackIsNull()
+    {
+        const string key = nameof(key);
+        const string element = nameof(element);
+        const Action<long, long, string> callback = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => context.ListLeftPush(key, element, callback, 0));
+
+        Assert.AreEqual(nameof(callback), exception!.ParamName);
+    }
+}

--- a/test/Garnet.test.client/GarnetClientAPI/GarnetClientSortedSetCommandsTests.cs
+++ b/test/Garnet.test.client/GarnetClientAPI/GarnetClientSortedSetCommandsTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using Garnet.client;
+using NUnit.Framework;
+
+namespace Garnet.test.client.GarnetClientAPI;
+
+[TestFixture]
+internal class GarnetClientSortedSetCommandsTests
+{
+    private GarnetClient context;
+
+    [SetUp]
+    public void Setup()
+    {
+        context = new GarnetClient("garnet", 9999);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        context.Dispose();
+    }
+
+    [Test]
+    public void ShouldThrowArgumentNullExceptionForSortedSetAddWhenKeyIsNull()
+    {
+        const string key = null!;
+        const string member = nameof(member);
+        const double score = 0d;
+        Action<long, long, string> callback = (_, _, _) => { };
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => context.SortedSetAdd(key, member, score, callback, 0));
+
+        Assert.AreEqual(nameof(key), exception!.ParamName);
+    }
+
+    [Test]
+    public void ShouldThrowArgumentNullExceptionForSortedSetAddWhenMemberIsNull()
+    {
+        const string key = nameof(key);
+        const string member = null!;
+        const double score = 0d;
+        Action<long, long, string> callback = (_, _, _) => { };
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => context.SortedSetAdd(key, member, score, callback, 0));
+
+        Assert.AreEqual(nameof(member), exception!.ParamName);
+    }
+
+    [Test]
+    public void ShouldThrowArgumentNullExceptionForSortedSetAddWhenCallbackIsNull()
+    {
+        const string key = nameof(key);
+        const string member = nameof(member);
+        const double score = 0d;
+        const Action<long, long, string> callback = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => context.SortedSetAdd(key, member, score, callback, 0));
+
+        Assert.AreEqual(nameof(callback), exception!.ParamName);
+    }
+}

--- a/test/Garnet.test.client/GarnetClientAPI/SortedSetPairCollectionTests.cs
+++ b/test/Garnet.test.client/GarnetClientAPI/SortedSetPairCollectionTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using Garnet.client.GarnetClientAPI;
+using NUnit.Framework;
+
+namespace Garnet.test.client.GarnetClientAPI;
+
+[TestFixture]
+internal class SortedSetPairCollectionTests
+{
+    private SortedSetPairCollection context;
+
+    [SetUp]
+    public void Setup()
+    {
+        context = new SortedSetPairCollection();
+    }
+
+    [Test]
+    public void ShouldThrowArgumentNullExceptionForAddSortedSetEntryWhenMemberIsNull()
+    {
+        const byte[] member = null!;
+        const double score = 0d;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => context.AddSortedSetEntry(member, score));
+
+        Assert.AreEqual(nameof(member), exception!.ParamName);
+    }
+}


### PR DESCRIPTION
Source [CA1062](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1062)

Cause
An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic).

You can [configure](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1062#configure-code-to-analyze) this rule to exclude certain types and parameters from analysis. You can also [indicate null-check validation methods](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1062#null-check-validation-methods).

Rule description
All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an [ArgumentNullException](https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception) when the argument is null.

If a method can be called from an unknown assembly because it is declared public or protected, you should validate all parameters of the method. If the method is designed to be called only by known assemblies, mark the method internal and apply the [InternalsVisibleToAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.internalsvisibletoattribute) attribute to the assembly that contains the method.

I implemented a small part so that you could evaluate and point out the necessary corrections.
It would also be nice if you indicated a list of classes (projects) that need to be covered with these tests.

I would suggest creating a issue so that you can solve the problem in parts and also for tracking