### PR TITLE
Fix Latency Tracking Issue

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -3,7 +3,7 @@
 #      1) update the name: string below (line 6)     -- this is the version for the nuget package (e.g. 1.0.0)
 #      2) update \libs\host\GarnetServer.cs readonly string version  (~line 53)   -- NOTE - these two values need to be the same 
 ###################################### 
-name: 1.0.22
+name: 1.0.23
 trigger:
   branches:
     include:

--- a/benchmark/BDN.benchmark/Resp/RespParseStress.cs
+++ b/benchmark/BDN.benchmark/Resp/RespParseStress.cs
@@ -62,6 +62,8 @@ namespace BDN.benchmark.Resp
             {
                 QuietMode = true,
                 AuthSettings = authSettings,
+                MetricsSamplingFrequency = 5,
+                LatencyMonitor = true,
             };
             server = new EmbeddedRespServer(opt);
 

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -49,7 +49,7 @@ namespace Garnet
         protected StoreWrapper storeWrapper;
 
         // IMPORTANT: Keep the version in sync with .azure\pipelines\azure-pipelines-external-release.yml line ~6.
-        readonly string version = "1.0.22";
+        readonly string version = "1.0.23";
 
         /// <summary>
         /// Resp protocol version

--- a/libs/server/Resp/AdminCommands.cs
+++ b/libs/server/Resp/AdminCommands.cs
@@ -20,7 +20,7 @@ namespace Garnet.server
     /// </summary>
     internal sealed unsafe partial class RespServerSession : ServerSessionBase
     {
-        private bool ProcessAdminCommands(RespCommand command)
+        private void ProcessAdminCommands(RespCommand command)
         {
             containsSlowCommand = true;
 
@@ -61,17 +61,16 @@ namespace Garnet.server
                 _ => cmdFound = false
             };
 
-            if (cmdFound) return true;
+            if (cmdFound) return;
 
             if (command.IsClusterSubCommand())
             {
                 NetworkProcessClusterCommand(command);
-                return true;
+                return;
             }
 
             while (!RespWriteUtils.WriteError(CmdStrings.RESP_ERR_GENERIC_UNK_CMD, ref dcurr, dend))
-                SendAndReset();
-            return true;
+                SendAndReset(); ;
         }
 
         /// <summary>

--- a/libs/server/Resp/AdminCommands.cs
+++ b/libs/server/Resp/AdminCommands.cs
@@ -22,8 +22,10 @@ namespace Garnet.server
     {
         private void ProcessAdminCommands(RespCommand command)
         {
+            /*
+             * WARNING: Here is safe to add @slow commands (check how containsSlowCommand is used).
+             */
             containsSlowCommand = true;
-
             if (_authenticator.CanAuthenticate && !_authenticator.IsAuthenticated)
             {
                 // If the current session is unauthenticated, we stop parsing, because no other commands are allowed

--- a/libs/server/Resp/AdminCommands.cs
+++ b/libs/server/Resp/AdminCommands.cs
@@ -39,6 +39,7 @@ namespace Garnet.server
                 RespCommand.CONFIG_SET => NetworkCONFIG_SET(),
                 RespCommand.FAILOVER or
                 RespCommand.REPLICAOF or
+                RespCommand.MIGRATE or
                 RespCommand.SECONDARYOF => NetworkProcessClusterCommand(command),
                 RespCommand.LATENCY_HELP => NetworkLatencyHelp(),
                 RespCommand.LATENCY_HISTOGRAM => NetworkLatencyHistogram(),

--- a/libs/server/Resp/AdminCommands.cs
+++ b/libs/server/Resp/AdminCommands.cs
@@ -70,7 +70,7 @@ namespace Garnet.server
             }
 
             while (!RespWriteUtils.WriteError(CmdStrings.RESP_ERR_GENERIC_UNK_CMD, ref dcurr, dend))
-                SendAndReset(); ;
+                SendAndReset();
         }
 
         /// <summary>

--- a/libs/server/Resp/AdminCommands.cs
+++ b/libs/server/Resp/AdminCommands.cs
@@ -22,7 +22,7 @@ namespace Garnet.server
     {
         private bool ProcessAdminCommands(RespCommand command)
         {
-            hasAdminCommand = true;
+            containsSlowCommand = true;
 
             if (_authenticator.CanAuthenticate && !_authenticator.IsAuthenticated)
             {

--- a/libs/server/Resp/AdminCommands.cs
+++ b/libs/server/Resp/AdminCommands.cs
@@ -20,7 +20,7 @@ namespace Garnet.server
     /// </summary>
     internal sealed unsafe partial class RespServerSession : ServerSessionBase
     {
-        private void ProcessAdminCommands(RespCommand command)
+        private bool ProcessAdminCommands(RespCommand command)
         {
             hasAdminCommand = true;
 
@@ -60,16 +60,17 @@ namespace Garnet.server
                 _ => cmdFound = false
             };
 
-            if (cmdFound) return;
+            if (cmdFound) return true;
 
             if (command.IsClusterSubCommand())
             {
                 NetworkProcessClusterCommand(command);
-                return;
+                return true;
             }
 
             while (!RespWriteUtils.WriteError(CmdStrings.RESP_ERR_GENERIC_UNK_CMD, ref dcurr, dend))
                 SendAndReset();
+            return true;
         }
 
         /// <summary>

--- a/libs/server/Resp/Parser/RespCommand.cs
+++ b/libs/server/Resp/Parser/RespCommand.cs
@@ -1993,6 +1993,10 @@ namespace Garnet.server
             }
             endReadHead = (int)(ptr - recvBufferPtr);
 
+            // Classify command as non data command
+            if (storeWrapper.serverOptions.LatencyMonitor)
+                containsSlowCommand |= !cmd.IsDataCommand();
+
             if (storeWrapper.appendOnlyFile != null && storeWrapper.serverOptions.WaitForCommit)
                 HandleAofCommitMode(cmd);
 

--- a/libs/server/Resp/Parser/RespCommand.cs
+++ b/libs/server/Resp/Parser/RespCommand.cs
@@ -1993,14 +1993,6 @@ namespace Garnet.server
             }
             endReadHead = (int)(ptr - recvBufferPtr);
 
-            // Classify command as slow to avoid accounting for its latency in NET_RS
-            if (storeWrapper.serverOptions.LatencyMonitor)
-            {
-                var normCmd = cmd.NormalizeForACLs();
-                _ = RespCommandsInfo.TryFastGetRespCommandInfo(normCmd, out var commandInfo);
-                containsSlowCommand |= commandInfo == null || !commandInfo.Flags.HasFlag(RespCommandFlags.Fast);
-            }
-
             if (storeWrapper.appendOnlyFile != null && storeWrapper.serverOptions.WaitForCommit)
                 HandleAofCommitMode(cmd);
 

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -697,7 +697,7 @@ namespace Garnet.server
                 RespCommand.SCRIPT => TrySCRIPT(),
                 RespCommand.EVAL => TryEVAL(),
                 RespCommand.EVALSHA => TryEVALSHA(),
-                _ => ProcessAdminCommands(command)
+                _ => Process(command)
             };
 
             bool NetworkCLIENTID()
@@ -739,6 +739,12 @@ namespace Garnet.server
                     currentCustomProcedure.CustomProcedureImpl);
 
                 currentCustomProcedure = null;
+                return true;
+            }
+
+            bool Process(RespCommand command)
+            {
+                ProcessAdminCommands(command);
                 return true;
             }
 

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -514,6 +514,7 @@ namespace Garnet.server
                 RespCommand.SETRANGE => NetworkSetRange(ref storageApi),
                 RespCommand.GETDEL => NetworkGETDEL(ref storageApi),
                 RespCommand.APPEND => NetworkAppend(ref storageApi),
+                RespCommand.STRLEN => NetworkSTRLEN(ref storageApi),
                 RespCommand.INCR => NetworkIncrement(RespCommand.INCR, ref storageApi),
                 RespCommand.INCRBY => NetworkIncrement(RespCommand.INCRBY, ref storageApi),
                 RespCommand.DECR => NetworkIncrement(RespCommand.DECR, ref storageApi),
@@ -523,7 +524,7 @@ namespace Garnet.server
                 RespCommand.BITCOUNT => NetworkStringBitCount(ref storageApi),
                 RespCommand.BITPOS => NetworkStringBitPosition(ref storageApi),
                 RespCommand.PUBLISH => NetworkPUBLISH(),
-                RespCommand.PING => parseState.Count == 0 ? NetworkPING() : ProcessArrayCommands(cmd, ref storageApi),
+                RespCommand.PING => parseState.Count == 0 ? NetworkPING() : NetworkArrayPING(),
                 RespCommand.ASKING => NetworkASKING(),
                 RespCommand.MULTI => NetworkMULTI(),
                 RespCommand.EXEC => NetworkEXEC(),
@@ -533,21 +534,6 @@ namespace Garnet.server
                 RespCommand.RUNTXP => NetworkRUNTXP(),
                 RespCommand.READONLY => NetworkREADONLY(),
                 RespCommand.READWRITE => NetworkREADWRITE(),
-                RespCommand.COMMAND => NetworkCOMMAND(),
-                RespCommand.COMMAND_COUNT => NetworkCOMMAND_COUNT(),
-                RespCommand.COMMAND_INFO => NetworkCOMMAND_INFO(),
-                RespCommand.ECHO => NetworkECHO(),
-                RespCommand.HELLO => NetworkHELLO(),
-                RespCommand.TIME => NetworkTIME(),
-                RespCommand.FLUSHALL => NetworkFLUSHALL(),
-                RespCommand.FLUSHDB => NetworkFLUSHDB(),
-                RespCommand.AUTH => NetworkAUTH(),
-                RespCommand.MEMORY_USAGE => NetworkMemoryUsage(ref storageApi),
-                RespCommand.ACL_CAT => NetworkAclCat(),
-                RespCommand.ACL_WHOAMI => NetworkAclWhoAmI(),
-                RespCommand.ASYNC => NetworkASYNC(),
-                RespCommand.MIGRATE => NetworkProcessClusterCommand(cmd),
-
                 _ => ProcessArrayCommands(cmd, ref storageApi)
             };
 
@@ -567,13 +553,6 @@ namespace Garnet.server
                 RespCommand.WATCH => NetworkWATCH(),
                 RespCommand.WATCH_MS => NetworkWATCH_MS(),
                 RespCommand.WATCH_OS => NetworkWATCH_OS(),
-                RespCommand.STRLEN => NetworkSTRLEN(ref storageApi),
-                RespCommand.PING => NetworkArrayPING(),
-                //General key commands
-                RespCommand.DBSIZE => NetworkDBSIZE(ref storageApi),
-                RespCommand.KEYS => NetworkKEYS(ref storageApi),
-                RespCommand.SCAN => NetworkSCAN(ref storageApi),
-                RespCommand.TYPE => NetworkTYPE(ref storageApi),
                 // Pub/sub commands
                 RespCommand.SUBSCRIBE => NetworkSUBSCRIBE(),
                 RespCommand.PSUBSCRIBE => NetworkPSUBSCRIBE(),
@@ -674,10 +653,6 @@ namespace Garnet.server
                 RespCommand.SUNIONSTORE => SetUnionStore(ref storageApi),
                 RespCommand.SDIFF => SetDiff(ref storageApi),
                 RespCommand.SDIFFSTORE => SetDiffStore(ref storageApi),
-                // Script Commands
-                RespCommand.SCRIPT => TrySCRIPT(),
-                RespCommand.EVAL => TryEVAL(),
-                RespCommand.EVALSHA => TryEVALSHA(),
                 _ => ProcessOtherCommands(cmd, ref storageApi)
             };
             return success;
@@ -690,16 +665,38 @@ namespace Garnet.server
 
             var success = command switch
             {
+                RespCommand.AUTH => NetworkAUTH(),
+                RespCommand.MEMORY_USAGE => NetworkMemoryUsage(ref storageApi),
                 RespCommand.CLIENT_ID => NetworkCLIENTID(),
                 RespCommand.CLIENT_INFO => NetworkCLIENTINFO(),
                 RespCommand.CLIENT_LIST => NetworkCLIENTLIST(),
                 RespCommand.CLIENT_KILL => NetworkCLIENTKILL(),
+                RespCommand.COMMAND => NetworkCOMMAND(),
+                RespCommand.COMMAND_COUNT => NetworkCOMMAND_COUNT(),
+                RespCommand.COMMAND_INFO => NetworkCOMMAND_INFO(),
+                RespCommand.ECHO => NetworkECHO(),
+                RespCommand.HELLO => NetworkHELLO(),
+                RespCommand.TIME => NetworkTIME(),
+                RespCommand.FLUSHALL => NetworkFLUSHALL(),
+                RespCommand.FLUSHDB => NetworkFLUSHDB(),
+                RespCommand.ACL_CAT => NetworkAclCat(),
+                RespCommand.ACL_WHOAMI => NetworkAclWhoAmI(),
+                RespCommand.ASYNC => NetworkASYNC(),
                 RespCommand.RUNTXP => NetworkRUNTXP(),
                 RespCommand.INFO => NetworkINFO(),
                 RespCommand.CustomTxn => NetworkCustomTxn(),
                 RespCommand.CustomRawStringCmd => NetworkCustomRawStringCmd(ref storageApi),
                 RespCommand.CustomObjCmd => NetworkCustomObjCmd(ref storageApi),
                 RespCommand.CustomProcedure => NetworkCustomProcedure(),
+                //General key commands
+                RespCommand.DBSIZE => NetworkDBSIZE(ref storageApi),
+                RespCommand.KEYS => NetworkKEYS(ref storageApi),
+                RespCommand.SCAN => NetworkSCAN(ref storageApi),
+                RespCommand.TYPE => NetworkTYPE(ref storageApi),
+                // Script Commands
+                RespCommand.SCRIPT => TrySCRIPT(),
+                RespCommand.EVAL => TryEVAL(),
+                RespCommand.EVALSHA => TryEVALSHA(),
                 _ => ProcessAdminCommands(command)
             };
 

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Buffers;
-using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -538,7 +537,6 @@ namespace Garnet.server
                 RespCommand.COMMAND_COUNT => NetworkCOMMAND_COUNT(),
                 RespCommand.COMMAND_INFO => NetworkCOMMAND_INFO(),
                 RespCommand.ECHO => NetworkECHO(),
-                RespCommand.INFO => NetworkINFO(),
                 RespCommand.HELLO => NetworkHELLO(),
                 RespCommand.TIME => NetworkTIME(),
                 RespCommand.FLUSHALL => NetworkFLUSHALL(),
@@ -688,6 +686,7 @@ namespace Garnet.server
         private bool ProcessOtherCommands<TGarnetApi>(RespCommand command, ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetApi
         {
+            hasAdminCommand = true;
             if (command == RespCommand.CLIENT_ID)
             {
                 if (parseState.Count != 0)
@@ -720,6 +719,10 @@ namespace Garnet.server
             else if (command == RespCommand.RUNTXP)
             {
                 return NetworkRUNTXP();
+            }
+            else if (command == RespCommand.INFO)
+            {
+                return NetworkINFO();
             }
             else if (command == RespCommand.CustomTxn)
             {

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -114,8 +114,8 @@ namespace Garnet.server
         /// </summary>
         public IGarnetServer Server { get; set; }
 
-        // Track whether the incoming network batch had some admin command
-        bool hasAdminCommand;
+        // Track whether the incoming network batch contains slow commands that should not be counter in NET_RS histogram
+        bool containsSlowCommand;
 
         readonly CustomCommandManagerSession customCommandManagerSession;
 
@@ -368,10 +368,10 @@ namespace Garnet.server
             {
                 if (latencyMetrics != null)
                 {
-                    if (hasAdminCommand)
+                    if (containsSlowCommand)
                     {
                         latencyMetrics.StopAndSwitch(LatencyMetricsType.NET_RS_LAT, LatencyMetricsType.NET_RS_LAT_ADMIN);
-                        hasAdminCommand = false;
+                        containsSlowCommand = false;
                     }
                     else
                         latencyMetrics.Stop(LatencyMetricsType.NET_RS_LAT);
@@ -661,7 +661,7 @@ namespace Garnet.server
         private bool ProcessOtherCommands<TGarnetApi>(RespCommand command, ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetApi
         {
-            hasAdminCommand = true;
+            containsSlowCommand = true;
 
             var success = command switch
             {

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -742,6 +742,7 @@ namespace Garnet.server
                 return true;
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             bool Process(RespCommand command)
             {
                 ProcessAdminCommands(command);

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -499,6 +499,10 @@ namespace Garnet.server
         private bool ProcessBasicCommands<TGarnetApi>(RespCommand cmd, ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetApi
         {
+            /*
+             * WARNING: Do not add any command here classified as @slow!
+             * Only @fast commands otherwise latency tracking will break for NET_RS (check how containsSlowCommand is used).
+             */
             _ = cmd switch
             {
                 RespCommand.GET => NetworkGET(ref storageApi),
@@ -547,6 +551,10 @@ namespace Garnet.server
         private bool ProcessArrayCommands<TGarnetApi>(RespCommand cmd, ref TGarnetApi storageApi)
            where TGarnetApi : IGarnetApi
         {
+            /*
+             * WARNING: Do not add any command here classified as @slow!
+             * Only @fast commands otherwise latency tracking will break for NET_RS (check how containsSlowCommand is used).
+             */
             var success = cmd switch
             {
                 RespCommand.MGET => NetworkMGET(ref storageApi),
@@ -665,8 +673,10 @@ namespace Garnet.server
         private bool ProcessOtherCommands<TGarnetApi>(RespCommand command, ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetApi
         {
+            /*
+             * WARNING: Here is safe to add @slow commands (check how containsSlowCommand is used).
+             */
             containsSlowCommand = true;
-
             var success = command switch
             {
                 RespCommand.AUTH => NetworkAUTH(),

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -442,6 +442,10 @@ namespace Garnet.server
                             SendAndReset();
                     }
                 }
+                else
+                {
+                    containsSlowCommand = true;
+                }
 
                 // Advance read head variables to process the next command
                 _origReadHead = readHead = endReadHead;


### PR DESCRIPTION
This PR fixes a latency tracking issue that was caused by moving INFO under ProcessBasicCommands. Because of this, the latency tracking numbers for NET_RS event were not accurate.
We now implicitly consider any command under ProcessBasicCommands and ProcessArrayCommands as "fast" and all other commands (under ProcessOtherCommands and ProcessAdminCommands) as "slow".
For this reason, this PR also moves certain commands that are considered to be slow under ProcessOtherCommands.

<details>
<summary>Notes</summary>
Explicit classification was dropped, and we use the implicit method. The below info is just for future reference.
The alternative solution was to explicitly classify the command using the RespCommandsInfo (https://github.com/microsoft/garnet/pull/659/commits/6e5cbc2f63374bd7c904f9a863d0926deff7c400) flags (i.e. "slow", "fast"). However, this solution incurs the following penalty as measured using RepsParseStress below.


### Main
| Method       | Mean       | Error     | StdDev    | Allocated |
|------------- |-----------:|----------:|----------:|----------:|
| InlinePing   |   2.230 us | 0.0033 us | 0.0030 us |         - |
| Set          |  17.073 us | 0.0521 us | 0.0462 us |         - |
| SetEx        |  24.267 us | 0.0478 us | 0.0448 us |         - |
| Get          |  12.646 us | 0.0258 us | 0.0241 us |         - |
| ZAddRem      | 173.760 us | 0.8113 us | 0.7589 us |   26624 B |
| LPushPop     | 142.637 us | 1.8688 us | 1.7481 us |   30721 B |
| SAddRem      | 112.647 us | 0.4345 us | 0.4064 us |   16384 B |
| HSetDel      | 155.358 us | 1.4137 us | 1.3224 us |   55297 B |
| MyDictSetGet | 244.953 us | 1.2858 us | 1.2027 us |   30720 B |

### With checking IsDataCommand()
| Method       | Mean       | Error     | StdDev    | Allocated |
|------------- |-----------:|----------:|----------:|----------:|
| InlinePing   |   2.443 us | 0.0036 us | 0.0032 us |         - |
| Set          |  15.940 us | 0.0123 us | 0.0102 us |         - |
| SetEx        |  23.955 us | 0.0552 us | 0.0516 us |         - |
| Get          |  12.780 us | 0.0167 us | 0.0148 us |         - |
| ZAddRem      | 158.164 us | 0.5077 us | 0.4501 us |   26624 B |
| LPushPop     | 152.503 us | 1.5758 us | 1.4740 us |   30721 B |
| SAddRem      | 115.242 us | 0.7184 us | 0.6719 us |   16384 B |
| HSetDel      | 164.699 us | 2.0440 us | 1.9119 us |   55297 B |
| MyDictSetGet | 238.705 us | 0.5843 us | 0.5465 us |   30720 B |

### Using RespCommandsInfo
| Method       | Mean       | Error     | StdDev    | Allocated |
|------------- |-----------:|----------:|----------:|----------:|
| InlinePing   |   2.440 us | 0.0008 us | 0.0006 us |         - |
| Set          |  16.672 us | 0.0274 us | 0.0256 us |         - |
| SetEx        |  24.646 us | 0.0559 us | 0.0496 us |         - |
| Get          |  13.061 us | 0.0126 us | 0.0118 us |         - |
| ZAddRem      | 156.820 us | 0.8423 us | 0.7879 us |   26624 B |
| LPushPop     | 147.941 us | 1.0840 us | 0.9610 us |   30721 B |
| SAddRem      | 119.299 us | 0.4573 us | 0.4278 us |   16384 B |
| HSetDel      | 164.228 us | 1.3445 us | 1.1919 us |   55297 B |
| MyDictSetGet | 236.392 us | 1.7909 us | 1.6752 us |   30720 B |
</details>