### PR TITLE
[Bug] Get modified length method returns wrong length for PERSIST commands

### DIFF
--- a/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
@@ -213,7 +213,7 @@ namespace Garnet.server
 
                     case RespCommand.SET:
                     case RespCommand.SETEXXX:
-                        return sizeof(int) + input.Length - RespInputHeader.Size;
+                        break;
                     case RespCommand.PERSIST:
                         return sizeof(int) + t.LengthWithoutMetadata;
 

--- a/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
@@ -213,8 +213,9 @@ namespace Garnet.server
 
                     case RespCommand.SET:
                     case RespCommand.SETEXXX:
+                        return sizeof(int) + t.LengthWithoutMetadata + input.MetadataSize;
                     case RespCommand.PERSIST:
-                        break;
+                        return sizeof(int) + t.LengthWithoutMetadata;
 
                     case RespCommand.EXPIRE:
                     case RespCommand.PEXPIRE:

--- a/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
@@ -213,7 +213,7 @@ namespace Garnet.server
 
                     case RespCommand.SET:
                     case RespCommand.SETEXXX:
-                        return sizeof(int) + t.LengthWithoutMetadata + input.MetadataSize;
+                        return sizeof(int) + input.Length - RespInputHeader.Size;
                     case RespCommand.PERSIST:
                         return sizeof(int) + t.LengthWithoutMetadata;
 


### PR DESCRIPTION
Modified the `GetRMWModifiedValueLength` method to return the wrong length for `PERSIST`.

PR created for https://github.com/microsoft/garnet/pull/695#discussion_r1802116909