### PR TITLE
Fix linsert before handling (microsoft#945)

### DIFF
--- a/libs/server/Objects/List/ListObjectImpl.cs
+++ b/libs/server/Objects/List/ListObjectImpl.cs
@@ -92,7 +92,7 @@ namespace Garnet.server
                 // get the string to INSERT into the list
                 var item = input.parseState.GetArgSliceByRef(2).SpanByte.ToByteArray();
 
-                var insertBefore = position.SequenceEqual(CmdStrings.BEFORE);
+                var insertBefore = position.EqualsUpperCaseSpanIgnoringCase(CmdStrings.BEFORE);
 
                 _output->result1 = -1;
 

--- a/test/Garnet.test/RespListTests.cs
+++ b/test/Garnet.test/RespListTests.cs
@@ -1391,6 +1391,22 @@ namespace Garnet.test
             ClassicAssert.AreEqual("ERR syntax error", exception.Message);
         }
 
+        // Issue 945
+        [Test]
+        public void CanHandleLowerCaseBefore()
+        {
+            using var lightClientRequest = TestUtils.CreateRequest();
+
+            lightClientRequest.SendCommands("RPUSH mylist a", "PING", 1, 1);
+            lightClientRequest.SendCommands("RPUSH mylist c", "PING", 1, 1);
+            lightClientRequest.SendCommands("LINSERT mylist before c b", "PING", 1, 1);
+
+            var response = lightClientRequest.SendCommands("LRANGE mylist 0 -1", "PING", 4, 1);
+            var expectedResponse = "*3\r\n$1\r\na\r\n$1\r\nb\r\n$1\r\nc\r\n+PONG\r\n";
+            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
+            ClassicAssert.AreEqual(expectedResponse, actualValue);
+        }
+
         [Test]
         public void CheckListOperationsOnWrongTypeObjectSE()
         {


### PR DESCRIPTION
ListObjectImpl made a case-sensitive comparison that ignored non-uppercase 'before' in LINSERT command. Do a proper comparison as advised by @badrishc . Also add a testcase to ensure this doesn't break in the future.