### PR TITLE
Update version to 1.0.53 and fix warning in config test

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- Versioning property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>1.0.52</VersionPrefix>
+		<VersionPrefix>1.0.53</VersionPrefix>
 	</PropertyGroup>
 </Project>

--- a/test/Garnet.test.cluster/ClusterConfigTests.cs
+++ b/test/Garnet.test.cluster/ClusterConfigTests.cs
@@ -65,7 +65,7 @@ namespace Garnet.test.cluster
         public void ClusterForgetAfterNodeRestartTest()
         {
             int nbInstances = 4;
-            context.CreateInstances(4);
+            context.CreateInstances(nbInstances);
             context.CreateConnection();
             var (shards, slots) = context.clusterTestUtils.SimpleSetupCluster(logger: context.logger);
 
@@ -77,7 +77,7 @@ namespace Garnet.test.cluster
 
             var firstNode = context.nodes[0];
             var nodesResult = context.clusterTestUtils.ClusterNodes(0);
-            Assert.That(nodesResult.Nodes.Count == 4);
+            Assert.That(nodesResult.Nodes.Count == nbInstances);
 
             try
             {
@@ -96,13 +96,13 @@ namespace Garnet.test.cluster
             }
 
             nodesResult = context.clusterTestUtils.ClusterNodes(0);
-            Assert.That(nodesResult.Nodes.Count == 4, "No node should've been removed from the cluster after an invalid id was passed.");
+            Assert.That(nodesResult.Nodes.Count == nbInstances, "No node should've been removed from the cluster after an invalid id was passed.");
             Assert.That(nodesResult.Nodes.ElementAt(0).IsMyself);
             Assert.That(nodesResult.Nodes.ElementAt(0).EndPoint.ToIPEndPoint().Port == 7000, "Expected the node to be replying to be the one with port 7000.");
 
             context.clusterTestUtils.ClusterForget(0, nodesResult.Nodes.Last().NodeId, 0);
             nodesResult = context.clusterTestUtils.ClusterNodes(0);
-            Assert.That(nodesResult.Nodes.Count == 3, "A node should've been removed from the cluster.");
+            Assert.That(nodesResult.Nodes.Count == nbInstances - 1, "A node should've been removed from the cluster.");
             Assert.That(nodesResult.Nodes.ElementAt(0).IsMyself);
             Assert.That(nodesResult.Nodes.ElementAt(0).EndPoint.ToIPEndPoint().Port == 7000, "Expected the node to be replying to be the one with port 7000.");
         }


### PR DESCRIPTION
Bump version to 1.0.53 and fix a warning that I introduced in a previous change.