### PR TITLE
Upgraded Release Pipeline task: GitHubRelease@0 to @1 since the @0 version is now deprecated

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -163,7 +163,7 @@ jobs:
     displayName: 'Publish Artifact: drop'
     enabled: True
 
-  - task: GitHubRelease@0
+  - task: GitHubRelease@1
     displayName: 'Create the GitHub release'
     enabled: True
     inputs:


### PR DESCRIPTION
The GitHubRelease task version 0 is deprecated and might stop working, so updated to version 1.

I disabled the release pipeline so when this change is merged, it won't try to run it and create a new release. It wouldn't be able to but just extra precaution.