### PR TITLE
add option to throw on recovery errors

### DIFF
--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -460,6 +460,10 @@ namespace Garnet
         [Option("index-resize-threshold", Required = false, HelpText = "Overflow bucket count over total index size in percentage to trigger index resize")]
         public int IndexResizeThreshold { get; set; }
 
+        [OptionValidation]
+        [Option("fail-on-recovery-error", Default = false, Required = false, HelpText = "Server bootup should fail if errors happen during bootup of AOF and checkpointing")]
+        public bool? FailOnRecoveryError { get; set; }
+
         /// <summary>
         /// This property contains all arguments that were not parsed by the command line argument parser
         /// </summary>
@@ -658,7 +662,8 @@ namespace Garnet
                 ExtensionAllowUnsignedAssemblies = ExtensionAllowUnsignedAssemblies.GetValueOrDefault(),
                 IndexResizeFrequencySecs = IndexResizeFrequencySecs,
                 IndexResizeThreshold = IndexResizeThreshold,
-                LoadModuleCS = LoadModuleCS
+                LoadModuleCS = LoadModuleCS,
+                FailOnRecoveryError = FailOnRecoveryError.GetValueOrDefault()
             };
         }
 

--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -306,5 +306,8 @@
 	"IndexResizeThreshold": 50,
 
 	/* List of module paths to be loaded at startup */
-	"LoadModuleCS": null
+	"LoadModuleCS": null,
+
+	/* Fails if encounters error during AOF replay or checkpointing */
+	"FailOnRecoveryError": false
 }

--- a/libs/server/AOF/AofProcessor.cs
+++ b/libs/server/AOF/AofProcessor.cs
@@ -146,6 +146,9 @@ namespace Garnet.server
             catch (Exception ex)
             {
                 logger?.LogError(ex, "An error occurred AofProcessor.RecoverReplay");
+
+                if (storeWrapper.serverOptions.FailOnRecoveryError)
+                    throw;
             }
             finally
             {

--- a/libs/server/Servers/ServerOptions.cs
+++ b/libs/server/Servers/ServerOptions.cs
@@ -94,6 +94,11 @@ namespace Garnet.server
         public string PubSubPageSize = "4k";
 
         /// <summary>
+        /// Server bootup should fail if errors happen during bootup of AOF and checkpointing.
+        /// </summary>
+        public bool FailOnRecoveryError = false;
+
+        /// <summary>
         /// Logger
         /// </summary>
         public ILogger logger;

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -265,9 +265,16 @@ namespace Garnet.server
                 if (storeVersion > 0 || objectStoreVersion > 0)
                     lastSaveTime = DateTimeOffset.UtcNow;
             }
+            catch (TsavoriteNoHybridLogException ex)
+            {
+                // No hybrid log being found is not the same as an error in recovery. e.g. fresh start
+                logger?.LogInformation(ex, "No Hybrid Log found for recovery; storeVersion = {storeVersion}; objectStoreVersion = {objectStoreVersion}", storeVersion, objectStoreVersion);
+            }
             catch (Exception ex)
             {
                 logger?.LogInformation(ex, "Error during recovery of store; storeVersion = {storeVersion}; objectStoreVersion = {objectStoreVersion}", storeVersion, objectStoreVersion);
+                if (serverOptions.FailOnRecoveryError)
+                    throw;
             }
         }
 
@@ -323,6 +330,8 @@ namespace Garnet.server
             catch (Exception ex)
             {
                 logger?.LogError(ex, "Error during recovery of AofProcessor");
+                if (serverOptions.FailOnRecoveryError)
+                    throw;
             }
             return replicationOffset;
         }

--- a/libs/storage/Tsavorite/cs/src/core/Index/Recovery/Recovery.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Recovery/Recovery.cs
@@ -324,7 +324,7 @@ namespace Tsavorite.core
             GetClosestHybridLogCheckpointInfo(requestedVersion, out var closestToken, out recoveredHlcInfo, out recoveredCommitCookie);
 
             if (recoveredHlcInfo.IsDefault())
-                throw new TsavoriteException("Unable to find valid HybridLog token");
+                throw new TsavoriteNoHybridLogException("Unable to find valid HybridLog token");
 
             if (recoveredHlcInfo.deltaLog != null)
             {

--- a/libs/storage/Tsavorite/cs/src/core/Utilities/TsavoriteException.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Utilities/TsavoriteException.cs
@@ -49,4 +49,18 @@ namespace Tsavorite.core
         {
         }
     }
+
+    /// <summary>
+    /// TsavoriteNoHybridLog exception type with message and inner exception.
+    /// </summary>
+    public class TsavoriteNoHybridLogException : TsavoriteException
+    {
+        /// <summary>
+        /// Throw Tsavorite exception
+        /// </summary>
+        /// <param name="message"></param>
+        public TsavoriteNoHybridLogException(string message) : base(message)
+        {
+        }
+    }
 }


### PR DESCRIPTION
Add a flag to avoid swallowing errors during exception.

This can be used for users running Garnet with strong persistence requirements by using AOF log and WaitForCommit enabled