### PR TITLE
Fixed so all BDN are based on Bytes

### DIFF
--- a/.github/workflows/ci-bdnbenchmark.yml
+++ b/.github/workflows/ci-bdnbenchmark.yml
@@ -42,7 +42,7 @@ jobs:
         os: [ ubuntu-latest, windows-latest ]
         framework: [ 'net8.0' ]
         configuration: [ 'Release' ]
-        test: [ 'Operations.BasicOperations', 'Operations.ObjectOperations', 'Operations.HashObjectOperations', 'Cluster.ClusterMigrate', 'Cluster.ClusterOperations', 'Lua.LuaScripts','Operations.RawStringOperations','Operations.ScriptOperations' ]
+        test: [ 'Operations.BasicOperations', 'Operations.ObjectOperations', 'Operations.HashObjectOperations', 'Cluster.ClusterMigrate', 'Cluster.ClusterOperations', 'Lua.LuaScripts', 'Operations.CustomOperations', 'Operations.RawStringOperations', 'Operations.ScriptOperations' ]
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/benchmark/BDN.benchmark/Program.cs
+++ b/benchmark/BDN.benchmark/Program.cs
@@ -7,7 +7,9 @@ using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
+using Perfolizer.Metrology;
 
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly)
 #if DEBUG
@@ -25,6 +27,7 @@ public class BaseConfig : ManualConfig
         AddLogger(ConsoleLogger.Default);
         AddExporter(DefaultExporters.Markdown);
         AddColumnProvider(DefaultColumnProviders.Instance);
+        WithSummaryStyle(SummaryStyle.Default.WithSizeUnit(SizeUnit.B));
 
         var baseJob = Job.Default.WithGcServer(true);
 

--- a/test/BDNPerfTests/BDN_Benchmark_Config.json
+++ b/test/BDNPerfTests/BDN_Benchmark_Config.json
@@ -9,15 +9,15 @@
     "expected_InlinePing_None": 0
   },
   "BDN.benchmark.Operations.ObjectOperations.*": {
-    "expected_ZAddRem_ACL": 17.97,
-    "expected_LPushPop_ACL": 14.06,
-    "expected_SAddRem_ACL": 12.5,
-    "expected_ZAddRem_AOF": 17.97,
-    "expected_LPushPop_AOF": 14.06,
-    "expected_SAddRem_AOF": 12.5,
-    "expected_ZAddRem_None": 17.97,
-    "expected_LPushPop_None": 14.06,
-    "expected_SAddRem_None": 12.5
+    "expected_ZAddRem_ACL": 18400,
+    "expected_LPushPop_ACL": 14400,
+    "expected_SAddRem_ACL": 12800,
+    "expected_ZAddRem_AOF": 18400,
+    "expected_LPushPop_AOF": 14400,
+    "expected_SAddRem_AOF": 12800,
+    "expected_ZAddRem_None": 18400,
+    "expected_LPushPop_None": 14400,
+    "expected_SAddRem_None": 12800
   },
   "BDN.benchmark.Operations.HashObjectOperations.*": {
     "expected_HSetDel_ACL": 16000,


### PR DESCRIPTION
Fixed so all BDN are based on Bytes (had one using KB). 
Updated Operations.ObjectOperations expected values to be in bytes. 
Also, noticed Operations.CustomOperations was accidentally removed from BDN tests so put that back.