### PR TITLE
Remove meet lock in TryMeet

### DIFF
--- a/libs/cluster/Server/GarnetServerNode.cs
+++ b/libs/cluster/Server/GarnetServerNode.cs
@@ -30,11 +30,6 @@ namespace Garnet.cluster
         ClusterConfig lastConfig = null;
 
         /// <summary>
-        /// Gossip with meet command lock
-        /// </summary>
-        SingleWriterMultiReaderLock meetLock;
-
-        /// <summary>
         /// Outstanding gossip task if any
         /// </summary>
         Task gossipTask = null;
@@ -202,17 +197,9 @@ namespace Garnet.cluster
         /// <returns></returns>
         public MemoryResult<byte> TryMeet(byte[] configByteArray)
         {
-            try
-            {
-                _ = meetLock.TryWriteLock();
-                UpdateGossipSend();
-                var resp = gc.GossipWithMeet(configByteArray).WaitAsync(clusterProvider.clusterManager.clusterTimeout, cts.Token).GetAwaiter().GetResult();
-                return resp;
-            }
-            finally
-            {
-                meetLock.WriteUnlock();
-            }
+            UpdateGossipSend();
+            var resp = gc.GossipWithMeet(configByteArray).WaitAsync(clusterProvider.clusterManager.clusterTimeout, cts.Token).GetAwaiter().GetResult();
+            return resp;
         }
 
         /// <summary>


### PR DESCRIPTION
The lock is not really protecting anything in this context as we still proceed with Meet rather than returning the thread until it's available. So doesn't seem like we really need a lock. In some cases during startup if there are multiple meets (and one or more nodes are unresponsive), it can cause CAS retries during it's release so better to remove it if it's not needed.
Also note that MEET is currently Blocking and consumes a threadpool thread.

CPU stacks indicating WriteUnlock taking time
![image](https://github.com/user-attachments/assets/726c2283-5662-4b5d-ac6c-846a8758734f)
