### PR TITLE
Correctly set IsInNewVersion bit + small null logger fix

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -3,7 +3,7 @@
 #      1) update the name: string below (line 6)     -- this is the version for the nuget package (e.g. 1.0.0)
 #      2) update \libs\host\GarnetServer.cs readonly string version  (~line 53)   -- NOTE - these two values need to be the same 
 ###################################### 
-name: 1.0.30
+name: 1.0.31
 trigger:
   branches:
     include:

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -52,7 +52,7 @@ namespace Garnet
         protected StoreWrapper storeWrapper;
 
         // IMPORTANT: Keep the version in sync with .azure\pipelines\azure-pipelines-external-release.yml line ~6.
-        readonly string version = "1.0.30";
+        readonly string version = "1.0.31";
 
         /// <summary>
         /// Resp protocol version

--- a/libs/storage/Tsavorite/cs/src/core/Index/CheckpointManagement/DeviceLogCommitCheckpointManager.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/CheckpointManagement/DeviceLogCommitCheckpointManager.cs
@@ -428,7 +428,7 @@ namespace Tsavorite.core
             if (errorCode != 0)
             {
                 var errorMessage = new Win32Exception((int)errorCode).Message;
-                logger.LogError("[DeviceLogCheckpointManager] OverlappedStream GetQueuedCompletionStatus error: {errorCode} msg: {errorMessage}", errorCode, errorMessage);
+                logger?.LogError("[DeviceLogCheckpointManager] OverlappedStream GetQueuedCompletionStatus error: {errorCode} msg: {errorMessage}", errorCode, errorMessage);
             }
             semaphore.Release();
         }

--- a/libs/storage/Tsavorite/cs/src/core/Index/Common/RecordInfo.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Common/RecordInfo.cs
@@ -223,7 +223,6 @@ namespace Tsavorite.core
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetIsInNewVersion() => word |= kInNewVersionBitMask;
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetDirtyAndModified() => word |= kDirtyBitMask | kModifiedBitMask;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/libs/storage/Tsavorite/cs/src/core/Index/Common/RecordInfo.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Common/RecordInfo.cs
@@ -3,7 +3,6 @@
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -223,7 +222,7 @@ namespace Tsavorite.core
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void SetIsInNewVersion() => word &= ~kInNewVersionBitMask;
+        public void SetIsInNewVersion() => word |= kInNewVersionBitMask;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetDirtyAndModified() => word |= kDirtyBitMask | kModifiedBitMask;


### PR DESCRIPTION
Correctly set IsInNewVersion bit for new records when operating in (v+1) during checkpointing. Needed to ensure that we start making in-place-updates on (v+1) version instead of continuously running in append-only mode during the checkpoint. 

Prior to this, we were not setting the IsInNewVersion bit, which implied that every update during most of the checkpointing lifetime (including the wait-flush phase) were being made in append-only mode, causing huge hybrid log growth and tail-of-log contention that would limit performance.

Also: Small fix to possibly null logger

Fixes https://github.com/microsoft/garnet/issues/704