### PR TITLE
package garnet-server as a .NET tool

### DIFF
--- a/main/GarnetServer/GarnetServer.csproj
+++ b/main/GarnetServer/GarnetServer.csproj
@@ -3,6 +3,29 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+
+    <!-- IMPORTANT: Keep the version in sync with .azure\pipelines\azure-pipelines-external-release.yml line ~6. -->
+    <Version>1.0.36</Version>
+    <PackageId>garnet-server</PackageId>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>garnet-server</ToolCommandName>
+    <Title>The Microsoft.Garnet RESP server, packaged as a .NET tool</Title>
+    <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">True</GeneratePackageOnBuild>
+    <Authors>Microsoft</Authors>
+    <Company>Microsoft</Company>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/microsoft/garnet.git</RepositoryUrl>
+    <PackageProjectUrl>https://microsoft.github.io/garnet</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <Description>
+      Garnet is a remote cache-store from Microsoft Research, that offers strong performance (throughput and latency),
+      scalability, storage, recovery, cluster sharding, key migration, and replication features. Garnet uses the Redis RESP wire
+      protocol and can work with existing Redis clients.
+    </Description>
+    <PackageReleaseNotes>See https://github.com/microsoft/garnet for details.</PackageReleaseNotes>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <Tags>Garnet key-value store cache dictionary hashtable concurrent persistent remote cluster Redis RESP</Tags>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,6 +44,10 @@
     <None Update="garnet.conf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="readme.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
+  </PropertyGroup>
 </Project>

--- a/main/GarnetServer/readme.md
+++ b/main/GarnetServer/readme.md
@@ -1,0 +1,9 @@
+﻿# garnet-server
+
+`garnet-server` is a .NET global tool that provides the [`Microsoft.Garnet`](https://www.nuget.org/packages/Microsoft.Garnet) RESP server.
+
+The `garnet-server` by itself will create a Garnet server using the default port; for full options, see `garnet-server --help`.
+
+
+- [Full Garnet documentation](https://microsoft.github.io/garnet/)
+- [Garnet GitHub repository](https://github.com/microsoft/garnet.git)

--- a/website/docs/welcome/releases.md
+++ b/website/docs/welcome/releases.md
@@ -8,6 +8,16 @@ title: Releases
 
 Find releases at [https://github.com/microsoft/garnet/releases](https://github.com/microsoft/garnet/releases).
 
+## .NET Tool
+
+Garnet can be installed as a [.NET tool](https://aka.ms/global-tools):
+
+``` txt
+> dotnet tool install --global garnet-server
+>
+> garnet-server
+```
+
 ## NuGet
 
 Find releases at [https://www.nuget.org/packages/Microsoft.Garnet](https://www.nuget.org/packages/Microsoft.Garnet). The NuGet


### PR DESCRIPTION
fixes https://github.com/microsoft/garnet/issues/774

preview (to check package details etc) is [here](nuget.org/packages/garnet-server/1.0.36-preview1) - I've separately initiated a handover of that package to the `Garnet` account.

Usage:

![image](https://github.com/user-attachments/assets/9f00d351-40a5-4c29-ba4d-a4113eef0276)

``` txt
   15:54:40  GarnetServer net-tool  3   8.0.300   153ms 
➜ dotnet tool install --global garnet-server --version 1.0.36-preview1
You can invoke the tool using the following command: garnet-server
Tool 'garnet-server' (version '1.0.36-preview1') was successfully installed.
   15:54:45  GarnetServer net-tool  3   8.0.300   2.637s 
➜ garnet-server
    _________
   /_||___||_\      Garnet 1.0.36 64 bit; standalone mode
   '. \   / .'      Port: 6379
     '.\ /.'        https://aka.ms/GetGarnet
       '.'

* Ready to accept connections
```

