### PR TITLE
Fix PExpire testcase

### DIFF
--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -2578,7 +2578,7 @@ namespace Garnet.test
             resp = (bool)db.Execute($"{command}", args);
             ClassicAssert.IsFalse(resp); // LT return false new expiry > current expiry
 
-            args[1] = 15;
+            args[1] = 1000;
             args[2] = testCaseSensitivity ? "lT" : "LT";// LT -- Set expiry only when the new expiry is less than current one
             resp = (bool)db.Execute($"{command}", args);
             ClassicAssert.IsTrue(resp); // LT return true new expiry < current expiry

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -2578,7 +2578,7 @@ namespace Garnet.test
             resp = (bool)db.Execute($"{command}", args);
             ClassicAssert.IsFalse(resp); // LT return false new expiry > current expiry
 
-            args[1] = 1000;
+            args[1] = 500;
             args[2] = testCaseSensitivity ? "lT" : "LT";// LT -- Set expiry only when the new expiry is less than current one
             resp = (bool)db.Execute($"{command}", args);
             ClassicAssert.IsTrue(resp); // LT return true new expiry < current expiry


### PR DESCRIPTION
Fix PExpire testcase

It was failing sporadically due to timing issues as the timeout was too low (15ms).

Example: https://github.com/microsoft/garnet/actions/runs/13042680970/job/36387756667#step:6:2873

```
  Error Message:
   System.InvalidOperationException : Nullable object must have a value.
  Stack Trace:
     at System.Nullable`1.get_Value()
   at Garnet.test.RespTests.KeyExpireOptionsTest(String command, Boolean testCaseSensitivity) in /_/test/Garnet.test/RespTests.cs:line 2587
   at InvokeStub_RespTests.KeyExpireOptionsTest(Object, Span`1)
   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
```