### PR TITLE
docs: Link defaults.conf from Configuration article

### DIFF
--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -7,7 +7,7 @@ title: Garnet Configuration
 ## How to Configure Garnet
 
 The Garnet server (GarnetServer.exe) can be configured using a configuration file (e.g. `garnet.conf` or `redis.conf`), while command line arguments can be used to override any settings specified in the file. /
-Any settings not specified in either configuration file or command line arguments are set to default valued specified in the [defaults.conf](../../../libs/host/defaults.conf) file (path to this file can be overridden via the command line arguments).
+Any settings not specified in either configuration file or command line arguments are set to default valued specified in the [defaults.conf](https://github.com/microsoft/garnet/blob/main/libs/host/defaults.conf) file (path to this file can be overridden via the command line arguments).
 
 Garnet currently supports two configuration file formats:
 1) The [`garnet.conf`](#garnetconf) file format (default) - a JSON-formatted collection of settings

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -7,7 +7,7 @@ title: Garnet Configuration
 ## How to Configure Garnet
 
 The Garnet server (GarnetServer.exe) can be configured using a configuration file (e.g. `garnet.conf` or `redis.conf`), while command line arguments can be used to override any settings specified in the file. /
-Any settings not specified in either configuration file or command line arguments are set to default valued specified in the `defaults.conf` file (path to this file can be overridden via the command line arguments).
+Any settings not specified in either configuration file or command line arguments are set to default valued specified in the [defaults.conf](../../../libs/host/defaults.conf) file (path to this file can be overridden via the command line arguments).
 
 Garnet currently supports two configuration file formats:
 1) The [`garnet.conf`](#garnetconf) file format (default) - a JSON-formatted collection of settings


### PR DESCRIPTION
Let's utilise the awesome feature of hyperlinking, especially, that the [Configurable Settings](https://github.com/microsoft/garnet/blob/55f94e3ea19c9204ed9154db40bf93dfa8d4f7ce/website/docs/getting-started/configuration.md?plain=1#L68) table does not offer displaying of the default values.