### PR TITLE
MSETNX must not set keys if any of them exists (issue #980)

### DIFF
--- a/libs/server/API/GarnetApi.cs
+++ b/libs/server/API/GarnetApi.cs
@@ -166,6 +166,12 @@ namespace Garnet.server
 
         #endregion
 
+        #region MSETNX
+        /// <inheritdoc />
+        public GarnetStatus MSET_Conditional(ref RawStringInput input) =>
+            storageSession.MSET_Conditional(ref input, ref context);
+        #endregion
+
         #region APPEND
 
         /// <inheritdoc />

--- a/libs/server/API/IGarnetApi.cs
+++ b/libs/server/API/IGarnetApi.cs
@@ -102,6 +102,15 @@ namespace Garnet.server
 
         #endregion
 
+        #region MSETNX
+        /// <summary>
+        /// MSETNX
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        GarnetStatus MSET_Conditional(ref RawStringInput input);
+        #endregion
+
         #region APPEND
 
         /// <summary>
@@ -1112,7 +1121,6 @@ namespace Garnet.server
         /// <param name="error"></param>
         /// <returns></returns>
         GarnetStatus HyperLogLogMerge(ref RawStringInput input, out bool error);
-
         #endregion
     }
 

--- a/libs/server/Resp/ArrayCommands.cs
+++ b/libs/server/Resp/ArrayCommands.cs
@@ -157,8 +157,6 @@ namespace Garnet.server
         private bool NetworkMSET<TGarnetApi>(ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetApi
         {
-            Debug.Assert(parseState.Count % 2 == 0);
-
             for (int c = 0; c < parseState.Count; c += 2)
             {
                 var key = parseState.GetArgSliceByRef(c).SpanByte;
@@ -176,23 +174,16 @@ namespace Garnet.server
         private bool NetworkMSETNX<TGarnetApi>(ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetApi
         {
-            var anyValuesSet = false;
-            var input = new RawStringInput(RespCommand.SETEXNX);
-
-            for (var c = 0; c < parseState.Count; c += 2)
+            if (parseState.Count == 0 || parseState.Count % 2 != 0)
             {
-                var key = parseState.GetArgSliceByRef(c).SpanByte;
-
-                input.parseState = parseState.Slice(c + 1, 1);
-                var status = storageApi.SET_Conditional(ref key, ref input);
-
-                // Status tells us whether an old image was found during RMW or not
-                // For a "set if not exists", NOTFOUND means that the operation succeeded
-                if (status == GarnetStatus.NOTFOUND)
-                    anyValuesSet = true;
+                return AbortWithWrongNumberOfArguments(nameof(RespCommand.MSETNX));
             }
 
-            while (!RespWriteUtils.TryWriteInt32(anyValuesSet ? 1 : 0, ref dcurr, dend))
+            var input = new RawStringInput(RespCommand.MSETNX, ref parseState);
+            var status = storageApi.MSET_Conditional(ref input);
+
+            // For a "set if not exists", NOTFOUND means that the operation succeeded
+            while (!RespWriteUtils.TryWriteInt32(status == GarnetStatus.NOTFOUND ? 1 : 0, ref dcurr, dend))
                 SendAndReset();
             return true;
         }

--- a/libs/server/Resp/ArrayCommands.cs
+++ b/libs/server/Resp/ArrayCommands.cs
@@ -157,6 +157,11 @@ namespace Garnet.server
         private bool NetworkMSET<TGarnetApi>(ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetApi
         {
+            if (parseState.Count == 0 || parseState.Count % 2 != 0)
+            {
+                return AbortWithWrongNumberOfArguments(nameof(RespCommand.MSET));
+            }
+
             for (int c = 0; c < parseState.Count; c += 2)
             {
                 var key = parseState.GetArgSliceByRef(c).SpanByte;

--- a/libs/server/Storage/Session/MainStore/MainStoreOps.cs
+++ b/libs/server/Storage/Session/MainStore/MainStoreOps.cs
@@ -423,7 +423,7 @@ namespace Garnet.server
                     break;
 
                 var srcKey = input.parseState.GetArgSliceByRef(i);
-                var srcVal = input.parseState.GetArgSliceByRef(i+1);
+                var srcVal = input.parseState.GetArgSliceByRef(i + 1);
                 var status = SET(srcKey, srcVal, ref context);
                 if (status != GarnetStatus.OK)
                 {

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -494,7 +494,10 @@ namespace Garnet.test
             var db = redis.GetDatabase(0);
 
             const int length = 15000;
-            KeyValuePair<RedisKey, RedisValue>[] input = new KeyValuePair<RedisKey, RedisValue>[length];
+            var input = new KeyValuePair<RedisKey, RedisValue>[length];
+            var inputNX = new KeyValuePair<RedisKey, RedisValue>[length];
+            var inputXX = new KeyValuePair<RedisKey, RedisValue>[length];
+
             for (int i = 0; i < length; i++)
                 input[i] = new KeyValuePair<RedisKey, RedisValue>(i.ToString(), i.ToString());
 
@@ -512,7 +515,8 @@ namespace Garnet.test
             result = db.StringSet(input);
             ClassicAssert.IsTrue(result);
 
-            value = db.StringGet(input.Select(e => e.Key).ToArray());
+            var keys = input.Select(e => e.Key).ToArray();
+            value = db.StringGet(keys);
             ClassicAssert.AreEqual(length, value.Length);
 
             for (int i = 0; i < length; i++)
@@ -520,32 +524,70 @@ namespace Garnet.test
 
             // MSET NX - existing values
             for (int i = 0; i < length; i++)
-                input[i] = new KeyValuePair<RedisKey, RedisValue>(i.ToString(), (i + 1).ToString());
+                inputXX[i] = new KeyValuePair<RedisKey, RedisValue>(i.ToString(), (i + 1).ToString());
 
-            result = db.StringSet(input, When.NotExists);
+            result = db.StringSet(inputXX, When.NotExists);
             ClassicAssert.IsFalse(result);
 
-            value = db.StringGet(input.Select(e => e.Key).ToArray());
+            value = db.StringGet(keys);
             ClassicAssert.AreEqual(length, value.Length);
 
+            // Should not change existing keys
             for (int i = 0; i < length; i++)
                 ClassicAssert.AreEqual(new RedisValue(i.ToString()), value[i]);
 
             // MSET NX - non-existing and existing values
             for (int i = 0; i < length; i++)
-                input[i] = new KeyValuePair<RedisKey, RedisValue>((i % 2 == 0 ? i : i + length).ToString(), (i + length).ToString());
+                inputNX[i] = new KeyValuePair<RedisKey, RedisValue>((i % 2 == 0 ? i : i + length).ToString(), (i + length).ToString());
 
-            result = db.StringSet(input, When.NotExists);
-            ClassicAssert.IsTrue(result);
+            result = db.StringSet(inputNX, When.NotExists);
+            ClassicAssert.IsFalse(result);
 
-            value = db.StringGet(input.Select(e => e.Key).ToArray());
+            value = db.StringGet(keys);
             ClassicAssert.AreEqual(length, value.Length);
 
             for (int i = 0; i < length; i++)
             {
-                ClassicAssert.AreEqual(i % 2 == 0 ? new RedisValue((int.Parse(input[i].Value) - length).ToString()) :
-                        input[i].Value, value[i]);
+                ClassicAssert.AreEqual(new RedisValue(i.ToString()), value[i]);
             }
+
+            // Should not create new keys if any existing keys were also specified
+            var nxKeys = inputNX.Select(x => x.Key).Where(x => !keys.Contains(x)).Take(10).ToArray();
+            value = db.StringGet(nxKeys);
+            for (int i = 0; i < value.Length; i++)
+            {
+                ClassicAssert.IsEmpty(value[i].ToString());
+            }
+        }
+
+        [Test]
+        public void MultiSetNX()
+        {
+            var lightClientRequest = TestUtils.CreateRequest();
+
+            // Set keys
+            var response = lightClientRequest.SendCommand("MSETNX key1 5 key2 6");
+            var expectedResponse = ":1\r\n";
+            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+
+            // MSETNX command should fail since key exists
+            response = lightClientRequest.SendCommand("MSETNX key3 7 key1 8");
+            expectedResponse = ":0\r\n";
+            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+
+            // Verify values
+            response = lightClientRequest.SendCommand("GET key1");
+            expectedResponse = "$1\r\n5\r\n";
+            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+
+            response = lightClientRequest.SendCommand("GET key2");
+            expectedResponse = "$1\r\n6\r\n";
+            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+
+            // Should not be set even though it was 'before' existing key1.
+            response = lightClientRequest.SendCommand("GET key3");
+            expectedResponse = "$-1\r\n";
+            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
         }
 
         [Test]


### PR DESCRIPTION
When msetnx gets several keys and one of them already exists, msetnx still sets the nonexisting keys when it shouldn't (#980). An alternative design would have done transaction + SET_Conditional and rollback if needed, but I'm not very clear on transaction semantics in Garnet.