### PR TITLE
BDN benchmark for custom operations.

### DIFF
--- a/benchmark/BDN.benchmark/BDN.benchmark.csproj
+++ b/benchmark/BDN.benchmark/BDN.benchmark.csproj
@@ -25,7 +25,7 @@
     <Compile Include="..\..\main\GarnetServer\Extensions\MyDictObject.cs" Link="Custom\MyDictObject.cs" />
     <Compile Include="..\..\main\GarnetServer\Extensions\MyDictSet.cs" Link="Custom\MyDictSet.cs" />
     <Compile Include="..\..\main\GarnetServer\Extensions\MyDictGet.cs" Link="Custom\MyDictGet.cs" />
-		<Compile Include="..\..\main\GarnetServer\Extensions\SetIfPM.cs" Link="Custom\SetIfPM.cs" />
-	</ItemGroup>
+    <Compile Include="..\..\main\GarnetServer\Extensions\SetIfPM.cs" Link="Custom\SetIfPM.cs" />
+  </ItemGroup>
 
 </Project>

--- a/benchmark/BDN.benchmark/BDN.benchmark.csproj
+++ b/benchmark/BDN.benchmark/BDN.benchmark.csproj
@@ -22,9 +22,10 @@
   <ItemGroup>
     <Compile Include="..\..\playground\Embedded.perftest\EmbeddedRespServer.cs" Link="Utils\EmbeddedRespServer.cs" />
     <Compile Include="..\..\playground\Embedded.perftest\DummyNetworkSender.cs" Link="Utils\DummyNetworkSender.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\MyDictObject.cs" Link="CustomProcs\MyDictObject.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\MyDictSet.cs" Link="CustomProcs\MyDictSet.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\MyDictGet.cs" Link="CustomProcs\MyDictGet.cs" />
+    <Compile Include="..\..\main\GarnetServer\Extensions\MyDictObject.cs" Link="Custom\MyDictObject.cs" />
+    <Compile Include="..\..\main\GarnetServer\Extensions\MyDictSet.cs" Link="Custom\MyDictSet.cs" />
+    <Compile Include="..\..\main\GarnetServer\Extensions\MyDictGet.cs" Link="Custom\MyDictGet.cs" />
+		<Compile Include="..\..\main\GarnetServer\Extensions\SetIfPM.cs" Link="Custom\SetIfPM.cs" />
 	</ItemGroup>
 
 </Project>

--- a/benchmark/BDN.benchmark/Cluster/ClusterOperations.cs
+++ b/benchmark/BDN.benchmark/Cluster/ClusterOperations.cs
@@ -36,14 +36,14 @@ namespace BDN.benchmark.Cluster
             cc.AddSlotRange([(0, 16383)]);
             cc.CreateGetSet();
             cc.CreateMGetMSet();
-            cc.CreateCPBSET();
+            cc.CreateCTXNSET();
 
             // Warmup/Prepopulate stage
             cc.Consume(cc.singleGetSet[1].ptr, cc.singleGetSet[1].buffer.Length);
             // Warmup/Prepopulate stage
             cc.Consume(cc.singleMGetMSet[1].ptr, cc.singleMGetMSet[1].buffer.Length);
             // Warmup/Prepopulate stage
-            cc.Consume(cc.singleCPBSET.ptr, cc.singleCPBSET.buffer.Length);
+            cc.Consume(cc.singleCTXNSET.ptr, cc.singleCTXNSET.buffer.Length);
         }
 
         [GlobalCleanup]
@@ -77,9 +77,9 @@ namespace BDN.benchmark.Cluster
         }
 
         [Benchmark]
-        public void CPBSET()
+        public void CTXNSET()
         {
-            cc.Consume(cc.singleCPBSET.ptr, cc.singleCPBSET.buffer.Length);
+            cc.Consume(cc.singleCTXNSET.ptr, cc.singleCTXNSET.buffer.Length);
         }
     }
 }

--- a/benchmark/BDN.benchmark/Custom/CustomProcSet.cs
+++ b/benchmark/BDN.benchmark/Custom/CustomProcSet.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Garnet.common;
+using Garnet.server;
+
+namespace BDN.benchmark.CustomProcs
+{
+    class CustomProcSet : CustomProcedure
+    {
+        /// <summary>
+        /// Parameters including command
+        /// </summary>
+        public const int Arity = 9;
+
+        /// <summary>
+        /// Command name
+        /// </summary>
+        public const string CommandName = "CPROCSET";
+
+        public override bool Execute<TGarnetApi>(TGarnetApi api, ref CustomProcedureInput procInput, ref MemoryResult<byte> output)
+        {
+            var offset = 0;
+            var setA = GetNextArg(ref procInput, ref offset);
+            var setB = GetNextArg(ref procInput, ref offset);
+            var setC = GetNextArg(ref procInput, ref offset);
+            var setD = GetNextArg(ref procInput, ref offset);
+
+            var valueA = GetNextArg(ref procInput, ref offset);
+            var valueB = GetNextArg(ref procInput, ref offset);
+            var valueC = GetNextArg(ref procInput, ref offset);
+            var valueD = GetNextArg(ref procInput, ref offset);
+
+            _ = api.SET(setA, valueA);
+            _ = api.SET(setB, valueB);
+            _ = api.SET(setC, valueC);
+            _ = api.SET(setD, valueD);
+
+            return true;
+        }
+    }
+}

--- a/benchmark/BDN.benchmark/Custom/CustomProcSet.cs
+++ b/benchmark/BDN.benchmark/Custom/CustomProcSet.cs
@@ -18,6 +18,14 @@ namespace BDN.benchmark.CustomProcs
         /// </summary>
         public const string CommandName = "CPROCSET";
 
+        /// <summary>
+        /// CPROCSET key1 key2 key3 key4 value1 value2 value3 value4
+        /// </summary>
+        /// <typeparam name="TGarnetApi"></typeparam>
+        /// <param name="api"></param>
+        /// <param name="procInput"></param>
+        /// <param name="output"></param>
+        /// <returns></returns>
         public override bool Execute<TGarnetApi>(TGarnetApi api, ref CustomProcedureInput procInput, ref MemoryResult<byte> output)
         {
             var offset = 0;

--- a/benchmark/BDN.benchmark/Custom/CustomTxnSet.cs
+++ b/benchmark/BDN.benchmark/Custom/CustomTxnSet.cs
@@ -8,7 +8,7 @@ using Tsavorite.core;
 namespace BDN.benchmark.CustomProcs
 {
     /// <summary>
-    /// Custom procedure to set values
+    /// Custom transaction to set values
     /// </summary>
     sealed class CustomTxnSet : CustomTransactionProcedure
     {

--- a/benchmark/BDN.benchmark/Custom/CustomTxnSet.cs
+++ b/benchmark/BDN.benchmark/Custom/CustomTxnSet.cs
@@ -10,7 +10,7 @@ namespace BDN.benchmark.CustomProcs
     /// <summary>
     /// Custom procedure to set values
     /// </summary>
-    sealed class CustomProcSet : CustomTransactionProcedure
+    sealed class CustomTxnSet : CustomTransactionProcedure
     {
         /// <summary>
         /// Parameters including command
@@ -20,7 +20,7 @@ namespace BDN.benchmark.CustomProcs
         /// <summary>
         /// Command name
         /// </summary>
-        public const string CommandName = "CPBSET";
+        public const string CommandName = "CTXNSET";
 
         ArgSlice setA;
         ArgSlice setB;
@@ -33,7 +33,7 @@ namespace BDN.benchmark.CustomProcs
         ArgSlice valueD;
 
         /// <summary>
-        ///  CPBSET key1 key2 key3 key4 value1 value2 value3 value4
+        ///  CTXNSET key1 key2 key3 key4 value1 value2 value3 value4
         /// </summary>
         /// <typeparam name="TGarnetReadApi"></typeparam>
         /// <param name="api"></param>

--- a/benchmark/BDN.benchmark/Operations/CustomOperations.cs
+++ b/benchmark/BDN.benchmark/Operations/CustomOperations.cs
@@ -14,16 +14,27 @@ namespace BDN.benchmark.Operations
     [MemoryDiagnoser]
     public unsafe class CustomOperations : OperationsBase
     {
+        static ReadOnlySpan<byte> SETIFPM => "*4\r\n$7\r\nSETIFPM\r\n$1\r\nk\r\n$3\r\nval\r\n$1\r\nv\r\n"u8;
+        byte[] setIfPmRequestBuffer;
+        byte* setIfPmRequestBufferPointer;
+
         static ReadOnlySpan<byte> MYDICTSETGET => "*4\r\n$9\r\nMYDICTSET\r\n$2\r\nck\r\n$1\r\nf\r\n$1\r\nv\r\n*3\r\n$9\r\nMYDICTGET\r\n$2\r\nck\r\n$1\r\nf\r\n"u8;
         byte[] myDictSetGetRequestBuffer;
         byte* myDictSetGetRequestBufferPointer;
 
-        static ReadOnlySpan<byte> CPBSET => "*9\r\n$6\r\nCPBSET\r\n$6\r\n{0}000\r\n$6\r\n{0}001\r\n$6\r\n{0}002\r\n$6\r\n{0}003\r\n$6\r\n{0}000\r\n$6\r\n{0}001\r\n$6\r\n{0}002\r\n$6\r\n{0}003\r\n"u8;
-        byte[] cpbsetBuffer;
-        byte* cpbsetBufferPointer;
+        static ReadOnlySpan<byte> CTXNSET => "*9\r\n$7\r\nCTXNSET\r\n$6\r\n{0}000\r\n$6\r\n{0}001\r\n$6\r\n{0}002\r\n$6\r\n{0}003\r\n$6\r\n{0}000\r\n$6\r\n{0}001\r\n$6\r\n{0}002\r\n$6\r\n{0}003\r\n"u8;
+        byte[] ctxnsetBuffer;
+        byte* ctxnsetBufferPointer;
+
+        static ReadOnlySpan<byte> CPROCSET => "*9\r\n$8\r\nCPROCSET\r\n$6\r\n{0}000\r\n$6\r\n{0}001\r\n$6\r\n{0}002\r\n$6\r\n{0}003\r\n$6\r\n{0}000\r\n$6\r\n{0}001\r\n$6\r\n{0}002\r\n$6\r\n{0}003\r\n"u8;
+        byte[] cprocsetBuffer;
+        byte* cprocsetBufferPointer;
 
         void CreateExtensions()
         {
+            // Register custom raw string command
+            server.Register.NewCommand("SETIFPM", CommandType.ReadModifyWrite, new SetIfPMCustomCommand(), new RespCommandsInfo { Arity = 4 });
+
             // Register custom object type and commands
             var factory = new MyDictFactory();
             server.Register.NewType(factory);
@@ -31,29 +42,52 @@ namespace BDN.benchmark.Operations
             server.Register.NewCommand("MYDICTGET", CommandType.Read, factory, new MyDictGet(), new RespCommandsInfo { Arity = 3 });
 
             // Register custom transaction
-            server.Register.NewTransactionProc(CustomProcs.CustomProcSet.CommandName, () => new CustomProcSet(), new RespCommandsInfo { Arity = CustomProcs.CustomProcSet.Arity });
+            server.Register.NewTransactionProc(CustomProcs.CustomTxnSet.CommandName, () => new CustomTxnSet(),
+                new RespCommandsInfo { Arity = CustomProcs.CustomTxnSet.Arity });
+
+            // Register custom procedure
+            server.Register.NewProcedure(CustomProcs.CustomProcSet.CommandName, new CustomProcSet(),
+                new RespCommandsInfo { Arity = CustomProcs.CustomProcSet.Arity });
         }
+
         public override void GlobalSetup()
         {
             base.GlobalSetup();
             CreateExtensions();
 
+            SetupOperation(ref setIfPmRequestBuffer, ref setIfPmRequestBufferPointer, SETIFPM);
             SetupOperation(ref myDictSetGetRequestBuffer, ref myDictSetGetRequestBufferPointer, MYDICTSETGET);
-            SetupOperation(ref cpbsetBuffer, ref cpbsetBufferPointer, CPBSET);
+            SetupOperation(ref ctxnsetBuffer, ref ctxnsetBufferPointer, CTXNSET);
+            SetupOperation(ref cprocsetBuffer, ref cprocsetBufferPointer, CPROCSET);
+
+            SlowConsumeMessage("*4\r\n$7\r\nSETIFPM\r\n$1\r\nk\r\n$3\r\nval\r\n$1\r\nv\r\n"u8);
             SlowConsumeMessage("*4\r\n$9\r\nMYDICTSET\r\n$2\r\nck\r\n$1\r\nf\r\n$1\r\nv\r\n"u8);
-            SlowConsumeMessage(cpbsetBuffer);
+            SlowConsumeMessage(ctxnsetBuffer);
+            SlowConsumeMessage(cprocsetBuffer);
         }
 
         [Benchmark]
-        public void MyDictSetGet()
+        public void CustomRawStringCommand()
+        {
+            _ = session.TryConsumeMessages(setIfPmRequestBufferPointer, setIfPmRequestBuffer.Length);
+        }
+
+        [Benchmark]
+        public void CustomObjectCommand()
         {
             _ = session.TryConsumeMessages(myDictSetGetRequestBufferPointer, myDictSetGetRequestBuffer.Length);
         }
 
         [Benchmark]
-        public void CustomProcSet()
+        public void CustomTransaction()
         {
-            _ = session.TryConsumeMessages(cpbsetBufferPointer, cpbsetBuffer.Length);
+            _ = session.TryConsumeMessages(ctxnsetBufferPointer, ctxnsetBuffer.Length);
+        }
+
+        [Benchmark]
+        public void CustomProcedure()
+        {
+            _ = session.TryConsumeMessages(cprocsetBufferPointer, cprocsetBuffer.Length);
         }
     }
 }

--- a/benchmark/BDN.benchmark/Operations/CustomOperations.cs
+++ b/benchmark/BDN.benchmark/Operations/CustomOperations.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using BDN.benchmark.CustomProcs;
+using BenchmarkDotNet.Attributes;
+using Garnet;
+using Garnet.server;
+
+namespace BDN.benchmark.Operations
+{
+    /// <summary>
+    /// Benchmark for ObjectOperations
+    /// </summary>
+    [MemoryDiagnoser]
+    public unsafe class CustomOperations : OperationsBase
+    {
+        static ReadOnlySpan<byte> MYDICTSETGET => "*4\r\n$9\r\nMYDICTSET\r\n$2\r\nck\r\n$1\r\nf\r\n$1\r\nv\r\n*3\r\n$9\r\nMYDICTGET\r\n$2\r\nck\r\n$1\r\nf\r\n"u8;
+        byte[] myDictSetGetRequestBuffer;
+        byte* myDictSetGetRequestBufferPointer;
+
+        static ReadOnlySpan<byte> CPBSET => "*9\r\n$6\r\nCPBSET\r\n$6\r\n{0}000\r\n$6\r\n{0}001\r\n$6\r\n{0}002\r\n$6\r\n{0}003\r\n$6\r\n{0}000\r\n$6\r\n{0}001\r\n$6\r\n{0}002\r\n$6\r\n{0}003\r\n"u8;
+        byte[] cpbsetBuffer;
+        byte* cpbsetBufferPointer;
+
+        void CreateExtensions()
+        {
+            // Register custom object type and commands
+            var factory = new MyDictFactory();
+            server.Register.NewType(factory);
+            server.Register.NewCommand("MYDICTSET", CommandType.ReadModifyWrite, factory, new MyDictSet(), new RespCommandsInfo { Arity = 4 });
+            server.Register.NewCommand("MYDICTGET", CommandType.Read, factory, new MyDictGet(), new RespCommandsInfo { Arity = 3 });
+
+            // Register custom transaction
+            server.Register.NewTransactionProc(CustomProcs.CustomProcSet.CommandName, () => new CustomProcSet(), new RespCommandsInfo { Arity = CustomProcs.CustomProcSet.Arity });
+        }
+        public override void GlobalSetup()
+        {
+            base.GlobalSetup();
+            CreateExtensions();
+
+            SetupOperation(ref myDictSetGetRequestBuffer, ref myDictSetGetRequestBufferPointer, MYDICTSETGET);
+            SetupOperation(ref cpbsetBuffer, ref cpbsetBufferPointer, CPBSET);
+            SlowConsumeMessage("*4\r\n$9\r\nMYDICTSET\r\n$2\r\nck\r\n$1\r\nf\r\n$1\r\nv\r\n"u8);
+            SlowConsumeMessage(cpbsetBuffer);
+        }
+
+        [Benchmark]
+        public void MyDictSetGet()
+        {
+            _ = session.TryConsumeMessages(myDictSetGetRequestBufferPointer, myDictSetGetRequestBuffer.Length);
+        }
+
+        [Benchmark]
+        public void CustomProcSet()
+        {
+            _ = session.TryConsumeMessages(cpbsetBufferPointer, cpbsetBuffer.Length);
+        }
+    }
+}


### PR DESCRIPTION
Benchmark for all custom operations

- [x] Added custom procedure benchmark
- [x] Added custom raw string command benchmark
- [x] Moved custom object command and custom transaction from ObjectOperations to CustomOperations

main

| Method        | Params | Mean     | Error    | StdDev   | Allocated |
|-------------- |------- |---------:|---------:|---------:|----------:|
| CustomProcSet | None   | 70.30 us | 1.117 us | 0.933 us |         - |


| Method       | Params | Mean     | Error   | StdDev  | Gen0   | Allocated |
|------------- |------- |---------:|--------:|--------:|-------:|----------:|
| MyDictSetGet | None   | 120.8 us | 2.39 us | 2.94 us | 0.2441 |  23.44 KB |

main's CustomProcSet maps to PR's CustomTransaction
main's MyDictSetGet maps to PR's CustomObjectCommand

PR 

| Method                 | Params | Mean      | Error    | StdDev   | Median    | Gen0   | Allocated |
|----------------------- |------- |----------:|---------:|---------:|----------:|-------:|----------:|
| CustomRawStringCommand | None   |  30.80 us | 0.484 us | 0.429 us |  30.82 us |      - |         - |
| CustomObjectCommand    | None   | 124.61 us | 2.441 us | 3.654 us | 124.42 us | 0.2441 |   24000 B |
| CustomTransaction      | None   |  73.31 us | 1.456 us | 1.495 us |  73.54 us |      - |         - |
| CustomProcedure        | None   |  57.40 us | 1.127 us | 1.206 us |  57.22 us |      - |         - |
