### PR TITLE
Returning "Friendly IDs" for Custom Commands / Custom Types

### DIFF
--- a/libs/server/Custom/CustomCommandManager.cs
+++ b/libs/server/Custom/CustomCommandManager.cs
@@ -14,9 +14,7 @@ namespace Garnet.server
     {
         private static readonly int MaxCustomRawStringCommands = 256;
 
-        private static readonly int CustomRawStringCommandMinId =
-            (ushort)RespCommand.INVALID - MaxCustomRawStringCommands;
-
+        private static readonly int CustomRawStringCommandMinId = (ushort)RespCommand.INVALID - MaxCustomRawStringCommands;
         private static readonly int CustomRawStringCommandMaxId = (ushort)RespCommand.INVALID - 1;
         private static readonly int CustomObjectTypeMinId = (byte)GarnetObjectTypeExtensions.LastObjectType + 1;
         private static readonly int CustomObjectTypeMaxId = (byte)GarnetObjectTypeExtensions.FirstSpecialObjectType - 1;

--- a/libs/server/Custom/CustomCommandManager.cs
+++ b/libs/server/Custom/CustomCommandManager.cs
@@ -12,13 +12,22 @@ namespace Garnet.server
     /// </summary>
     public class CustomCommandManager
     {
-        internal static readonly int MinMapSize = 8;
-        internal static readonly byte TypeIdStartOffset = byte.MaxValue - (byte)GarnetObjectTypeExtensions.FirstSpecialObjectType;
+        private static readonly int MaxCustomRawStringCommands = 256;
+
+        private static readonly int CustomRawStringCommandMinId =
+            (ushort)RespCommand.INVALID - MaxCustomRawStringCommands;
+
+        private static readonly int CustomRawStringCommandMaxId = (ushort)RespCommand.INVALID - 1;
+        private static readonly int CustomObjectTypeMinId = (byte)GarnetObjectTypeExtensions.LastObjectType + 1;
+        private static readonly int CustomObjectTypeMaxId = (byte)GarnetObjectTypeExtensions.FirstSpecialObjectType - 1;
 
         private ConcurrentExpandableMap<CustomRawStringCommand> rawStringCommandMap;
         private ConcurrentExpandableMap<CustomObjectCommandWrapper> objectCommandMap;
         private ConcurrentExpandableMap<CustomTransaction> transactionProcMap;
         private ConcurrentExpandableMap<CustomProcedureWrapper> customProcedureMap;
+
+        internal static readonly int MinMapSize = 8;
+        internal static readonly byte CustomTypeIdStartOffset = (byte)CustomObjectTypeMinId;
 
         internal int CustomCommandsInfoCount => customCommandsInfo.Count;
         internal readonly ConcurrentDictionary<string, RespCommandsInfo> customCommandsInfo = new(StringComparer.OrdinalIgnoreCase);
@@ -29,22 +38,25 @@ namespace Garnet.server
         /// </summary>
         public CustomCommandManager()
         {
+            Debug.Assert(CustomRawStringCommandMinId > (ushort)RespCommandExtensions.LastValidCommand);
+
             rawStringCommandMap = new ConcurrentExpandableMap<CustomRawStringCommand>(MinMapSize,
-                (ushort)RespCommand.INVALID - 1,
-                (ushort)RespCommandExtensions.LastValidCommand + 1);
+                CustomRawStringCommandMinId, CustomRawStringCommandMaxId);
+
             objectCommandMap = new ConcurrentExpandableMap<CustomObjectCommandWrapper>(MinMapSize,
-                (byte)GarnetObjectTypeExtensions.FirstSpecialObjectType - 1,
-                (byte)GarnetObjectTypeExtensions.LastObjectType + 1);
+                CustomObjectTypeMinId, CustomObjectTypeMaxId);
+
             transactionProcMap = new ConcurrentExpandableMap<CustomTransaction>(MinMapSize, 0, byte.MaxValue);
             customProcedureMap = new ConcurrentExpandableMap<CustomProcedureWrapper>(MinMapSize, 0, byte.MaxValue);
         }
 
-        internal int Register(string name, CommandType type, CustomRawStringFunctions customFunctions, RespCommandsInfo commandInfo, RespCommandDocs commandDocs, long expirationTicks)
+        internal int Register(string name, CommandType type, CustomRawStringFunctions customFunctions,
+            RespCommandsInfo commandInfo, RespCommandDocs commandDocs, long expirationTicks)
         {
             if (!rawStringCommandMap.TryGetNextId(out var cmdId))
                 throw new Exception("Out of registration space");
             Debug.Assert(cmdId <= ushort.MaxValue);
-            var extId = GetRawStringExternalId(cmdId);
+            var extId = cmdId - CustomRawStringCommandMinId;
             var newCmd = new CustomRawStringCommand(name, (ushort)extId, type, customFunctions, expirationTicks);
             var setSuccessful = rawStringCommandMap.TrySetValue(cmdId, ref newCmd);
             Debug.Assert(setSuccessful);
@@ -53,7 +65,8 @@ namespace Garnet.server
             return extId;
         }
 
-        internal int Register(string name, Func<CustomTransactionProcedure> proc, RespCommandsInfo commandInfo = null, RespCommandDocs commandDocs = null)
+        internal int Register(string name, Func<CustomTransactionProcedure> proc, RespCommandsInfo commandInfo = null,
+            RespCommandDocs commandDocs = null)
         {
             if (!transactionProcMap.TryGetNextId(out var cmdId))
                 throw new Exception("Out of registration space");
@@ -72,36 +85,18 @@ namespace Garnet.server
             if (objectCommandMap.TryGetFirstId(c => c.factory == factory, out var dupRegistrationId))
                 throw new Exception($"Type already registered with ID {dupRegistrationId}");
 
-            if (!objectCommandMap.TryGetNextId(out var cmdId))
-                throw new Exception("Out of registration space");
-            Debug.Assert(cmdId <= byte.MaxValue);
-
-            var extId = GetTypeExternalId(cmdId);
-            var newCmd = new CustomObjectCommandWrapper((byte)extId, factory);
-            var setSuccessful = objectCommandMap.TrySetValue(cmdId, ref newCmd);
-            Debug.Assert(setSuccessful);
-
-            return extId;
+            var typeId = RegisterNewType(factory);
+            return typeId - CustomObjectTypeMinId;
         }
 
         internal (int objectTypeId, int subCommand) Register(string name, CommandType commandType, CustomObjectFactory factory, RespCommandsInfo commandInfo, RespCommandDocs commandDocs, CustomObjectFunctions customObjectFunctions = null)
         {
-            int extId;
             if (!objectCommandMap.TryGetFirstId(c => c.factory == factory, out var typeId))
             {
-                if (!objectCommandMap.TryGetNextId(out typeId))
-                    throw new Exception("Out of registration space");
+                typeId = RegisterNewType(factory);
+            }
 
-                Debug.Assert(typeId <= byte.MaxValue);
-                extId = GetTypeExternalId(typeId);
-                var newCmd = new CustomObjectCommandWrapper((byte)extId, factory);
-                var setSuccessful = objectCommandMap.TrySetValue(typeId, ref newCmd);
-                Debug.Assert(setSuccessful);
-            }
-            else
-            {
-                extId = GetTypeExternalId(typeId);
-            }
+            var extId = typeId - CustomObjectTypeMinId;
 
             objectCommandMap.TryGetValue(typeId, out var wrapper);
             if (!wrapper.commandMap.TryGetNextId(out var scId))
@@ -186,15 +181,23 @@ namespace Garnet.server
         }
 
         internal RespCommand GetCustomRespCommand(int id)
-            => (RespCommand)rawStringCommandMap.GetIdFromIndex(id);
+            => (RespCommand)(CustomRawStringCommandMinId + id);
 
         internal GarnetObjectType GetCustomGarnetObjectType(int id)
-            => (GarnetObjectType)objectCommandMap.GetIdFromIndex(id);
+            => (GarnetObjectType)(CustomObjectTypeMinId + id);
 
-        private int GetRawStringExternalId(int cmdId)
-            => rawStringCommandMap.GetIndexFromId(cmdId);
+        private int RegisterNewType(CustomObjectFactory factory)
+        {
+            if (!objectCommandMap.TryGetNextId(out var typeId))
+                throw new Exception("Out of registration space");
+            Debug.Assert(typeId <= byte.MaxValue);
 
-        private int GetTypeExternalId(int cmdId)
-            => objectCommandMap.GetIndexFromId(cmdId);
+            var extId = typeId - CustomObjectTypeMinId;
+            var newCmd = new CustomObjectCommandWrapper((byte)extId, factory);
+            var setSuccessful = objectCommandMap.TrySetValue(typeId, ref newCmd);
+            Debug.Assert(setSuccessful);
+
+            return typeId;
+        }
     }
 }

--- a/libs/server/Custom/CustomCommandManagerSession.cs
+++ b/libs/server/Custom/CustomCommandManagerSession.cs
@@ -59,6 +59,12 @@ namespace Garnet.server
             return GetCustomTransactionProcedureAndSetArity(entry, respServerSession, txnManager, scratchBufferManager, cmdInfo?.Arity ?? 0);
         }
 
+        public int GetRawStringCommandIdFromFriendlyId(int friendlyId)
+            => customCommandManager.GetRawStringCommandIdFromFriendlyId(friendlyId);
+
+        public int GetTypeIdFromFriendlyId(int friendlyId)
+            => customCommandManager.GetTypeIdFromFriendlyId(friendlyId);
+
         private CustomTransactionProcedure GetCustomTransactionProcedureAndSetArity(CustomTransaction entry, RespServerSession respServerSession, TransactionManager txnManager, ScratchBufferManager scratchBufferManager, int arity)
         {
             int id = entry.id;

--- a/libs/server/Custom/CustomCommandManagerSession.cs
+++ b/libs/server/Custom/CustomCommandManagerSession.cs
@@ -59,11 +59,11 @@ namespace Garnet.server
             return GetCustomTransactionProcedureAndSetArity(entry, respServerSession, txnManager, scratchBufferManager, cmdInfo?.Arity ?? 0);
         }
 
-        public int GetRawStringCommandIdFromFriendlyId(int friendlyId)
-            => customCommandManager.GetRawStringCommandIdFromFriendlyId(friendlyId);
+        public RespCommand GetCustomRespCommand(int id)
+            => customCommandManager.GetCustomRespCommand(id);
 
-        public int GetTypeIdFromFriendlyId(int friendlyId)
-            => customCommandManager.GetTypeIdFromFriendlyId(friendlyId);
+        public GarnetObjectType GetCustomGarnetObjectType(int id)
+            => customCommandManager.GetCustomGarnetObjectType(id);
 
         private CustomTransactionProcedure GetCustomTransactionProcedureAndSetArity(CustomTransaction entry, RespServerSession respServerSession, TransactionManager txnManager, ScratchBufferManager scratchBufferManager, int arity)
         {

--- a/libs/server/Custom/CustomRespCommands.cs
+++ b/libs/server/Custom/CustomRespCommands.cs
@@ -54,7 +54,6 @@ namespace Garnet.server
             var proc = customCommandManagerSession
                 .GetCustomTransactionProcedure(id, this, txnManager, scratchBufferManager, out _);
             return txnManager.RunTransactionProc(id, ref procInput, proc, ref output);
-
         }
 
         private void TryCustomProcedure(CustomProcedure proc, int startIdx = 0)
@@ -226,7 +225,8 @@ namespace Garnet.server
             var sbKey = key.SpanByte;
             var inputArg = customCommand.expirationTicks > 0 ? DateTimeOffset.UtcNow.Ticks + customCommand.expirationTicks : customCommand.expirationTicks;
             customCommandParseState.InitializeWithArguments(args);
-            var rawStringInput = new RawStringInput((RespCommand)customCommand.id, ref customCommandParseState, arg1: inputArg);
+            var cmdId = customCommandManagerSession.GetRawStringCommandIdFromFriendlyId(customCommand.id);
+            var rawStringInput = new RawStringInput((RespCommand)cmdId, ref customCommandParseState, arg1: inputArg);
 
             var _output = new SpanByteAndMemory(null);
             GarnetStatus status;
@@ -290,7 +290,8 @@ namespace Garnet.server
             var keyBytes = key.ToArray();
 
             // Prepare input
-            var header = new RespInputHeader((GarnetObjectType)customObjCommand.id) { SubId = customObjCommand.subid };
+            var typeId = customCommandManagerSession.GetTypeIdFromFriendlyId(customObjCommand.id);
+            var header = new RespInputHeader((GarnetObjectType)typeId) { SubId = customObjCommand.subid };
             customCommandParseState.InitializeWithArguments(args);
             var input = new ObjectInput(header, ref customCommandParseState);
 

--- a/libs/server/Custom/CustomRespCommands.cs
+++ b/libs/server/Custom/CustomRespCommands.cs
@@ -225,8 +225,8 @@ namespace Garnet.server
             var sbKey = key.SpanByte;
             var inputArg = customCommand.expirationTicks > 0 ? DateTimeOffset.UtcNow.Ticks + customCommand.expirationTicks : customCommand.expirationTicks;
             customCommandParseState.InitializeWithArguments(args);
-            var cmdId = customCommandManagerSession.GetRawStringCommandIdFromFriendlyId(customCommand.id);
-            var rawStringInput = new RawStringInput((RespCommand)cmdId, ref customCommandParseState, arg1: inputArg);
+            var cmd = customCommandManagerSession.GetCustomRespCommand(customCommand.id);
+            var rawStringInput = new RawStringInput(cmd, ref customCommandParseState, arg1: inputArg);
 
             var _output = new SpanByteAndMemory(null);
             GarnetStatus status;
@@ -290,8 +290,8 @@ namespace Garnet.server
             var keyBytes = key.ToArray();
 
             // Prepare input
-            var typeId = customCommandManagerSession.GetTypeIdFromFriendlyId(customObjCommand.id);
-            var header = new RespInputHeader((GarnetObjectType)typeId) { SubId = customObjCommand.subid };
+            var type = customCommandManagerSession.GetCustomGarnetObjectType(customObjCommand.id);
+            var header = new RespInputHeader(type) { SubId = customObjCommand.subid };
             customCommandParseState.InitializeWithArguments(args);
             var input = new ObjectInput(header, ref customCommandParseState);
 

--- a/libs/server/Custom/ExpandableMap.cs
+++ b/libs/server/Custom/ExpandableMap.cs
@@ -59,6 +59,20 @@ namespace Garnet.server
         /// <param name="id">ID if found, otherwise -1</param>
         /// <returns>True if ID found</returns>
         bool TryGetFirstId(Func<T, bool> predicate, out int id);
+
+        /// <summary>
+        /// Maps underlying map index to item ID
+        /// </summary>
+        /// <param name="index">Map index</param>
+        /// <returns>Item ID</returns>
+        int GetIdFromIndex(int index);
+
+        /// <summary>
+        /// Maps an item ID to underlying map index
+        /// </summary>
+        /// <param name="id">Item ID</param>
+        /// <returns>Map index</returns>
+        int GetIndexFromId(int id);
     }
 
     /// <summary>
@@ -168,6 +182,12 @@ namespace Garnet.server
             return false;
         }
 
+        /// <inheritdoc />
+        public int GetIdFromIndex(int index) => descIds ? minId - index : index;
+
+        /// <inheritdoc />
+        public int GetIndexFromId(int id) => descIds ? minId - id : id;
+
         /// <summary>
         /// Get next item ID for assignment with atomic incrementation of underlying index
         /// </summary>
@@ -247,20 +267,6 @@ namespace Garnet.server
             if (updateSize) TryUpdateSize(id);
             return true;
         }
-
-        /// <summary>
-        /// Maps map index to item ID
-        /// </summary>
-        /// <param name="index">Map index</param>
-        /// <returns>Item ID</returns>
-        private int GetIdFromIndex(int index) => descIds ? minId - index : index;
-
-        /// <summary>
-        /// Maps an item ID to a map index
-        /// </summary>
-        /// <param name="id">Item ID</param>
-        /// <returns>Map index</returns>
-        private int GetIndexFromId(int id) => descIds ? minId - id : id;
     }
 
     /// <summary>
@@ -397,6 +403,12 @@ namespace Garnet.server
                 eMapLock.ReadUnlock();
             }
         }
+
+        /// <inheritdoc />
+        public int GetIdFromIndex(int index) => eMapUnsafe.GetIdFromIndex(index);
+
+        /// <inheritdoc />
+        public int GetIndexFromId(int id) => eMapUnsafe.GetIndexFromId(id);
     }
 
     /// <summary>

--- a/libs/server/Objects/Types/GarnetObjectSerializer.cs
+++ b/libs/server/Objects/Types/GarnetObjectSerializer.cs
@@ -58,7 +58,7 @@ namespace Garnet.server
 
         private IGarnetObject CustomDeserialize(byte type, BinaryReader binaryReader)
         {
-            if (type < CustomCommandManager.TypeIdStartOffset ||
+            if (type < CustomCommandManager.CustomTypeIdStartOffset ||
                 !customCommandManager.TryGetCustomObjectCommand(type, out var cmd)) return null;
             return cmd.factory.Deserialize(type, binaryReader);
         }

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -826,7 +826,8 @@ namespace Garnet.server
             }
 
             // Perform the operation
-            TryCustomRawStringCommand((RespCommand)currentCustomRawStringCommand.id,
+            var cmdId = customCommandManagerSession.GetRawStringCommandIdFromFriendlyId(currentCustomRawStringCommand.id);
+            TryCustomRawStringCommand((RespCommand)cmdId,
                 currentCustomRawStringCommand.expirationTicks, currentCustomRawStringCommand.type, ref storageApi);
             currentCustomRawStringCommand = null;
             return true;
@@ -842,7 +843,8 @@ namespace Garnet.server
             }
 
             // Perform the operation
-            TryCustomObjectCommand((GarnetObjectType)currentCustomObjectCommand.id, currentCustomObjectCommand.subid,
+            var typeId = customCommandManagerSession.GetTypeIdFromFriendlyId(currentCustomObjectCommand.id);
+            TryCustomObjectCommand((GarnetObjectType)typeId, currentCustomObjectCommand.subid,
                 currentCustomObjectCommand.type, ref storageApi);
             currentCustomObjectCommand = null;
             return true;

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -826,9 +826,8 @@ namespace Garnet.server
             }
 
             // Perform the operation
-            var cmdId = customCommandManagerSession.GetRawStringCommandIdFromFriendlyId(currentCustomRawStringCommand.id);
-            TryCustomRawStringCommand((RespCommand)cmdId,
-                currentCustomRawStringCommand.expirationTicks, currentCustomRawStringCommand.type, ref storageApi);
+            var cmd = customCommandManagerSession.GetCustomRespCommand(currentCustomRawStringCommand.id);
+            TryCustomRawStringCommand(cmd, currentCustomRawStringCommand.expirationTicks, currentCustomRawStringCommand.type, ref storageApi);
             currentCustomRawStringCommand = null;
             return true;
         }
@@ -843,8 +842,8 @@ namespace Garnet.server
             }
 
             // Perform the operation
-            var typeId = customCommandManagerSession.GetTypeIdFromFriendlyId(currentCustomObjectCommand.id);
-            TryCustomObjectCommand((GarnetObjectType)typeId, currentCustomObjectCommand.subid,
+            var type = customCommandManagerSession.GetCustomGarnetObjectType(currentCustomObjectCommand.id);
+            TryCustomObjectCommand(type, currentCustomObjectCommand.subid,
                 currentCustomObjectCommand.type, ref storageApi);
             currentCustomObjectCommand = null;
             return true;

--- a/libs/server/Storage/Functions/ObjectStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/ObjectStore/RMWMethods.cs
@@ -26,7 +26,7 @@ namespace Garnet.server
                 case GarnetObjectType.Persist:
                     return false;
                 default:
-                    if ((byte)type < CustomCommandManager.TypeIdStartOffset)
+                    if ((byte)type < CustomCommandManager.CustomTypeIdStartOffset)
                         return GarnetObject.NeedToCreate(input.header);
                     else
                     {
@@ -44,7 +44,7 @@ namespace Garnet.server
         public bool InitialUpdater(ref byte[] key, ref ObjectInput input, ref IGarnetObject value, ref GarnetObjectStoreOutput output, ref RMWInfo rmwInfo, ref RecordInfo recordInfo)
         {
             var type = input.header.type;
-            if ((byte)type < CustomCommandManager.TypeIdStartOffset)
+            if ((byte)type < CustomCommandManager.CustomTypeIdStartOffset)
             {
                 value = GarnetObject.Create(type);
                 value.Operate(ref input, ref output.spanByteAndMemory, out _, out _);
@@ -139,7 +139,7 @@ namespace Garnet.server
                         CopyDefaultResp(CmdStrings.RESP_RETURN_VAL_0, ref output.spanByteAndMemory);
                     return true;
                 default:
-                    if ((byte)input.header.type < CustomCommandManager.TypeIdStartOffset)
+                    if ((byte)input.header.type < CustomCommandManager.CustomTypeIdStartOffset)
                     {
                         var operateSuccessful = value.Operate(ref input, ref output.spanByteAndMemory, out sizeChange,
                         out var removeKey);
@@ -231,7 +231,7 @@ namespace Garnet.server
                         CopyDefaultResp(CmdStrings.RESP_RETURN_VAL_0, ref output.spanByteAndMemory);
                     break;
                 default:
-                    if ((byte)input.header.type < CustomCommandManager.TypeIdStartOffset)
+                    if ((byte)input.header.type < CustomCommandManager.CustomTypeIdStartOffset)
                     {
                         value.Operate(ref input, ref output.spanByteAndMemory, out _, out var removeKey);
                         if (removeKey)

--- a/libs/server/Storage/Functions/ObjectStore/ReadMethods.cs
+++ b/libs/server/Storage/Functions/ObjectStore/ReadMethods.cs
@@ -46,7 +46,7 @@ namespace Garnet.server
                         return true;
 
                     default:
-                        if ((byte)input.header.type < CustomCommandManager.TypeIdStartOffset)
+                        if ((byte)input.header.type < CustomCommandManager.CustomTypeIdStartOffset)
                             return value.Operate(ref input, ref dst.spanByteAndMemory, out _, out _);
 
                         if (IncorrectObjectType(ref input, value, ref dst.spanByteAndMemory))


### PR DESCRIPTION
Following changes in PR #848 we now assign raw string command IDs & custom type IDs in descending order starting from last valid ID available.
To make IDs returned to the client "friendlier", this PR converts the "large" custom command / type IDs to start at index 0.