### PR TITLE
Changed tagSource: in the GitHub Release part of  release yml from manual to userSpecifiedTag

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -169,7 +169,7 @@ jobs:
     inputs:
       action: 'create'
       gitHubConnection: ADO_to_Github_ServiceConnection
-      tagSource: manual
+      tagSource: userSpecifiedTag
       tag: 'v$(Build.BuildNumber)'
       title: 'Garnet v$(Build.BuildNumber)'
       releaseNotesSource: input


### PR DESCRIPTION
The tagSource used to allow manual but it has changed to "userSpecifiedTag".  We need this set because we set the tag setting to: tag: 'v$(Build.BuildNumber)'

Info on Tag Source (tagSource):

Specifies the tag you want to use for release creation. The gitTag option automatically uses the tag that is associated with the Git commit. Use the userSpecifiedTag option to manually provide a tag.