### PR TITLE
Skip Interlocked.Exchange and FlushConfig when no update detected

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- Versioning property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>1.0.49</VersionPrefix>
+		<VersionPrefix>1.0.50</VersionPrefix>
 	</PropertyGroup>
 </Project>

--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -943,6 +943,8 @@ namespace Garnet.cluster
 
         public ClusterConfig MergeSlotMap(ClusterConfig senderConfig, ILogger logger = null)
         {
+            // Track if update happened to avoid expensive merge and FlushConfig operation when possible
+            var updated = false;
             var senderSlotMap = senderConfig.slotMap;
             var senderWorkerId = GetWorkerIdFromNodeId(senderConfig.LocalNodeId);
 
@@ -982,9 +984,12 @@ namespace Garnet.cluster
                 // Update ownership of node
                 newSlotMap[i]._workerId = senderWorkerId;
                 newSlotMap[i]._state = SlotState.STABLE;
+
+                // Update happened, need to merge and FlushConfig
+                updated = true;
             }
 
-            return new(newSlotMap, workers);
+            return updated ? new(newSlotMap, workers) : this;
         }
 
         /// <summary>

--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -981,12 +981,13 @@ namespace Garnet.cluster
                 if (senderConfig.LocalNodeConfigEpoch != 0 && workers[currentOwnerId].ConfigEpoch >= senderConfig.LocalNodeConfigEpoch)
                     continue;
 
+                // Update happened only if workerId or state changed
+                // NOTE: this avoids message flooding when sender epoch equals zero
+                updated = newSlotMap[i]._workerId != senderWorkerId || newSlotMap[i]._state != SlotState.STABLE;
+
                 // Update ownership of node
                 newSlotMap[i]._workerId = senderWorkerId;
                 newSlotMap[i]._state = SlotState.STABLE;
-
-                // Update happened, need to merge and FlushConfig
-                updated = true;
             }
 
             return updated ? new(newSlotMap, workers) : this;

--- a/test/Garnet.test.cluster/ClusterMigrateTests.cs
+++ b/test/Garnet.test.cluster/ClusterMigrateTests.cs
@@ -1847,6 +1847,8 @@ namespace Garnet.test.cluster
                         var node = config.GetBySlot(slot);
                         if (node != null && node.NodeId.Equals(nodeIds[_src]))
                             break;
+                        // Force set slot to src node
+                        SetSlot(_src);
                         ClusterTestUtils.BackOff(cancellationToken: cancellationToken);
                     }
 

--- a/test/Garnet.test.cluster/ClusterMigrateTests.cs
+++ b/test/Garnet.test.cluster/ClusterMigrateTests.cs
@@ -1808,7 +1808,7 @@ namespace Garnet.test.cluster
                     var status = context.clusterTestUtils.SetSlot(_tgt, slot, "IMPORTING", nodeIds[_src], logger: context.logger);
                     while (string.IsNullOrEmpty(status) || !status.Equals("OK"))
                     {
-                        SetSlot(_src);
+                        SetSlot(_src, slot);
                         ClusterTestUtils.BackOff(cancellationToken: cancellationToken, msg: $"{nodeIds[_src]}({nodeEndpoints[_src].Port}) > {slot} > {nodeIds[_tgt]}({nodeEndpoints[_tgt].Port})");
                         status = context.clusterTestUtils.SetSlot(_tgt, slot, "IMPORTING", nodeIds[_src], logger: context.logger);
                     }
@@ -1848,7 +1848,7 @@ namespace Garnet.test.cluster
                         if (node != null && node.NodeId.Equals(nodeIds[_src]))
                             break;
                         // Force set slot to src node
-                        SetSlot(_src);
+                        SetSlot(_src, slot);
                         ClusterTestUtils.BackOff(cancellationToken: cancellationToken);
                     }
 
@@ -1878,15 +1878,6 @@ namespace Garnet.test.cluster
                         if (node != null && node.NodeId.Equals(nodeIds[_tgt]))
                             break;
                         ClusterTestUtils.BackOff(cancellationToken: cancellationToken);
-                    }
-                }
-
-                void SetSlot(int nodeIndex)
-                {
-                    for (var i = 0; i < shards; i++)
-                    {
-                        var resp = context.clusterTestUtils.SetSlot(i, slot, "NODE", nodeIds[nodeIndex], logger: context.logger);
-                        ClassicAssert.AreEqual("OK", resp);
                     }
                 }
             }
@@ -1934,12 +1925,23 @@ namespace Garnet.test.cluster
 
                         if (node == null || nodeIds[shards - 1] != node.NodeId)
                         {
+                            // If failed to converge start from the beginning and backOff to give time to converge
                             i = 0;
+                            SetSlot(shards - 1, slot);
                             ClusterTestUtils.BackOff(cancellationToken: cancellationToken);
                             continue;
                         }
                         ClassicAssert.AreEqual(nodeIds[shards - 1], node.NodeId);
                     }
+                }
+            }
+
+            void SetSlot(int nodeIndex, int slot)
+            {
+                for (var i = 0; i < shards; i++)
+                {
+                    var resp = context.clusterTestUtils.SetSlot(i, slot, "NODE", nodeIds[nodeIndex], logger: context.logger);
+                    ClassicAssert.AreEqual("OK", resp);
                 }
             }
         }


### PR DESCRIPTION
This PR fixes an issue that caused message flooding across the cluster. This happened because the config object kept being updated even when the received config did not change the local config during merge.

The check for an updated config is happening implicitly by comparing the new and current config objects 
https://github.com/microsoft/garnet/blob/af9cf0eb5d1bd22036ec1fb00be71f860fadc71d/libs/cluster/Server/Gossip.cs#L116-L123

This meant that the call to currentCopy.Merge should return the same object if no update has happened. This occurs correctly when merging the worker info
https://github.com/microsoft/garnet/blob/af9cf0eb5d1bd22036ec1fb00be71f860fadc71d/libs/cluster/Server/ClusterConfig.cs#L917

However, an equivalent check was not there when the object was updated during the merging of the slotMap information.
The PR adds this check to fix the issue of message flooding when the cluster configuration is stable


Fixes https://github.com/microsoft/garnet/issues/900