### PR TITLE
Tsavorite allocator - tighten the packing of pages

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -3,7 +3,7 @@
 #      1) update the name: string below (line 6)     -- this is the version for the nuget package (e.g. 1.0.0)
 #      2) update \libs\host\GarnetServer.cs readonly string version  (~line 53)   -- NOTE - these two values need to be the same 
 ###################################### 
-name: 1.0.24
+name: 1.0.25
 trigger:
   branches:
     include:

--- a/libs/cluster/Server/Replication/PrimaryOps/AofTaskStore.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/AofTaskStore.cs
@@ -41,7 +41,7 @@ namespace Garnet.cluster
                 logPageSizeMask = logPageSize - 1;
                 if (clusterProvider.serverOptions.MainMemoryReplication)
                     clusterProvider.storeWrapper.appendOnlyFile.SafeTailShiftCallback = SafeTailShiftCallback;
-                TruncateLagAddress = clusterProvider.storeWrapper.appendOnlyFile.UnsafeGetReadOnlyLagAddress() - 2 * logPageSize;
+                TruncateLagAddress = clusterProvider.storeWrapper.appendOnlyFile.UnsafeGetReadOnlyAddressLagOffset() - 2 * logPageSize;
             }
             TruncatedUntil = 0;
         }

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicationReplicaAofSync.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicationReplicaAofSync.cs
@@ -38,9 +38,9 @@ namespace Garnet.cluster
 
                 if (clusterProvider.serverOptions.MainMemoryReplication)
                 {
-                    var firstRecordLength = GetFirstAofEntryLength(record);
-                    if (previousAddress > ReplicationOffset ||
-                        currentAddress >= previousAddress + firstRecordLength)
+                    // If the incoming AOF chunk fits in the space between previousAddress and currentAddress (ReplicationOffset),
+                    // an enqueue will result in an offset mismatch. So, we have to first reset the AOF to point to currentAddress.
+                    if (currentAddress >= previousAddress + recordLength)
                     {
                         logger?.LogWarning("MainMemoryReplication: Skipping from {ReplicaReplicationOffset} to {currentAddress}", ReplicationOffset, currentAddress);
                         storeWrapper.appendOnlyFile.Initialize(currentAddress, currentAddress);
@@ -54,15 +54,6 @@ namespace Garnet.cluster
                     logger?.LogInformation("Processing {recordLength} bytes; previousAddress {previousAddress}, currentAddress {currentAddress}, nextAddress {nextAddress}, current AOF tail {tail}", recordLength, previousAddress, currentAddress, nextAddress, storeWrapper.appendOnlyFile.TailAddress);
                     logger?.LogError("Before ProcessPrimaryStream: Replication offset mismatch: ReplicaReplicationOffset {ReplicaReplicationOffset}, aof.TailAddress {tailAddress}", ReplicationOffset, storeWrapper.appendOnlyFile.TailAddress);
                     throw new GarnetException($"Before ProcessPrimaryStream: Replication offset mismatch: ReplicaReplicationOffset {ReplicationOffset}, aof.TailAddress {storeWrapper.appendOnlyFile.TailAddress}", LogLevel.Warning, clientResponse: false);
-                }
-
-                // If there is a gap between the local tail and incoming currentAddress, try to skip local AOF to the next page
-                if (currentAddress >= storeWrapper.appendOnlyFile.TailAddress + recordLength
-                    && storeWrapper.appendOnlyFile.GetPage(currentAddress) == storeWrapper.appendOnlyFile.GetPage(storeWrapper.appendOnlyFile.TailAddress) + 1)
-                {
-                    logger?.LogWarning("SkipPage from {previousAddress} to {currentAddress}, tail is {tailAddress}", previousAddress, currentAddress, storeWrapper.appendOnlyFile.TailAddress);
-                    storeWrapper.appendOnlyFile.UnsafeSkipPage();
-                    logger?.LogWarning("New tail after SkipPage is {tailAddress}", storeWrapper.appendOnlyFile.TailAddress);
                 }
 
                 // Enqueue to AOF

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicationReplicaAofSync.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicationReplicaAofSync.cs
@@ -42,7 +42,7 @@ namespace Garnet.cluster
                     // an enqueue will result in an offset mismatch. So, we have to first reset the AOF to point to currentAddress.
                     if (currentAddress >= previousAddress + recordLength)
                     {
-                        //logger?.LogWarning("MainMemoryReplication: Skipping from {ReplicaReplicationOffset} to {currentAddress}", ReplicationOffset, currentAddress);
+                        logger?.LogWarning("MainMemoryReplication: Skipping from {ReplicaReplicationOffset} to {currentAddress}", ReplicationOffset, currentAddress);
                         storeWrapper.appendOnlyFile.Initialize(currentAddress, currentAddress);
                         ReplicationOffset = currentAddress;
                     }

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicationReplicaAofSync.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicationReplicaAofSync.cs
@@ -42,7 +42,7 @@ namespace Garnet.cluster
                     // an enqueue will result in an offset mismatch. So, we have to first reset the AOF to point to currentAddress.
                     if (currentAddress >= previousAddress + recordLength)
                     {
-                        logger?.LogWarning("MainMemoryReplication: Skipping from {ReplicaReplicationOffset} to {currentAddress}", ReplicationOffset, currentAddress);
+                        //logger?.LogWarning("MainMemoryReplication: Skipping from {ReplicaReplicationOffset} to {currentAddress}", ReplicationOffset, currentAddress);
                         storeWrapper.appendOnlyFile.Initialize(currentAddress, currentAddress);
                         ReplicationOffset = currentAddress;
                     }

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -49,7 +49,7 @@ namespace Garnet
         protected StoreWrapper storeWrapper;
 
         // IMPORTANT: Keep the version in sync with .azure\pipelines\azure-pipelines-external-release.yml line ~6.
-        readonly string version = "1.0.24";
+        readonly string version = "1.0.25";
 
         /// <summary>
         /// Resp protocol version

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Buffers;
-using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -433,7 +432,7 @@ namespace Garnet.server
                         }
                         else
                         {
-                            if (CanServeSlot(cmd))
+                            if (clusterSession == null || CanServeSlot(cmd))
                                 _ = ProcessBasicCommands(cmd, ref basicGarnetApi);
                         }
                     }

--- a/libs/server/Resp/RespServerSessionSlotVerify.cs
+++ b/libs/server/Resp/RespServerSessionSlotVerify.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Diagnostics;
 using Garnet.common;
 
 namespace Garnet.server
@@ -33,9 +34,7 @@ namespace Garnet.server
 
         bool CanServeSlot(RespCommand cmd)
         {
-            // If cluster is disable all commands
-            if (clusterSession == null)
-                return true;
+            Debug.Assert(clusterSession != null);
 
             // Verify slot for command if it falls into data command category
             if (!cmd.IsDataCommand())

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
@@ -577,8 +577,8 @@ namespace Tsavorite.core
             if (SegmentSize < PageSize)
                 throw new TsavoriteException($"Segment ({SegmentSize}) must be at least of page size ({PageSize})");
 
-            if ((LogTotalSizeBits != 0) && (LogTotalSizeBytes < PageSize))
-                throw new TsavoriteException($"Memory size ({LogTotalSizeBytes}) must be configured to be either 1 (i.e., 0 bits) or at least page size ({PageSize})");
+            if ((LogTotalSizeBits != 0) && (LogTotalSizeBytes < PageSize * 2))
+                throw new TsavoriteException($"Memory size ({LogTotalSizeBytes}) must be at least twice the page size ({PageSize})");
 
             // Readonlymode has MemorySizeBits 0 => skip the check
             if (settings.MemorySizeBits > 0 && settings.MinEmptyPageCount > MaxEmptyPageCount)

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
@@ -66,7 +66,7 @@ namespace Tsavorite.core
         /// <summary>How many pages do we leave empty in the in-memory buffer (between 0 and BufferSize-1)</summary>
         private int emptyPageCount;
 
-        /// <summary>HeadOFfset lag address</summary>
+        /// <summary>HeadOffset lag address</summary>
         internal long HeadOffsetLagAddress;
 
         /// <summary>
@@ -861,8 +861,17 @@ namespace Tsavorite.core
         {
             // Issue the shift of address
             var shiftAddress = pageIndex << LogPageSizeBits;
-            PageAlignedShiftReadOnlyAddress(shiftAddress);
-            PageAlignedShiftHeadAddress(shiftAddress);
+            var tailAddress = GetTailAddress();
+
+            long desiredReadOnlyAddress = shiftAddress - ReadOnlyLagAddress;
+            if (desiredReadOnlyAddress > tailAddress)
+                desiredReadOnlyAddress = tailAddress;
+            ShiftReadOnlyAddress(desiredReadOnlyAddress);
+
+            long desiredHeadAddress = shiftAddress - HeadOffsetLagAddress;
+            if (desiredHeadAddress > tailAddress)
+                desiredHeadAddress = tailAddress;
+            ShiftHeadAddress(desiredHeadAddress);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
@@ -879,7 +879,9 @@ namespace Tsavorite.core
                 return -1; // RETRY_NOW
             }
 
-            // The single thread that "owns" the page-increment proceeds below.
+            // The single thread that "owns" the page-increment proceeds below. This is the thread for which:
+            // 1. Old image of offset (pre-Interlocked.Increment) is <= PageSize, and
+            // 2. New image of offset (post-Interlocked.Increment) is > PageSize.
             if (NeedToWait(pageIndex))
             {
                 // Reset to previous tail so that next attempt can retry
@@ -894,7 +896,7 @@ namespace Tsavorite.core
                     return 0; // RETRY_LATER
             }
 
-            // The thread that "makes" the offset incorrect should allocate next page and set new tail
+            // Allocate next page and set new tail
             if (CannotAllocate(pageIndex))
             {
                 // Reset to previous tail so that next attempt can retry

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
@@ -783,6 +783,8 @@ namespace Tsavorite.core
             var local = TailPageOffset;
 
             // Handle corner cases during page overflow
+            // The while loop is guaranteed to terminate because HandlePageOverflow
+            // ensures that it fixes the unstable TailPageOffset immediately.
             while (local.Offset >= PageSize)
             {
                 if (local.Offset == PageSize)

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/BlockAllocate.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/BlockAllocate.cs
@@ -28,6 +28,7 @@ namespace Tsavorite.core
                 return true;
             }
 
+            // logicalAddress less than 0 (RETRY_NOW) should already have been handled
             Debug.Assert(logicalAddress == 0);
             // We expect flushEvent to be signaled.
             internalStatus = OperationStatus.ALLOCATE_FAILED;

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/BlockAllocate.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/BlockAllocate.cs
@@ -20,7 +20,7 @@ namespace Tsavorite.core
                 out OperationStatus internalStatus)
         {
             pendingContext.flushEvent = allocator.FlushEvent;
-            logicalAddress = allocator.TryAllocate(recordSize);
+            logicalAddress = allocator.TryAllocateRetryNow(recordSize);
             if (logicalAddress > 0)
             {
                 pendingContext.flushEvent = default;
@@ -28,17 +28,9 @@ namespace Tsavorite.core
                 return true;
             }
 
-            if (logicalAddress == 0)
-            {
-                // We expect flushEvent to be signaled.
-                internalStatus = OperationStatus.ALLOCATE_FAILED;
-                return false;
-            }
-
-            // logicalAddress is < 0 so we do not expect flushEvent to be signaled; return RETRY_LATER to refresh the epoch.
-            pendingContext.flushEvent = default;
-            allocator.TryComplete();
-            internalStatus = OperationStatus.RETRY_LATER;
+            Debug.Assert(logicalAddress == 0);
+            // We expect flushEvent to be signaled.
+            internalStatus = OperationStatus.ALLOCATE_FAILED;
             return false;
         }
 

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/BlockAllocate.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/BlockAllocate.cs
@@ -34,10 +34,14 @@ namespace Tsavorite.core
             return false;
         }
 
+        /// <summary>Options for TryAllocateRecord.</summary>
         internal struct AllocateOptions
         {
+            /// <summary>If true, use the non-revivification recycling of records that failed to CAS and are carried in PendingContext through RETRY.</summary>
             internal bool Recycle;
-            internal bool IgnoreHeiAddress;
+
+            /// <summary>If true, the source record is elidable so we can try to elide from the tag chain (and transfer it to the FreeList if we're doing Revivification).</summary>
+            internal bool ElideSourceRecord;
         };
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -56,7 +60,7 @@ namespace Tsavorite.core
                 return true;
             if (RevivificationManager.UseFreeRecordPool)
             {
-                if (!options.IgnoreHeiAddress && stackCtx.hei.Address >= minMutableAddress)
+                if (!options.ElideSourceRecord && stackCtx.hei.Address >= minMutableAddress)
                     minRevivAddress = stackCtx.hei.Address;
                 if (sessionFunctions.Ctx.IsInV1)
                 {

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalUpsert.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalUpsert.cs
@@ -139,6 +139,13 @@ namespace Tsavorite.core
                     // ConcurrentWriter failed (e.g. insufficient space, another thread set Tombstone, etc). Write a new record, but track that we have to seal and unlock this one.
                     goto CreateNewRecord;
                 }
+                if (stackCtx.recSrc.LogicalAddress >= hlogBase.HeadAddress)
+                {
+                    // Safe Read-Only Region: Create a record in the mutable region, but set srcRecordInfo in case we are eliding.
+                    if (stackCtx.recSrc.HasMainLogSrc)
+                        srcRecordInfo = ref stackCtx.recSrc.GetInfo();
+                    goto CreateNewRecord;
+                }
 
                 // No record exists, or readonly or below. Drop through to create new record.
                 Debug.Assert(!sessionFunctions.IsManualLocking || LockTable.IsLockedExclusive(ref stackCtx.hei), "A Lockable-session Upsert() of an on-disk or non-existent key requires a LockTable lock");
@@ -303,9 +310,7 @@ namespace Tsavorite.core
             AllocateOptions allocOptions = new()
             {
                 Recycle = true,
-
-                // If the source record is elidable we can try to elide from the chain and transfer it to the FreeList if we're doing Revivification
-                IgnoreHeiAddress = stackCtx.recSrc.HasMainLogSrc && CanElide<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref stackCtx, ref srcRecordInfo)
+                ElideSourceRecord = stackCtx.recSrc.HasMainLogSrc && CanElide<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref stackCtx, ref srcRecordInfo)
             };
 
             if (!TryAllocateRecord(sessionFunctions, ref pendingContext, ref stackCtx, actualSize, ref allocatedSize, keySize, allocOptions,
@@ -313,7 +318,7 @@ namespace Tsavorite.core
                 return status;
 
             ref RecordInfo newRecordInfo = ref WriteNewRecordInfo(ref key, hlogBase, newPhysicalAddress, inNewVersion: sessionFunctions.Ctx.InNewVersion, stackCtx.recSrc.LatestLogicalAddress);
-            if (allocOptions.IgnoreHeiAddress)
+            if (allocOptions.ElideSourceRecord)
                 newRecordInfo.PreviousAddress = srcRecordInfo.PreviousAddress;
             stackCtx.SetNewRecord(newLogicalAddress);
 
@@ -353,9 +358,9 @@ namespace Tsavorite.core
 
                 sessionFunctions.PostSingleWriter(ref key, ref input, ref value, ref newRecordValue, ref output, ref upsertInfo, WriteReason.Upsert, ref newRecordInfo);
 
-                // IgnoreHeiAddress means we have verified that the old source record is elidable and now that CAS has replaced it in the HashBucketEntry with
+                // ElideSourceRecord means we have verified that the old source record is elidable and now that CAS has replaced it in the HashBucketEntry with
                 // the new source record that does not point to the old source record, we have elided it, so try to transfer to freelist.
-                if (allocOptions.IgnoreHeiAddress)
+                if (allocOptions.ElideSourceRecord)
                 {
                     // Success should always Seal the old record. This may be readcache, readonly, or the temporary recordInfo, which is OK and saves the cost of an "if".
                     srcRecordInfo.SealAndInvalidate();    // The record was elided, so Invalidate

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/LogAccessor.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/LogAccessor.cs
@@ -92,7 +92,7 @@ namespace Tsavorite.core
             allocatorBase.EmptyPageCount = pageCount;
             if (wait)
             {
-                long newHeadAddress = (allocatorBase.GetTailAddress() & ~allocatorBase.PageSizeMask) - allocatorBase.HeadOffsetLagAddress;
+                long newHeadAddress = (allocatorBase.GetTailAddress() & ~allocatorBase.PageSizeMask) - allocatorBase.HeadAddressLagOffset;
                 ShiftHeadAddress(newHeadAddress, wait);
             }
         }

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -864,7 +864,10 @@ namespace Tsavorite.core
                 var logicalAddress = allocator.TryAllocateRetryNow(recordSize);
                 if (logicalAddress > 0)
                     return logicalAddress;
+
+                // logicalAddress less than 0 (RETRY_NOW) should already have been handled
                 Debug.Assert(logicalAddress == 0);
+
                 epoch.Suspend();
                 if (cannedException != null) throw cannedException;
                 try

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -434,17 +434,6 @@ namespace Tsavorite.core
             => allocator.LogPageSizeBits;
 
         /// <summary>
-        /// Get page number for given address
-        /// </summary>
-        /// <param name="logicalAddress"></param>
-        /// <returns></returns>
-        public long GetPage(long logicalAddress)
-            => allocator.GetPage(logicalAddress);
-
-        public void UnsafeSkipPage()
-            => allocator.SkipPage();
-
-        /// <summary>
         /// Get read only lag address
         /// </summary>
         public long UnsafeGetReadOnlyLagAddress()

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -436,8 +436,8 @@ namespace Tsavorite.core
         /// <summary>
         /// Get read only lag address
         /// </summary>
-        public long UnsafeGetReadOnlyLagAddress()
-            => allocator.GetReadOnlyLagAddress();
+        public long UnsafeGetReadOnlyAddressLagOffset()
+            => allocator.GetReadOnlyAddressLagOffset();
 
         /// <summary>
         /// Enqueue batch of entries to log (in memory) - no guarantee of flush/commit

--- a/libs/storage/Tsavorite/cs/test/InsertAtTailSpanByteStressTests.cs
+++ b/libs/storage/Tsavorite/cs/test/InsertAtTailSpanByteStressTests.cs
@@ -19,7 +19,7 @@ namespace Tsavorite.test.InsertAtTailStressTests
 
     // Number of mutable pages for this test
     public enum MutablePages
-    { 
+    {
         Zero,
         One,
         Two
@@ -35,12 +35,12 @@ namespace Tsavorite.test.InsertAtTailStressTests
         const long NumKeys = 2_000;
 
         long GetMutablePageCount(MutablePages mp) => mp switch
-            {
-                MutablePages.Zero => 0,
-                MutablePages.One => 1,
-                MutablePages.Two => 2,
-                _ => 8
-            };
+        {
+            MutablePages.Zero => 0,
+            MutablePages.One => 1,
+            MutablePages.Two => 2,
+            _ => 8
+        };
 
         [SetUp]
         public void Setup()

--- a/libs/storage/Tsavorite/cs/test/InsertAtTailSpanByteStressTests.cs
+++ b/libs/storage/Tsavorite/cs/test/InsertAtTailSpanByteStressTests.cs
@@ -21,7 +21,8 @@ namespace Tsavorite.test.InsertAtTailStressTests
     public enum MutablePages
     { 
         Zero,
-        Eight
+        One,
+        Two
     }
 
     class SpanByteInsertAtTailChainTests
@@ -36,7 +37,8 @@ namespace Tsavorite.test.InsertAtTailStressTests
         long GetMutablePageCount(MutablePages mp) => mp switch
             {
                 MutablePages.Zero => 0,
-                MutablePages.Eight => 8,
+                MutablePages.One => 0,
+                MutablePages.Two => 2,
                 _ => 8
             };
 
@@ -49,7 +51,7 @@ namespace Tsavorite.test.InsertAtTailStressTests
             log = new NullDevice();
 
             HashModulo modRange = HashModulo.NoMod;
-            long mutablePages = GetMutablePageCount(MutablePages.Eight);
+            long mutablePages = GetMutablePageCount(MutablePages.Two);
             foreach (var arg in TestContext.CurrentContext.Test.Arguments)
             {
                 if (arg is HashModulo cr)

--- a/libs/storage/Tsavorite/cs/test/InsertAtTailSpanByteStressTests.cs
+++ b/libs/storage/Tsavorite/cs/test/InsertAtTailSpanByteStressTests.cs
@@ -37,7 +37,7 @@ namespace Tsavorite.test.InsertAtTailStressTests
         long GetMutablePageCount(MutablePages mp) => mp switch
             {
                 MutablePages.Zero => 0,
-                MutablePages.One => 0,
+                MutablePages.One => 1,
                 MutablePages.Two => 2,
                 _ => 8
             };

--- a/libs/storage/Tsavorite/cs/test/InsertAtTailSpanByteStressTests.cs
+++ b/libs/storage/Tsavorite/cs/test/InsertAtTailSpanByteStressTests.cs
@@ -1,0 +1,294 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using Tsavorite.core;
+using static Tsavorite.test.TestUtils;
+
+#pragma warning disable  // Add parentheses for clarity
+
+namespace Tsavorite.test.InsertAtTailStressTests
+{
+    using SpanByteStoreFunctions = StoreFunctions<SpanByte, SpanByte, SpanByteComparerModulo, SpanByteRecordDisposer>;
+
+    class SpanByteInsertAtTailChainTests
+    {
+        private TsavoriteKV<SpanByte, SpanByte, SpanByteStoreFunctions, SpanByteAllocator<SpanByteStoreFunctions>> store;
+        private IDevice log;
+        SpanByteComparerModulo comparer;
+
+        const long ValueAdd = 1_000_000_000;
+        const long NumKeys = 2_000;
+
+        [SetUp]
+        public void Setup()
+        {
+            DeleteDirectory(MethodTestDir, wait: true);
+
+            string filename = Path.Join(MethodTestDir, $"{GetType().Name}.log");
+            log = new NullDevice();
+
+            HashModulo modRange = HashModulo.NoMod;
+            foreach (var arg in TestContext.CurrentContext.Test.Arguments)
+            {
+                if (arg is HashModulo cr)
+                {
+                    modRange = cr;
+                    continue;
+                }
+            }
+
+            // Make the main log mutable region small enough that we force the readonly region to stay close to tail, causing inserts.
+            int pageBits = 15, memoryBits = 34;
+            store = new(new()
+                {
+                    LogDevice = log,
+                    PageSize = 1L << 15,
+                    MemorySize = 1L << 34,
+                    MutableFraction = 1.0 / (1 << memoryBits - pageBits + 2),
+                }, StoreFunctions<SpanByte, SpanByte>.Create(comparer, SpanByteRecordDisposer.Instance)
+                , (allocatorSettings, storeFunctions) => new(allocatorSettings, storeFunctions)
+            );
+
+            comparer = new SpanByteComparerModulo(modRange);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            store?.Dispose();
+            store = null;
+            log?.Dispose();
+            log = null;
+            DeleteDirectory(MethodTestDir);
+        }
+
+        internal class RmwSpanByteFunctions : SpanByteFunctions<Empty>
+        {
+            /// <inheritdoc/>
+            public override bool ConcurrentWriter(ref SpanByte key, ref SpanByte input, ref SpanByte src, ref SpanByte dst, ref SpanByteAndMemory output, ref UpsertInfo upsertInfo, ref RecordInfo recordInfo)
+            {
+                src.CopyTo(ref dst);
+                src.CopyTo(ref output, memoryPool);
+                return true;
+            }
+
+            /// <inheritdoc/>
+            public override bool SingleWriter(ref SpanByte key, ref SpanByte input, ref SpanByte src, ref SpanByte dst, ref SpanByteAndMemory output, ref UpsertInfo upsertInfo, WriteReason reason, ref RecordInfo recordInfo)
+            {
+                src.CopyTo(ref dst);
+                src.CopyTo(ref output, memoryPool);
+                return true;
+            }
+
+            /// <inheritdoc/>
+            public override bool CopyUpdater(ref SpanByte key, ref SpanByte input, ref SpanByte oldValue, ref SpanByte newValue, ref SpanByteAndMemory output, ref RMWInfo rmwInfo, ref RecordInfo recordInfo)
+            {
+                input.CopyTo(ref newValue);
+                input.CopyTo(ref output, memoryPool);
+                return true;
+            }
+
+            /// <inheritdoc/>
+            public override bool InPlaceUpdater(ref SpanByte key, ref SpanByte input, ref SpanByte value, ref SpanByteAndMemory output, ref RMWInfo rmwInfo, ref RecordInfo recordInfo)
+            {
+                // The default implementation of IPU simply writes input to destination, if there is space
+                base.InPlaceUpdater(ref key, ref input, ref value, ref output, ref rmwInfo, ref recordInfo);
+                input.CopyTo(ref output, memoryPool);
+                return true;
+            }
+
+            /// <inheritdoc/>
+            public override bool InitialUpdater(ref SpanByte key, ref SpanByte input, ref SpanByte value, ref SpanByteAndMemory output, ref RMWInfo rmwInfo, ref RecordInfo recordInfo)
+            {
+                Assert.Fail("For these tests, InitialUpdater should never be called");
+                return false;
+            }
+        }
+
+        unsafe void PopulateAndSetReadOnlyToTail()
+        {
+            using var session = store.NewSession<SpanByte, SpanByteAndMemory, Empty, SpanByteFunctions<Empty>>(new SpanByteFunctions<Empty>());
+            var bContext = session.BasicContext;
+
+            Span<byte> keyVec = stackalloc byte[sizeof(long)];
+            var key = SpanByte.FromPinnedSpan(keyVec);
+
+            for (long ii = 0; ii < NumKeys; ii++)
+            {
+                ClassicAssert.IsTrue(BitConverter.TryWriteBytes(keyVec, ii));
+                var status = bContext.Upsert(ref key, ref key);
+                ClassicAssert.IsTrue(status.Record.Created, status.ToString());
+            }
+            bContext.CompletePending(true);
+            store.Log.ShiftReadOnlyAddress(store.Log.TailAddress, wait: true);
+        }
+
+        [Test]
+        [Category(TsavoriteKVTestCategory)]
+        [Category(StressTestCategory)]
+        //[Repeat(300)]
+        public void SpanByteTailInsertMultiThreadTest([Values] HashModulo modRange, [Values(0, 1, 2, 8)] int numReadThreads, [Values(0, 1, 2, 8)] int numWriteThreads,
+                                                [Values(UpdateOp.Upsert, UpdateOp.RMW)] UpdateOp updateOp)
+        {
+            if (numReadThreads == 0 && numWriteThreads == 0)
+                Assert.Ignore("Skipped due to 0 threads for both read and update");
+            if ((numReadThreads > 2 || numWriteThreads > 2) && IsRunningAzureTests)
+                Assert.Ignore("Skipped because > 2 threads when IsRunningAzureTests");
+            if (TestContext.CurrentContext.CurrentRepeatCount > 0)
+                Debug.WriteLine($"*** Current test iteration: {TestContext.CurrentContext.CurrentRepeatCount + 1} ***");
+
+            // Initial population so we know we can read the keys.
+            PopulateAndSetReadOnlyToTail();
+
+            const int numIterations = 10;
+            unsafe void runReadThread(int tid)
+            {
+                using var session = store.NewSession<SpanByte, SpanByteAndMemory, Empty, SpanByteFunctions<Empty>>(new SpanByteFunctions<Empty>());
+                var bContext = session.BasicContext;
+
+                Span<byte> keyVec = stackalloc byte[sizeof(long)];
+                var key = SpanByte.FromPinnedSpan(keyVec);
+
+                for (var iteration = 0; iteration < numIterations; ++iteration)
+                {
+                    var numCompleted = 0;
+                    for (var ii = 0; ii < NumKeys; ++ii)
+                    {
+                        SpanByteAndMemory output = default;
+
+                        ClassicAssert.IsTrue(BitConverter.TryWriteBytes(keyVec, ii));
+                        var status = bContext.Read(ref key, ref output);
+
+                        var numPending = ii - numCompleted;
+                        if (status.IsPending)
+                            ++numPending;
+                        else
+                        {
+                            ++numCompleted;
+
+                            ClassicAssert.IsTrue(status.Found, $"tid {tid}, key {ii}, {status}, wasPending {false}, pt 1");
+                            ClassicAssert.IsNotNull(output.Memory, $"tid {tid}, key {ii}, wasPending {false}, pt 2");
+                            long value = BitConverter.ToInt64(output.AsReadOnlySpan());
+                            ClassicAssert.AreEqual(ii, value % ValueAdd, $"tid {tid}, key {ii}, wasPending {false}, pt 3");
+                            output.Memory.Dispose();
+                        }
+
+                        if (numPending > 0)
+                        {
+                            bContext.CompletePendingWithOutputs(out var completedOutputs, wait: true);
+                            using (completedOutputs)
+                            {
+                                while (completedOutputs.Next())
+                                {
+                                    ++numCompleted;
+
+                                    status = completedOutputs.Current.Status;
+                                    output = completedOutputs.Current.Output;
+                                    // Note: do NOT overwrite 'key' here
+                                    long keyLong = BitConverter.ToInt64(completedOutputs.Current.Key.AsReadOnlySpan());
+
+                                    ClassicAssert.AreEqual(completedOutputs.Current.RecordMetadata.Address == Constants.kInvalidAddress, status.Record.CopiedToReadCache, $"key {keyLong}: {status}");
+
+                                    ClassicAssert.IsTrue(status.Found, $"tid {tid}, key {keyLong}, {status}, wasPending {true}, pt 1");
+                                    ClassicAssert.IsNotNull(output.Memory, $"tid {tid}, key {keyLong}, wasPending {true}, pt 2");
+                                    long value = BitConverter.ToInt64(output.AsReadOnlySpan());
+                                    ClassicAssert.AreEqual(keyLong, value % ValueAdd, $"tid {tid}, key {keyLong}, wasPending {true}, pt 3");
+                                    output.Memory.Dispose();
+                                }
+                            }
+                        }
+                    }
+                    ClassicAssert.AreEqual(NumKeys, numCompleted, "numCompleted");
+                }
+            }
+
+            unsafe void runUpdateThread(int tid)
+            {
+                using var session = store.NewSession<SpanByte, SpanByteAndMemory, Empty, SpanByteFunctions<Empty>>(new RmwSpanByteFunctions());
+                var bContext = session.BasicContext;
+
+                Span<byte> keyVec = stackalloc byte[sizeof(long)];
+                var key = SpanByte.FromPinnedSpan(keyVec);
+                Span<byte> inputVec = stackalloc byte[sizeof(long)];
+                var input = SpanByte.FromPinnedSpan(inputVec);
+
+                for (var iteration = 0; iteration < numIterations; ++iteration)
+                {
+                    var numCompleted = 0;
+                    for (var ii = 0; ii < NumKeys; ++ii)
+                    {
+                        SpanByteAndMemory output = default;
+
+                        ClassicAssert.IsTrue(BitConverter.TryWriteBytes(keyVec, ii));
+                        ClassicAssert.IsTrue(BitConverter.TryWriteBytes(inputVec, ii + ValueAdd));
+                        var status = updateOp == UpdateOp.RMW
+                                        ? bContext.RMW(ref key, ref input, ref output)
+                                        : bContext.Upsert(ref key, ref input, ref input, ref output);
+
+                        var numPending = ii - numCompleted;
+                        if (status.IsPending)
+                        {
+                            ClassicAssert.AreNotEqual(UpdateOp.Upsert, updateOp, "Upsert should not go pending");
+                            ++numPending;
+                        }
+                        else
+                        {
+                            ++numCompleted;
+                            if (updateOp == UpdateOp.RMW)   // Upsert will not try to find records below HeadAddress, but it may find them in-memory
+                                ClassicAssert.IsTrue(status.Found, $"tid {tid}, key {ii}, {status}");
+
+                            long value = BitConverter.ToInt64(output.AsReadOnlySpan());
+                            ClassicAssert.AreEqual(ii + ValueAdd, value, $"tid {tid}, key {ii}, wasPending {false}");
+
+                            output.Memory?.Dispose();
+                        }
+
+                        if (numPending > 0)
+                        {
+                            bContext.CompletePendingWithOutputs(out var completedOutputs, wait: true);
+                            using (completedOutputs)
+                            {
+                                while (completedOutputs.Next())
+                                {
+                                    ++numCompleted;
+
+                                    status = completedOutputs.Current.Status;
+                                    output = completedOutputs.Current.Output;
+                                    // Note: do NOT overwrite 'key' here
+                                    long keyLong = BitConverter.ToInt64(completedOutputs.Current.Key.AsReadOnlySpan());
+
+                                    if (updateOp == UpdateOp.RMW)   // Upsert will not try to find records below HeadAddress, but it may find them in-memory
+                                        ClassicAssert.IsTrue(status.Found, $"tid {tid}, key {keyLong}, {status}");
+
+                                    long value = BitConverter.ToInt64(output.AsReadOnlySpan());
+                                    ClassicAssert.AreEqual(keyLong + ValueAdd, value, $"tid {tid}, key {keyLong}, wasPending {true}");
+
+                                    output.Memory?.Dispose();
+                                }
+                            }
+                        }
+                    }
+                    ClassicAssert.AreEqual(NumKeys, numCompleted, "numCompleted");
+                }
+            }
+
+            List<Task> tasks = new();   // Task rather than Thread for propagation of exception.
+            for (int t = 1; t <= numReadThreads + numWriteThreads; t++)
+            {
+                var tid = t;
+                if (t <= numReadThreads)
+                    tasks.Add(Task.Factory.StartNew(() => runReadThread(tid)));
+                else
+                    tasks.Add(Task.Factory.StartNew(() => runUpdateThread(tid)));
+            }
+            Task.WaitAll(tasks.ToArray());
+        }
+    }
+}

--- a/libs/storage/Tsavorite/cs/test/LogResumeTests.cs
+++ b/libs/storage/Tsavorite/cs/test/LogResumeTests.cs
@@ -44,7 +44,7 @@ namespace Tsavorite.test
             var input3 = new byte[] { 11, 12 };
             string readerName = "abc";
 
-            using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum }))
+            using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 17, LogChecksum = logChecksum }))
             {
                 await l.EnqueueAsync(input1, cancellationToken);
                 await l.EnqueueAsync(input2);
@@ -58,7 +58,7 @@ namespace Tsavorite.test
                 await l.CommitAsync();
             }
 
-            using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum }))
+            using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 17, LogChecksum = logChecksum }))
             {
                 using var recoveredIterator = l.Scan(0, long.MaxValue, readerName);
                 ClassicAssert.IsTrue(recoveredIterator.GetNext(out byte[] outBuf, out _, out _, out _));
@@ -77,7 +77,7 @@ namespace Tsavorite.test
             var input3 = new byte[] { 11, 12 };
             string readerName = "abc";
 
-            using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum }))
+            using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 17, LogChecksum = logChecksum }))
             {
                 await l.EnqueueAsync(input1, cancellationToken);
                 await l.EnqueueAsync(input2);
@@ -91,7 +91,7 @@ namespace Tsavorite.test
                 await l.CommitAsync();
             }
 
-            using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum }))
+            using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 17, LogChecksum = logChecksum }))
             {
                 using var recoveredIterator = l.Scan(0, long.MaxValue, readerName);
                 ClassicAssert.IsTrue(recoveredIterator.GetNext(out byte[] outBuf, out _, out _, out _));
@@ -112,7 +112,7 @@ namespace Tsavorite.test
             {
                 long originalCompleted;
 
-                using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitManager = logCommitManager }))
+                using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 17, LogChecksum = logChecksum, LogCommitManager = logCommitManager }))
                 {
                     await l.EnqueueAsync(input1);
                     await l.CommitAsync();
@@ -129,7 +129,7 @@ namespace Tsavorite.test
                     originalCompleted = originalIterator.CompletedUntilAddress;
                 }
 
-                using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitManager = logCommitManager }))
+                using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 17, LogChecksum = logChecksum, LogCommitManager = logCommitManager }))
                 {
                     using var recoveredIterator = l.Scan(0, long.MaxValue, readerName);
                     ClassicAssert.IsTrue(recoveredIterator.GetNext(out byte[] outBuf, out _, out _, out _));
@@ -155,7 +155,7 @@ namespace Tsavorite.test
             {
                 long originalCompleted;
 
-                using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitManager = logCommitManager }))
+                using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 17, LogChecksum = logChecksum, LogCommitManager = logCommitManager }))
                 {
                     await l.EnqueueAsync(input1);
                     await l.CommitAsync();
@@ -180,7 +180,7 @@ namespace Tsavorite.test
                     originalCompleted = originalIterator.CompletedUntilAddress;
                 }
 
-                using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitManager = logCommitManager }))
+                using (var l = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 17, LogChecksum = logChecksum, LogCommitManager = logCommitManager }))
                 {
                     using var recoveredIterator = l.Scan(0, l.TailAddress, readerName);
 

--- a/libs/storage/Tsavorite/cs/test/LogTests.cs
+++ b/libs/storage/Tsavorite/cs/test/LogTests.cs
@@ -618,7 +618,7 @@ namespace Tsavorite.test
             {
                 LogDevice = device,
                 PageSizeBits = 16,
-                MemorySizeBits = 16,
+                MemorySizeBits = 17,
                 LogChecksum = logChecksum,
                 LogCommitManager = manager,
                 SegmentSizeBits = 22

--- a/libs/storage/Tsavorite/cs/test/NeedCopyUpdateTests.cs
+++ b/libs/storage/Tsavorite/cs/test/NeedCopyUpdateTests.cs
@@ -187,7 +187,7 @@ namespace Tsavorite.test
                 IndexSize = 1L << 13,
                 LogDevice = log,
                 MutableFraction = 0.1,
-                MemorySize = 1L << PageSizeBits,
+                MemorySize = 1L << (PageSizeBits + 1),
                 PageSize = 1L << PageSizeBits
             }, StoreFunctions<long, long>.Create(LongKeyComparer.Instance)
                 , (allocatorSettings, storeFunctions) => new(allocatorSettings, storeFunctions)

--- a/libs/storage/Tsavorite/cs/test/ReadCacheChainTests.cs
+++ b/libs/storage/Tsavorite/cs/test/ReadCacheChainTests.cs
@@ -18,37 +18,6 @@ using static Tsavorite.test.TestUtils;
 
 namespace Tsavorite.test.ReadCacheTests
 {
-    // Must be in a separate block so the "using StructStoreFunctions" is the first line in its namespace declaration.
-    internal class LongComparerModulo : IKeyComparer<long>
-    {
-        readonly long mod;
-
-        internal LongComparerModulo(long mod) => this.mod = mod;
-
-        public bool Equals(ref long k1, ref long k2) => k1 == k2;
-
-        public long GetHashCode64(ref long k) => mod == 0 ? k : k % mod;
-    }
-
-    internal struct SpanByteComparerModulo : IKeyComparer<SpanByte>
-    {
-        readonly HashModulo modRange;
-
-        internal SpanByteComparerModulo(HashModulo mod) => modRange = mod;
-
-        public readonly bool Equals(ref SpanByte k1, ref SpanByte k2) => SpanByteComparer.StaticEquals(ref k1, ref k2);
-
-        // Force collisions to create a chain
-        public readonly long GetHashCode64(ref SpanByte k)
-        {
-            var value = SpanByteComparer.StaticGetHashCode64(ref k);
-            return modRange != HashModulo.NoMod ? value % (long)modRange : value;
-        }
-    }
-}
-
-namespace Tsavorite.test.ReadCacheTests
-{
     using LongAllocator = BlittableAllocator<long, long, StoreFunctions<long, long, LongComparerModulo, DefaultRecordDisposer<long, long>>>;
     using LongStoreFunctions = StoreFunctions<long, long, LongComparerModulo, DefaultRecordDisposer<long, long>>;
     using SpanByteStoreFunctions = StoreFunctions<SpanByte, SpanByte, SpanByteComparerModulo, SpanByteRecordDisposer>;

--- a/libs/storage/Tsavorite/cs/test/TestUtils.cs
+++ b/libs/storage/Tsavorite/cs/test/TestUtils.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using Tsavorite.core;
 using Tsavorite.devices;
+using static Tsavorite.test.TestUtils;
 
 namespace Tsavorite.test
 {
@@ -266,6 +267,33 @@ namespace Tsavorite.test
             var success = store.FindTag(ref hei);
             entry = hei.entry;
             return success;
+        }
+    }
+
+    internal class LongComparerModulo : IKeyComparer<long>
+    {
+        readonly long mod;
+
+        internal LongComparerModulo(long mod) => this.mod = mod;
+
+        public bool Equals(ref long k1, ref long k2) => k1 == k2;
+
+        public long GetHashCode64(ref long k) => mod == 0 ? k : k % mod;
+    }
+
+    internal struct SpanByteComparerModulo : IKeyComparer<SpanByte>
+    {
+        readonly HashModulo modRange;
+
+        internal SpanByteComparerModulo(HashModulo mod) => modRange = mod;
+
+        public readonly bool Equals(ref SpanByte k1, ref SpanByte k2) => SpanByteComparer.StaticEquals(ref k1, ref k2);
+
+        // Force collisions to create a chain
+        public readonly long GetHashCode64(ref SpanByte k)
+        {
+            var value = SpanByteComparer.StaticGetHashCode64(ref k);
+            return modRange != HashModulo.NoMod ? value % (long)modRange : value;
         }
     }
 

--- a/test/Garnet.test/GarnetBitmapTests.cs
+++ b/test/Garnet.test/GarnetBitmapTests.cs
@@ -168,7 +168,7 @@ namespace Garnet.test
             server.Dispose();
             server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
                 lowMemory: true,
-                MemorySize: (bitmapBytes << 1).ToString(),
+                MemorySize: (bitmapBytes << 2).ToString(),
                 PageSize: (bitmapBytes << 1).ToString());
             server.Start();
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
@@ -450,7 +450,7 @@ namespace Garnet.test
             server.Dispose();
             server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
                 lowMemory: true,
-                MemorySize: (bitmapBytes << 1).ToString(),
+                MemorySize: (bitmapBytes << 2).ToString(),
                 PageSize: (bitmapBytes << 1).ToString());
             server.Start();
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
@@ -647,7 +647,7 @@ namespace Garnet.test
             server.Dispose();
             server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
                 lowMemory: true,
-                MemorySize: (bitmapBytes << 1).ToString(),
+                MemorySize: (bitmapBytes << 2).ToString(),
                 PageSize: (bitmapBytes << 1).ToString());
             server.Start();
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
@@ -1271,7 +1271,7 @@ namespace Garnet.test
             server.Dispose();
             server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
                 lowMemory: true,
-                MemorySize: (bitmapBytes << 1).ToString(),
+                MemorySize: (bitmapBytes << 2).ToString(),
                 PageSize: (bitmapBytes << 1).ToString());
             //MemorySize: "16g",
             //PageSize: "32m");
@@ -1472,7 +1472,7 @@ namespace Garnet.test
             server.Dispose();
             server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
                 lowMemory: true,
-                MemorySize: (bitmapBytes << 1).ToString(),
+                MemorySize: (bitmapBytes << 2).ToString(),
                 PageSize: (bitmapBytes << 1).ToString());
             //MemorySize: "16g",
             //PageSize: "32m");
@@ -1938,7 +1938,7 @@ namespace Garnet.test
             server.Dispose();
             server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
                 lowMemory: true,
-                MemorySize: (bitmapBytes << 1).ToString(),
+                MemorySize: (bitmapBytes << 2).ToString(),
                 PageSize: (bitmapBytes << 1).ToString());
             //MemorySize: "16g",
             //PageSize: "32m");

--- a/test/Garnet.test/HyperLogLogTests.cs
+++ b/test/Garnet.test/HyperLogLogTests.cs
@@ -571,13 +571,13 @@ namespace Garnet.test
             if (seqSize < 128)
                 server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
                     lowMemory: true,
-                    MemorySize: "512",
+                    MemorySize: "1024",
                     PageSize: "512");
             else
                 server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
                     lowMemory: true,
-                    MemorySize: "16384",
-                    PageSize: "16384");
+                    MemorySize: "32k",
+                    PageSize: "16k");
             server.Start();
 
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
@@ -689,7 +689,7 @@ namespace Garnet.test
             server.Dispose();
             server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
                 lowMemory: true,
-                MemorySize: "512",
+                MemorySize: "1024",
                 PageSize: "512");
             server.Start();
 
@@ -798,8 +798,8 @@ namespace Garnet.test
         {
             server.Dispose();
             server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
-                MemorySize: "16384",
-                PageSize: "16384");
+                MemorySize: "32k",
+                PageSize: "16k");
             server.Start();
 
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
@@ -908,8 +908,8 @@ namespace Garnet.test
             server.Dispose();
             server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
                 lowMemory: true,
-                MemorySize: "16384",
-                PageSize: "16384");
+                MemorySize: "32k",
+                PageSize: "16k");
             server.Start();
 
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());

--- a/test/Garnet.test/RespAdminCommandsTests.cs
+++ b/test/Garnet.test/RespAdminCommandsTests.cs
@@ -306,7 +306,7 @@ namespace Garnet.test
 
         [Test]
         [TestCase(63, 15, 1)]
-        [TestCase(63, 1, 1)]
+        [TestCase(63, 2, 1)]
         [TestCase(16, 16, 1)]
         [TestCase(5, 64, 1)]
         public void SeSaveRecoverMultipleObjectsTest(int memorySize, int recoveryMemorySize, int pageSize)
@@ -363,7 +363,7 @@ namespace Garnet.test
             bool disableObj = true;
 
             server.Dispose();
-            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, DisableObjects: disableObj, lowMemory: true, MemorySize: memorySize, PageSize: "1k", enableAOF: true);
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, DisableObjects: disableObj, lowMemory: true, MemorySize: memorySize, PageSize: "512", enableAOF: true);
             server.Start();
 
             using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true)))
@@ -402,7 +402,7 @@ namespace Garnet.test
             }
 
             server.Dispose(false);
-            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, DisableObjects: disableObj, tryRecover: true, lowMemory: true, MemorySize: recoveryMemorySize, PageSize: "1k", enableAOF: true);
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, DisableObjects: disableObj, tryRecover: true, lowMemory: true, MemorySize: recoveryMemorySize, PageSize: "512", enableAOF: true);
             server.Start();
 
             using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true)))

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -264,7 +264,7 @@ namespace Garnet.test
 
             if (lowMemory)
             {
-                opts.MemorySize = opts.ObjectStoreLogMemorySize = MemorySize == default ? "512" : MemorySize;
+                opts.MemorySize = opts.ObjectStoreLogMemorySize = MemorySize == default ? "1024" : MemorySize;
                 opts.PageSize = opts.ObjectStorePageSize = PageSize == default ? "512" : PageSize;
             }
 

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -504,7 +504,7 @@ namespace Garnet.test
 
             if (lowMemory)
             {
-                opts.MemorySize = opts.ObjectStoreLogMemorySize = MemorySize == default ? "512" : MemorySize;
+                opts.MemorySize = opts.ObjectStoreLogMemorySize = MemorySize == default ? "1024" : MemorySize;
                 opts.PageSize = opts.ObjectStorePageSize = PageSize == default ? "512" : PageSize;
             }
 


### PR DESCRIPTION
This is a change to the Tsavorite allocator base to make its page-filling algorithm (primarily for TsavoriteLog) deterministic.
 
We change the allocator to enqueue at tail with the invariant that the first record of page `(p+1)` is guaranteed to have not fit in the empty space at the end of the previous page (`p`).
 
This allows replication to independently replay AOF records and guarantee that they fit on the AOF created on the secondary, exactly in the same way as they do on the primary. I.e., they will be in perfect lockstep.
 
Previously it was possible that two threads raced to add at the end of a page, the larger allocation won first and closed that page, but the smaller allocation won on the new page and populated the first entry with a record that could have fitted on the previous page. On the replica, this record would end up on the previous page, resulting in offset mismatch.

We already have a workaround in the replica replay logic to correct for this, but this PR makes that workaround unnecessary.

PR also includes an unrelated fix to Upsert logic from Ted: [Fix InernalUpsert srcRecordInfo setting when found below ReadOnlyAddress](https://github.com/microsoft/garnet/pull/657/commits/1c95a5ac908952225920a2d431a1e8124246b8b2)