### PR TITLE
Fix cluster command metric

### DIFF
--- a/libs/cluster/Session/ClusterCommands.cs
+++ b/libs/cluster/Session/ClusterCommands.cs
@@ -178,6 +178,7 @@ namespace Garnet.cluster
                 RespCommand.CLUSTER_SLOTSTATE => NetworkClusterSlotState(out invalidParameters),
                 _ => throw new Exception($"Unexpected cluster subcommand: {command}")
             };
+            this.sessionMetrics?.incr_total_cluster_commands_processed();
         }
     }
 }


### PR DESCRIPTION
There seems to be a regression in #373 where the total_cluster_commands_processed was left out while processing and shows up as 0 always whereas total_commands_processed accounted for this. This fix ensures that total_cluster_commands_processed is also appropriately updated for "admin" commands.