### PR TITLE
Don't crash if innerException is null

### DIFF
--- a/libs/server/Lua/LuaCommands.cs
+++ b/libs/server/Lua/LuaCommands.cs
@@ -231,7 +231,7 @@ namespace Garnet.server
             }
             catch (LuaScriptException ex)
             {
-                logger?.LogError(ex.InnerException, "Error executing Lua script callback");
+                logger?.LogError(ex.InnerException ?? ex, "Error executing Lua script callback");
                 while (!RespWriteUtils.WriteError("ERR " + (ex.InnerException ?? ex).Message, ref dcurr, dend))
                     SendAndReset();
                 return true;

--- a/libs/server/Lua/LuaCommands.cs
+++ b/libs/server/Lua/LuaCommands.cs
@@ -232,7 +232,7 @@ namespace Garnet.server
             catch (LuaScriptException ex)
             {
                 logger?.LogError(ex.InnerException, "Error executing Lua script callback");
-                while (!RespWriteUtils.WriteError("ERR " + ex.InnerException.Message, ref dcurr, dend))
+                while (!RespWriteUtils.WriteError("ERR " + (ex.InnerException ?? ex).Message, ref dcurr, dend))
                     SendAndReset();
                 return true;
             }


### PR DESCRIPTION
This PR keeps Garnet from crashing if a `LuaScriptException` is thrown that does not have an `InnerException`