### PR TITLE
Adding .editorconfig file to build in dockerfiles + suppressing unnecessary warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY main/GarnetServer/*.csproj main/GarnetServer/
 COPY metrics/HdrHistogram/*.csproj metrics/HdrHistogram/
 COPY Directory.Build.props Directory.Build.props
 COPY Directory.Packages.props Directory.Packages.props
+COPY .editorconfig .editorconfig
 
 RUN dotnet restore main/GarnetServer/GarnetServer.csproj -a $TARGETARCH
 
@@ -26,7 +27,7 @@ COPY metrics/ metrics/
 COPY test/testcerts test/testcerts
 
 WORKDIR /src/main/GarnetServer
-RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contained false -f net8.0
+RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contained false -f net8.0 -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false
 
 # Final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:8.0 AS runtime

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -15,6 +15,7 @@ COPY main/GarnetServer/*.csproj main/GarnetServer/
 COPY metrics/HdrHistogram/*.csproj metrics/HdrHistogram/
 COPY Directory.Build.props Directory.Build.props
 COPY Directory.Packages.props Directory.Packages.props
+COPY .editorconfig .editorconfig
 
 RUN dotnet restore main/GarnetServer/GarnetServer.csproj -a $TARGETARCH
 
@@ -26,7 +27,7 @@ COPY metrics/ metrics/
 COPY test/testcerts test/testcerts
 
 WORKDIR /src/main/GarnetServer
-RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contained false -f net8.0
+RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contained false -f net8.0 -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false
 
 # Final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine AS runtime

--- a/Dockerfile.cbl-mariner
+++ b/Dockerfile.cbl-mariner
@@ -15,6 +15,7 @@ COPY main/GarnetServer/*.csproj main/GarnetServer/
 COPY metrics/HdrHistogram/*.csproj metrics/HdrHistogram/
 COPY Directory.Build.props Directory.Build.props
 COPY Directory.Packages.props Directory.Packages.props
+COPY .editorconfig .editorconfig
 
 RUN dotnet restore main/GarnetServer/GarnetServer.csproj -a $TARGETARCH
 
@@ -26,7 +27,7 @@ COPY metrics/ metrics/
 COPY test/testcerts test/testcerts
 
 WORKDIR /src/main/GarnetServer
-RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contained false -f net8.0
+RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contained false -f net8.0 -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false
 
 # Final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:8.0-cbl-mariner2.0 AS runtime

--- a/Dockerfile.chiseled
+++ b/Dockerfile.chiseled
@@ -19,6 +19,7 @@ COPY main/GarnetServer/*.csproj main/GarnetServer/
 COPY metrics/HdrHistogram/*.csproj metrics/HdrHistogram/
 COPY Directory.Build.props Directory.Build.props
 COPY Directory.Packages.props Directory.Packages.props
+COPY .editorconfig .editorconfig
 
 RUN dotnet restore main/GarnetServer/GarnetServer.csproj -a $TARGETARCH
 
@@ -30,7 +31,7 @@ COPY metrics/ metrics/
 COPY test/testcerts test/testcerts
 
 WORKDIR /src/main/GarnetServer
-RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contained false -f net8.0
+RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contained false -f net8.0 -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false
 
 # Final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:8.0-jammy-chiseled AS runtime

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -11,7 +11,7 @@ RUN dotnet restore
 RUN dotnet build -c Release
 
 # Copy and publish app and libraries
-RUN dotnet publish -c Release -o /app -r win-x64 --self-contained false -f net8.0
+RUN dotnet publish -c Release -o /app -r win-x64 --self-contained false -f net8.0 -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false
 
 # Final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:8.0-nanoserver-$TAG AS runtime

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -15,6 +15,7 @@ COPY main/GarnetServer/*.csproj main/GarnetServer/
 COPY metrics/HdrHistogram/*.csproj metrics/HdrHistogram/
 COPY Directory.Build.props Directory.Build.props
 COPY Directory.Packages.props Directory.Packages.props
+COPY .editorconfig .editorconfig
 
 RUN dotnet restore main/GarnetServer/GarnetServer.csproj -a $TARGETARCH
 
@@ -26,7 +27,7 @@ COPY metrics/ metrics/
 COPY test/testcerts test/testcerts
 
 WORKDIR /src/main/GarnetServer
-RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contained false -f net8.0
+RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contained false -f net8.0 -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false
 
 # Final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:8.0-jammy AS runtime


### PR DESCRIPTION
This is to fix large amount of warnings appearing in docker pipelines but not in the CI.