### PR TITLE
Bump helm chart to garnet-1.0.46

### DIFF
--- a/charts/garnet/Chart.yaml
+++ b/charts/garnet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: garnet
 description: A Helm chart for Microsoft garnet
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: Version.props
 home: https://github.com/microsoft/garnet
 icon: https://avatars.githubusercontent.com/u/6154722?s=200&v=4

--- a/charts/garnet/README.md
+++ b/charts/garnet/README.md
@@ -1,6 +1,6 @@
 # garnet
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.18](https://img.shields.io/badge/AppVersion-1.0.18-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.46](https://img.shields.io/badge/AppVersion-1.0.46-informational?style=flat-square)
 
 A Helm chart for Microsoft garnet
 


### PR DESCRIPTION
The goal of this PR is to build the helm chart via the github workflows.