### PR TITLE
Use generics for CustomProcedure

### DIFF
--- a/libs/server/Custom/CustomProcedureWrapper.cs
+++ b/libs/server/Custom/CustomProcedureWrapper.cs
@@ -15,7 +15,8 @@ namespace Garnet.server
         /// Custom command implementation
         /// </summary>
         /// <param name="garnetApi"></param>
-        public abstract bool Execute(IGarnetApi garnetApi, ArgSlice input, ref MemoryResult<byte> output);
+        public abstract bool Execute<TGarnetApi>(TGarnetApi garnetApi, ArgSlice input, ref MemoryResult<byte> output)
+            where TGarnetApi : IGarnetApi;
     }
 
     class CustomProcedureWrapper

--- a/main/GarnetServer/Extensions/SetStringAndList.cs
+++ b/main/GarnetServer/Extensions/SetStringAndList.cs
@@ -8,7 +8,7 @@ namespace Garnet
 {
     class SetStringAndList : CustomProcedure
     {
-        public override bool Execute(IGarnetApi garnetApi, ArgSlice input, ref MemoryResult<byte> output)
+        public override bool Execute<TGarnetApi>(TGarnetApi garnetApi, ArgSlice input, ref MemoryResult<byte> output)
         {
             var offset = 0;
             var key = GetNextArg(input, ref offset);

--- a/main/GarnetServer/Extensions/Sum.cs
+++ b/main/GarnetServer/Extensions/Sum.cs
@@ -8,7 +8,7 @@ namespace Garnet
 {
     class Sum : CustomProcedure
     {
-        public override bool Execute(IGarnetApi garnetApi, ArgSlice input, ref MemoryResult<byte> output)
+        public override bool Execute<TGarnetApi>(TGarnetApi garnetApi, ArgSlice input, ref MemoryResult<byte> output)
         {
             var offset = 0;
             var sum = 0;

--- a/test/Garnet.test/RespCustomCommandTests.cs
+++ b/test/Garnet.test/RespCustomCommandTests.cs
@@ -21,9 +21,9 @@ namespace Garnet.test
 {
     public class LargeGet : CustomProcedure
     {
-        public override bool Execute(IGarnetApi garnetApi, ArgSlice input, ref MemoryResult<byte> output)
+        public override bool Execute<TGarnetApi>(TGarnetApi garnetApi, ArgSlice input, ref MemoryResult<byte> output)
         {
-            static bool ResetBuffer(IGarnetApi garnetApi, ref MemoryResult<byte> output, int buffOffset)
+            static bool ResetBuffer(TGarnetApi garnetApi, ref MemoryResult<byte> output, int buffOffset)
             {
                 bool status = garnetApi.ResetScratchBuffer(buffOffset);
                 if (!status)
@@ -92,7 +92,7 @@ namespace Garnet.test
 
     public class OutOfOrderFreeBuffer : CustomProcedure
     {
-        public override bool Execute(IGarnetApi garnetApi, ArgSlice input, ref MemoryResult<byte> output)
+        public override bool Execute<TGarnetApi>(TGarnetApi garnetApi, ArgSlice input, ref MemoryResult<byte> output)
         {
             var offset = 0;
             var key = GetNextArg(input, ref offset);


### PR DESCRIPTION
To ensure high performance when executing custom procedures, the Execute method is modified to utilize generic type of GarnetApi instead of as a parameter that needs an interface call and boxing.