### PR TITLE
Additional validation around enum parsing

### DIFF
--- a/libs/cluster/CmdStrings.cs
+++ b/libs/cluster/CmdStrings.cs
@@ -52,6 +52,7 @@ namespace Garnet.cluster
         public static ReadOnlySpan<byte> RESP_ERR_INVALID_SLOT => "ERR Invalid or out of range slot"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_VALUE_IS_NOT_INTEGER => "ERR value is not an integer or out of range."u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_VALUE_IS_NOT_BOOLEAN => "ERR value is not a boolean."u8;
+        public static ReadOnlySpan<byte> RESP_SYNTAX_ERROR => "ERR syntax error"u8;
 
         /// <summary>
         /// Generic error response strings for <c>MIGRATE</c> command

--- a/libs/cluster/Server/HashSlot.cs
+++ b/libs/cluster/Server/HashSlot.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace Garnet.cluster
@@ -38,6 +39,23 @@ namespace Garnet.cluster
         /// Invalid slot state
         /// </summary>
         INVALID,
+    }
+
+    /// <summary>
+    /// Extension methods for <see cref="SlotState"/>.
+    /// </summary>
+    public static class SloteStateExtensions
+    {
+        /// <summary>
+        /// Validate that the given <see cref="SlotState"/> is legal, and _could_ have come from the given <see cref="ReadOnlySpan{T}"/>.
+        /// 
+        /// TODO: Long term we can kill this and use <see cref="IUtf8SpanParsable{ClientType}"/> instead of <see cref="Enum.TryParse{TEnum}(string?, bool, out TEnum)"/>
+        /// and avoid extra validation.  See: https://github.com/dotnet/runtime/issues/81500 .
+        /// </summary>
+        public static bool IsValid(this SlotState type, ReadOnlySpan<byte> fromSpan)
+        {
+            return type != SlotState.INVALID && type != SlotState.OFFLINE && Enum.IsDefined(type) && !fromSpan.ContainsAnyInRange((byte)'0', (byte)'9');
+        }
     }
 
     /// <summary>

--- a/libs/cluster/Server/HashSlot.cs
+++ b/libs/cluster/Server/HashSlot.cs
@@ -44,7 +44,7 @@ namespace Garnet.cluster
     /// <summary>
     /// Extension methods for <see cref="SlotState"/>.
     /// </summary>
-    public static class SloteStateExtensions
+    public static class SlotStateExtensions
     {
         /// <summary>
         /// Validate that the given <see cref="SlotState"/> is legal, and _could_ have come from the given <see cref="ReadOnlySpan{T}"/>.

--- a/libs/cluster/Session/FailoverCommand.cs
+++ b/libs/cluster/Session/FailoverCommand.cs
@@ -21,11 +21,15 @@ namespace Garnet.cluster
             var currTokenIdx = 0;
             while (currTokenIdx < parseState.Count)
             {
-                if (!parseState.TryGetEnum(currTokenIdx++, true, out FailoverOption failoverOption))
-                    failoverOption = FailoverOption.INVALID;
+                if (!parseState.TryGetEnum(currTokenIdx, true, out FailoverOption failoverOption) || !failoverOption.IsValid(parseState.GetArgSliceByRef(currTokenIdx).ReadOnlySpan))
+                {
+                    while (!RespWriteUtils.WriteError(CmdStrings.RESP_SYNTAX_ERROR, ref dcurr, dend))
+                        SendAndReset();
 
-                if (failoverOption == FailoverOption.INVALID)
-                    continue;
+                    return true;
+                }
+
+                currTokenIdx++;
 
                 switch (failoverOption)
                 {

--- a/libs/common/FailoverOption.cs
+++ b/libs/common/FailoverOption.cs
@@ -59,4 +59,21 @@ namespace Garnet.common
         public static byte[] GetRespFormattedFailoverOption(FailoverOption failoverOption)
             => infoSections[(int)failoverOption];
     }
+
+    /// <summary>
+    /// Extension methods for <see cref="FailoverOption"/>.
+    /// </summary>
+    public static class FailoverOptionExtensions
+    {
+        /// <summary>
+        /// Validate that the given <see cref="FailoverOption"/> is legal, and _could_ have come from the given <see cref="ReadOnlySpan{T}"/>.
+        /// 
+        /// TODO: Long term we can kill this and use <see cref="IUtf8SpanParsable{ClientType}"/> instead of <see cref="Enum.TryParse{TEnum}(string?, bool, out TEnum)"/>
+        /// and avoid extra validation.  See: https://github.com/dotnet/runtime/issues/81500 .
+        /// </summary>
+        public static bool IsValid(this FailoverOption type, ReadOnlySpan<byte> fromSpan)
+        {
+            return type != FailoverOption.DEFAULT && type != FailoverOption.INVALID && Enum.IsDefined(type) && !fromSpan.ContainsAnyInRange((byte)'0', (byte)'9');
+        }
+    }
 }

--- a/libs/server/ACL/ACLParser.cs
+++ b/libs/server/ACL/ACLParser.cs
@@ -250,7 +250,7 @@ namespace Garnet.server.ACL
 
                 string effectiveName = isSubCommand ? commandName[..subCommandSepIx] + "_" + commandName[(subCommandSepIx + 1)..] : commandName;
 
-                if (!Enum.TryParse(effectiveName, ignoreCase: true, out command))
+                if (!Enum.TryParse(effectiveName, ignoreCase: true, out command) || !IsValidParse(command, effectiveName))
                 {
                     // We handle these commands specially because blind replacements would cause
                     // us to be too accepting of different values
@@ -283,6 +283,15 @@ namespace Garnet.server.ACL
                 }
 
                 return !IsInvalidCommandToAcl(command);
+            }
+
+            // Returns true if the parsed value could possibly result in this command
+            //
+            // Used to handle the weirdness in Enum.TryParse - long term we probably
+            // shift to something like IUtf8SpanParsable.
+            static bool IsValidParse(RespCommand command, ReadOnlySpan<char> fromStr)
+            {
+                return command != RespCommand.NONE && command != RespCommand.INVALID && !fromStr.ContainsAnyInRange('0', '9');
             }
 
             // Some commands aren't really commands, so ACLs shouldn't accept their names

--- a/libs/server/ExpireOption.cs
+++ b/libs/server/ExpireOption.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
+
 namespace Garnet.server
 {
     /// <summary>
@@ -28,5 +30,22 @@ namespace Garnet.server
         /// Set expiry only when the new expiry is less than current one
         /// </summary>
         LT
+    }
+
+    /// <summary>
+    /// Extension methods for <see cref="ExpireOption"/>.
+    /// </summary>
+    public static class ExpireOptionExtensions
+    {
+        /// <summary>
+        /// Validate that the given <see cref="ExpireOption"/> is legal, and _could_ have come from the given <see cref="ArgSlice"/>.
+        /// 
+        /// TODO: Long term we can kill this and use <see cref="IUtf8SpanParsable{ClientType}"/> instead of <see cref="Enum.TryParse{TEnum}(string?, bool, out TEnum)"/>
+        /// and avoid extra validation.  See: https://github.com/dotnet/runtime/issues/81500 .
+        /// </summary>
+        public static bool IsValid(this ExpireOption type, ref ArgSlice fromSlice)
+        {
+            return type != ExpireOption.None && Enum.IsDefined(type) && !fromSlice.ReadOnlySpan.ContainsAnyInRange((byte)'0', (byte)'9');
+        }
     }
 }

--- a/libs/server/Resp/KeyAdminCommands.cs
+++ b/libs/server/Resp/KeyAdminCommands.cs
@@ -134,23 +134,18 @@ namespace Garnet.server
                 ? TimeSpan.FromSeconds(expiryValue)
                 : TimeSpan.FromMilliseconds(expiryValue);
 
-            var invalidOption = false;
             var expireOption = ExpireOption.None;
-            var optionStr = "";
 
             if (parseState.Count > 2)
             {
-                if (!parseState.TryGetEnum(2, true, out expireOption))
+                if (!parseState.TryGetEnum(2, true, out expireOption) || !expireOption.IsValid(ref parseState.GetArgSliceByRef(2)))
                 {
-                    invalidOption = true;
-                }
-            }
+                    var optionStr = parseState.GetString(2);
 
-            if (invalidOption)
-            {
-                while (!RespWriteUtils.WriteError($"ERR Unsupported option {optionStr}", ref dcurr, dend))
-                    SendAndReset();
-                return true;
+                    while (!RespWriteUtils.WriteError($"ERR Unsupported option {optionStr}", ref dcurr, dend))
+                        SendAndReset();
+                    return true;
+                }
             }
 
             var status = command == RespCommand.EXPIRE ?

--- a/libs/server/Resp/Parser/SessionParseState.cs
+++ b/libs/server/Resp/Parser/SessionParseState.cs
@@ -211,7 +211,7 @@ namespace Garnet.server
         /// </summary>
         /// <returns>True if enum parsed successfully</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public T GetEnum<T>(int i, bool ignoreCase) where T : struct
+        public T GetEnum<T>(int i, bool ignoreCase) where T : struct, Enum
         {
             Debug.Assert(i < Count);
             return Enum.Parse<T>(GetString(i), ignoreCase);
@@ -222,7 +222,7 @@ namespace Garnet.server
         /// </summary>
         /// <returns>True if integer parsed successfully</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool TryGetEnum<T>(int i, bool ignoreCase, out T value) where T : struct
+        public bool TryGetEnum<T>(int i, bool ignoreCase, out T value) where T : struct, Enum
         {
             Debug.Assert(i < Count);
             return Enum.TryParse(GetString(i), ignoreCase, out value);

--- a/test/Garnet.test.cluster/ClusterManagementTests.cs
+++ b/test/Garnet.test.cluster/ClusterManagementTests.cs
@@ -317,5 +317,42 @@ namespace Garnet.test.cluster
                 ClassicAssert.AreEqual("ERR syntax error", errorMsg);
             }
         }
+
+
+
+        [Test]
+        public void ClusterFailoverBadOptions()
+        {
+            var node_count = 4;
+            context.CreateInstances(node_count);
+            context.CreateConnection();
+            var (_, _) = context.clusterTestUtils.SimpleSetupCluster(node_count, 0, logger: context.logger);
+
+            var endpoint = (IPEndPoint)context.endpoints[0];
+
+            // Default rejected
+            {
+                var errorMsg = (string)context.clusterTestUtils.Execute(endpoint, "CLUSTER", ["FAILOVER", "DEFAULT"]);
+                ClassicAssert.AreEqual("ERR Failover option (DEFAULT) not supported", errorMsg);
+            }
+
+            // Invalid rejected
+            {
+                var errorMsg = (string)context.clusterTestUtils.Execute(endpoint, "CLUSTER", ["FAILOVER", "Invalid"]);
+                ClassicAssert.AreEqual("ERR Failover option (Invalid) not supported", errorMsg);
+            }
+
+            // Numeric equivalent rejected
+            {
+                var errorMsg = (string)context.clusterTestUtils.Execute(endpoint, "CLUSTER", ["FAILOVER", "2"]);
+                ClassicAssert.AreEqual("ERR Failover option (2) not supported", errorMsg);
+            }
+
+            // Numeric out of range rejected
+            {
+                var errorMsg = (string)context.clusterTestUtils.Execute(endpoint, "CLUSTER", ["FAILOVER", "128"]);
+                ClassicAssert.AreEqual("ERR Failover option (128) not supported", errorMsg);
+            }
+        }
     }
 }

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -1592,7 +1592,16 @@ namespace Garnet.test.cluster
 
         public static string SetSlot(ref LightClientRequest node, int slot, string state, string nodeid)
         {
-            var resp = node.SendCommand($"cluster setslot {slot} {state} {nodeid}");
+            byte[] resp;
+            if (nodeid != "")
+            {
+                resp = node.SendCommand($"cluster setslot {slot} {state} {nodeid}");
+            }
+            else
+            {
+                resp = node.SendCommand($"cluster setslot {slot} {state}");
+            }
+
             return ParseRespToString(resp, out _);
         }
 
@@ -1607,7 +1616,17 @@ namespace Garnet.test.cluster
             var server = GetServer(endPoint);
             try
             {
-                return (string)server.Execute("cluster", "setslot", $"{slot}", $"{state}", $"{nodeid}");
+                string ret;
+                if (nodeid != "")
+                {
+                    ret = (string)server.Execute("cluster", "setslot", $"{slot}", $"{state}", $"{nodeid}");
+                }
+                else
+                {
+                    ret = (string)server.Execute("cluster", "setslot", $"{slot}", $"{state}");
+                }
+
+                return ret;
             }
             catch (RedisTimeoutException tex)
             {

--- a/test/Garnet.test/Resp/ACL/AclConfigurationFileTests.cs
+++ b/test/Garnet.test/Resp/ACL/AclConfigurationFileTests.cs
@@ -289,12 +289,42 @@ namespace Garnet.test.Resp.ACL
         [Test]
         public void BadInputMalformedStatement()
         {
-            // Create an empty input file
-            var configurationFile = Path.Join(TestUtils.MethodTestDir, "users.acl");
-            File.WriteAllText(configurationFile, "user test on >password123 +@admin\r\nuser testB badinput on >passw0rd >password +@admin ");
+            // Test badinput
+            {
+                var configurationFile = Path.Join(TestUtils.MethodTestDir, "users.acl");
+                File.WriteAllText(configurationFile, "user test on >password123 +@admin\r\nuser testB badinput on >passw0rd >password +@admin ");
 
-            // Ensure Garnet starts up and just ignores the malformed statement
-            Assert.Throws<ACLException>(() => TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, useAcl: true, aclFile: configurationFile));
+                // Ensure Garnet starts up and just ignores the malformed statement
+                Assert.Throws<ACLException>(() => TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, useAcl: true, aclFile: configurationFile));
+            }
+
+            // Test numeric RespCommand rejected
+            //{
+            //    var configurationFile = Path.Join(TestUtils.MethodTestDir, "users2.acl");
+            //    File.WriteAllText(configurationFile, "user test on >password123 +1");
+
+            //    // Ensure Garnet starts up and just ignores the malformed statement
+            //    Assert.Throws<ACLException>(() => TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, useAcl: true, aclFile: configurationFile));
+            //}
+
+            // Test None rejected
+            {
+                var configurationFile = Path.Join(TestUtils.MethodTestDir, "users3.acl");
+                File.WriteAllText(configurationFile, "user test on >password123 +none");
+
+                // Ensure Garnet starts up and just ignores the malformed statement
+                Assert.Throws<ACLException>(() => TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, useAcl: true, aclFile: configurationFile));
+            }
+
+
+            // Test Invalid rejected
+            {
+                var configurationFile = Path.Join(TestUtils.MethodTestDir, "users4.acl");
+                File.WriteAllText(configurationFile, "user test on >password123 +invalid");
+
+                // Ensure Garnet starts up and just ignores the malformed statement
+                Assert.Throws<ACLException>(() => TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, useAcl: true, aclFile: configurationFile));
+            }
         }
 
         [Test]

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -1588,6 +1588,41 @@ namespace Garnet.test
         }
 
         [Test]
+        [TestCase("EXPIRE")]
+        [TestCase("PEXPIRE")]
+        public void KeyExpireBadOptionTests(string command)
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            ClassicAssert.IsTrue(db.StringSet("foo", "bar"));
+
+            // Invalid should be rejected
+            {
+                var exc = ClassicAssert.Throws<RedisServerException>(() => db.Execute(command, "foo", "100", "Q"));
+                ClassicAssert.AreEqual("ERR Unsupported option Q", exc.Message);
+            }
+
+            // None should be rejected
+            {
+                var exc = ClassicAssert.Throws<RedisServerException>(() => db.Execute(command, "foo", "100", "None"));
+                ClassicAssert.AreEqual("ERR Unsupported option None", exc.Message);
+            }
+
+            // Numeric equivalent should be rejected
+            {
+                var exc = ClassicAssert.Throws<RedisServerException>(() => db.Execute(command, "foo", "100", "1"));
+                ClassicAssert.AreEqual("ERR Unsupported option 1", exc.Message);
+            }
+
+            // Numeric out of bounds should be rejected
+            {
+                var exc = ClassicAssert.Throws<RedisServerException>(() => db.Execute(command, "foo", "100", "128"));
+                ClassicAssert.AreEqual("ERR Unsupported option 128", exc.Message);
+            }
+        }
+
+        [Test]
         public async Task ReAddExpiredKey()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());


### PR DESCRIPTION
Noticed as part of #620 that some invalid options were accepted, which is rooted in use of `Enum.TryParse`.

`Enum.(Try)Parse` is a weird one, because it accepts _any_ numeric value that'll fit in the underlying type as well as named types.  Additionally we're not checking that certain internal/default values aren't provided.

Long term the fix is probably to use [`IUtf8SpanParsable`](https://learn.microsoft.com/en-us/dotnet/api/system.iutf8spanparsable-1?view=net-8.0) (which isn't implemented for enums yet), or some other custom parsing, in order to remove the intermediate string allocation.  But for now, I'm just adding correct validation.

I think it would make sense for all of this to be enforced in `SessionParseState` instead of with per-enum extension methods, but that would be a larger change - and would probably require some code gen (or reflection).  It would make sense to do as part of a large parsing rationalization, in my opinion.

Changes:
 - Options to `FAILOVER` and `CLUSTER|FAILOVER` are validated (`FailoverOption` enum)
 - Options to `EXPIRE` and `PEXPIRE` are validated (`ExpireOption` enum)
 - Options to `CLUSTER|SETSLOT` are validated (`SlotState` enum)
 - Command names are validated as part of ACL rules (`RespCommand` enum, but as a one off instead of an extension method)
 
 Other notes:
 - `CLUSTER|SETSLOT` incorrectly allowed node id to be passed along with `STABLE` option, that is fixed in this PR.
 - I didn't modify `INFO` - in Redis it just ignores bad section names, current Garnet behavior is to error.  So it's kind wrong either way, fixing the parse isn't sufficient.
 - Similarly `LATENCY|HISTOGRAM` differs enough from Redis behavior that I didn't modify it.
 - `CLUSTER|SETSLOTSRANGE` is internal to clustering, so I left it alone.