### PR TITLE
Fix HINCRBYFLOAT precision, use double, not float

### DIFF
--- a/libs/server/Objects/Hash/HashObjectImpl.cs
+++ b/libs/server/Objects/Hash/HashObjectImpl.cs
@@ -393,7 +393,7 @@ namespace Garnet.server
                 }
                 else
                 {
-                    if (!NumUtils.TryParse(incrSlice.ReadOnlySpan, out float incr))
+                    if (!NumUtils.TryParse(incrSlice.ReadOnlySpan, out double incr))
                     {
                         while (!RespWriteUtils.WriteError(CmdStrings.RESP_ERR_NOT_VALID_FLOAT, ref curr, end))
                             ObjectUtils.ReallocateOutput(ref output, ref isMemory, ref ptr, ref ptrHandle, ref curr,
@@ -405,7 +405,7 @@ namespace Garnet.server
 
                     if (valueExists)
                     {
-                        if (!NumUtils.TryParse(value, out float result))
+                        if (!NumUtils.TryParse(value, out double result))
                         {
                             while (!RespWriteUtils.WriteError(CmdStrings.RESP_ERR_HASH_VALUE_IS_NOT_FLOAT, ref curr,
                                        end))

--- a/test/Garnet.test/RespHashTests.cs
+++ b/test/Garnet.test/RespHashTests.cs
@@ -274,6 +274,16 @@ namespace Garnet.test
         }
 
         [Test]
+        public void CheckHashIncrementDoublePrecision()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+            db.HashSet("user:user1", [new HashEntry("Field1", "1.1111111111")]);
+            var result = db.HashIncrement(new RedisKey("user:user1"), new RedisValue("Field1"), 2.2222222222);
+            ClassicAssert.AreEqual(3.3333333333, result, 1e-15);
+        }
+
+        [Test]
         public void CanDoHSETNXCommand()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());


### PR DESCRIPTION
**Problem:**
`HashObject.HashIncrement` uses `float` as `NumUtils.TryParse` output type, instead of the presumably intended `double`.
This results in floating precision loss, e.g. 2.1 decremented by 1.2 gives 0.89999986 instead of expected 0.9 +/- 1e-15.

**Solution:**
Use `double` as the output type in `NumUtils.TryParse` calls , one for the input and one for the existing value.

**Test:**
Added the test `CheckHashIncrementDoublePrecision`, it fails with the original code, passes with the amended.
