### PR TITLE
Darrenge/fix external release pipeline to use net 6.0 for code signing

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -165,7 +165,7 @@ jobs:
 
   - task: GitHubRelease@0
     displayName: 'Create the GitHub release'
-    enabled: False
+    enabled: True
     inputs:
       action: 'create'
       gitHubConnection: ADO_to_Github_ServiceConnection
@@ -190,7 +190,7 @@ jobs:
 
   - task: NuGetCommand@2
     displayName: 'Push to NuGet.org'
-    enabled: False
+    enabled: True
     inputs:
       command: push
       packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'

--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -28,6 +28,10 @@ jobs:
     submodules: recursive
     persistCredentials: True
   - task: UseDotNet@2
+    displayName: Use .NET Core sdk 6.0.x - needed for code signing
+    inputs:
+      version: 6.0.x
+  - task: UseDotNet@2
     displayName: Use .NET Core sdk 8.0.x
     inputs:
       version: 8.0.x
@@ -161,7 +165,7 @@ jobs:
 
   - task: GitHubRelease@0
     displayName: 'Create the GitHub release'
-    enabled: True
+    enabled: False
     inputs:
       action: 'create'
       gitHubConnection: ADO_to_Github_ServiceConnection
@@ -186,7 +190,7 @@ jobs:
 
   - task: NuGetCommand@2
     displayName: 'Push to NuGet.org'
-    enabled: True
+    enabled: False
     inputs:
       command: push
       packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'


### PR DESCRIPTION
Code Signing tasks were not working because removed net6.0 which is required for code signing. Put the use net 6.0 task back in and it is working. 