### PR TITLE
API to clear scratch buffer

### DIFF
--- a/libs/server/API/GarnetApi.cs
+++ b/libs/server/API/GarnetApi.cs
@@ -397,6 +397,7 @@ namespace Garnet.server
         public GarnetStatus ObjectScan(byte[] key, ref ObjectInput input, ref GarnetObjectStoreOutput outputFooter)
          => storageSession.ObjectScan(key, ref input, ref outputFooter, ref objectContext);
 
+        /// <inheritdoc />
         public bool FreeBuffer(ref ArgSlice arg)
          => storageSession.scratchBufferManager.RewindScratchBuffer(ref arg);
 

--- a/libs/server/API/GarnetApi.cs
+++ b/libs/server/API/GarnetApi.cs
@@ -397,7 +397,7 @@ namespace Garnet.server
         public GarnetStatus ObjectScan(byte[] key, ref ObjectInput input, ref GarnetObjectStoreOutput outputFooter)
          => storageSession.ObjectScan(key, ref input, ref outputFooter, ref objectContext);
 
-        public bool ClearBuffer(ref ArgSlice arg)
+        public bool FreeBuffer(ref ArgSlice arg)
          => storageSession.scratchBufferManager.RewindScratchBuffer(ref arg);
 
         #endregion

--- a/libs/server/API/GarnetApi.cs
+++ b/libs/server/API/GarnetApi.cs
@@ -398,9 +398,12 @@ namespace Garnet.server
          => storageSession.ObjectScan(key, ref input, ref outputFooter, ref objectContext);
 
         /// <inheritdoc />
-        public bool FreeBuffer(ref ArgSlice arg)
-         => storageSession.scratchBufferManager.RewindScratchBuffer(ref arg);
+        public int GetScratchBufferOffset()
+            => storageSession.scratchBufferManager.scratchBufferOffset;
 
+        /// <inheritdoc />
+        public bool ResetScratchBuffer(int offset)
+            => storageSession.scratchBufferManager.ResetScratchBuffer(offset);
         #endregion
     }
 }

--- a/libs/server/API/GarnetApi.cs
+++ b/libs/server/API/GarnetApi.cs
@@ -399,7 +399,7 @@ namespace Garnet.server
 
         /// <inheritdoc />
         public int GetScratchBufferOffset()
-            => storageSession.scratchBufferManager.scratchBufferOffset;
+            => storageSession.scratchBufferManager.ScratchBufferOffset;
 
         /// <inheritdoc />
         public bool ResetScratchBuffer(int offset)

--- a/libs/server/API/GarnetApi.cs
+++ b/libs/server/API/GarnetApi.cs
@@ -397,6 +397,9 @@ namespace Garnet.server
         public GarnetStatus ObjectScan(byte[] key, ref ObjectInput input, ref GarnetObjectStoreOutput outputFooter)
          => storageSession.ObjectScan(key, ref input, ref outputFooter, ref objectContext);
 
+        public bool ClearBuffer(ref ArgSlice arg)
+         => storageSession.scratchBufferManager.RewindScratchBuffer(ref arg);
+
         #endregion
     }
 }

--- a/libs/server/API/GarnetWatchApi.cs
+++ b/libs/server/API/GarnetWatchApi.cs
@@ -546,6 +546,10 @@ namespace Garnet.server
             return garnetApi.ObjectScan(key, ref input, ref outputFooter);
         }
 
+        public bool ClearBuffer(ref ArgSlice arg)
+        {
+            return garnetApi.ClearBuffer(ref arg);
+        }
         #endregion
     }
 }

--- a/libs/server/API/GarnetWatchApi.cs
+++ b/libs/server/API/GarnetWatchApi.cs
@@ -546,9 +546,9 @@ namespace Garnet.server
             return garnetApi.ObjectScan(key, ref input, ref outputFooter);
         }
 
-        public bool ClearBuffer(ref ArgSlice arg)
+        public bool FreeBuffer(ref ArgSlice arg)
         {
-            return garnetApi.ClearBuffer(ref arg);
+            return garnetApi.FreeBuffer(ref arg);
         }
         #endregion
     }

--- a/libs/server/API/GarnetWatchApi.cs
+++ b/libs/server/API/GarnetWatchApi.cs
@@ -546,10 +546,14 @@ namespace Garnet.server
             return garnetApi.ObjectScan(key, ref input, ref outputFooter);
         }
 
-        public bool FreeBuffer(ref ArgSlice arg)
-        {
-            return garnetApi.FreeBuffer(ref arg);
-        }
+        /// <inheritdoc />
+        public int GetScratchBufferOffset()
+            => garnetApi.GetScratchBufferOffset();
+
+        /// <inheritdoc />
+        public bool ResetScratchBuffer(int offset)
+            => garnetApi.ResetScratchBuffer(offset);
+
         #endregion
     }
 }

--- a/libs/server/API/IGarnetApi.cs
+++ b/libs/server/API/IGarnetApi.cs
@@ -1700,6 +1700,8 @@ namespace Garnet.server
         /// <param name="outputFooter"></param>
         GarnetStatus ObjectScan(byte[] key, ref ObjectInput input, ref GarnetObjectStoreOutput outputFooter);
 
+        bool ClearBuffer(ref ArgSlice arg);
+
         #endregion
 
     }

--- a/libs/server/API/IGarnetApi.cs
+++ b/libs/server/API/IGarnetApi.cs
@@ -1700,7 +1700,7 @@ namespace Garnet.server
         /// <param name="outputFooter"></param>
         GarnetStatus ObjectScan(byte[] key, ref ObjectInput input, ref GarnetObjectStoreOutput outputFooter);
 
-        bool ClearBuffer(ref ArgSlice arg);
+        bool FreeBuffer(ref ArgSlice arg);
 
         #endregion
 

--- a/libs/server/API/IGarnetApi.cs
+++ b/libs/server/API/IGarnetApi.cs
@@ -1701,15 +1701,17 @@ namespace Garnet.server
         GarnetStatus ObjectScan(byte[] key, ref ObjectInput input, ref GarnetObjectStoreOutput outputFooter);
 
         /// <summary>
-        /// Frees the last allocation in the scratch buffer. This is useful to avoid overflowing the scratch buffer
-        /// in case of repeated large allocations.
-        /// Note that only the last allocation could be freed this way as the next call could end up reallocating the
-        /// scratch buffer due to lack of sufficient length which would make the pointers in ArgSlice invalid. The API will
-        /// gracefully handle this case, but the buffer will not be freed for reuse.
+        /// Retrieve the current scratch buffer offset.
         /// </summary>
-        /// <param name="arg"></param>
-        /// <returns></returns>
-        bool FreeBuffer(ref ArgSlice arg);
+        /// <returns>Current offset</returns>
+        int GetScratchBufferOffset();
+
+        /// <summary>
+        /// Resets the scratch buffer to the given offset.
+        /// </summary>
+        /// <param name="offset">Offset to reset to</param>
+        /// <returns>True if successful, else false</returns>
+        bool ResetScratchBuffer(int offset);
 
         #endregion
 

--- a/libs/server/API/IGarnetApi.cs
+++ b/libs/server/API/IGarnetApi.cs
@@ -1700,6 +1700,15 @@ namespace Garnet.server
         /// <param name="outputFooter"></param>
         GarnetStatus ObjectScan(byte[] key, ref ObjectInput input, ref GarnetObjectStoreOutput outputFooter);
 
+        /// <summary>
+        /// Frees the last allocation in the scratch buffer. This is useful to avoid overflowing the scratch buffer
+        /// in case of repeated large allocations.
+        /// Note that only the last allocation could be freed this way as the next call could end up reallocating the
+        /// scratch buffer due to lack of sufficient length which would make the pointers in ArgSlice invalid. The API will
+        /// gracefully handle this case, but the buffer will not be freed for reuse.
+        /// </summary>
+        /// <param name="arg"></param>
+        /// <returns></returns>
         bool FreeBuffer(ref ArgSlice arg);
 
         #endregion

--- a/libs/server/ArgSlice/ScratchBufferManager.cs
+++ b/libs/server/ArgSlice/ScratchBufferManager.cs
@@ -29,7 +29,7 @@ namespace Garnet.server
         /// <summary>
         /// Current offset in scratch buffer
         /// </summary>
-        int scratchBufferOffset;
+        internal int scratchBufferOffset { get; private set; }
 
         public ScratchBufferManager()
         {
@@ -53,6 +53,20 @@ namespace Garnet.server
                 return true;
             }
             return false;
+        }
+
+        /// <summary>
+        /// Resets scratch buffer offset to the specified offset.
+        /// </summary>
+        /// <param name="offset">Offset to reset to</param>
+        /// <returns>True if successful, else false</returns>
+        public bool ResetScratchBuffer(int offset)
+        {
+            if (offset < 0 || offset > scratchBufferOffset)
+                return false;
+
+            scratchBufferOffset = offset;
+            return true;
         }
 
         /// <summary>

--- a/libs/server/ArgSlice/ScratchBufferManager.cs
+++ b/libs/server/ArgSlice/ScratchBufferManager.cs
@@ -29,7 +29,10 @@ namespace Garnet.server
         /// <summary>
         /// Current offset in scratch buffer
         /// </summary>
-        internal int scratchBufferOffset { get; private set; }
+        int scratchBufferOffset;
+
+        /// <summary>Current offset in scratch buffer</summary>
+        internal int ScratchBufferOffset => scratchBufferOffset;
 
         public ScratchBufferManager()
         {

--- a/libs/server/Custom/CustomFunctions.cs
+++ b/libs/server/Custom/CustomFunctions.cs
@@ -172,6 +172,17 @@ namespace Garnet.server
         }
 
         /// <summary>
+        /// Create output as error message, from given string
+        /// </summary>
+        protected static unsafe void WriteError(ref MemoryResult<byte> output, ReadOnlySpan<char> errorMessage)
+        {
+            var _output = (output.MemoryOwner, output.Length);
+            WriteError(ref _output, errorMessage);
+            output.MemoryOwner = _output.MemoryOwner;
+            output.Length = _output.Length;
+        }
+
+        /// <summary>
         /// Get argument from input, at specified offset (starting from 0)
         /// </summary>
         /// <param name="input">Input as ArgSlice</param>

--- a/website/docs/extensions/procedure.md
+++ b/website/docs/extensions/procedure.md
@@ -24,6 +24,10 @@ Registering the custom procedure is done on the server-side by calling the
 
 method on the Garnet server object's `RegisterAPI` object with its name, an instance of the custom procedure class and optional commandInfo.
 
+**NOTE** When invoking APIs on `IGarnetApi` multiple times with large outputs, it is possible to exhaust the internal buffer capacity. If such usage scenarios are expected, the buffer could be reset as described below.
+* Retrieve the initial buffer offset using `IGarnetApi.GetScratchBufferOffset`
+* Invoke necessary apis on `IGarnetApi`
+* Reset the buffer back to where it was using `IGarnetApi.ResetScratchBuffer(offset)`
 
 :::tip 
 As a reference of an implementation of a custom procedure, see the example in GarnetServer\Extensions\Sum.cs.

--- a/website/docs/extensions/transactions.md
+++ b/website/docs/extensions/transactions.md
@@ -26,6 +26,11 @@ These are the helper methods for developing custom transactions.
 - `GetNextArg(ArgSlice input, ref int offset)` This method is used to retrieve the next argument from the input at the specified offset. It takes an ArgSlice parameter representing the input and a reference to an int offset. It returns an ArgSlice object representing the argument as a span. The method internally reads a pointer with a length header to extract the argument.
 These member functions provide utility and convenience methods for manipulating and working with the transaction data, scratch buffer, and input arguments within the CustomTransactionProcedure class.
 
+**NOTE** When invoking APIs on `IGarnetApi` multiple times with large outputs, it is possible to exhaust the internal buffer capacity. If such usage scenarios are expected, the buffer could be reset as described below.
+* Retrieve the initial buffer offset using `IGarnetApi.GetScratchBufferOffset`
+* Invoke necessary apis on `IGarnetApi`
+* Reset the buffer back to where it was using `IGarnetApi.ResetScratchBuffer(offset)`
+
 Registering the custom transaction is done on the server-side by calling the `NewTransactionProc(string name, int numParams, Func<CustomTransactionProcedure> proc)` method on the Garnet server object's `RegisterAPI` object with its name, number of parameters and a method that returns an instance of the custom transaction class.\
 It is possible to register the custom transaction from the client-side as well (as an admin command, given that the code already resides on the server) by using the `REGISTER` command (see [Custom Commands](../dev/custom-commands.md)). 
 


### PR DESCRIPTION
When repeated large values are retrieved from custom commands, it is possible that the scratch buffer could overflow.
In such scenarios, the GetScratchBufferOffset and ResetScratchBuffer APIs could be invoked to free up the space occupied by the last retrieved data.