### PR TITLE
SETNX command should return integer value

### DIFF
--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -444,10 +444,8 @@ namespace Garnet.server
             var input = new RawStringInput(RespCommand.SETEXNX, ref parseState, startIdx: 1, arg1: 0);
             var status = storageApi.SET_Conditional(ref sbKey, ref input);
 
-            // the status returned for SETNX as NOTFOUND is the expected status in the happy path, so flip the ok flag
-            bool ok = status == GarnetStatus.NOTFOUND;
-
-            if (ok)
+            // The status returned for SETNX as NOTFOUND is the expected status in the happy path
+            if (status == GarnetStatus.NOTFOUND)
             {
                 while (!RespWriteUtils.TryWriteInt32(1, ref dcurr, dend))
                     SendAndReset();

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -440,16 +440,9 @@ namespace Garnet.server
             var status = storageApi.SET_Conditional(ref sbKey, ref input);
 
             // The status returned for SETNX as NOTFOUND is the expected status in the happy path
-            if (status == GarnetStatus.NOTFOUND)
-            {
-                while (!RespWriteUtils.TryWriteInt32(1, ref dcurr, dend))
-                    SendAndReset();
-            }
-            else
-            {
-                while (!RespWriteUtils.TryWriteInt32(0, ref dcurr, dend))
-                    SendAndReset();
-            }
+            var retVal = status == GarnetStatus.NOTFOUND ? 1 : 0;
+            while (!RespWriteUtils.TryWriteInt32(retVal, ref dcurr, dend))
+                SendAndReset();
 
             return true;
         }

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -434,12 +434,7 @@ namespace Garnet.server
         {
             Debug.Assert(parseState.Count == 2);
             var key = parseState.GetArgSliceByRef(0);
-            var value = parseState.GetArgSliceByRef(1);
-            var getOption = ArgSlice.FromPinnedSpan(CmdStrings.NX);
-            parseState.InitializeWithArguments(key, value, getOption);
-
-            var nkey = parseState.GetArgSliceByRef(0);
-            var sbKey = nkey.SpanByte;
+            var sbKey = key.SpanByte;
 
             var input = new RawStringInput(RespCommand.SETEXNX, ref parseState, startIdx: 1, arg1: 0);
             var status = storageApi.SET_Conditional(ref sbKey, ref input);

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -436,7 +436,7 @@ namespace Garnet.server
             var key = parseState.GetArgSliceByRef(0);
             var sbKey = key.SpanByte;
 
-            var input = new RawStringInput(RespCommand.SETEXNX, ref parseState, startIdx: 1, arg1: 0);
+            var input = new RawStringInput(RespCommand.SETEXNX, ref parseState, startIdx: 1);
             var status = storageApi.SET_Conditional(ref sbKey, ref input);
 
             // The status returned for SETNX as NOTFOUND is the expected status in the happy path

--- a/test/Garnet.test/Resp/ACL/RespCommandTests.cs
+++ b/test/Garnet.test/Resp/ACL/RespCommandTests.cs
@@ -5369,8 +5369,8 @@ namespace Garnet.test.Resp.ACL
 
             async Task DoSetIfNotExistAsync(GarnetClient client)
             {
-                string val = await client.ExecuteForStringResultAsync("SETNX", [$"foo-{keyIx++}", "bar"]);
-                ClassicAssert.AreEqual(val, "OK");
+                var val = await client.ExecuteForLongResultAsync("SETNX", [$"foo-{keyIx++}", "bar"]);
+                ClassicAssert.AreEqual(1, val);
             }
         }
 

--- a/test/Garnet.test/RespSetTest.cs
+++ b/test/Garnet.test/RespSetTest.cs
@@ -1389,27 +1389,6 @@ namespace Garnet.test
             expectedResponse = ":0\r\n";
             ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
         }
-
-        [Test]
-        public void SetNXCorrectResponse()
-        {
-            var lightClientRequest = TestUtils.CreateRequest();
-
-            // Set key
-            var response = lightClientRequest.SendCommand("SETNX key1 2");
-            var expectedResponse = ":1\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
-
-            // Setnx command should fail since key exists
-            response = lightClientRequest.SendCommand("SETNX key1 3");
-            expectedResponse = ":0\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
-
-            // Be sure key wasn't modified
-            response = lightClientRequest.SendCommand("GET key1");
-            expectedResponse = "$1\r\n2\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
-        }
         #endregion
 
 

--- a/test/Garnet.test/RespSetTest.cs
+++ b/test/Garnet.test/RespSetTest.cs
@@ -1390,6 +1390,26 @@ namespace Garnet.test
             ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
         }
 
+        [Test]
+        public void SetNXCorrectResponse()
+        {
+            var lightClientRequest = TestUtils.CreateRequest();
+
+            // Set key
+            var response = lightClientRequest.SendCommand("SETNX key1 2");
+            var expectedResponse = ":1\r\n";
+            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            
+            // Setnx command should fail since key exists
+            response = lightClientRequest.SendCommand("SETNX key1 3");
+            expectedResponse = ":0\r\n";
+            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+
+            // Be sure key wasn't modified
+            response = lightClientRequest.SendCommand("GET key1");
+            expectedResponse = "$1\r\n2\r\n";
+            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+        }
         #endregion
 
 

--- a/test/Garnet.test/RespSetTest.cs
+++ b/test/Garnet.test/RespSetTest.cs
@@ -1399,7 +1399,7 @@ namespace Garnet.test
             var response = lightClientRequest.SendCommand("SETNX key1 2");
             var expectedResponse = ":1\r\n";
             ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
-            
+
             // Setnx command should fail since key exists
             response = lightClientRequest.SendCommand("SETNX key1 3");
             expectedResponse = ":0\r\n";

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -4581,6 +4581,26 @@ namespace Garnet.test
             ClassicAssert.AreEqual(newValue, result);
         }
 
+        [Test]
+        public void SetNXCorrectResponse()
+        {
+            var lightClientRequest = TestUtils.CreateRequest();
+
+            // Set key
+            var response = lightClientRequest.SendCommand("SETNX key1 2");
+            var expectedResponse = ":1\r\n";
+            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+
+            // Setnx command should fail since key exists
+            response = lightClientRequest.SendCommand("SETNX key1 3");
+            expectedResponse = ":0\r\n";
+            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+
+            // Be sure key wasn't modified
+            response = lightClientRequest.SendCommand("GET key1");
+            expectedResponse = "$1\r\n2\r\n";
+            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+        }
         #endregion
 
         #region SUBSTR


### PR DESCRIPTION
https://redis.io/docs/latest/commands/setnx/

Per redis docs, SETNX command should return 1 or 0. However, garnet translates it internally to SET with NX flag and therefore incorrectly returns SET return values ("OK" or nil). Fix by inlining the correct code path into NetworkSETNX function and then returning the correct response. Also add test and fix existing test.