### PR TITLE
Security fix - Setting up config files during mirroring

### DIFF
--- a/.azure/pipelines/azure-pipelines-mirror.yml
+++ b/.azure/pipelines/azure-pipelines-mirror.yml
@@ -44,7 +44,7 @@ jobs:
       git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" remote add vso https://dev.azure.com/msresearch/_git/Garnet
       git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" fetch vso cfs-remediation
       git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" cherry-pick 0bae2b8a7d3dc9bfc59d25acf30b470ff97f6a7f
-      git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" push --force https://dev.azure.com/msresearch/_git/Garnet main
+      git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" push https://dev.azure.com/msresearch/_git/Garnet main
 
     displayName: 'Mirror GitHub main to Azure DevOps main'
     env:

--- a/.azure/pipelines/azure-pipelines-mirror.yml
+++ b/.azure/pipelines/azure-pipelines-mirror.yml
@@ -44,7 +44,7 @@ jobs:
       git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" remote add vso https://dev.azure.com/msresearch/_git/Garnet
       git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" fetch vso cfs-remediation
       git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" cherry-pick 0bae2b8a7d3dc9bfc59d25acf30b470ff97f6a7f
-      git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" push https://dev.azure.com/msresearch/_git/Garnet main
+      git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" push --force https://dev.azure.com/msresearch/_git/Garnet main
 
     displayName: 'Mirror GitHub main to Azure DevOps main'
     env:

--- a/.azure/pipelines/azure-pipelines-mirror.yml
+++ b/.azure/pipelines/azure-pipelines-mirror.yml
@@ -40,8 +40,11 @@ jobs:
       # Reset the main branch to match the origin/main branch
       # git reset --hard origin/main
 
-      # Push the updated main branch to Azure DevOps
-      git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" push https://dev.azure.com/msresearch/_git/Garnet main
+      # Push the updated main branch to Azure DevOps - make sure to get the config files each push so compliant with security policy
+      git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" remote add vso https://dev.azure.com/msresearch/_git/Garnet
+      git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" fetch vso cfs-remediation
+      git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" cherry-pick 0bae2b8a7d3dc9bfc59d25acf30b470ff97f6a7f
+      git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" push --force https://dev.azure.com/msresearch/_git/Garnet main
 
     displayName: 'Mirror GitHub main to Azure DevOps main'
     env:


### PR DESCRIPTION
Central Feed Services (CFS) require a nuget.config (in root) and a .npmrc (in website folder) to satisfy the CFS security policy of not pulling packages straight from internet and instead to go through Azure feed. This will not work for OSS so we can't have files there but we need them in the mirror ADO repo. This changes puts the files in there directly on the push.