### PR TITLE
Fix bug when setting epoch value

### DIFF
--- a/libs/cluster/Session/RespClusterBasicCommands.cs
+++ b/libs/cluster/Session/RespClusterBasicCommands.cs
@@ -286,7 +286,7 @@ namespace Garnet.cluster
                 return true;
             }
 
-            if (!parseState.TryGetInt(0, out var configEpoch))
+            if (!parseState.TryGetLong(0, out var configEpoch))
             {
                 while (!RespWriteUtils.WriteError(CmdStrings.RESP_ERR_GENERIC_VALUE_IS_NOT_INTEGER, ref dcurr, dend))
                     SendAndReset();


### PR DESCRIPTION
This PR fixes the issue when setting the epoch value. When parsing the comment argument, GetLong should be used instead of GetInt