### PR TITLE
Fix Migration for Larger Payloads

### DIFF
--- a/libs/client/ClientSession/GarnetClientSessionMigrationExtensions.cs
+++ b/libs/client/ClientSession/GarnetClientSessionMigrationExtensions.cs
@@ -393,23 +393,14 @@ namespace Garnet.client
 
         private bool WriteSerializedSpanByte(ref SpanByte key, ref SpanByte value)
         {
-            // We include space for newline at the end, to be added before sending
-            int totalLen = key.TotalSize + value.TotalSize + 2 + 2;
+            var totalLen = key.TotalSize + value.TotalSize + 2 + 2;
             if (totalLen > (int)(end - curr))
                 return false;
 
-            *(int*)curr = key.Length;
-            curr += sizeof(int);
-            Buffer.MemoryCopy(key.ToPointerWithMetadata(), curr, key.Length, key.Length);
-            curr += key.Length;
-            *curr++ = (byte)key.MetadataSize;
-
-            *(int*)curr = value.Length;
-            curr += sizeof(int);
-            Buffer.MemoryCopy(value.ToPointerWithMetadata(), curr, value.Length, value.Length);
-            curr += value.Length;
-            *curr++ = (byte)value.MetadataSize;
-
+            key.CopyTo(curr);
+            curr += key.TotalSize;
+            value.CopyTo(curr);
+            curr += value.TotalSize;
             return true;
         }
 

--- a/libs/cluster/Server/Migration/MigrateSessionKeys.cs
+++ b/libs/cluster/Server/Migration/MigrateSessionKeys.cs
@@ -73,10 +73,12 @@ namespace Garnet.cluster
                         value = ref SpanByte.ReinterpretWithoutLength(o.Memory.Memory.Span);
 
                     if (!ClusterSession.Expired(ref value) && !WriteOrSendMainStoreKeyValuePair(ref key, ref value))
+                    {
+                        if (!o.IsSpanByte) o.Memory.Dispose();
                         return false;
+                    }
 
-                    if (!o.IsSpanByte)
-                        o.Memory.Dispose();
+                    if (!o.IsSpanByte) o.Memory.Dispose();
                 }
 
                 // Flush data in client buffer

--- a/libs/cluster/Session/RespClusterMigrateCommands.cs
+++ b/libs/cluster/Session/RespClusterMigrateCommands.cs
@@ -71,16 +71,10 @@ namespace Garnet.cluster
                 TrackImportProgress(keyCount, isMainStore: true, keyCount == 0);
                 while (i < keyCount)
                 {
-                    byte* keyPtr = null, valPtr = null;
-                    byte keyMetaDataSize = 0, valMetaDataSize = 0;
-                    if (!RespReadUtils.ReadSerializedSpanByte(ref keyPtr, ref keyMetaDataSize, ref valPtr,
-                            ref valMetaDataSize, ref payloadPtr, payloadEndPtr))
-                        return false;
-
-                    ref var key = ref SpanByte.Reinterpret(keyPtr);
-                    if (keyMetaDataSize > 0) key.ExtraMetadata = *(long*)(keyPtr + 4);
-                    ref var value = ref SpanByte.Reinterpret(valPtr);
-                    if (valMetaDataSize > 0) value.ExtraMetadata = *(long*)(valPtr + 4);
+                    ref var key = ref SpanByte.Reinterpret(payloadPtr);
+                    payloadPtr += key.TotalSize;
+                    ref var value = ref SpanByte.Reinterpret(payloadPtr);
+                    payloadPtr += value.TotalSize;
 
                     // An error has occurred
                     if (migrateState > 0)

--- a/libs/server/Resp/Parser/RespCommand.cs
+++ b/libs/server/Resp/Parser/RespCommand.cs
@@ -153,7 +153,7 @@ namespace Garnet.server
         BITOP_XOR,
         BITOP_NOT, // Note: Update OneIfWrite if adding new write commands after this
 
-        // Neither read nor write commands
+        // Neither read nor write key commands
         ASYNC,
 
         PING,

--- a/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
@@ -105,12 +105,9 @@ namespace Garnet.server
                     }
 
                     dst.ConvertToHeap();
-                    dst.Length = value.Length;
+                    dst.Length = value.TotalSize;
                     dst.Memory = functionsState.memoryPool.Rent(dst.Length);
-                    // Need to explicitly set metadataSize because it is not serialized using AsReadOnlySpanWithMetadata
-                    fixed (byte* ptr = dst.Memory.Memory.Span)
-                        *(int*)ptr = value.MetadataSize;
-                    value.AsReadOnlySpanWithMetadata().CopyTo(dst.Memory.Memory.Span.Slice(sizeof(int)));
+                    value.CopyTo(dst.Memory.Memory.Span);
                     break;
 
                 case RespCommand.GET:

--- a/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
@@ -106,7 +106,16 @@ namespace Garnet.server
 
                     dst.ConvertToHeap();
                     dst.Length = value.TotalSize;
-                    dst.Memory = functionsState.memoryPool.Rent(dst.Length);
+
+                    if (dst.Memory == default) // Allocate new heap buffer
+                        dst.Memory = functionsState.memoryPool.Rent(dst.Length);
+                    else if (dst.Memory.Memory.Span.Length < value.TotalSize)
+                    // Allocate new heap buffer only if existing one is smaller
+                    // otherwise it is safe to re-use existing buffer
+                    {
+                        dst.Memory.Dispose();
+                        dst.Memory = functionsState.memoryPool.Rent(dst.Length);
+                    }
                     value.CopyTo(dst.Memory.Memory.Span);
                     break;
 

--- a/libs/storage/Tsavorite/cs/src/core/VarLen/SpanByte.cs
+++ b/libs/storage/Tsavorite/cs/src/core/VarLen/SpanByte.cs
@@ -461,6 +461,16 @@ namespace Tsavorite.core
         /// Copy serialized version to specified memory location
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CopyTo(Span<byte> buffer)
+        {
+            fixed (byte* ptr = buffer)
+                CopyTo(ptr);
+        }
+
+        /// <summary>
+        /// Copy serialized version to specified memory location
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void CopyTo(byte* destination)
         {
             if (Serialized)

--- a/test/Garnet.test.cluster/ClusterMigrateTests.cs
+++ b/test/Garnet.test.cluster/ClusterMigrateTests.cs
@@ -1677,7 +1677,7 @@ namespace Garnet.test.cluster
 
             var srcNodeIndex = 0;
             var dstNodeIndex = 1;
-            Assert.AreEqual("OK", context.clusterTestUtils.AddDelSlotsRange(srcNodeIndex, [(0, 16383)], addslot: true, logger: context.logger));
+            ClassicAssert.AreEqual("OK", context.clusterTestUtils.AddDelSlotsRange(srcNodeIndex, [(0, 16383)], addslot: true, logger: context.logger));
 
             context.clusterTestUtils.SetConfigEpoch(srcNodeIndex, srcNodeIndex + 1, logger: context.logger);
             context.clusterTestUtils.SetConfigEpoch(dstNodeIndex, dstNodeIndex + 2, logger: context.logger);
@@ -1685,7 +1685,7 @@ namespace Garnet.test.cluster
             context.clusterTestUtils.WaitUntilNodeIsKnown(dstNodeIndex, srcNodeIndex, logger: context.logger);
             var config1 = context.clusterTestUtils.ClusterNodes(srcNodeIndex, logger: context.logger);
             var config2 = context.clusterTestUtils.ClusterNodes(dstNodeIndex, logger: context.logger);
-            Assert.AreEqual(config1.GetBySlot(0).NodeId, config2.GetBySlot(0).NodeId);
+            ClassicAssert.AreEqual(config1.GetBySlot(0).NodeId, config2.GetBySlot(0).NodeId);
 
             var db = context.clusterTestUtils.GetDatabase();
 
@@ -1694,15 +1694,15 @@ namespace Garnet.test.cluster
             var value = new byte[largePayload ? 6789 : 123];
             context.clusterTestUtils.RandomBytes(ref value);
 
-            Assert.IsTrue(db.StringSet(key, value));
+            ClassicAssert.IsTrue(db.StringSet(key, value));
             var returnedValue = (string)db.StringGet(key);
-            Assert.AreEqual(value, returnedValue);
+            ClassicAssert.AreEqual(value, returnedValue);
 
             if (expiration)
             {
-                Assert.IsNull(db.KeyTimeToLive(key), "set key should not have an existing expiry");
-                Assert.AreEqual(true, db.KeyExpire(key, TimeSpan.FromSeconds(10000)));
-                Assert.IsNotNull(db.KeyTimeToLive(key));
+                ClassicAssert.IsNull(db.KeyTimeToLive(key), "set key should not have an existing expiry");
+                ClassicAssert.AreEqual(true, db.KeyExpire(key, TimeSpan.FromSeconds(10000)));
+                ClassicAssert.IsNotNull(db.KeyTimeToLive(key));
             }
 
             var sourceEndPoint = context.clusterTestUtils.GetEndPoint(srcNodeIndex);
@@ -1717,10 +1717,10 @@ namespace Garnet.test.cluster
             context.clusterTestUtils.WaitForMigrationCleanup(srcNodeIndex, logger: context.logger);
 
             returnedValue = (string)db.StringGet(key);
-            Assert.AreEqual(value, returnedValue, "returned value mismatch after migration");
+            ClassicAssert.AreEqual(value, returnedValue, "returned value mismatch after migration");
 
             if (expiration)
-                Assert.IsNotNull(db.KeyTimeToLive(key), "key does not have expiry after migration");
+                ClassicAssert.IsNotNull(db.KeyTimeToLive(key), "key does not have expiry after migration");
         }
     }
 }

--- a/test/Garnet.test.cluster/ClusterMigrateTests.cs
+++ b/test/Garnet.test.cluster/ClusterMigrateTests.cs
@@ -1671,6 +1671,40 @@ namespace Garnet.test.cluster
         [Category("CLUSTER")]
         public void ClusterMigrateLargePayload([Values] bool expiration, [Values] bool largePayload)
         {
+            var r = new Random(674386);
+            var key = new byte[12];
+            ClusterTestUtils.RandomBytes(ref r, ref key);
+            var value = new byte[largePayload ? 6789 : 123];
+            ClusterTestUtils.RandomBytes(ref r, ref value);
+
+            List<(byte[], byte[])> data = [(key, value)];
+            ClusterMigrateExpirationWithVaryingPayload(expiration, data);
+        }
+
+        [Test, Order(16)]
+        [Category("CLUSTER")]
+        public void ClusterMigrateIncreasingPayload([Values] bool expiration, [Values] bool largeSameSize)
+        {
+            var r = new Random(674386);
+            List<(byte[], byte[])> data = [];
+            var valueSize = largeSameSize ? 1234 : 12;
+
+            for (var i = 0; i < 8; i++)
+            {
+                var key = new byte[12];
+                ClusterTestUtils.RandomBytes(ref r, ref key);
+                var value = new byte[valueSize];
+                ClusterTestUtils.RandomBytes(ref r, ref value);
+
+                data.Add((key, value));
+                if (!largeSameSize) valueSize += valueSize * 2;
+            }
+
+            ClusterMigrateExpirationWithVaryingPayload(expiration, data);
+        }
+
+        private void ClusterMigrateExpirationWithVaryingPayload(bool expiration, List<(byte[], byte[])> data)
+        {
             var Shards = 2;
             context.CreateInstances(Shards, useTLS: UseTLS);
             context.CreateConnection(useTLS: UseTLS);
@@ -1689,20 +1723,23 @@ namespace Garnet.test.cluster
 
             var db = context.clusterTestUtils.GetDatabase();
 
-            var key = new byte[12];
-            context.clusterTestUtils.RandomBytes(ref key);
-            var value = new byte[largePayload ? 6789 : 123];
-            context.clusterTestUtils.RandomBytes(ref value);
+            foreach (var pair in data)
+                ClassicAssert.IsTrue(db.StringSet(pair.Item1, pair.Item2));
 
-            ClassicAssert.IsTrue(db.StringSet(key, value));
-            var returnedValue = (string)db.StringGet(key);
-            ClassicAssert.AreEqual(value, returnedValue);
+            foreach (var pair in data)
+            {
+                var returnedValue = (string)db.StringGet(pair.Item1);
+                ClassicAssert.AreEqual(pair.Item2, returnedValue);
+            }
 
             if (expiration)
             {
-                ClassicAssert.IsNull(db.KeyTimeToLive(key), "set key should not have an existing expiry");
-                ClassicAssert.AreEqual(true, db.KeyExpire(key, TimeSpan.FromSeconds(10000)));
-                ClassicAssert.IsNotNull(db.KeyTimeToLive(key));
+                foreach (var pair in data)
+                {
+                    ClassicAssert.IsNull(db.KeyTimeToLive(pair.Item1), "set key should not have an existing expiry");
+                    ClassicAssert.AreEqual(true, db.KeyExpire(pair.Item1, TimeSpan.FromSeconds(10000)));
+                    ClassicAssert.IsNotNull(db.KeyTimeToLive(pair.Item1));
+                }
             }
 
             var sourceEndPoint = context.clusterTestUtils.GetEndPoint(srcNodeIndex);
@@ -1716,11 +1753,18 @@ namespace Garnet.test.cluster
 
             context.clusterTestUtils.WaitForMigrationCleanup(srcNodeIndex, logger: context.logger);
 
-            returnedValue = (string)db.StringGet(key);
-            ClassicAssert.AreEqual(value, returnedValue, "returned value mismatch after migration");
+            foreach (var pair in data)
+            {
+                var returnedValue = (string)db.StringGet(pair.Item1);
+                ClassicAssert.AreEqual(pair.Item2, returnedValue, "returned value mismatch after migration");
+            }
+
 
             if (expiration)
-                ClassicAssert.IsNotNull(db.KeyTimeToLive(key), "key does not have expiry after migration");
+            {
+                foreach (var pair in data)
+                    ClassicAssert.IsNotNull(db.KeyTimeToLive(pair.Item1), "key does not have expiry after migration");
+            }
         }
     }
 }

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -709,6 +709,9 @@ namespace Garnet.test.cluster
         }
 
         public void RandomBytes(ref byte[] data, int startOffset = -1, int endOffset = -1)
+            => RandomBytes(ref r, ref data, startOffset, endOffset);
+
+        public static void RandomBytes(ref Random r, ref byte[] data, int startOffset = -1, int endOffset = -1)
         {
             startOffset = startOffset == -1 ? 0 : startOffset;
             endOffset = endOffset == -1 ? data.Length : endOffset;


### PR DESCRIPTION
This PR fixes migration bug when values are larger than the given read buffer and require conversion from SpanByteAndMemory back to SpanByte.
The bug resulted in memory bloating since the acquired buffer to write the SpanByte was larger and thus migration was augmenting the size of the value.