### PR TITLE
HINCRBY should use 64bit signed integers, not 32bit ints.

### DIFF
--- a/libs/server/Objects/Hash/HashObjectImpl.cs
+++ b/libs/server/Objects/Hash/HashObjectImpl.cs
@@ -383,7 +383,7 @@ namespace Garnet.server
                 var valueExists = TryGetValue(key, out var value);
                 if (op == HashOperation.HINCRBY)
                 {
-                    if (!NumUtils.TryParse(incrSlice.ReadOnlySpan, out int incr))
+                    if (!NumUtils.TryParse(incrSlice.ReadOnlySpan, out long incr))
                     {
                         while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_GENERIC_VALUE_IS_NOT_INTEGER, ref curr, end))
                             ObjectUtils.ReallocateOutput(ref output, ref isMemory, ref ptr, ref ptrHandle, ref curr, ref end);
@@ -394,7 +394,7 @@ namespace Garnet.server
 
                     if (valueExists)
                     {
-                        if (!NumUtils.TryParse(value, out int result))
+                        if (!NumUtils.TryParse(value, out long result))
                         {
                             while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_HASH_VALUE_IS_NOT_INTEGER, ref curr,
                                        end))
@@ -406,7 +406,7 @@ namespace Garnet.server
                         result += incr;
 
                         var resultSpan = (Span<byte>)stackalloc byte[NumUtils.MaximumFormatInt64Length];
-                        var success = Utf8Formatter.TryFormat((long)result, resultSpan, out int bytesWritten,
+                        var success = Utf8Formatter.TryFormat(result, resultSpan, out int bytesWritten,
                             format: default);
                         Debug.Assert(success);
 

--- a/test/Garnet.test/RespHashTests.cs
+++ b/test/Garnet.test/RespHashTests.cs
@@ -1302,6 +1302,7 @@ namespace Garnet.test
 
         #region LightClientTests
 
+
         /// <summary>
         /// HSET used explictly always returns the number of fields that were added.
         /// HSET can manage more than one field in the input
@@ -1316,7 +1317,6 @@ namespace Garnet.test
             var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
             ClassicAssert.AreEqual(expectedResponse, actualValue);
         }
-
 
         [Test]
         [TestCase(30)]
@@ -1794,6 +1794,20 @@ namespace Garnet.test
             ClassicAssert.AreEqual(expectedResponse, actualValue);
         }
 
+        [Test]
+        public void CanIncrementBeyond32bits()
+        {
+            using var lightClientRequest = TestUtils.CreateRequest();
+            var response = lightClientRequest.SendCommand($"HSET myhash int64 {1L + int.MaxValue}");
+            var expectedResponse = ":1\r\n";
+            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
+            ClassicAssert.AreEqual(expectedResponse, actualValue);
+
+            response = lightClientRequest.SendCommand("HINCRBY myhash int64 1");
+            expectedResponse = $":{2L + int.MaxValue}\r\n";
+            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
+            ClassicAssert.AreEqual(expectedResponse, actualValue);
+        }
         #endregion
 
         private static string FormatWrongNumOfArgsError(string commandName) => $"-{string.Format(CmdStrings.GenericErrWrongNumArgs, commandName)}\r\n";


### PR DESCRIPTION
Per redis docs, HINCRBY should use 64bit ints, function was mistakenly limited to 32bits.

----

"The range of values supported by HINCRBY is limited to 64 bit signed integers."

https://redis.io/docs/latest/commands/hincrby/