### PR TITLE
Configure min and max IO completion threads

### DIFF
--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -341,7 +341,7 @@ namespace Garnet
 
         [IntRangeValidation(0, int.MaxValue)]
         [Option("miniothreads", Required = false, HelpText = "Minimum IO completion threads in thread pool, 0 uses the system default.")]
-        public int ThreadPoolMinIoCompletionThreads { get; set; }
+        public int ThreadPoolMinIOCompletionThreads { get; set; }
 
         [IntRangeValidation(0, int.MaxValue)]
         [Option("maxiothreads", Required = false, HelpText = "Maximum IO completion threads in thread pool, 0 uses the system default.")]
@@ -688,7 +688,7 @@ namespace Garnet
                 QuietMode = QuietMode.GetValueOrDefault(),
                 ThreadPoolMinThreads = ThreadPoolMinThreads,
                 ThreadPoolMaxThreads = ThreadPoolMaxThreads,
-                ThreadPoolMinIOCompletionThreads = ThreadPoolMinIoCompletionThreads,
+                ThreadPoolMinIOCompletionThreads = ThreadPoolMinIOCompletionThreads,
                 ThreadPoolMaxIOCompletionThreads = ThreadPoolMaxIOCompletionThreads,
                 NetworkConnectionLimit = NetworkConnectionLimit,
                 DeviceFactoryCreator = useAzureStorage

--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -332,12 +332,20 @@ namespace Garnet
         public string FileLogger { get; set; }
 
         [IntRangeValidation(0, int.MaxValue)]
-        [Option("minthreads", Required = false, HelpText = "Minimum worker and completion threads in thread pool, 0 uses the system default.")]
+        [Option("minthreads", Required = false, HelpText = "Minimum worker threads in thread pool, 0 uses the system default.")]
         public int ThreadPoolMinThreads { get; set; }
 
         [IntRangeValidation(0, int.MaxValue)]
-        [Option("maxthreads", Required = false, HelpText = "Maximum worker and completion threads in thread pool, 0 uses the system default.")]
+        [Option("maxthreads", Required = false, HelpText = "Maximum worker threads in thread pool, 0 uses the system default.")]
         public int ThreadPoolMaxThreads { get; set; }
+
+        [IntRangeValidation(0, int.MaxValue)]
+        [Option("miniothreads", Required = false, HelpText = "Minimum IO completion threads in thread pool, 0 uses the system default.")]
+        public int ThreadPoolMinIoCompletionThreads { get; set; }
+
+        [IntRangeValidation(0, int.MaxValue)]
+        [Option("maxiothreads", Required = false, HelpText = "Maximum IO completion threads in thread pool, 0 uses the system default.")]
+        public int ThreadPoolMaxIOCompletionThreads { get; set; }
 
         [IntRangeValidation(-1, int.MaxValue)]
         [Option("network-connection-limit", Required = false, Default = -1, HelpText = "Maximum number of simultaneously active network connections.")]
@@ -680,6 +688,8 @@ namespace Garnet
                 QuietMode = QuietMode.GetValueOrDefault(),
                 ThreadPoolMinThreads = ThreadPoolMinThreads,
                 ThreadPoolMaxThreads = ThreadPoolMaxThreads,
+                ThreadPoolMinIOCompletionThreads = ThreadPoolMinIoCompletionThreads,
+                ThreadPoolMaxIOCompletionThreads = ThreadPoolMaxIOCompletionThreads,
                 NetworkConnectionLimit = NetworkConnectionLimit,
                 DeviceFactoryCreator = useAzureStorage
                     ? () => new AzureStorageNamedDeviceFactory(AzureStorageConnectionString, logger)

--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -245,11 +245,17 @@
 	/* Enable file logger and write to the specified path. */
 	"FileLogger" : null,
 
-	/* Minimum worker and completion threads in thread pool, 0 uses the system default. */
+	/* Minimum worker threads in thread pool, 0 uses the system default. */
 	"ThreadPoolMinThreads" : 0,
 
-	/* Maximum worker and completion threads in thread pool, 0 uses the system default. */
+	/* Maximum worker threads in thread pool, 0 uses the system default. */
 	"ThreadPoolMaxThreads" : 0,
+
+	/* Minimum IO completion threads in thread pool, 0 uses the system default. */
+	"ThreadPoolMinIOCompletionThreads" : 0,
+
+	/* Maximum IO completion threads in thread pool, 0 uses the system default. */
+	"ThreadPoolMaxIOCompletionThreads" : 0,
 
 	/* Maximum number of simultaneously active network connections. */
 	"NetworkConnectionLimit" : -1,

--- a/libs/server/Servers/GarnetServerOptions.cs
+++ b/libs/server/Servers/GarnetServerOptions.cs
@@ -237,14 +237,24 @@ namespace Garnet.server
         public bool UseFoldOverCheckpoints = false;
 
         /// <summary>
-        /// Minimum worker and completion port threads in thread pool (0 for default)
+        /// Minimum worker threads in thread pool (0 for default)
         /// </summary>
         public int ThreadPoolMinThreads = 0;
 
         /// <summary>
-        /// Maximum worker and completion port threads in thread pool (0 for default)
+        /// Maximum worker threads in thread pool (0 for default)
         /// </summary>
         public int ThreadPoolMaxThreads = 0;
+
+        /// <summary>
+        /// Minimum IO completion threads in thread pool (0 for default)
+        /// </summary>
+        public int ThreadPoolMinIOCompletionThreads = 0;
+
+        /// <summary>
+        /// Maximum IO completion threads in thread pool (0 for default)
+        /// </summary>
+        public int ThreadPoolMaxIOCompletionThreads = 0;
 
         /// <summary>
         /// Maximum client connection limit


### PR DESCRIPTION
Configure min and max IO completion threads separately from min and max threads (in the ThreadPool). This is needed as some scenarios may limit number of thread pool threads but require a larger number of IO completion threads.