### PR TITLE
Bugfix in RespReadUtils

### DIFF
--- a/libs/common/RespReadUtils.cs
+++ b/libs/common/RespReadUtils.cs
@@ -378,7 +378,7 @@ namespace Garnet.common
             }
 
             // Validate length
-            if (value > int.MaxValue)
+            if (value > int.MaxValue + (ulong)(negative ? 1 : 0)) // int.MinValue = -int.MaxValue + 1
             {
                 RespParsingException.ThrowIntegerOverflow(readHead - digitsRead, (int)digitsRead);
             }


### PR DESCRIPTION
RespReadUtils.ReadSignedLengthHeader was throwing an overflow exception when parsing an int.MinValue, this caused BDN.benchmark to throw when running RespToInteger.