### PR TITLE
Removed Net6.0 from test matrix and bumped up timeout for Tsav tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        framework: [ 'net6.0', 'net8.0' ]
+        framework: [ 'net8.0' ]
         configuration: [ 'Debug', 'Release' ]
         test: [ 'Garnet.test', 'Garnet.test.cluster' ]
     if: needs.changes.outputs.garnet == 'true'
@@ -115,7 +115,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        framework: [ 'net6.0', 'net8.0' ]
+        framework: [ 'net8.0' ]
         configuration: [ 'Debug', 'Release' ]
     if: needs.changes.outputs.tsavorite == 'true'   
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-22.04, ubuntu-20.04, windows-2022, windows-2019 ]
-        framework: [ 'net6.0', 'net8.0' ]
+        framework: [ 'net8.0' ]
         configuration: [ 'Debug', 'Release' ]
         test: [ 'Garnet.test', 'Garnet.test.cluster' ]
     steps:
@@ -34,7 +34,7 @@ jobs:
         run: dotnet build --configuration ${{ matrix.configuration }}
       - name: Run tests ${{ matrix.test }}
         run: dotnet test test/${{ matrix.test }} -f ${{ matrix.framework }} --logger "console;verbosity=detailed" --logger trx --results-directory "GarnetTestResults-${{ matrix.os }}-${{ matrix.framework }}-${{ matrix.configuration }}-${{ matrix.test }}"
-        timeout-minutes: 30 
+        timeout-minutes: 45 
       - name: Upload test results
         uses: actions/upload-artifact@v4
         with:
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-22.04, ubuntu-20.04, windows-2022, windows-2019 ]
-        framework: [ 'net6.0', 'net8.0' ]
+        framework: [ 'net8.0' ]
         configuration: [ 'Debug', 'Release' ]
     steps:
       - name: Check out code
@@ -82,7 +82,7 @@ jobs:
         run: dotnet build libs/storage/Tsavorite/cs/test/Tsavorite.test.csproj --configuration ${{ matrix.configuration }}
       - name: Run Tsavorite tests
         run: dotnet test libs/storage/Tsavorite/cs/test/Tsavorite.test.csproj -f ${{ matrix.framework }} --logger "console;verbosity=detailed" --logger trx --results-directory "TsavoriteTestResults-${{ matrix.os }}-${{ matrix.framework }}-${{ matrix.configuration }}"
-        timeout-minutes: 30 
+        timeout-minutes: 45 
       - name: Upload test results
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Since we no longer support Net6.0 for Garnet, I removed NET6.0 tests from the CI run as well as the Nightly Run.   This will speed up CIs and Nightly runs too.