### PR TITLE
add repository details to Garnet.nuspec

### DIFF
--- a/Garnet.nuspec
+++ b/Garnet.nuspec
@@ -6,6 +6,7 @@
     <title>Garnet</title>
     <authors>Microsoft</authors>
     <projectUrl>https://microsoft.github.io/garnet</projectUrl>
+    <repository type="git" url="https://github.com/microsoft/garnet.git" />
     <description>Garnet is a remote cache-store from Microsoft Research, that offers strong performance (throughput and latency), 
   scalability, storage, recovery, cluster sharding, key migration, and replication features. Garnet uses the Redis RESP wire
   protocol and can work with existing Redis clients.</description>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Garnet
 [![.NET CI](https://github.com/microsoft/garnet/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/microsoft/garnet/actions/workflows/ci.yml)
+[![](https://img.shields.io/github/release/microsoft/garnet.svg?label=latest%20release&color=007edf)](https://github.com/microsoft/garnet/releases/latest)
+[![](https://img.shields.io/nuget/dt/microsoft.garnet.svg?label=downloads&color=007edf&logo=nuget)](https://www.nuget.org/packages/microsoft.garnet)
 [![Discord Shield](https://discordapp.com/api/guilds/1213937452272582676/widget.png?style=shield)](https://aka.ms/garnet-discord)
 
 Garnet is a new remote cache-store from Microsoft Research, that offers several unique benefits:


### PR DESCRIPTION
see https://learn.microsoft.com/en-us/nuget/reference/nuspec#repository

https://www.nuget.org/packages/Microsoft.Garnet is missing a link to the git repository
![image](https://github.com/user-attachments/assets/7882d02e-0e72-4231-b809-768957cc5c12)
