### PR TITLE
Align Replica Checkpoint Correctly on Attach

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -4,7 +4,7 @@
 #      2) update \libs\host\GarnetServer.cs readonly string version  (~line 32)   -- NOTE - these two values need to be the same 
 #      3) update the version in GarnetServer.csproj (~line 8) 
 ###################################### 
-name: 1.0.38
+name: 1.0.39
 trigger:
   branches:
     include:

--- a/libs/cluster/Server/ClusterProvider.cs
+++ b/libs/cluster/Server/ClusterProvider.cs
@@ -153,20 +153,20 @@ namespace Garnet.cluster
 
             if (storeType is StoreType.Main or StoreType.All)
             {
-                entry.storeVersion = storeWrapper.store.CurrentVersion;
-                entry.storeHlogToken = storeCheckpointToken;
-                entry.storeIndexToken = storeCheckpointToken;
-                entry.storeCheckpointCoveredAofAddress = CheckpointCoveredAofAddress;
-                entry.storePrimaryReplId = replicationManager.PrimaryReplId;
+                entry.metadata.storeVersion = storeWrapper.store.CurrentVersion;
+                entry.metadata.storeHlogToken = storeCheckpointToken;
+                entry.metadata.storeIndexToken = storeCheckpointToken;
+                entry.metadata.storeCheckpointCoveredAofAddress = CheckpointCoveredAofAddress;
+                entry.metadata.storePrimaryReplId = replicationManager.PrimaryReplId;
             }
 
             if (storeType is StoreType.Object or StoreType.All)
             {
-                entry.objectStoreVersion = serverOptions.DisableObjects ? -1 : storeWrapper.objectStore.CurrentVersion;
-                entry.objectStoreHlogToken = serverOptions.DisableObjects ? default : objectStoreCheckpointToken;
-                entry.objectStoreIndexToken = serverOptions.DisableObjects ? default : objectStoreCheckpointToken;
-                entry.objectCheckpointCoveredAofAddress = CheckpointCoveredAofAddress;
-                entry.objectStorePrimaryReplId = replicationManager.PrimaryReplId;
+                entry.metadata.objectStoreVersion = serverOptions.DisableObjects ? -1 : storeWrapper.objectStore.CurrentVersion;
+                entry.metadata.objectStoreHlogToken = serverOptions.DisableObjects ? default : objectStoreCheckpointToken;
+                entry.metadata.objectStoreIndexToken = serverOptions.DisableObjects ? default : objectStoreCheckpointToken;
+                entry.metadata.objectCheckpointCoveredAofAddress = CheckpointCoveredAofAddress;
+                entry.metadata.objectStorePrimaryReplId = replicationManager.PrimaryReplId;
             }
 
             // Keep track of checkpoints for replica

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaReceiveCheckpoint.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaReceiveCheckpoint.cs
@@ -316,20 +316,17 @@ namespace Garnet.cluster
 
                 logger?.LogInformation("Replica Recover MainStore: {storeVersion}>[{sIndexToken} {sHlogToken}]" +
                     "\nObjectStore: {objectStoreVersion}>[{oIndexToken} {oHlogToken}]",
-                    remoteCheckpoint.storeVersion,
-                    remoteCheckpoint.storeIndexToken,
-                    remoteCheckpoint.storeHlogToken,
-                    remoteCheckpoint.objectStoreVersion,
-                    remoteCheckpoint.objectStoreIndexToken,
-                    remoteCheckpoint.objectStoreHlogToken);
+                    remoteCheckpoint.metadata.storeVersion,
+                    remoteCheckpoint.metadata.storeIndexToken,
+                    remoteCheckpoint.metadata.storeHlogToken,
+                    remoteCheckpoint.metadata.objectStoreVersion,
+                    remoteCheckpoint.metadata.objectStoreIndexToken,
+                    remoteCheckpoint.metadata.objectStoreHlogToken);
 
                 storeWrapper.RecoverCheckpoint(
                     recoverMainStoreFromToken,
                     recoverObjectStoreFromToken,
-                    remoteCheckpoint.storeIndexToken,
-                    remoteCheckpoint.storeHlogToken,
-                    remoteCheckpoint.objectStoreIndexToken,
-                    remoteCheckpoint.objectStoreHlogToken);
+                    remoteCheckpoint.metadata);
 
                 if (replayAOF)
                 {
@@ -347,15 +344,15 @@ namespace Garnet.cluster
                 // If checkpoint for main store was send add its token here in preparation for purge later on
                 if (recoverMainStoreFromToken)
                 {
-                    cEntry.storeIndexToken = remoteCheckpoint.storeIndexToken;
-                    cEntry.storeHlogToken = remoteCheckpoint.storeHlogToken;
+                    cEntry.metadata.storeIndexToken = remoteCheckpoint.metadata.storeIndexToken;
+                    cEntry.metadata.storeHlogToken = remoteCheckpoint.metadata.storeHlogToken;
                 }
 
                 // If checkpoint for object store was send add its token here in preparation for purge later on
                 if (recoverObjectStoreFromToken)
                 {
-                    cEntry.objectStoreIndexToken = remoteCheckpoint.objectStoreIndexToken;
-                    cEntry.objectStoreHlogToken = remoteCheckpoint.objectStoreHlogToken;
+                    cEntry.metadata.objectStoreIndexToken = remoteCheckpoint.metadata.objectStoreIndexToken;
+                    cEntry.metadata.objectStoreHlogToken = remoteCheckpoint.metadata.objectStoreHlogToken;
                 }
                 checkpointStore.PurgeAllCheckpointsExceptEntry(cEntry);
 

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaReceiveCheckpoint.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaReceiveCheckpoint.cs
@@ -324,6 +324,7 @@ namespace Garnet.cluster
                     remoteCheckpoint.metadata.objectStoreHlogToken);
 
                 storeWrapper.RecoverCheckpoint(
+                    replicaRecover: true,
                     recoverMainStoreFromToken,
                     recoverObjectStoreFromToken,
                     remoteCheckpoint.metadata);

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaReceiveCheckpoint.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaReceiveCheckpoint.cs
@@ -46,7 +46,6 @@ namespace Garnet.cluster
             try
             {
                 logger?.LogTrace("CLUSTER REPLICATE {nodeid}", nodeid);
-
                 if (!clusterProvider.clusterManager.TryAddReplica(nodeid, force: force, out errorMessage, logger: logger))
                     return false;
 
@@ -315,9 +314,22 @@ namespace Garnet.cluster
             {
                 UpdateLastPrimarySyncTime();
 
-                logger?.LogInformation("Initiating Checkpoint Recovery at replica {sIndexToken} {sHlogToken} {oIndexToken} {oHlogToken}", remoteCheckpoint.storeIndexToken, remoteCheckpoint.storeHlogToken, remoteCheckpoint.objectStoreIndexToken, remoteCheckpoint.objectStoreHlogToken);
-                storeWrapper.RecoverCheckpoint(recoverMainStoreFromToken, recoverObjectStoreFromToken,
-                    remoteCheckpoint.storeIndexToken, remoteCheckpoint.storeHlogToken, remoteCheckpoint.objectStoreIndexToken, remoteCheckpoint.objectStoreHlogToken);
+                logger?.LogInformation("Replica Recover MainStore: {storeVersion}>[{sIndexToken} {sHlogToken}]" +
+                    "\nObjectStore: {objectStoreVersion}>[{oIndexToken} {oHlogToken}]",
+                    remoteCheckpoint.storeVersion,
+                    remoteCheckpoint.storeIndexToken,
+                    remoteCheckpoint.storeHlogToken,
+                    remoteCheckpoint.objectStoreVersion,
+                    remoteCheckpoint.objectStoreIndexToken,
+                    remoteCheckpoint.objectStoreHlogToken);
+
+                storeWrapper.RecoverCheckpoint(
+                    recoverMainStoreFromToken,
+                    recoverObjectStoreFromToken,
+                    remoteCheckpoint.storeIndexToken,
+                    remoteCheckpoint.storeHlogToken,
+                    remoteCheckpoint.objectStoreIndexToken,
+                    remoteCheckpoint.objectStoreHlogToken);
 
                 if (replayAOF)
                 {

--- a/libs/cluster/Server/Replication/ReplicationCheckpointManagement.cs
+++ b/libs/cluster/Server/Replication/ReplicationCheckpointManagement.cs
@@ -31,8 +31,8 @@ namespace Garnet.cluster
             index_size = -1;
             try
             {
-                hlog_size = storeWrapper.store.GetLogFileSize(entry.storeHlogToken);
-                index_size = storeWrapper.store.GetIndexFileSize(entry.storeIndexToken);
+                hlog_size = storeWrapper.store.GetLogFileSize(entry.metadata.storeHlogToken);
+                index_size = storeWrapper.store.GetIndexFileSize(entry.metadata.storeIndexToken);
                 return true;
             }
             catch
@@ -54,8 +54,8 @@ namespace Garnet.cluster
             index_size = -1;
             try
             {
-                hlog_size = storeWrapper.objectStore.GetLogFileSize(entry.objectStoreHlogToken);
-                index_size = storeWrapper.objectStore.GetIndexFileSize(entry.objectStoreIndexToken);
+                hlog_size = storeWrapper.objectStore.GetLogFileSize(entry.metadata.objectStoreHlogToken);
+                index_size = storeWrapper.objectStore.GetIndexFileSize(entry.metadata.objectStoreIndexToken);
                 return true;
             }
             catch

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -29,7 +29,7 @@ namespace Garnet
     public class GarnetServer : IDisposable
     {
         // IMPORTANT: Keep the version in sync with .azure\pipelines\azure-pipelines-external-release.yml line ~7 and GarnetServer.csproj line ~8.
-        readonly string version = "1.0.38";
+        readonly string version = "1.0.39";
 
         internal GarnetProvider Provider;
 

--- a/libs/server/Cluster/CheckpointMetadata.cs
+++ b/libs/server/Cluster/CheckpointMetadata.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+
+namespace Garnet.server
+{
+    public sealed class CheckpointMetadata
+    {
+        public long storeVersion;
+        public Guid storeHlogToken;
+        public Guid storeIndexToken;
+        public long storeCheckpointCoveredAofAddress;
+        public string storePrimaryReplId;
+
+        public long objectStoreVersion;
+        public Guid objectStoreHlogToken;
+        public Guid objectStoreIndexToken;
+        public long objectCheckpointCoveredAofAddress;
+        public string objectStorePrimaryReplId;
+
+        public CheckpointMetadata()
+        {
+            storeVersion = -1;
+            storeHlogToken = default;
+            storeIndexToken = default;
+            storeCheckpointCoveredAofAddress = long.MaxValue;
+            storePrimaryReplId = null;
+
+            objectStoreVersion = -1;
+            objectStoreHlogToken = default;
+            objectStoreIndexToken = default;
+            objectCheckpointCoveredAofAddress = long.MaxValue;
+            objectStorePrimaryReplId = null;
+        }
+    }
+}

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -237,13 +237,31 @@ namespace Garnet.server
         /// <summary>
         /// Caller will have to decide if recover is necessary, so we do not check if recover option is enabled
         /// </summary>
-        public void RecoverCheckpoint(bool recoverMainStoreFromToken = false, bool recoverObjectStoreFromToken = false, CheckpointMetadata metadata = null)
+        public void RecoverCheckpoint(bool replicaRecover = false, bool recoverMainStoreFromToken = false, bool recoverObjectStoreFromToken = false, CheckpointMetadata metadata = null)
         {
             long storeVersion = -1, objectStoreVersion = -1;
             try
             {
-                storeVersion = !recoverMainStoreFromToken ? store.Recover() : store.Recover(metadata.storeIndexToken, metadata.storeHlogToken);
-                if (objectStore != null) objectStoreVersion = !recoverObjectStoreFromToken ? objectStore.Recover() : objectStore.Recover(metadata.objectStoreIndexToken, metadata.objectStoreHlogToken);
+                if (replicaRecover)
+                {
+                    if (metadata.storeIndexToken != default && metadata.storeHlogToken != default)
+                    {
+                        storeVersion = !recoverMainStoreFromToken ? store.Recover() : store.Recover(metadata.storeIndexToken, metadata.storeHlogToken);
+                    }
+
+                    if (!serverOptions.DisableObjects)
+                    {
+                        if (metadata.objectStoreIndexToken != default && metadata.objectStoreHlogToken != default)
+                        {
+                            objectStoreVersion = !recoverObjectStoreFromToken ? objectStore.Recover() : objectStore.Recover(metadata.objectStoreIndexToken, metadata.objectStoreHlogToken);
+                        }
+                    }
+                }
+                else
+                {
+                    storeVersion = store.Recover();
+                    if (objectStore != null) objectStoreVersion = objectStore.Recover();
+                }
                 if (storeVersion > 0 || objectStoreVersion > 0)
                     lastSaveTime = DateTimeOffset.UtcNow;
             }

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -237,14 +237,13 @@ namespace Garnet.server
         /// <summary>
         /// Caller will have to decide if recover is necessary, so we do not check if recover option is enabled
         /// </summary>
-        public void RecoverCheckpoint(bool recoverMainStoreFromToken = false, bool recoverObjectStoreFromToken = false,
-            Guid storeIndexToken = default, Guid storeHlogToken = default, Guid objectStoreIndexToken = default, Guid objectStoreHlogToken = default)
+        public void RecoverCheckpoint(bool recoverMainStoreFromToken = false, bool recoverObjectStoreFromToken = false, CheckpointMetadata metadata = null)
         {
             long storeVersion = -1, objectStoreVersion = -1;
             try
             {
-                storeVersion = !recoverMainStoreFromToken ? store.Recover() : store.Recover(storeIndexToken, storeHlogToken);
-                if (objectStore != null) objectStoreVersion = !recoverObjectStoreFromToken ? objectStore.Recover() : objectStore.Recover(objectStoreIndexToken, objectStoreHlogToken);
+                storeVersion = !recoverMainStoreFromToken ? store.Recover() : store.Recover(metadata.storeIndexToken, metadata.storeHlogToken);
+                if (objectStore != null) objectStoreVersion = !recoverObjectStoreFromToken ? objectStore.Recover() : objectStore.Recover(metadata.objectStoreIndexToken, metadata.objectStoreHlogToken);
                 if (storeVersion > 0 || objectStoreVersion > 0)
                     lastSaveTime = DateTimeOffset.UtcNow;
             }

--- a/libs/storage/Tsavorite/cs/src/core/Index/CheckpointManagement/DeviceLogCommitCheckpointManager.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/CheckpointManagement/DeviceLogCommitCheckpointManager.cs
@@ -428,7 +428,7 @@ namespace Tsavorite.core
             if (errorCode != 0)
             {
                 var errorMessage = new Win32Exception((int)errorCode).Message;
-                logger?.LogError("[DeviceLogCheckpointManager] OverlappedStream GetQueuedCompletionStatus error: {errorCode} msg: {errorMessage}", errorCode, errorMessage);
+                logger?.LogError("[DeviceLogManager] OverlappedStream GetQueuedCompletionStatus error: {errorCode} msg: {errorMessage}", errorCode, errorMessage);
             }
             semaphore.Release();
         }

--- a/libs/storage/Tsavorite/cs/src/core/Index/Recovery/Recovery.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Recovery/Recovery.cs
@@ -414,6 +414,10 @@ namespace Tsavorite.core
 
             // Reset the hybrid log
             hlogBase.Reset();
+
+            // Reset system state
+            systemState = SystemState.Make(Phase.REST, 1);
+            lastVersion = 0;
         }
 
 

--- a/main/GarnetServer/GarnetServer.csproj
+++ b/main/GarnetServer/GarnetServer.csproj
@@ -5,7 +5,7 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
 
     <!-- IMPORTANT: Keep the version in sync with .azure\pipelines\azure-pipelines-external-release.yml line ~7 and GarnetServer.cs line ~32. -->
-    <Version>1.0.38</Version>
+    <Version>1.0.39</Version>
     <PackageId>garnet-server</PackageId>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>garnet-server</ToolCommandName>

--- a/test/Garnet.test.cluster/ClusterReplicationTests.cs
+++ b/test/Garnet.test.cluster/ClusterReplicationTests.cs
@@ -1049,7 +1049,7 @@ namespace Garnet.test.cluster
             ClassicAssert.IsTrue(exc.Message.StartsWith("ERR I don't know about node "));
         }
 
-        [Test, Order(22), Timeout(testTimeout)]
+        [Test, Order(22), CancelAfter(testTimeout)]
         public void ClusterReplicationCheckpointAlignmentTest([Values] bool performRMW)
         {
             var replica_count = 1;// Per primary
@@ -1057,7 +1057,7 @@ namespace Garnet.test.cluster
             var nodes_count = primary_count + (primary_count * replica_count);
             var primaryNodeIndex = 0;
             var replicaNodeIndex = 1;
-            Assert.IsTrue(primary_count > 0);
+            ClassicAssert.IsTrue(primary_count > 0);
             context.CreateInstances(nodes_count, disableObjects: false, MainMemoryReplication: true, CommitFrequencyMs: -1, OnDemandCheckpoint: true, enableAOF: true, useTLS: useTLS);
             context.CreateConnection(useTLS: useTLS);
             _ = context.clusterTestUtils.SimpleSetupCluster(primary_count, replica_count, logger: context.logger);
@@ -1086,8 +1086,8 @@ namespace Garnet.test.cluster
 
             var primaryVersion = context.clusterTestUtils.GetInfo(primaryNodeIndex, "store", "CurrentVersion", logger: context.logger);
             var replicaVersion = context.clusterTestUtils.GetInfo(replicaNodeIndex, "store", "CurrentVersion", logger: context.logger);
-            Assert.AreEqual("6", primaryVersion);
-            Assert.AreEqual(primaryVersion, replicaVersion);
+            ClassicAssert.AreEqual("6", primaryVersion);
+            ClassicAssert.AreEqual(primaryVersion, replicaVersion);
 
             context.ValidateKVCollectionAgainstReplica(ref context.kvPairs, replicaNodeIndex);
 
@@ -1128,11 +1128,11 @@ namespace Garnet.test.cluster
             // Assert primary version is 1 and replica has recovered to previous checkpoint
             primaryVersion = context.clusterTestUtils.GetInfo(primaryNodeIndex, "store", "CurrentVersion", logger: context.logger);
             replicaVersion = context.clusterTestUtils.GetInfo(replicaNodeIndex, "store", "CurrentVersion", logger: context.logger);
-            Assert.AreEqual("1", primaryVersion);
-            Assert.AreEqual("6", replicaVersion);
+            ClassicAssert.AreEqual("1", primaryVersion);
+            ClassicAssert.AreEqual("6", replicaVersion);
 
             // Setup cluster
-            Assert.AreEqual("OK", context.clusterTestUtils.AddDelSlotsRange(primaryNodeIndex, [(0, 16383)], addslot: true, logger: context.logger));
+            ClassicAssert.AreEqual("OK", context.clusterTestUtils.AddDelSlotsRange(primaryNodeIndex, [(0, 16383)], addslot: true, logger: context.logger));
             context.clusterTestUtils.SetConfigEpoch(primaryNodeIndex, primaryNodeIndex + 1, logger: context.logger);
             context.clusterTestUtils.SetConfigEpoch(replicaNodeIndex, replicaNodeIndex + 1, logger: context.logger);
             context.clusterTestUtils.Meet(primaryNodeIndex, replicaNodeIndex, logger: context.logger);
@@ -1140,19 +1140,19 @@ namespace Garnet.test.cluster
 
             // Enable replication
             context.clusterTestUtils.WaitUntilNodeIdIsKnown(replicaNodeIndex, primaryNodeId, logger: context.logger);
-            Assert.AreEqual("OK", context.clusterTestUtils.ClusterReplicate(replicaNodeIndex, primaryNodeIndex, logger: context.logger));
+            ClassicAssert.AreEqual("OK", context.clusterTestUtils.ClusterReplicate(replicaNodeIndex, primaryNodeIndex, logger: context.logger));
 
             // Both nodes are at version 1 despite replica recovering to version earlier
             primaryVersion = context.clusterTestUtils.GetInfo(primaryNodeIndex, "store", "CurrentVersion", logger: context.logger);
             replicaVersion = context.clusterTestUtils.GetInfo(replicaNodeIndex, "store", "CurrentVersion", logger: context.logger);
-            Assert.AreEqual("1", primaryVersion);
-            Assert.AreEqual("1", replicaVersion);
+            ClassicAssert.AreEqual("1", primaryVersion);
+            ClassicAssert.AreEqual("1", replicaVersion);
 
             // At this point attached replica should be empty because primary did not have any data because it did not recover
             foreach (var pair in context.kvPairs)
             {
                 var resp = context.clusterTestUtils.GetKey(replicaNodeIndex, Encoding.ASCII.GetBytes(pair.Key), out _, out _, out _, out var state, logger: context.logger);
-                Assert.IsNull(resp);
+                ClassicAssert.IsNull(resp);
             }
         }
     }

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -2688,7 +2688,7 @@ namespace Garnet.test.cluster
             {
                 var server = redis.GetServer(endPoint);
                 var result = server.Info(section);
-                Assert.AreEqual(1, result.Length, "section does not exist");
+                ClassicAssert.AreEqual(1, result.Length, "section does not exist");
                 foreach (var item in result[0])
                     if (item.Key.Equals(segment))
                         return item.Value;

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -2679,6 +2679,30 @@ namespace Garnet.test.cluster
             return items;
         }
 
+        public string GetInfo(int nodeIndex, string section, string segment, ILogger logger = null)
+            => GetInfo(endpoints[nodeIndex].ToIPEndPoint(), section, segment, logger);
+
+        public string GetInfo(IPEndPoint endPoint, string section, string segment, ILogger logger = null)
+        {
+            try
+            {
+                var server = redis.GetServer(endPoint);
+                var result = server.Info(section);
+                Assert.AreEqual(1, result.Length, "section does not exist");
+                foreach (var item in result[0])
+                    if (item.Key.Equals(segment))
+                        return item.Value;
+                Assert.Fail($"Segment not available for {section} section");
+                return "";
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "An error has occurred; GetFailoverState");
+                Assert.Fail(ex.Message);
+                return null;
+            }
+        }
+
         public void WaitForReplicaAofSync(int primaryIndex, int secondaryIndex, ILogger logger = null)
         {
             long primaryReplicationOffset;


### PR DESCRIPTION
This PR fixes an issue with the replica recovering from its local checkpoint when the corresponding primary did not have any checkpoints to share.
Now the replica will only recover from its local checkpoint when explicitly requested by the primary to do so.