### PR TITLE
Mark PUBSUB CHANNELS, NUMPAT, NUMSUB as implemented in docs

### DIFF
--- a/website/docs/commands/acl.md
+++ b/website/docs/commands/acl.md
@@ -75,6 +75,22 @@ Returns +OK on success, otherwise --ERR message if any.
 
 ---
 
+### ACL SAVE
+
+#### Syntax
+
+```bash
+    ACL SAVE
+```
+
+When Redis is configured to use an ACL file (with the aclfile configuration option), this command will save the currently defined ACLs from the server memory to the ACL file.
+
+#### Resp Reply
+
+Returns +OK on success, otherwise --ERR message if any.
+
+---
+
 ### ACL SETUSER
 
 #### Syntax

--- a/website/docs/commands/api-compatibility.md
+++ b/website/docs/commands/api-compatibility.md
@@ -248,10 +248,10 @@ Note that this list is subject to change as we continue to expand our API comman
 |  | REFCOUNT | ➖ |  |
 | <span id="pubsub">**PUB/SUB**</span> | [PSUBSCRIBE](analytics.md#psubscribe) | ➕ |  |
 |  | [PUBLISH](analytics.md#publish) | ➕ |  |
-|  | [PUBSUB CHANNELS](analytics.md#pubsub-channels) | ➖ |  |
+|  | [PUBSUB CHANNELS](analytics.md#pubsub-channels) | ➕ |  |
 |  | PUBSUB HELP | ➖ |  |
-|  | [PUBSUB NUMPAT](analytics.md#pubsub-numpat) | ➖ |  |
-|  | [PUBSUB NUMSUB](analytics.md#pubsub-numsub) | ➖ |  |
+|  | [PUBSUB NUMPAT](analytics.md#pubsub-numpat) | ➕ |  |
+|  | [PUBSUB NUMSUB](analytics.md#pubsub-numsub) | ➕ |  |
 |  | PUBSUB SHARDCHANNELS | ➖ |  |
 |  | PUBSUB SHARDNUMSUB | ➖ |  |
 |  | [PUNSUBSCRIBE](analytics.md#punsubscribe) | ➕ |  |

--- a/website/docs/commands/api-compatibility.md
+++ b/website/docs/commands/api-compatibility.md
@@ -48,7 +48,7 @@ Note that this list is subject to change as we continue to expand our API comman
 |  | [LOAD](acl.md#acl-load) | ➕ |  |
 |  | HELP | ➖ |  |
 |  | LOG | ➖ |  |
-|  | SAVE | ➖ |  |
+|  | [SAVE](acl.md#acl-save) | ➕ |  |
 |  | [SETUSER](acl.md#acl-setuser) | ➕ |  |
 |  | [USERS](acl.md#acl-users) | ➕ |  |
 |  | [WHOAMI](acl.md#acl-whoami) | ➕ |  |


### PR DESCRIPTION
This PR fixes minor documentation hiccups. These commands seem to be
implemented but not marked as such with the plus sign at the commands
compatibility page:
https://microsoft.github.io/garnet/docs/commands/api-compatibility

- `PUBSUB CHANNELS`
- `PUBSUB NUMPAT`
- `PUBSUB NUMSUB`
