### PR TITLE
Switching Enum.HasFlag calls with bitwise operations

### DIFF
--- a/libs/server/Objects/Hash/HashObject.cs
+++ b/libs/server/Objects/Hash/HashObject.cs
@@ -501,9 +501,9 @@ namespace Garnet.server
 
             if (expirationTimes.TryGetValue(key, out var currentExpiration))
             {
-                if (expireOption.HasFlag(ExpireOption.NX) ||
-                    (expireOption.HasFlag(ExpireOption.GT) && expiration <= currentExpiration) ||
-                    (expireOption.HasFlag(ExpireOption.LT) && expiration >= currentExpiration))
+                if ((expireOption & ExpireOption.NX) == ExpireOption.NX ||
+                    ((expireOption & ExpireOption.GT) == ExpireOption.GT && expiration <= currentExpiration) ||
+                    ((expireOption & ExpireOption.LT) == ExpireOption.LT && expiration >= currentExpiration))
                 {
                     return (int)ExpireResult.ExpireConditionNotMet;
                 }
@@ -515,7 +515,8 @@ namespace Garnet.server
             }
             else
             {
-                if (expireOption.HasFlag(ExpireOption.XX) || expireOption.HasFlag(ExpireOption.GT))
+                if ((expireOption & ExpireOption.XX) == ExpireOption.XX ||
+                    (expireOption & ExpireOption.GT) == ExpireOption.GT)
                 {
                     return (int)ExpireResult.ExpireConditionNotMet;
                 }

--- a/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
@@ -47,17 +47,21 @@ namespace Garnet.server
             ReadOnlySpan<byte> optionsError = default;
 
             // XX & NX are mutually exclusive
-            if (options.HasFlag(SortedSetAddOption.XX) && options.HasFlag(SortedSetAddOption.NX))
+            if ((options & SortedSetAddOption.XX) == SortedSetAddOption.XX && 
+                (options & SortedSetAddOption.NX) == SortedSetAddOption.NX)
                 optionsError = CmdStrings.RESP_ERR_XX_NX_NOT_COMPATIBLE;
 
             // NX, GT & LT are mutually exclusive
-            if ((options.HasFlag(SortedSetAddOption.GT) && options.HasFlag(SortedSetAddOption.LT)) ||
-               ((options.HasFlag(SortedSetAddOption.GT) || options.HasFlag(SortedSetAddOption.LT)) &&
-                options.HasFlag(SortedSetAddOption.NX)))
+            if (((options & SortedSetAddOption.GT) == SortedSetAddOption.GT && 
+                 (options & SortedSetAddOption.LT) == SortedSetAddOption.LT) ||
+               (((options & SortedSetAddOption.GT) == SortedSetAddOption.GT || 
+                 (options & SortedSetAddOption.LT) == SortedSetAddOption.LT) &&
+                (options & SortedSetAddOption.NX) == SortedSetAddOption.NX))
                 optionsError = CmdStrings.RESP_ERR_GT_LT_NX_NOT_COMPATIBLE;
 
             // INCR supports only one score-element pair
-            if (options.HasFlag(SortedSetAddOption.INCR) && (input.parseState.Count - currTokenIdx > 2))
+            if ((options & SortedSetAddOption.INCR) == SortedSetAddOption.INCR && 
+                (input.parseState.Count - currTokenIdx > 2))
                 optionsError = CmdStrings.RESP_ERR_INCR_SUPPORTS_ONLY_SINGLE_PAIR;
 
             if (!optionsError.IsEmpty)
@@ -131,7 +135,7 @@ namespace Garnet.server
                     if (!sortedSetDict.TryGetValue(member, out var scoreStored))
                     {
                         // Don't add new member if XX flag is set
-                        if (options.HasFlag(SortedSetAddOption.XX)) continue;
+                        if ((options & SortedSetAddOption.XX) == SortedSetAddOption.XX) continue;
 
                         sortedSetDict.Add(member, score);
                         if (sortedSet.Add((score, member)))
@@ -143,7 +147,7 @@ namespace Garnet.server
                     else
                     {
                         // Update new score if INCR flag is set
-                        if (options.HasFlag(SortedSetAddOption.INCR))
+                        if ((options & SortedSetAddOption.INCR) == SortedSetAddOption.INCR)
                         {
                             score += scoreStored;
                             incrResult = score;
@@ -155,9 +159,9 @@ namespace Garnet.server
 
                         // Don't update existing member if NX flag is set
                         // or if GT/LT flag is set and existing score is higher/lower than new score, respectively
-                        if (options.HasFlag(SortedSetAddOption.NX) ||
-                            (options.HasFlag(SortedSetAddOption.GT) && scoreStored > score) ||
-                            (options.HasFlag(SortedSetAddOption.LT) && scoreStored < score)) continue;
+                        if ((options & SortedSetAddOption.NX) == SortedSetAddOption.NX ||
+                            ((options & SortedSetAddOption.GT) == SortedSetAddOption.GT && scoreStored > score) ||
+                            ((options & SortedSetAddOption.LT) == SortedSetAddOption.LT && scoreStored < score)) continue;
 
                         sortedSetDict[member] = score;
                         var success = sortedSet.Remove((scoreStored, member));
@@ -166,12 +170,12 @@ namespace Garnet.server
                         Debug.Assert(success);
 
                         // If CH flag is set, add changed member to final count
-                        if (options.HasFlag(SortedSetAddOption.CH))
+                        if ((options & SortedSetAddOption.CH) == SortedSetAddOption.CH)
                             addedOrChanged++;
                     }
                 }
 
-                if (options.HasFlag(SortedSetAddOption.INCR))
+                if ((options & SortedSetAddOption.INCR) == SortedSetAddOption.INCR)
                 {
                     while (!RespWriteUtils.TryWriteDoubleBulkString(incrResult, ref curr, end))
                         ObjectUtils.ReallocateOutput(ref output, ref isMemory, ref ptr, ref ptrHandle, ref curr, ref end);

--- a/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
@@ -47,20 +47,20 @@ namespace Garnet.server
             ReadOnlySpan<byte> optionsError = default;
 
             // XX & NX are mutually exclusive
-            if ((options & SortedSetAddOption.XX) == SortedSetAddOption.XX && 
+            if ((options & SortedSetAddOption.XX) == SortedSetAddOption.XX &&
                 (options & SortedSetAddOption.NX) == SortedSetAddOption.NX)
                 optionsError = CmdStrings.RESP_ERR_XX_NX_NOT_COMPATIBLE;
 
             // NX, GT & LT are mutually exclusive
-            if (((options & SortedSetAddOption.GT) == SortedSetAddOption.GT && 
+            if (((options & SortedSetAddOption.GT) == SortedSetAddOption.GT &&
                  (options & SortedSetAddOption.LT) == SortedSetAddOption.LT) ||
-               (((options & SortedSetAddOption.GT) == SortedSetAddOption.GT || 
+               (((options & SortedSetAddOption.GT) == SortedSetAddOption.GT ||
                  (options & SortedSetAddOption.LT) == SortedSetAddOption.LT) &&
                 (options & SortedSetAddOption.NX) == SortedSetAddOption.NX))
                 optionsError = CmdStrings.RESP_ERR_GT_LT_NX_NOT_COMPATIBLE;
 
             // INCR supports only one score-element pair
-            if ((options & SortedSetAddOption.INCR) == SortedSetAddOption.INCR && 
+            if ((options & SortedSetAddOption.INCR) == SortedSetAddOption.INCR &&
                 (input.parseState.Count - currTokenIdx > 2))
                 optionsError = CmdStrings.RESP_ERR_INCR_SUPPORTS_ONLY_SINGLE_PAIR;
 

--- a/libs/server/Objects/Types/GarnetObjectStoreOutput.cs
+++ b/libs/server/Objects/Types/GarnetObjectStoreOutput.cs
@@ -50,6 +50,16 @@ namespace Garnet.server
         /// </summary>
         public ObjectStoreOutputFlags OutputFlags;
 
+        /// <summary>
+        /// True if output flag WrongType is set
+        /// </summary>
+        public bool IsWrongType => (OutputFlags & ObjectStoreOutputFlags.WrongType) == ObjectStoreOutputFlags.WrongType;
+
+        /// <summary>
+        /// True if output flag RemoveKey is set
+        /// </summary>
+        public bool RemoveKey => (OutputFlags & ObjectStoreOutputFlags.RemoveKey) == ObjectStoreOutputFlags.RemoveKey;
+
         public void ConvertToHeap()
         {
             // Does not convert to heap when going pending, because we immediately complete pending operations for object store.

--- a/libs/server/Objects/Types/GarnetObjectStoreOutput.cs
+++ b/libs/server/Objects/Types/GarnetObjectStoreOutput.cs
@@ -53,12 +53,12 @@ namespace Garnet.server
         /// <summary>
         /// True if output flag WrongType is set
         /// </summary>
-        public bool IsWrongType => (OutputFlags & ObjectStoreOutputFlags.WrongType) == ObjectStoreOutputFlags.WrongType;
+        public bool HasWrongType => (OutputFlags & ObjectStoreOutputFlags.WrongType) == ObjectStoreOutputFlags.WrongType;
 
         /// <summary>
         /// True if output flag RemoveKey is set
         /// </summary>
-        public bool RemoveKey => (OutputFlags & ObjectStoreOutputFlags.RemoveKey) == ObjectStoreOutputFlags.RemoveKey;
+        public bool HasRemoveKey => (OutputFlags & ObjectStoreOutputFlags.RemoveKey) == ObjectStoreOutputFlags.RemoveKey;
 
         public void ConvertToHeap()
         {

--- a/libs/server/Resp/RespCommandsInfo.cs
+++ b/libs/server/Resp/RespCommandsInfo.cs
@@ -326,7 +326,7 @@ namespace Garnet.server
                 tmpRespCommandInfo = FlattenedRespCommandsInfo[cmd];
 
             if (tmpRespCommandInfo == default ||
-                (txnOnly && tmpRespCommandInfo.Flags.HasFlag(RespCommandFlags.NoMulti))) return false;
+                (txnOnly && (tmpRespCommandInfo.Flags & RespCommandFlags.NoMulti) == RespCommandFlags.NoMulti)) return false;
 
             respCommandsInfo = tmpRespCommandInfo;
             return true;

--- a/libs/server/Storage/Functions/ObjectStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/ObjectStore/RMWMethods.cs
@@ -142,10 +142,10 @@ namespace Garnet.server
                     if ((byte)input.header.type < CustomCommandManager.CustomTypeIdStartOffset)
                     {
                         var operateSuccessful = value.Operate(ref input, ref output, out sizeChange);
-                        if (output.OutputFlags.HasFlag(ObjectStoreOutputFlags.WrongType))
+                        if (output.IsWrongType)
                             return true;
 
-                        if (output.OutputFlags.HasFlag(ObjectStoreOutputFlags.RemoveKey))
+                        if (output.RemoveKey)
                         {
                             rmwInfo.Action = RMWAction.ExpireAndStop;
                             return false;
@@ -239,10 +239,10 @@ namespace Garnet.server
                     if ((byte)input.header.type < CustomCommandManager.CustomTypeIdStartOffset)
                     {
                         value.Operate(ref input, ref output, out _);
-                        if (output.OutputFlags.HasFlag(ObjectStoreOutputFlags.WrongType))
+                        if (output.IsWrongType)
                             return true;
 
-                        if (output.OutputFlags.HasFlag(ObjectStoreOutputFlags.RemoveKey))
+                        if (output.RemoveKey)
                         {
                             rmwInfo.Action = RMWAction.ExpireAndStop;
                             return false;

--- a/libs/server/Storage/Functions/ObjectStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/ObjectStore/RMWMethods.cs
@@ -142,10 +142,10 @@ namespace Garnet.server
                     if ((byte)input.header.type < CustomCommandManager.CustomTypeIdStartOffset)
                     {
                         var operateSuccessful = value.Operate(ref input, ref output, out sizeChange);
-                        if (output.IsWrongType)
+                        if (output.HasWrongType)
                             return true;
 
-                        if (output.RemoveKey)
+                        if (output.HasRemoveKey)
                         {
                             rmwInfo.Action = RMWAction.ExpireAndStop;
                             return false;
@@ -239,10 +239,10 @@ namespace Garnet.server
                     if ((byte)input.header.type < CustomCommandManager.CustomTypeIdStartOffset)
                     {
                         value.Operate(ref input, ref output, out _);
-                        if (output.IsWrongType)
+                        if (output.HasWrongType)
                             return true;
 
-                        if (output.RemoveKey)
+                        if (output.HasRemoveKey)
                         {
                             rmwInfo.Action = RMWAction.ExpireAndStop;
                             return false;

--- a/libs/server/Storage/Functions/ObjectStore/ReadMethods.cs
+++ b/libs/server/Storage/Functions/ObjectStore/ReadMethods.cs
@@ -49,7 +49,7 @@ namespace Garnet.server
                         if ((byte)input.header.type < CustomCommandManager.CustomTypeIdStartOffset)
                         {
                             var opResult = value.Operate(ref input, ref dst, out _);
-                            if (dst.OutputFlags.HasFlag(ObjectStoreOutputFlags.WrongType))
+                            if (dst.IsWrongType)
                                 return true;
 
                             return opResult;

--- a/libs/server/Storage/Functions/ObjectStore/ReadMethods.cs
+++ b/libs/server/Storage/Functions/ObjectStore/ReadMethods.cs
@@ -49,7 +49,7 @@ namespace Garnet.server
                         if ((byte)input.header.type < CustomCommandManager.CustomTypeIdStartOffset)
                         {
                             var opResult = value.Operate(ref input, ref dst, out _);
-                            if (dst.IsWrongType)
+                            if (dst.HasWrongType)
                                 return true;
 
                             return opResult;

--- a/libs/server/Storage/Session/ObjectStore/AdvancedOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/AdvancedOps.cs
@@ -21,7 +21,7 @@ namespace Garnet.server
 
             if (status.Found)
             {
-                if (output.OutputFlags.HasFlag(ObjectStoreOutputFlags.WrongType))
+                if (output.IsWrongType)
                     return GarnetStatus.WRONGTYPE;
 
                 return GarnetStatus.OK;
@@ -40,7 +40,7 @@ namespace Garnet.server
 
             if (status.Found)
             {
-                if (output.OutputFlags.HasFlag(ObjectStoreOutputFlags.WrongType))
+                if (output.IsWrongType)
                     return GarnetStatus.WRONGTYPE;
 
                 return GarnetStatus.OK;

--- a/libs/server/Storage/Session/ObjectStore/AdvancedOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/AdvancedOps.cs
@@ -21,7 +21,7 @@ namespace Garnet.server
 
             if (status.Found)
             {
-                if (output.IsWrongType)
+                if (output.HasWrongType)
                     return GarnetStatus.WRONGTYPE;
 
                 return GarnetStatus.OK;
@@ -40,7 +40,7 @@ namespace Garnet.server
 
             if (status.Found)
             {
-                if (output.IsWrongType)
+                if (output.HasWrongType)
                     return GarnetStatus.WRONGTYPE;
 
                 return GarnetStatus.OK;

--- a/libs/server/Storage/Session/ObjectStore/Common.cs
+++ b/libs/server/Storage/Session/ObjectStore/Common.cs
@@ -498,7 +498,7 @@ namespace Garnet.server
             if (status.IsPending)
                 CompletePendingForObjectStoreSession(ref status, ref _output, ref objectStoreContext);
 
-            if (_output.IsWrongType)
+            if (_output.HasWrongType)
                 return GarnetStatus.WRONGTYPE;
 
             Debug.Assert(_output.SpanByteAndMemory.IsSpanByte);
@@ -533,7 +533,7 @@ namespace Garnet.server
             if (status.IsPending)
                 CompletePendingForObjectStoreSession(ref status, ref _output, ref objectStoreContext);
 
-            if (_output.IsWrongType)
+            if (_output.HasWrongType)
                 return GarnetStatus.WRONGTYPE;
 
             Debug.Assert(_output.SpanByteAndMemory.IsSpanByte);
@@ -579,7 +579,7 @@ namespace Garnet.server
             if (status.NotFound && !status.Record.Created)
                 return GarnetStatus.NOTFOUND;
 
-            if (status.Found && outputFooter.IsWrongType)
+            if (status.Found && outputFooter.HasWrongType)
                 return GarnetStatus.WRONGTYPE;
 
             return GarnetStatus.OK;

--- a/libs/server/Storage/Session/ObjectStore/Common.cs
+++ b/libs/server/Storage/Session/ObjectStore/Common.cs
@@ -498,7 +498,7 @@ namespace Garnet.server
             if (status.IsPending)
                 CompletePendingForObjectStoreSession(ref status, ref _output, ref objectStoreContext);
 
-            if (_output.OutputFlags.HasFlag(ObjectStoreOutputFlags.WrongType))
+            if (_output.IsWrongType)
                 return GarnetStatus.WRONGTYPE;
 
             Debug.Assert(_output.SpanByteAndMemory.IsSpanByte);
@@ -533,7 +533,7 @@ namespace Garnet.server
             if (status.IsPending)
                 CompletePendingForObjectStoreSession(ref status, ref _output, ref objectStoreContext);
 
-            if (_output.OutputFlags.HasFlag(ObjectStoreOutputFlags.WrongType))
+            if (_output.IsWrongType)
                 return GarnetStatus.WRONGTYPE;
 
             Debug.Assert(_output.SpanByteAndMemory.IsSpanByte);
@@ -579,7 +579,7 @@ namespace Garnet.server
             if (status.NotFound && !status.Record.Created)
                 return GarnetStatus.NOTFOUND;
 
-            if (status.Found && outputFooter.OutputFlags.HasFlag(ObjectStoreOutputFlags.WrongType))
+            if (status.Found && outputFooter.IsWrongType)
                 return GarnetStatus.WRONGTYPE;
 
             return GarnetStatus.OK;


### PR DESCRIPTION
Switching a few areas in the code from using Enum.HasFlag (which apparently uses reflection and thus incur overhead) to using more efficient bitwise operations.