### PR TITLE
Bugfix CustomTransaction AOF Replay Bug

### DIFF
--- a/libs/server/AOF/AofProcessor.cs
+++ b/libs/server/AOF/AofProcessor.cs
@@ -275,7 +275,7 @@ namespace Garnet.server
 
         unsafe void RunStoredProc(byte id, CustomProcedureInput customProcInput, byte* ptr)
         {
-            var curr = ptr;
+            var curr = ptr + sizeof(AofHeader);
 
             // Reconstructing CustomProcedureInput
 

--- a/test/Garnet.test/RespAofTests.cs
+++ b/test/Garnet.test/RespAofTests.cs
@@ -647,5 +647,47 @@ namespace Garnet.test
                 ClassicAssert.AreEqual(ldata, returnedData);
             }
         }
+
+        [Test]
+        public void AofCustomTxnRecoverTest()
+        {
+            server.Register.NewTransactionProc("READWRITETX", () => new ReadWriteTxn(), new RespCommandsInfo { Arity = 4 });
+            string readkey = "readme";
+            string readVal = "surewhynot";
+
+            string writeKey1 = "writeme";
+            string writeKey2 = "writemetoo";
+
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
+            {
+                var db = redis.GetDatabase(0);
+                ClassicAssert.IsTrue(db.StringSet(readkey, readVal));
+
+                RedisResult result = db.Execute("READWRITETX", readkey, writeKey1, writeKey2);
+
+                ClassicAssert.AreEqual("SUCCESS", result.ToString());
+            }
+
+            server.Store.CommitAOF(true);
+            server.Dispose(false);
+
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, tryRecover: true, enableAOF: true);
+            server.Register.NewTransactionProc("READWRITETX", () => new ReadWriteTxn(), new RespCommandsInfo { Arity = 4 });
+            server.Start();
+
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
+            {
+                var db = redis.GetDatabase(0);
+
+                string readKeysVal = db.StringGet(readkey);
+                ClassicAssert.AreEqual(readVal, readKeysVal);
+
+                string writeKeysVal = db.StringGet(writeKey1);
+                ClassicAssert.AreEqual(readVal, writeKeysVal);
+
+                string writeKeysVal2 = db.StringGet(writeKey2);
+                ClassicAssert.AreEqual(readVal, writeKeysVal2);
+            }
+        }
     }
 }


### PR DESCRIPTION
After our command handling refactor we had an untested part that was not skipping AOF header when doing a replay. I caught it, and now skip it. This fixes the issue as seen by the UNit test.
