### PR TITLE
Added https://www.nuget.org/packages/garnet-server link under the GH Release docs

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -172,8 +172,8 @@ jobs:
       releaseNotesSource: inline
       releaseNotesInline: |
        Get NuGet binaries at:
-       * https://www.nuget.org/packages/Microsoft.Garnet
-       * https://www.nuget.org/packages/garnet-server
+       * Library: https://www.nuget.org/packages/Microsoft.Garnet
+       * Tool: https://www.nuget.org/packages/garnet-server
 
        More information at:
        * https://microsoft.github.io/garnet

--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -173,6 +173,7 @@ jobs:
       releaseNotesInline: |
        Get NuGet binaries at:
        * https://www.nuget.org/packages/Microsoft.Garnet
+       * https://www.nuget.org/packages/garnet-server
 
        More information at:
        * https://microsoft.github.io/garnet

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Garnet
 [![.NET CI](https://github.com/microsoft/garnet/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/microsoft/garnet/actions/workflows/ci.yml)
-[![](https://img.shields.io/github/release/microsoft/garnet.svg?label=latest%20release&color=007edf)](https://github.com/microsoft/garnet/releases/latest)
-[![](https://img.shields.io/nuget/dt/microsoft.garnet.svg?label=downloads&color=007edf&logo=nuget)](https://www.nuget.org/packages/microsoft.garnet)
+[![](https://img.shields.io/nuget/dt/microsoft.garnet.svg?label=nuget%20library&color=007edf&logo=nuget)](https://www.nuget.org/packages/microsoft.garnet)
+[![](https://img.shields.io/nuget/dt/garnet-server.svg?label=dotnet%20tool&color=007edf&logo=nuget)](https://www.nuget.org/packages/garnet-server)
 [![Discord Shield](https://discordapp.com/api/guilds/1213937452272582676/widget.png?style=shield)](https://aka.ms/garnet-discord)
 
 Garnet is a new remote cache-store from Microsoft Research, that offers several unique benefits:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Garnet
 [![.NET CI](https://github.com/microsoft/garnet/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/microsoft/garnet/actions/workflows/ci.yml)
+[![](https://img.shields.io/github/release/microsoft/garnet.svg?label=latest%20release&color=007edf)](https://github.com/microsoft/garnet/releases/latest)
 [![](https://img.shields.io/nuget/dt/microsoft.garnet.svg?label=nuget%20library&color=007edf&logo=nuget)](https://www.nuget.org/packages/microsoft.garnet)
 [![](https://img.shields.io/nuget/dt/garnet-server.svg?label=dotnet%20tool&color=007edf&logo=nuget)](https://www.nuget.org/packages/garnet-server)
 [![Discord Shield](https://discordapp.com/api/guilds/1213937452272582676/widget.png?style=shield)](https://aka.ms/garnet-discord)


### PR DESCRIPTION
Since we release the server now, we should add it to our GH release docs.

Added https://www.nuget.org/packages/garnet-server link under the "Get Nuget Binaries" under the Github release docs. 