### PR TITLE
[Docs] Removed non exist BZPOP command from doc

### DIFF
--- a/website/docs/commands/api-compatibility.md
+++ b/website/docs/commands/api-compatibility.md
@@ -188,9 +188,9 @@ Note that this list is subject to change as we continue to expand our API comman
 |  | [HVALS](data-structures.md#hvals) | ➕ |  |
 | <span id="hyperloglog">**HYPERLOGLOG**</span> | [PFADD](analytics.md#pfadd) | ➕ |  |
 |  | [PFCOUNT](analytics.md#pfcount) | ➕ |  |
-|  | PFDEBUG | ➖ |  |
+|  | PFDEBUG | ➖ | Internal command |
 |  | [PFMERGE](analytics.md#pfmerge) | ➕ |  |
-|  | PFSELFTEST | ➖ |  |
+|  | PFSELFTEST | ➖ | Internal command |
 | <span id="keys">**KEYS**</span> | COPY | ➖ |  |
 |  | [DEL](generic-commands.md#del) | ➕ |  |
 |  | DUMP | ➖ |  |
@@ -318,8 +318,7 @@ Note that this list is subject to change as we continue to expand our API comman
 |  | HELP | ➖ |  |
 |  | LEN | ➖ |  |
 |  | RESET | ➖ |  |
-| <span id="sorted-set">**SORTED SET**</span> | BZPOP | ➖ |  |
-|  | BZMPOP | ➖ |  |
+| <span id="sorted-set">**SORTED SET**</span> | BZMPOP | ➖ |  |
 |  | BZPOPMAX | ➖ |  |
 |  | BZPOPMIN | ➖ |  |
 |  | [ZADD](data-structures.md#zadd) | ➕ |  |


### PR DESCRIPTION
The BZPOP command is not available in Redis but was in our ApiCompatibility doc. This PR is to move that