### PR TITLE
Show Test FullName

### DIFF
--- a/.azure/pipelines/azure-pipelines.yml
+++ b/.azure/pipelines/azure-pipelines.yml
@@ -66,7 +66,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Garnet.test.cluster.csproj'
-      arguments: '--configuration $(buildConfiguration) --logger:"console;verbosity=detailed" --collect "Code coverage" --settings $(Build.SourcesDirectory)\.azure\pipelines\CodeCoverage.runsettings'
+      arguments: '--configuration $(buildConfiguration) --logger:"console;verbosity=detailed" --collect "Code coverage" --settings $(Build.SourcesDirectory)\.azure\pipelines\CodeCoverage.runsettings -- NUnit.DisplayName=FullName'
   
   - task: DotNetCoreCLI@2
     displayName: 'Build Garnet binaries and tests $(buildConfiguration)'
@@ -80,7 +80,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Garnet.test.csproj'
-      arguments: '--configuration $(buildConfiguration) --logger:"console;verbosity=detailed" --collect "Code coverage" --settings $(Build.SourcesDirectory)\.azure\pipelines\CodeCoverage.runsettings'
+      arguments: '--configuration $(buildConfiguration) --logger:"console;verbosity=detailed" --collect "Code coverage" --settings $(Build.SourcesDirectory)\.azure\pipelines\CodeCoverage.runsettings -- NUnit.DisplayName=FullName'
 
   - task: NuGetCommand@2
     displayName: Pack nuget package to test nuspec is correct
@@ -146,7 +146,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Garnet.test.cluster.csproj'
-      arguments: '--configuration $(buildConfiguration) --logger:"console;verbosity=detailed" --collect "Code coverage" --settings $(Build.SourcesDirectory)\.azure\pipelines\CodeCoverage.runsettings'
+      arguments: '--configuration $(buildConfiguration) --logger:"console;verbosity=detailed" --collect "Code coverage" --settings $(Build.SourcesDirectory)\.azure\pipelines\CodeCoverage.runsettings -- NUnit.DisplayName=FullName'
 
   - task: DotNetCoreCLI@2
     displayName: '.NET Core build Garnet binaries and tests $(buildConfiguration)'
@@ -160,7 +160,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Garnet.test.csproj'
-      arguments: '--configuration $(buildConfiguration) --logger:"console;verbosity=detailed" --collect "Code coverage" --settings $(Build.SourcesDirectory)\.azure\pipelines\CodeCoverage.runsettings'
+      arguments: '--configuration $(buildConfiguration) --logger:"console;verbosity=detailed" --collect "Code coverage" --settings $(Build.SourcesDirectory)\.azure\pipelines\CodeCoverage.runsettings -- NUnit.DisplayName=FullName'
       publishTestResults: true
       
   - task: PublishTestResults@2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Build Garnet
         run: dotnet build --configuration ${{ matrix.configuration }}
       - name: Run tests ${{ matrix.test }}
-        run: dotnet test test/${{ matrix.test }} -f ${{ matrix.framework }} --configuration ${{ matrix.configuration }} --logger "console;verbosity=detailed" --logger trx --results-directory "GarnetTestResults-${{ matrix.os }}-${{ matrix.framework }}-${{ matrix.configuration }}-${{ matrix.test }}"
+        run: dotnet test test/${{ matrix.test }} -f ${{ matrix.framework }} --configuration ${{ matrix.configuration }} --logger "console;verbosity=detailed" --logger trx --results-directory "GarnetTestResults-${{ matrix.os }}-${{ matrix.framework }}-${{ matrix.configuration }}-${{ matrix.test }}" -- NUnit.DisplayName=FullName
         timeout-minutes: 45 
       - name: Upload test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR updates the ci files to output the FullName of the test fixture that is being executed running Garnet tests.