### PR TITLE
Bugfix: Fix AOF commit mode when not in Transactions

### DIFF
--- a/libs/server/Resp/Parser/RespCommand.cs
+++ b/libs/server/Resp/Parser/RespCommand.cs
@@ -1902,9 +1902,7 @@ namespace Garnet.server
             if (dcurr == networkSender.GetResponseObjectHead())
                 waitForAofBlocking = false;
 
-            // If we are in NetworkSkip's state we do not need to be changing the AOF blocking flag
-            // since we do not interact with AOF in that path.
-            if (txnManager.state != TxnState.None && txnManager.state == TxnState.Running)
+            if (txnManager.state == TxnState.None || txnManager.state == TxnState.Running)
             {
                 /* 
                     keeping the expensive call inside the conditional only adds ~4 MSIL instructions in hotpath

--- a/test/Garnet.test/RespCommandTests.cs
+++ b/test/Garnet.test/RespCommandTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -215,6 +216,54 @@ namespace Garnet.test
             {
                 var info = results[i];
                 VerifyCommandInfo(commands[i], info);
+            }
+        }
+
+        [Test]
+        public void AofIndependentCommandsTest()
+        {
+            RespCommand[] aofIndpendentCmds = [
+                RespCommand.ASYNC,
+                RespCommand.PING,
+                RespCommand.SELECT,
+                RespCommand.ECHO,
+                RespCommand.CLIENT,
+                RespCommand.MONITOR,
+                RespCommand.MODULE_LOADCS,
+                RespCommand.REGISTERCS,
+                RespCommand.INFO,
+                RespCommand.TIME,
+                RespCommand.LASTSAVE,
+                // ACL
+                RespCommand.ACL_CAT,
+                RespCommand.ACL_DELUSER,
+                RespCommand.ACL_LIST,
+                RespCommand.ACL_LOAD,
+                RespCommand.ACL_SAVE,
+                RespCommand.ACL_SETUSER,
+                RespCommand.ACL_USERS,
+                RespCommand.ACL_WHOAMI,
+                // Command
+                RespCommand.COMMAND,
+                RespCommand.COMMAND_COUNT,
+                RespCommand.COMMAND_INFO,
+                RespCommand.MEMORY_USAGE,
+                // Config
+                RespCommand.CONFIG_GET,
+                RespCommand.CONFIG_REWRITE,
+                RespCommand.CONFIG_SET,
+                // Latency
+                RespCommand.LATENCY_HELP,
+                RespCommand.LATENCY_HISTOGRAM,
+                RespCommand.LATENCY_RESET,
+                // Transactions
+                RespCommand.MULTI,
+            ];
+
+            foreach (RespCommand cmd in Enum.GetValues(typeof(RespCommand)))
+            {
+                var expectedAofIndependence = Array.IndexOf(aofIndpendentCmds, cmd) != -1;
+                Assert.AreEqual(expectedAofIndependence, cmd.IsAofIndependent());
             }
         }
 


### PR DESCRIPTION
Per my last PR I introduced a bug which made the AOF related test flaky. The error was coming from the fact that AOF commit was not being called when we were executing from outside the context of a transaction. This was meant to not invoke the IsAoFIndependent method when we are in NetworkSkip mode.