### PR TITLE
Fixing case-sensitivity in enum parsing

### DIFF
--- a/libs/server/Resp/Parser/SessionParseState.cs
+++ b/libs/server/Resp/Parser/SessionParseState.cs
@@ -209,6 +209,8 @@ namespace Garnet.server
 
         /// <summary>
         /// Get enum argument at the given index
+        /// Note: this method exists for compatibility with existing code.
+        /// For best performance use: ReadOnlySpan.EqualsUpperCaseSpanIgnoringCase(""VALUE""u8) to figure out the current enum value
         /// </summary>
         /// <returns>True if enum parsed successfully</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -217,11 +219,15 @@ namespace Garnet.server
             Debug.Assert(i < Count);
             var strRep = GetString(i);
             var value = Enum.Parse<T>(strRep, ignoreCase);
-            return !Enum.IsDefined(typeof(T), strRep) ? default : value;
+            // Extra check is to avoid numerical values being successfully parsed as enum value
+            return Enum.GetNames<T>().Any(name => string.Equals(strRep, name,
+                    ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal)) ? default : value;
         }
 
         /// <summary>
         /// Try to get enum argument at the given index
+        /// Note: this method exists for compatibility with existing code.
+        /// For best performance use: ReadOnlySpan.EqualsUpperCaseSpanIgnoringCase(""VALUE""u8) to figure out the current enum value
         /// </summary>
         /// <returns>True if integer parsed successfully</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/libs/server/Resp/Parser/SessionParseState.cs
+++ b/libs/server/Resp/Parser/SessionParseState.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Garnet.common;
@@ -230,8 +231,8 @@ namespace Garnet.server
             var strRep = GetString(i);
             var successful = Enum.TryParse(strRep, ignoreCase, out value) &&
                              // Extra check is to avoid numerical values being successfully parsed as enum value
-                             string.Equals(strRep, value.ToString(),
-                                 ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+                             Enum.GetNames<T>().Any(name => string.Equals(strRep, name,
+                                 ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal));
             if (!successful) value = default;
             return successful;
         }

--- a/libs/server/Resp/Parser/SessionParseState.cs
+++ b/libs/server/Resp/Parser/SessionParseState.cs
@@ -228,8 +228,9 @@ namespace Garnet.server
         {
             Debug.Assert(i < Count);
             var strRep = GetString(i);
-            var successful = Enum.TryParse(strRep, ignoreCase, out value);
-            successful = successful && Enum.IsDefined(typeof(T), strRep);
+            var successful = Enum.TryParse(strRep, ignoreCase, out value) &&
+                             string.Equals(strRep, value.ToString(),
+                                 ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
             if (!successful) value = default;
             return successful;
         }

--- a/libs/server/Resp/Parser/SessionParseState.cs
+++ b/libs/server/Resp/Parser/SessionParseState.cs
@@ -220,8 +220,8 @@ namespace Garnet.server
             var strRep = GetString(i);
             var value = Enum.Parse<T>(strRep, ignoreCase);
             // Extra check is to avoid numerical values being successfully parsed as enum value
-            return Enum.GetNames<T>().Any(name => string.Equals(strRep, name,
-                    ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal)) ? default : value;
+            return string.Equals(Enum.GetName(value), strRep,
+                ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) ? default : value;
         }
 
         /// <summary>
@@ -237,8 +237,8 @@ namespace Garnet.server
             var strRep = GetString(i);
             var successful = Enum.TryParse(strRep, ignoreCase, out value) &&
                              // Extra check is to avoid numerical values being successfully parsed as enum value
-                             Enum.GetNames<T>().Any(name => string.Equals(strRep, name,
-                                 ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal));
+                             string.Equals(Enum.GetName(value), strRep,
+                                 ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
             if (!successful) value = default;
             return successful;
         }

--- a/libs/server/Resp/Parser/SessionParseState.cs
+++ b/libs/server/Resp/Parser/SessionParseState.cs
@@ -229,6 +229,7 @@ namespace Garnet.server
             Debug.Assert(i < Count);
             var strRep = GetString(i);
             var successful = Enum.TryParse(strRep, ignoreCase, out value) &&
+                             // Extra check is to avoid numerical values being successfully parsed as enum value
                              string.Equals(strRep, value.ToString(),
                                  ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
             if (!successful) value = default;

--- a/libs/server/Resp/Parser/SessionParseState.cs
+++ b/libs/server/Resp/Parser/SessionParseState.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Garnet.common;

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -1577,7 +1577,7 @@ namespace Garnet.test
         }
 
         [Test]
-        public void KeyExpireOptionsTest([Values("EXPIRE", "PEXPIRE")]string command, [Values(false, true)]bool testCaseSensitivity)
+        public void KeyExpireOptionsTest([Values("EXPIRE", "PEXPIRE")] string command, [Values(false, true)] bool testCaseSensitivity)
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = redis.GetDatabase(0);


### PR DESCRIPTION
Note: this is by no means the optimal way to get an enum value from the parse state. We should be using ReadOnlySpan.EqualsUpperCaseSpanIgnoringCase("OPT"u8) for best performance. This is just for compatibility with existing code.
e.g.:
```
var param = parseState.GetArgSliceByRef(i).ReadOnlySpan;
if (param.EqualsUpperCaseSpanIgnoringCase("<OPT>"u8))
  ...
...
```