### PR TITLE
Migration Misc Fixes

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -3,7 +3,7 @@
 #      1) update the name: string below (line 6)     -- this is the version for the nuget package (e.g. 1.0.0)
 #      2) update \libs\host\GarnetServer.cs readonly string version  (~line 45)   -- NOTE - these two values need to be the same 
 ###################################### 
-name: 1.0.17
+name: 1.0.18
 trigger:
   branches:
     include:

--- a/libs/cluster/CmdStrings.cs
+++ b/libs/cluster/CmdStrings.cs
@@ -56,6 +56,7 @@ namespace Garnet.cluster
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_MIGRATE_TO_MYSELF => "ERR Can't MIGRATE to myself"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_INCOMPLETESLOTSRANGE => "ERR incomplete slotrange"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_SLOTNOTMIGRATING => "ERR slot state not set to MIGRATING state"u8;
+        public static ReadOnlySpan<byte> RESP_ERR_GENERIC_FAILEDTOADDKEY => "ERR Failed to add key for migration tracking"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_PARSING => "ERR Parsing error"u8;
 
         /// <summary>

--- a/libs/cluster/Server/ClusterManager.cs
+++ b/libs/cluster/Server/ClusterManager.cs
@@ -123,11 +123,7 @@ namespace Garnet.cluster
         public void FlushConfig()
         {
             lock (this)
-            {
-                logger?.LogTrace("Start FlushConfig {path}", clusterConfigDevice.FileName);
                 ClusterUtils.WriteInto(clusterConfigDevice, pool, 0, currentConfig.ToByteArray(), logger: logger);
-                logger?.LogTrace("End FlushConfig {path}", clusterConfigDevice.FileName);
-            }
         }
 
         /// <summary>

--- a/libs/cluster/Server/ClusterManagerSlotState.cs
+++ b/libs/cluster/Server/ClusterManagerSlotState.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using Garnet.common;
 using Garnet.server;
+using Microsoft.Extensions.Logging;
 using Tsavorite.core;
 
 namespace Garnet.cluster
@@ -46,6 +48,7 @@ namespace Garnet.cluster
                     break;
             }
             FlushConfig();
+            logger?.LogTrace("AddSlots {slots}", GetRange(slots.ToArray()));
             return true;
         }
 
@@ -75,6 +78,7 @@ namespace Garnet.cluster
                     break;
             }
             FlushConfig();
+            logger?.LogTrace("RemoveSlots {slots}", GetRange(slots.ToArray()));
             return true;
         }
 
@@ -139,6 +143,7 @@ namespace Garnet.cluster
                     break;
             }
             FlushConfig();
+            logger?.LogTrace("SetSlot MIGRATING {slot} TO {nodeId}", slot, currentConfig.GetWorkerAddressFromNodeId(nodeid));
             return true;
         }
 
@@ -205,6 +210,7 @@ namespace Garnet.cluster
                     break;
             }
             FlushConfig();
+            logger?.LogTrace("SetSlotsRange MIGRATING {slot} TO {nodeId}", GetRange(slots.ToArray()), currentConfig.GetWorkerAddressFromNodeId(nodeid));
             return true;
         }
 
@@ -258,6 +264,7 @@ namespace Garnet.cluster
                     break;
             }
             FlushConfig();
+            logger?.LogTrace("SetSlot IMPORTING {slot} TO {nodeId}", slot, currentConfig.GetWorkerAddressFromNodeId(nodeid));
             return true;
         }
 
@@ -319,6 +326,8 @@ namespace Garnet.cluster
                 if (Interlocked.CompareExchange(ref currentConfig, newConfig, current) == current)
                     break;
             }
+            FlushConfig();
+            logger?.LogTrace("SetSlotsRange IMPORTING {slot} TO {nodeId}", GetRange(slots.ToArray()), currentConfig.GetWorkerAddressFromNodeId(nodeid));
             return true;
         }
 
@@ -352,6 +361,7 @@ namespace Garnet.cluster
                         break;
                 }
                 FlushConfig();
+                logger?.LogTrace("SLOT {slot} MIGRATED TO {nodeid}", slot, currentConfig.GetWorkerAddressFromNodeId(nodeid));
                 return true;
             }
             else if (current.GetState((ushort)slot) is SlotState.IMPORTING)
@@ -372,6 +382,7 @@ namespace Garnet.cluster
                         break;
                 }
                 FlushConfig();
+                logger?.LogTrace("SLOT {slot} IMPORTED FROM {nodeid}", slot, currentConfig.GetWorkerAddressFromNodeId(nodeid));
                 return true;
             }
             return true;
@@ -404,6 +415,7 @@ namespace Garnet.cluster
             }
 
             FlushConfig();
+            logger?.LogInformation("Slots {slot} IMPORTED TO {endpoint}", GetRange(slots.ToArray()), currentConfig.GetWorkerAddressFromNodeId(nodeid));
             return true;
         }
 

--- a/libs/cluster/Server/ClusterManagerSlotState.cs
+++ b/libs/cluster/Server/ClusterManagerSlotState.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using Garnet.common;
 using Garnet.server;
-using Microsoft.Extensions.Logging;
 using Tsavorite.core;
 
 namespace Garnet.cluster
@@ -48,7 +46,6 @@ namespace Garnet.cluster
                     break;
             }
             FlushConfig();
-            logger?.LogTrace("ADD SLOTS {slots}", GetRange(slots.ToArray()));
             return true;
         }
 
@@ -78,7 +75,6 @@ namespace Garnet.cluster
                     break;
             }
             FlushConfig();
-            logger?.LogTrace("REMOVE SLOTS {slots}", string.Join(",", slots));
             return true;
         }
 
@@ -143,8 +139,6 @@ namespace Garnet.cluster
                     break;
             }
             FlushConfig();
-
-            logger?.LogInformation("MIGRATE {slot} TO {currentConfig.GetWorkerAddressFromNodeId(nodeid)}", slot, currentConfig.GetWorkerAddressFromNodeId(nodeid));
             return true;
         }
 
@@ -211,8 +205,6 @@ namespace Garnet.cluster
                     break;
             }
             FlushConfig();
-
-            logger?.LogInformation("MIGRATE {slot} TO {migrating node}", string.Join(' ', slots), currentConfig.GetWorkerAddressFromNodeId(nodeid));
             return true;
         }
 
@@ -266,8 +258,6 @@ namespace Garnet.cluster
                     break;
             }
             FlushConfig();
-
-            logger?.LogInformation("IMPORT {slot} FROM {currentConfig.GetWorkerAddressFromNodeId(nodeid)}", slot, currentConfig.GetWorkerAddressFromNodeId(nodeid));
             return true;
         }
 
@@ -329,8 +319,6 @@ namespace Garnet.cluster
                 if (Interlocked.CompareExchange(ref currentConfig, newConfig, current) == current)
                     break;
             }
-
-            logger?.LogInformation("IMPORT {slot} FROM {importingNode}", string.Join(' ', slots), currentConfig.GetWorkerAddressFromNodeId(nodeid));
             return true;
         }
 
@@ -364,7 +352,6 @@ namespace Garnet.cluster
                         break;
                 }
                 FlushConfig();
-                logger?.LogInformation("SLOT {slot} IMPORTED TO {nodeid}", slot, currentConfig.GetWorkerAddressFromNodeId(nodeid));
                 return true;
             }
             else if (current.GetState((ushort)slot) is SlotState.IMPORTING)
@@ -385,7 +372,6 @@ namespace Garnet.cluster
                         break;
                 }
                 FlushConfig();
-                logger?.LogInformation("SLOT {slot} IMPORTED FROM {nodeid}", slot, currentConfig.GetWorkerAddressFromNodeId(nodeid));
                 return true;
             }
             return true;
@@ -418,7 +404,6 @@ namespace Garnet.cluster
             }
 
             FlushConfig();
-            logger?.LogInformation("SLOT {slot} IMPORTED TO {endpoint}", slots, currentConfig.GetWorkerAddressFromNodeId(nodeid));
             return true;
         }
 

--- a/libs/cluster/Server/ClusterManagerSlotState.cs
+++ b/libs/cluster/Server/ClusterManagerSlotState.cs
@@ -415,7 +415,7 @@ namespace Garnet.cluster
             }
 
             FlushConfig();
-            logger?.LogInformation("Slots {slot} IMPORTED TO {endpoint}", GetRange(slots.ToArray()), currentConfig.GetWorkerAddressFromNodeId(nodeid));
+            logger?.LogTrace("Slots {slot} IMPORTED TO {endpoint}", GetRange(slots.ToArray()), currentConfig.GetWorkerAddressFromNodeId(nodeid));
             return true;
         }
 

--- a/libs/cluster/Server/Migration/MigrateSession.cs
+++ b/libs/cluster/Server/Migration/MigrateSession.cs
@@ -45,6 +45,7 @@ namespace Garnet.cluster
         readonly List<(int, int)> _slotRanges;
         readonly Dictionary<ArgSlice, KeyMigrationStatus> _keys;
         SingleWriterMultiReaderLock _keyDictLock;
+        SingleWriterMultiReaderLock _disposed;
 
         readonly HashSet<int> _sslots;
         readonly CancellationTokenSource _cts = new();
@@ -222,6 +223,7 @@ namespace Garnet.cluster
         /// </summary>
         public void Dispose()
         {
+            if (!_disposed.TryWriteLock()) return;
             _cts?.Cancel();
             _cts?.Dispose();
             _gcs.Dispose();

--- a/libs/cluster/Server/Migration/MigrateSessionSlots.cs
+++ b/libs/cluster/Server/Migration/MigrateSessionSlots.cs
@@ -22,8 +22,7 @@ namespace Garnet.cluster
                 while (true)
                 {
                     // Iterate main store
-                    if (!localServerSession.BasicGarnetApi.IterateMainStore(ref mainStoreGetKeysInSlots, storeTailAddress))
-                        return false;
+                    _ = localServerSession.BasicGarnetApi.IterateMainStore(ref mainStoreGetKeysInSlots, storeTailAddress);
 
                     // If did not acquire any keys stop scanning
                     if (_keys.IsNullOrEmpty())
@@ -50,8 +49,7 @@ namespace Garnet.cluster
                 while (true)
                 {
                     // Iterate object store
-                    if (!localServerSession.BasicGarnetApi.IterateObjectStore(ref objectStoreGetKeysInSlots, objectStoreTailAddress))
-                        return false;
+                    _ = localServerSession.BasicGarnetApi.IterateObjectStore(ref objectStoreGetKeysInSlots, objectStoreTailAddress);
 
                     // If did not acquire any keys stop scanning
                     if (_keys.IsNullOrEmpty())

--- a/libs/cluster/Server/Migration/MigrateSessionTaskStore.cs
+++ b/libs/cluster/Server/Migration/MigrateSessionTaskStore.cs
@@ -51,8 +51,13 @@ namespace Garnet.cluster
                 _lock.ReadLock();
                 if (_disposed) return 0;
 
+                HashSet<MigrateSession> ss = [];
                 for (var i = 0; i < sessions.Length; i++)
-                    count += sessions[i] != null ? 1 : 0;
+                {
+                    if (sessions[i] != null)
+                        _ = ss.Add(sessions[i]);
+                }
+                count = ss.Count;
             }
             finally
             {

--- a/libs/cluster/Server/Migration/MigrationKeyIterationFunctions.cs
+++ b/libs/cluster/Server/Migration/MigrationKeyIterationFunctions.cs
@@ -139,8 +139,9 @@ namespace Garnet.cluster
                 /// <returns></returns>
                 public bool Consume(ref Span<byte> key)
                 {
-                    // Check if key is within the current processing window
-                    if (currentOffset < offset)
+                    // Check if key is within the current processing window only if _copyOption is set
+                    // in order to skip keys that have been send over to target node but not deleted locally
+                    if (session._copyOption && currentOffset < offset)
                     {
                         currentOffset++;
                         return true;

--- a/libs/cluster/Session/MigrateCommand.cs
+++ b/libs/cluster/Session/MigrateCommand.cs
@@ -233,6 +233,9 @@ namespace Garnet.cluster
                 }
                 else if (option.Equals("SLOTSRANGE", StringComparison.OrdinalIgnoreCase))
                 {
+                    if (transferOption == TransferOption.KEYS)
+                        pstate = MigrateCmdParseState.MULTI_TRANSFER_OPTION;
+                    transferOption = TransferOption.SLOTS;
                     slots = [];
                     if (args == 0 || (args & 0x1) > 0)
                     {

--- a/libs/cluster/Session/MigrateCommand.cs
+++ b/libs/cluster/Session/MigrateCommand.cs
@@ -30,6 +30,7 @@ namespace Garnet.cluster
             SLOTOUTOFRANGE,
             NOTMIGRATING,
             MULTI_TRANSFER_OPTION,
+            FAILEDTOADDKEY
         }
 
         private bool HandleCommandParsingErrors(MigrateCmdParseState mpState, string targetAddress, int targetPort, int slotMultiRef)
@@ -48,6 +49,7 @@ namespace Garnet.cluster
                 MigrateCmdParseState.INCOMPLETESLOTSRANGE => CmdStrings.RESP_ERR_GENERIC_INCOMPLETESLOTSRANGE,
                 MigrateCmdParseState.SLOTOUTOFRANGE => Encoding.ASCII.GetBytes($"ERR Slot {slotMultiRef} out of range."),
                 MigrateCmdParseState.NOTMIGRATING => CmdStrings.RESP_ERR_GENERIC_SLOTNOTMIGRATING,
+                MigrateCmdParseState.FAILEDTOADDKEY => CmdStrings.RESP_ERR_GENERIC_FAILEDTOADDKEY,
                 _ => CmdStrings.RESP_ERR_GENERIC_PARSING,
             };
             while (!RespWriteUtils.WriteError(errorMessage, ref dcurr, dend))
@@ -181,9 +183,12 @@ namespace Garnet.cluster
 
                         // Add pointer of current parsed key
                         if (!keys.TryAdd(new ArgSlice(keyPtr, ksize), KeyMigrationStatus.QUEUED))
+                        {
                             logger?.LogWarning($"Failed to add {{key}}", Encoding.ASCII.GetString(keyPtr, ksize));
-                        else
-                            _ = slots.Add(slot);
+                            pstate = MigrateCmdParseState.FAILEDTOADDKEY;
+                            continue;
+                        }
+                        _ = slots.Add(slot);
                     }
                 }
                 else if (option.Equals("SLOTS", StringComparison.OrdinalIgnoreCase))

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -50,7 +50,7 @@ namespace Garnet
         protected StoreWrapper storeWrapper;
 
         // IMPORTANT: Keep the version in sync with .azure\pipelines\azure-pipelines-external-release.yml line ~6.
-        readonly string version = "1.0.17";
+        readonly string version = "1.0.18";
 
         /// <summary>
         /// Resp protocol version

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -1725,6 +1725,9 @@ namespace Garnet.test.cluster
             }
         }
 
+        public void WaitForMigrationCleanup(int nodeIndex, ILogger logger = null)
+            => WaitForMigrationCleanup(endpoints[nodeIndex].ToIPEndPoint(), logger);
+
         public void WaitForMigrationCleanup(IPEndPoint endPoint, ILogger logger)
         {
             while (MigrateTasks(endPoint, logger) > 0) { BackOff(); }
@@ -2867,6 +2870,25 @@ namespace Garnet.test.cluster
 
             Assert.Fail("Single node cluster");
             return null;
+        }
+
+        public int DBSize(int nodeIndex, ILogger logger = null)
+            => DBSize(endpoints[nodeIndex].ToIPEndPoint(), logger);
+
+        public int DBSize(IPEndPoint endPoint, ILogger logger = null)
+        {
+            try
+            {
+                var server = redis.GetServer(endPoint);
+                var count = (int)server.Execute("DBSIZE");
+                return count;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "An error has occurred; DBSize");
+                Assert.Fail();
+                return -1;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes the following bugs related to migration operation

- [x]  When adding creating a new migration session check if associated slot is already owned by an existing migration session.
- [x] Fix SLOTSRANGE option.
- [x] When removing migrate session by targetNodeId dispose session immediately to avoid collection allocations.
- [x] Fix issue with migration window tracking when copyOption is not set.
- [x] Refactor logger messages to reduce verbosity.