### PR TITLE
Use `Random.Shared` instead of `static readonly Random` instances

### DIFF
--- a/libs/server/Resp/Objects/HashCommands.cs
+++ b/libs/server/Resp/Objects/HashCommands.cs
@@ -309,7 +309,7 @@ namespace Garnet.server
             var countWithMetadata = (((paramCount << 1) | (includedCount ? 1 : 0)) << 1) | (withValues ? 1 : 0);
 
             // Create a random seed
-            var seed = RandomGen.Next();
+            var seed = Random.Shared.Next();
 
             // Prepare input
             var input = new ObjectInput

--- a/libs/server/Resp/Objects/SetCommands.cs
+++ b/libs/server/Resp/Objects/SetCommands.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using Garnet.common;
 using Tsavorite.core;
 
@@ -647,7 +648,7 @@ namespace Garnet.server
             }
 
             // Create a random seed
-            var seed = RandomGen.Next();
+            var seed = Random.Shared.Next();
 
             // Prepare input
             var input = new ObjectInput

--- a/libs/server/Resp/Objects/SortedSetCommands.cs
+++ b/libs/server/Resp/Objects/SortedSetCommands.cs
@@ -859,7 +859,7 @@ namespace Garnet.server
             }
 
             // Create a random seed
-            var seed = RandomGen.Next();
+            var seed = Random.Shared.Next();
 
             // Prepare input
             var input = new ObjectInput

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -156,11 +156,6 @@ namespace Garnet.server
         bool waitForAofBlocking = false;
 
         /// <summary>
-        /// Random number generator for operations, using a cryptographic generator as the base seed
-        /// </summary>
-        private static readonly Random RandomGen = new(RandomNumberGenerator.GetInt32(int.MaxValue));
-
-        /// <summary>
         /// A per-session cache for storing lua scripts
         /// </summary>
         internal readonly SessionScriptCache sessionScriptCache;

--- a/libs/server/Storage/Session/ObjectStore/HashOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/HashOps.cs
@@ -381,7 +381,7 @@ namespace Garnet.server
                 return GarnetStatus.OK;
 
             // Create a random seed
-            var seed = RandomGen.Next();
+            var seed = Random.Shared.Next();
 
             // Prepare the input
             var input = new ObjectInput
@@ -427,7 +427,7 @@ namespace Garnet.server
                 return GarnetStatus.OK;
 
             // Create a random seed
-            var seed = RandomGen.Next();
+            var seed = Random.Shared.Next();
 
             // Prepare the input
             var input = new ObjectInput

--- a/libs/server/Storage/Session/StorageSession.cs
+++ b/libs/server/Storage/Session/StorageSession.cs
@@ -50,8 +50,6 @@ namespace Garnet.server
 
         public readonly int ObjectScanCountLimit;
 
-        private static Random RandomGen = new();
-
         public StorageSession(StoreWrapper storeWrapper,
             ScratchBufferManager scratchBufferManager,
             GarnetSessionMetrics sessionMetrics,


### PR DESCRIPTION
When working on #620 I went down a little deadend randomizing client ids, and noticed these `static readonly Random` fields.

[Random isn't thread safe](https://learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-random#thread-safety), so these are all a little dangerous.

In .NET 6, [`Random.Shared`](https://learn.microsoft.com/en-us/dotnet/api/system.random.shared?view=net-8.0) was introduced and should be used instead.

Best I can tell the [thread local `Random` instances returned are seeded with the platforms CPRNG ](https://github.com/dotnet/runtime/blob/063ae05c63307becef004eefbc8704ccb03c7f04/src/libraries/System.Private.CoreLib/src/System/Random.Xoshiro128StarStarImpl.cs#L38) - so this shouldn't have any functional impact.