### PR TITLE
CommandInfoUpdater fix - Ignore Garnet-internal sub-commands

### DIFF
--- a/playground/CommandInfoUpdater/CommandDocsUpdater.cs
+++ b/playground/CommandInfoUpdater/CommandDocsUpdater.cs
@@ -45,7 +45,7 @@ namespace CommandInfoUpdater
                 if (ci.Value.SubCommands == null) continue;
                 var internalSubCmds =
                     ci.Value.SubCommands.Where(sc => sc.IsInternal).Select(sc => sc.Name).ToHashSet();
-                
+
                 if (internalSubCmds.Count > 0)
                     internalSubCommands.Add(ci.Key, internalSubCmds);
             }

--- a/playground/CommandInfoUpdater/CommandDocsUpdater.cs
+++ b/playground/CommandInfoUpdater/CommandDocsUpdater.cs
@@ -39,8 +39,19 @@ namespace CommandInfoUpdater
                 return false;
             }
 
+            var internalSubCommands = new Dictionary<string, HashSet<string>>();
+            foreach (var ci in updatedCommandsInfo)
+            {
+                if (ci.Value.SubCommands == null) continue;
+                var internalSubCmds =
+                    ci.Value.SubCommands.Where(sc => sc.IsInternal).Select(sc => sc.Name).ToHashSet();
+                
+                if (internalSubCmds.Count > 0)
+                    internalSubCommands.Add(ci.Key, internalSubCmds);
+            }
+
             var (commandsToAdd, commandsToRemove) =
-                CommonUtils.GetCommandsToAddAndRemove(existingCommandsDocs, ignoreCommands);
+                CommonUtils.GetCommandsToAddAndRemove(existingCommandsDocs, ignoreCommands, internalSubCommands);
 
             if (!CommonUtils.GetUserConfirmation(commandsToAdd, commandsToRemove, logger))
             {

--- a/playground/CommandInfoUpdater/CommandInfoUpdater.cs
+++ b/playground/CommandInfoUpdater/CommandInfoUpdater.cs
@@ -45,7 +45,7 @@ namespace CommandInfoUpdater
             }
 
             var (commandsToAdd, commandsToRemove) =
-                CommonUtils.GetCommandsToAddAndRemove(existingCommandsInfo, ignoreCommands);
+                CommonUtils.GetCommandsToAddAndRemove(existingCommandsInfo, ignoreCommands, null);
 
             if (!CommonUtils.GetUserConfirmation(commandsToAdd, commandsToRemove, logger))
             {

--- a/playground/CommandInfoUpdater/CommonUtils.cs
+++ b/playground/CommandInfoUpdater/CommonUtils.cs
@@ -65,14 +65,16 @@ namespace CommandInfoUpdater
         /// </summary>
         /// <param name="existingCommandsInfo">Existing command names mapped to current command info</param>
         /// <param name="ignoreCommands">Commands to ignore</param>
+        /// <param name="ignoreSubCommands">Sub-commands to ignore</param>
         /// <returns>Commands to add and commands to remove mapped to a boolean determining if parent command should be added / removed</returns>
         internal static (IDictionary<SupportedCommand, bool>, IDictionary<SupportedCommand, bool>)
             GetCommandsToAddAndRemove<TData>(IReadOnlyDictionary<string, TData> existingCommandsInfo,
-                IEnumerable<string> ignoreCommands) where TData : class, IRespCommandData<TData>
+                IEnumerable<string> ignoreCommands, IDictionary<string, HashSet<string>> ignoreSubCommands) where TData : class, IRespCommandData<TData>
         {
             var commandsToAdd = new Dictionary<SupportedCommand, bool>();
             var commandsToRemove = new Dictionary<SupportedCommand, bool>();
             var commandsToIgnore = ignoreCommands != null ? new HashSet<string>(ignoreCommands) : null;
+            var subCommandsToIgnore = ignoreSubCommands ?? new Dictionary<string, HashSet<string>>();
 
             // Supported commands
             var supportedCommands = SupportedCommand.SupportedCommandsMap;
@@ -97,7 +99,13 @@ namespace CommandInfoUpdater
                 // If existing commands contain parent command and have no sub-commands, set sub-commands to add as supported command's sub-commands
                 if (existingCommandsInfo[supportedCommand.Command].SubCommands == null)
                 {
-                    subCommandsToAdd = [.. supportedCommand.SubCommands.Values];
+                    subCommandsToAdd =
+                    [
+                        .. supportedCommand.SubCommands.Where(subCommand =>
+                                !subCommandsToIgnore.ContainsKey(supportedCommand.Command) ||
+                                !subCommandsToIgnore[supportedCommand.Command].Contains(subCommand.Key))
+                            .Select(sc => sc.Value)
+                    ];
                 }
                 // Set sub-commands to add as the difference between existing sub-commands and supported command's sub-commands
                 else
@@ -105,8 +113,16 @@ namespace CommandInfoUpdater
                     var existingSubCommands = new HashSet<string>(existingCommandsInfo[supportedCommand.Command]
                         .SubCommands
                         .Select(sc => sc.Name));
-                    subCommandsToAdd = [.. supportedCommand.SubCommands
-                        .Where(subCommand => !existingSubCommands.Contains(subCommand.Key)).Select(sc => sc.Value)];
+
+                    subCommandsToAdd =
+                    [
+                        .. supportedCommand.SubCommands
+                            .Where(subCommand =>
+                                !existingSubCommands.Contains(subCommand.Key) &&
+                                (!subCommandsToIgnore.ContainsKey(supportedCommand.Command) ||
+                                 !subCommandsToIgnore[supportedCommand.Command].Contains(subCommand.Key)))
+                            .Select(sc => sc.Value)
+                    ];
                 }
 
                 // If there are sub-commands to add, add a new supported command with the sub-commands to add


### PR DESCRIPTION
Ignore Garnet-internal subcommands when trying to resolve commands to update (when updating docs only)