### PR TITLE
[DRAFT] fnv hash for benchmarking comparison

### DIFF
--- a/libs/storage/Tsavorite/cs/src/core/Utilities/Utility.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Utilities/Utility.cs
@@ -178,21 +178,19 @@ namespace Tsavorite.core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe long HashBytes(byte* pbString, int len)
         {
-            const long magicno = 40343;
+            ulong _hash = 0xCBF29CE484222325UL;
             char* pwString = (char*)pbString;
-            int cbBuf = len / 2;
-            ulong hashState = (ulong)len;
 
-            for (int i = 0; i < cbBuf; i++, pwString++)
-                hashState = magicno * hashState + *pwString;
-
-            if ((len & 1) > 0)
+            for (int i = 0; i < len; i++, pwString++)
             {
-                byte* pC = (byte*)pwString;
-                hashState = magicno * hashState + *pC;
+                unchecked
+                {
+                    _hash ^= *pwString;
+                    _hash *= 0x00000100000001B3UL;
+                }
             }
 
-            return (long)Rotr64(magicno * hashState, 4);
+            return (long)_hash;
         }
 
         /// <summary>


### PR DESCRIPTION
I'm not sure what's the motivation behind the current hash function. It's not a function I know (my CS education is missing a lot granted), it seems a bit odd (looking at half the array but adding in the length? Why 40343 and not another prime?). Maybe some cache locality thing? git blame says it's the same starting from the FASTER initial commit, and I couldn't find any documentation in the research PDFs about it. It reminds me of FNV but isn't FNV.

I've implemented FNV for comparison purposes. Running Resp.benchmark locally seems to show FNV has improved performance**. Maybe there's a better benchmark, or a different consideration for choosing this hash?

** FNV implementation uses unchecked. Merely adding unchecked to the existing function seems to improve performance a bit, but not as much as FNV while locally testing.