### PR TITLE
chore: skip nightly & locker workflows on forks

### DIFF
--- a/.github/workflows/locker.yml
+++ b/.github/workflows/locker.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   main:
+    if: github.repository == 'microsoft/garnet'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,7 @@ jobs:
   build-test-garnet:
     name: Garnet
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'microsoft/garnet'
     strategy:
       fail-fast: false
       matrix:
@@ -46,6 +47,7 @@ jobs:
   build-test-tsavorite:        
     name: Tsavorite
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'microsoft/garnet'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
both the nightly & locker workflow depend on some configuration that is set only on the main garnet repo (not on forks)