### PR TITLE
Fix Tsavorite CI pipeline on Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+      - name: Set workaround for libaio on Ubuntu 24.04 (see https://askubuntu.com/questions/1512196/libaio1-on-noble/1512197#1512197)
+        run: |
+          sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
+        if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Set environment variable for Linux
         run: echo "RunAzureTests=yes" >> $GITHUB_ENV
         if: ${{ matrix.os == 'ubuntu-latest' }}


### PR DESCRIPTION
Ubuntu 24.04 uses `libaio.so.1t64` instead of `libaio.so.1` which causes pipelines to fail on `ubuntu-latest`. This PR offers a workaround by symbolically linking `libaio.so.1` to `libaio.so.1t64` to fix the CI pipeline, as described [here](https://askubuntu.com/questions/1512196/libaio1-on-noble/1512197).