### PR TITLE
Add separate active connection tracker

### DIFF
--- a/libs/server/Metrics/GarnetServerMetrics.cs
+++ b/libs/server/Metrics/GarnetServerMetrics.cs
@@ -10,6 +10,7 @@ namespace Garnet.server
         /// </summary>
         public long total_connections_received;
         public long total_connections_disposed;
+        public long total_connections_active;
 
         /// <summary>
         /// Instantaneous metrics
@@ -38,6 +39,7 @@ namespace Garnet.server
         {
             total_connections_received = 0;
             total_connections_disposed = 0;
+            total_connections_active = 0;
 
             instantaneous_cmd_per_sec = 0;
             instantaneous_net_input_tpt = 0;

--- a/libs/server/Metrics/GarnetServerMonitor.cs
+++ b/libs/server/Metrics/GarnetServerMonitor.cs
@@ -258,6 +258,7 @@ namespace Garnet.server
                     var garnetServer = ((GarnetServerBase)server);
                     globalMetrics.total_connections_received = garnetServer.get_conn_recv();
                     globalMetrics.total_connections_disposed = garnetServer.get_conn_disp();
+                    globalMetrics.total_connections_active = garnetServer.get_conn_active();
 
                     UpdateInstantaneousMetrics();
                     UpdateAllMetricsHistory();

--- a/libs/server/Metrics/Info/GarnetInfoMetrics.cs
+++ b/libs/server/Metrics/Info/GarnetInfoMetrics.cs
@@ -169,9 +169,11 @@ namespace Garnet.server
             var globalMetrics = metricsDisabled ? default : storeWrapper.monitor.GlobalMetrics;
             var tt = metricsDisabled ? 0 : (double)(globalMetrics.globalSessionMetrics.get_total_found() + globalMetrics.globalSessionMetrics.get_total_notfound());
             var garnet_hit_rate = metricsDisabled ? 0 : (tt > 0 ? (double)globalMetrics.globalSessionMetrics.get_total_found() / tt : 0) * 100;
+
             statsInfo =
                 [
-                    new("total_connections_active", metricsDisabled ? "0" : globalMetrics.total_connections_received.ToString()),
+                    new("total_connections_active", metricsDisabled ? "0" : globalMetrics.total_connections_active.ToString()),
+                    new("total_connections_received", metricsDisabled ? "0" : globalMetrics.total_connections_received.ToString()),
                     new("total_connections_disposed", metricsDisabled ? "0" : globalMetrics.total_connections_disposed.ToString()),
                     new("total_commands_processed", metricsDisabled ? "0" : globalMetrics.globalSessionMetrics.get_total_commands_processed().ToString()),
                     new("instantaneous_ops_per_sec", metricsDisabled ? "0" : globalMetrics.instantaneous_cmd_per_sec.ToString()),

--- a/libs/server/Metrics/Info/InfoCommand.cs
+++ b/libs/server/Metrics/Info/InfoCommand.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using Garnet.common;
 

--- a/libs/server/Resp/ClientCommands.cs
+++ b/libs/server/Resp/ClientCommands.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Garnet.common;
-using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Logging;
 
 namespace Garnet.server

--- a/libs/server/Servers/GarnetServerBase.cs
+++ b/libs/server/Servers/GarnetServerBase.cs
@@ -86,6 +86,12 @@ namespace Garnet.server
         }
 
         /// <summary>
+        /// Get total_connections_active
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long get_conn_active() => this.activeHandlers.Count;
+
+        /// <summary>
         /// Get total_connections_received
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
This PR adds a separate field to track active number of connections separately from received number of connections.