### PR TITLE
IPv6 Cluster Support

### DIFF
--- a/libs/client/GarnetClient.cs
+++ b/libs/client/GarnetClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
@@ -247,7 +248,8 @@ namespace Garnet.client
 
         Socket GetSendSocket(int millisecondsTimeout = 0)
         {
-            _ = Format.TryParseEndPoint($"{address}:{port}", out var endPoint);
+            var ip = IPAddress.Parse(address);
+            var endPoint = new IPEndPoint(ip, port);
 
             var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
             {
@@ -256,7 +258,7 @@ namespace Garnet.client
 
             if (millisecondsTimeout > 0)
             {
-                IAsyncResult result = socket.BeginConnect(endPoint, null, null);
+                var result = socket.BeginConnect(endPoint, null, null);
                 result.AsyncWaitHandle.WaitOne(millisecondsTimeout, true);
 
                 if (socket.Connected)

--- a/libs/cluster/Server/ClusterManager.cs
+++ b/libs/cluster/Server/ClusterManager.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using Garnet.common;
-using Garnet.server;
 using Garnet.server.TLS;
 using Microsoft.Extensions.Logging;
 using Tsavorite.core;
@@ -50,7 +49,7 @@ namespace Garnet.cluster
             clusterConfigDevice = deviceFactory.Get(new FileDescriptor(directoryName: "", fileName: "nodes.conf"));
             pool = new(1, (int)clusterConfigDevice.SectorSize);
 
-            var address = opts.Address ?? StoreWrapper.GetIp();
+            var address = clusterProvider.storeWrapper.GetIp();
             this.logger = logger;
             var recoverConfig = clusterConfigDevice.GetFileSize(0) > 0 && !opts.CleanClusterConfig;
 

--- a/libs/cluster/Server/ClusterProvider.cs
+++ b/libs/cluster/Server/ClusterProvider.cs
@@ -293,7 +293,7 @@ namespace Garnet.cluster
         /// <returns></returns>
         internal bool BumpAndWaitForEpochTransition()
         {
-            var server = storeWrapper.GetServer();
+            var server = storeWrapper.GetTcpServer();
             BumpCurrentEpoch();
             while (true)
             {

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -7,7 +7,6 @@ using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography;
 using System.Text;
 using Garnet.common;
 using Garnet.common.Parsing;
@@ -191,7 +190,7 @@ namespace Garnet.server
             this.customCommandManagerSession = new CustomCommandManagerSession(storeWrapper.customCommandManager);
             this.sessionMetrics = storeWrapper.serverOptions.MetricsSamplingFrequency > 0 ? new GarnetSessionMetrics() : null;
             this.LatencyMetrics = storeWrapper.serverOptions.LatencyMonitor ? new GarnetLatencyMetricsSession(storeWrapper.monitor) : null;
-            logger = storeWrapper.sessionLogger != null ? new SessionLogger(storeWrapper.sessionLogger, $"[{storeWrapper.localEndpoint}] [{networkSender?.RemoteEndpointName}] [{GetHashCode():X8}] ") : null;
+            logger = storeWrapper.sessionLogger != null ? new SessionLogger(storeWrapper.sessionLogger, $"[{networkSender?.RemoteEndpointName}] [{GetHashCode():X8}] ") : null;
 
             this.Id = id;
             this.CreationTicks = Environment.TickCount64;

--- a/libs/server/Servers/GarnetServerBase.cs
+++ b/libs/server/Servers/GarnetServerBase.cs
@@ -116,7 +116,7 @@ namespace Garnet.server
         /// <param name="logger"></param>
         public GarnetServerBase(string address, int port, int networkBufferSize, ILogger logger = null)
         {
-            this.logger = logger == null ? null : new SessionLogger(logger, $"[{address ?? StoreWrapper.GetIp()}:{port}] ");
+            this.logger = logger;
             this.address = address;
             this.port = port;
             this.networkBufferSize = networkBufferSize;

--- a/libs/server/Servers/GarnetServerTcp.cs
+++ b/libs/server/Servers/GarnetServerTcp.cs
@@ -24,6 +24,15 @@ namespace Garnet.server
         readonly int networkSendThrottleMax;
         readonly LimitedFixedBufferPool networkPool;
 
+        public IPEndPoint GetEndPoint
+        {
+            get
+            {
+                var ip = string.IsNullOrEmpty(Address) ? IPAddress.Any : IPAddress.Parse(Address);
+                return new IPEndPoint(ip, Port);
+            }
+        }
+
         /// <summary>
         /// Get active consumers
         /// </summary>
@@ -65,8 +74,7 @@ namespace Garnet.server
             this.tlsOptions = tlsOptions;
             this.networkSendThrottleMax = networkSendThrottleMax;
             this.networkPool = new LimitedFixedBufferPool(BufferSizeUtils.ServerBufferSize(new MaxSizeSettings()), logger: logger);
-            var ip = string.IsNullOrEmpty(Address) ? IPAddress.Any : IPAddress.Parse(Address);
-            servSocket = new Socket(ip.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            servSocket = new Socket(GetEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
             acceptEventArg = new SocketAsyncEventArgs();
             acceptEventArg.Completed += AcceptEventArg_Completed;
         }
@@ -88,8 +96,7 @@ namespace Garnet.server
         /// </summary>
         public override void Start()
         {
-            var ip = Address == null ? IPAddress.Any : IPAddress.Parse(Address);
-            var endPoint = new IPEndPoint(ip, Port);
+            var endPoint = GetEndPoint;
             servSocket.Bind(endPoint);
             servSocket.Listen(512);
             if (!servSocket.AcceptAsync(acceptEventArg))


### PR DESCRIPTION
This PR fixes the following issues:

- [x] Add support for mapping empty string to IPAddress.Any
- [x] Correctly calculate IPv4 and IPv6 address in cluster nodes when IPAddress.Any is provided.
- [x] Parse check client address at socket initialization using CLR methods.