### PR TITLE
Copy CI benchmark charts into website publishing action

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -28,9 +28,10 @@ jobs:
           sparse-checkout: |
             website/static/charts
           path: continuousbenchmark
-      - run: |
-          mkdir -p website/static/charts
-          cp continuousbenchmark/website/static/charts/* website/static/charts
+      - name: Copy charts
+        run: |
+          mkdir -p static/charts
+          cp continuousbenchmark/website/static/charts/* static/charts
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Copy charts
         run: |
           mkdir -p static/charts
-          cp continuousbenchmark/website/static/charts/* static/charts
+          cp ../continuousbenchmark/website/static/charts/* static/charts
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches:
       - main
-      - continuousbenchmark
     paths:
       - '.github/workflows/deploy-website.yml'
       - 'website/**'
-    # Review gh actions docs if you want to further define triggers, paths, etc
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
-
+  workflow_run:
+    workflows: [Garnet CI BDN.benchmark]
+    types:
+      - completed
 permissions:
   contents: write
 

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - continuousbenchmark
     paths:
       - '.github/workflows/deploy-website.yml'
       - 'website/**'
@@ -22,6 +23,8 @@ jobs:
         working-directory: website
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
       - uses: actions/checkout@v4
         with:
           ref: continuousbenchmark

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -22,6 +22,11 @@ jobs:
         working-directory: website
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          ref: continuousbenchmark
+          sparse-checkout: |
+            website/static/charts
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -27,6 +27,10 @@ jobs:
           ref: continuousbenchmark
           sparse-checkout: |
             website/static/charts
+          path: continuousbenchmark
+      - run: |
+          mkdir -p website/static/charts
+          cp continuousbenchmark/website/static/charts/* website/static/charts
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
* Grabs the latest charts from the branch `continuousbenchmark`, in the folder `website/static/charts`
* Copies the charts into the `static` folder before running `yarn`
* The pages deploy is updated to trigger on both `main` and `continuousbenchmark` branches

After merge, the benchmarking history charts should be available at https://microsoft.github.io/garnet/charts