### PR TITLE
COMMAND to work with optional data being not set.

### DIFF
--- a/libs/server/Resp/RespCommandsInfo.cs
+++ b/libs/server/Resp/RespCommandsInfo.cs
@@ -361,17 +361,23 @@ namespace Garnet.server
         /// <returns>Serialized value</returns>
         public string ToRespFormat()
         {
-            var sb = new StringBuilder();
+            if (string.IsNullOrWhiteSpace(this.Name))
+                return "$-1\r\n";
 
+            var sb = new StringBuilder();
             sb.Append("*10\r\n");
             // 1) Name
             sb.Append($"${this.Name.Length}\r\n{this.Name}\r\n");
             // 2) Arity
             sb.Append($":{this.Arity}\r\n");
             // 3) Flags
-            sb.Append($"*{this.respFormatFlags.Length}\r\n");
-            foreach (var flag in this.respFormatFlags)
-                sb.Append($"+{flag}\r\n");
+            sb.Append($"*{this.respFormatFlags?.Length ?? 0}\r\n");
+            if (this.respFormatFlags != null && this.respFormatFlags.Length > 0)
+            {
+                foreach (var flag in this.respFormatFlags)
+                    sb.Append($"+{flag}\r\n");
+            }
+
             // 4) First key
             sb.Append($":{this.FirstKey}\r\n");
             // 5) Last key
@@ -379,9 +385,13 @@ namespace Garnet.server
             // 6) Step
             sb.Append($":{this.Step}\r\n");
             // 7) ACL categories
-            sb.Append($"*{this.respFormatAclCategories.Length}\r\n");
-            foreach (var aclCat in this.respFormatAclCategories)
-                sb.Append($"+@{aclCat}\r\n");
+            sb.Append($"*{this.respFormatAclCategories?.Length ?? 0}\r\n");
+            if (this.respFormatAclCategories != null && this.respFormatAclCategories.Length > 0)
+            {
+                foreach (var aclCat in this.respFormatAclCategories)
+                    sb.Append($"+@{aclCat}\r\n");
+            }
+
             // 8) Tips
             var tipCount = this.Tips?.Length ?? 0;
             sb.Append($"*{tipCount}\r\n");

--- a/main/GarnetServer/Program.cs
+++ b/main/GarnetServer/Program.cs
@@ -62,8 +62,10 @@ namespace Garnet
             // Register custom commands on objects
             var factory = new MyDictFactory();
             server.Register.NewType(factory);
-            server.Register.NewCommand("MYDICTSET", CommandType.ReadModifyWrite, factory, new MyDictSet(), new RespCommandsInfo { Arity = 4 });
-            server.Register.NewCommand("MYDICTGET", CommandType.Read, factory, new MyDictGet(), new RespCommandsInfo { Arity = 3 });
+            server.Register.NewCommand("MYDICTSET", CommandType.ReadModifyWrite, factory, new MyDictSet(),
+                new RespCommandsInfo { Name = "MYDICTSET", Arity = 4, FirstKey = 1, LastKey = 1, Step = 1, Flags = RespCommandFlags.DenyOom | RespCommandFlags.Write, AclCategories = RespAclCategories.Write });
+            server.Register.NewCommand("MYDICTGET", CommandType.Read, factory, new MyDictGet(),
+                new RespCommandsInfo { Name = "MYDICTGET", Arity = 3, FirstKey = 1, LastKey = 1, Step = 1, Flags = RespCommandFlags.ReadOnly, AclCategories = RespAclCategories.Read });
 
             // Register stored procedure to run a transactional command
             // Add RESP command info to registration for command to appear when client runs COMMAND / COMMAND INFO
@@ -86,11 +88,14 @@ namespace Garnet
             server.Register.NewTransactionProc("MGETIFPM", () => new MGetIfPM());
 
             // Register stored procedure to run a non-transactional command
-            server.Register.NewTransactionProc("GETTWOKEYSNOTXN", () => new GetTwoKeysNoTxn(), new RespCommandsInfo { Arity = 3 });
+            server.Register.NewTransactionProc("GETTWOKEYSNOTXN", () => new GetTwoKeysNoTxn(),
+                new RespCommandsInfo { Name = "GETTWOKEYSNOTXN", Arity = 3, Flags = RespCommandFlags.ReadOnly, AclCategories = RespAclCategories.Read });
 
             // Register sample transactional procedures
-            server.Register.NewTransactionProc("SAMPLEUPDATETX", () => new SampleUpdateTxn(), new RespCommandsInfo { Arity = 9 });
-            server.Register.NewTransactionProc("SAMPLEDELETETX", () => new SampleDeleteTxn(), new RespCommandsInfo { Arity = 6 });
+            server.Register.NewTransactionProc("SAMPLEUPDATETX", () => new SampleUpdateTxn(),
+                new RespCommandsInfo { Name = "SAMPLEUPDATETX", Arity = 9, Flags = RespCommandFlags.Write | RespCommandFlags.DenyOom, AclCategories = RespAclCategories.Write });
+            server.Register.NewTransactionProc("SAMPLEDELETETX", () => new SampleDeleteTxn(),
+                new RespCommandsInfo { Name = "SAMPLEDELETETX", Arity = 6, Flags = RespCommandFlags.Write | RespCommandFlags.DenyOom, AclCategories = RespAclCategories.Write });
 
             server.Register.NewProcedure("SUM", new Sum());
             server.Register.NewProcedure("SETMAINANDOBJECT", new SetStringAndList());

--- a/main/GarnetServer/Program.cs
+++ b/main/GarnetServer/Program.cs
@@ -62,10 +62,8 @@ namespace Garnet
             // Register custom commands on objects
             var factory = new MyDictFactory();
             server.Register.NewType(factory);
-            server.Register.NewCommand("MYDICTSET", CommandType.ReadModifyWrite, factory, new MyDictSet(),
-                new RespCommandsInfo { Name = "MYDICTSET", Arity = 4, FirstKey = 1, LastKey = 1, Step = 1, Flags = RespCommandFlags.DenyOom | RespCommandFlags.Write, AclCategories = RespAclCategories.Write });
-            server.Register.NewCommand("MYDICTGET", CommandType.Read, factory, new MyDictGet(),
-                new RespCommandsInfo { Name = "MYDICTGET", Arity = 3, FirstKey = 1, LastKey = 1, Step = 1, Flags = RespCommandFlags.ReadOnly, AclCategories = RespAclCategories.Read });
+            server.Register.NewCommand("MYDICTSET", CommandType.ReadModifyWrite, factory, new MyDictSet(), new RespCommandsInfo { Arity = 4 });
+            server.Register.NewCommand("MYDICTGET", CommandType.Read, factory, new MyDictGet(), new RespCommandsInfo { Arity = 3 });
 
             // Register stored procedure to run a transactional command
             // Add RESP command info to registration for command to appear when client runs COMMAND / COMMAND INFO
@@ -88,14 +86,11 @@ namespace Garnet
             server.Register.NewTransactionProc("MGETIFPM", () => new MGetIfPM());
 
             // Register stored procedure to run a non-transactional command
-            server.Register.NewTransactionProc("GETTWOKEYSNOTXN", () => new GetTwoKeysNoTxn(),
-                new RespCommandsInfo { Name = "GETTWOKEYSNOTXN", Arity = 3, Flags = RespCommandFlags.ReadOnly, AclCategories = RespAclCategories.Read });
+            server.Register.NewTransactionProc("GETTWOKEYSNOTXN", () => new GetTwoKeysNoTxn(), new RespCommandsInfo { Arity = 3 });
 
             // Register sample transactional procedures
-            server.Register.NewTransactionProc("SAMPLEUPDATETX", () => new SampleUpdateTxn(),
-                new RespCommandsInfo { Name = "SAMPLEUPDATETX", Arity = 9, Flags = RespCommandFlags.Write | RespCommandFlags.DenyOom, AclCategories = RespAclCategories.Write });
-            server.Register.NewTransactionProc("SAMPLEDELETETX", () => new SampleDeleteTxn(),
-                new RespCommandsInfo { Name = "SAMPLEDELETETX", Arity = 6, Flags = RespCommandFlags.Write | RespCommandFlags.DenyOom, AclCategories = RespAclCategories.Write });
+            server.Register.NewTransactionProc("SAMPLEUPDATETX", () => new SampleUpdateTxn(), new RespCommandsInfo { Arity = 9 });
+            server.Register.NewTransactionProc("SAMPLEDELETETX", () => new SampleDeleteTxn(), new RespCommandsInfo { Arity = 6 });
 
             server.Register.NewProcedure("SUM", new Sum());
             server.Register.NewProcedure("SETMAINANDOBJECT", new SetStringAndList());


### PR DESCRIPTION
Resp output format of COMMAND family of commands should continue to work even for commands that are registered with missing optional data.