### PR TITLE
Handle status_reply and error_reply properly

### DIFF
--- a/libs/server/Lua/LuaCommands.cs
+++ b/libs/server/Lua/LuaCommands.cs
@@ -196,7 +196,12 @@ namespace Garnet.server
                 object scriptResult = scriptRunner.Run(count, parseState);
                 if (scriptResult != null)
                 {
-                    if (scriptResult is string s)
+                    if (scriptResult is LuaSimpleString lss)
+                    {
+                        while (!RespWriteUtils.WriteSimpleString(lss.getContents(), ref dcurr, dend))
+                            SendAndReset();
+                    }
+                    else if (scriptResult is string s)
                     {
                         while (!RespWriteUtils.WriteAsciiBulkString(s, ref dcurr, dend))
                             SendAndReset();

--- a/libs/server/Lua/LuaCommands.cs
+++ b/libs/server/Lua/LuaCommands.cs
@@ -229,6 +229,13 @@ namespace Garnet.server
                         SendAndReset();
                 }
             }
+            catch (LuaResultException ex)
+            {
+                // A LuaResultException is thrown for the return from redis.error_reply() and should not be prefixed with ERR
+                while (!RespWriteUtils.WriteError(ex.Message, ref dcurr, dend))
+                    SendAndReset();
+                return true;
+            }
             catch (LuaScriptException ex)
             {
                 logger?.LogError(ex.InnerException ?? ex, "Error executing Lua script callback");

--- a/libs/server/Lua/LuaResultException.cs
+++ b/libs/server/Lua/LuaResultException.cs
@@ -8,10 +8,10 @@ using Azure.Messaging;
 namespace Garnet.server
 {
     [Serializable]
-    public class LuaResultException: Exception
+    public class LuaResultException : Exception
     {
         public LuaResultException() : base() { }
-        public LuaResultException(String message) : base(message) { }            
+        public LuaResultException(String message) : base(message) { }
         public LuaResultException(string message, Exception innerException) : base(message, innerException) { }
     }
 }

--- a/libs/server/Lua/LuaResultException.cs
+++ b/libs/server/Lua/LuaResultException.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Transactions;
+using Azure.Messaging;
+
+namespace Garnet.server
+{
+    [Serializable]
+    public class LuaResultException: Exception
+    {
+        public LuaResultException() : base() { }
+        public LuaResultException(String message) : base(message) { }            
+        public LuaResultException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/libs/server/Lua/LuaRunner.cs
+++ b/libs/server/Lua/LuaRunner.cs
@@ -400,7 +400,7 @@ namespace Garnet.server
                 {
                     if (luaTable["ok"] != null)
                     {
-                        return luaTable["ok"].ToString();
+                        return new LuaSimpleString(luaTable["ok"].ToString());
                     }
                     else if (luaTable["err"] != null)
                     {

--- a/libs/server/Lua/LuaSimpleString.cs
+++ b/libs/server/Lua/LuaSimpleString.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+
+
+namespace Garnet.server
+{
+    class LuaSimpleString
+    {
+        private string contents;
+
+        public LuaSimpleString(string contents)
+        {
+            this.contents = contents;
+        }
+
+        public string getContents()
+        {
+            return contents;
+        }
+    }
+}

--- a/test/Garnet.test/LuaScriptTests.cs
+++ b/test/Garnet.test/LuaScriptTests.cs
@@ -337,7 +337,7 @@ namespace Garnet.test
             {
                 ClassicAssert.AreEqual(ex.Message, "Failure");
             }
-            var directReplyScript = "return { err = 'Success' }";
+            var directReplyScript = "return { err = 'Failure' }";
             try
             {
                 _ = db.ScriptEvaluate(directReplyScript);


### PR DESCRIPTION
This PR adds the `redis.status_reply` and `redis.error_reply` Lua functions to the code base. It also adds code to handle the return value from these functions (a Lua table) correctly - thanks to @danielchristianschroeter for example code.
To match Redis behavior in the `redis.error_reply` case I added a new exception type that does not add the "ERR " prefix to the return message.
Redis output:
```
127.0.0.1:6379> EVAL "return { ok = 'Success' }" 0
Success
127.0.0.1:6379> EVAL "return { err = 'Failure' }" 0
(error) Failure
127.0.0.1:6379> EVAL "return redis.status_reply('Success')" 0
Success
127.0.0.1:6379> EVAL "return redis.error_reply('Failure')" 0
(error) Failure
```
Garnet output with this code:
```
172.24.80.1:6379> EVAL "return { ok = 'Success' }" 0
Success
172.24.80.1:6379> EVAL "return { err = 'Failure' }" 0
(error) Failure
172.24.80.1:6379> EVAL "return redis.status_reply('Success')" 0
Success
172.24.80.1:6379> EVAL "return redis.error_reply('Failure')" 0
(error) Failure
```
I also added a wrapper around String that can be used to allow methods to specify that their return value should be a SimpleString instead of a BulkString to bring Garnet's replies closer to what Redis returns.