### PR TITLE
Fix for CanDoHashExpire test case failure

### DIFF
--- a/test/Garnet.test/RespHashTests.cs
+++ b/test/Garnet.test/RespHashTests.cs
@@ -1030,26 +1030,26 @@ namespace Garnet.test
             var db = redis.GetDatabase(0);
             db.HashSet("myhash", [new HashEntry("field1", "hello"), new HashEntry("field2", "world"), new HashEntry("field3", "value3"), new HashEntry("field4", "value4"), new HashEntry("field5", "value5"), new HashEntry("field6", "value6")]);
 
-            var result = db.Execute("HEXPIRE", "myhash", "3", "FIELDS", "3", "field1", "field5", "nonexistfield");
+            var result = db.Execute("HEXPIRE", "myhash", "3", "FIELDS", "4", "field1", "field5", "nonexistfield");
             var results = (RedisResult[])result;
             ClassicAssert.AreEqual(3, results.Length);
             ClassicAssert.AreEqual(1, (long)results[0]);
             ClassicAssert.AreEqual(1, (long)results[1]);
             ClassicAssert.AreEqual(-2, (long)results[2]);
 
-            result = db.Execute("HPEXPIRE", "myhash", "3000", "FIELDS", "2", "field2", "nonexistfield");
+            result = db.Execute("HPEXPIRE", "myhash", "4000", "FIELDS", "2", "field2", "nonexistfield");
             results = (RedisResult[])result;
             ClassicAssert.AreEqual(2, results.Length);
             ClassicAssert.AreEqual(1, (long)results[0]);
             ClassicAssert.AreEqual(-2, (long)results[1]);
 
-            result = db.Execute("HEXPIREAT", "myhash", DateTimeOffset.UtcNow.AddSeconds(3).ToUnixTimeSeconds().ToString(), "FIELDS", "2", "field3", "nonexistfield");
+            result = db.Execute("HEXPIREAT", "myhash", DateTimeOffset.UtcNow.AddSeconds(4).ToUnixTimeSeconds().ToString(), "FIELDS", "2", "field3", "nonexistfield");
             results = (RedisResult[])result;
             ClassicAssert.AreEqual(2, results.Length);
             ClassicAssert.AreEqual(1, (long)results[0]);
             ClassicAssert.AreEqual(-2, (long)results[1]);
 
-            result = db.Execute("HPEXPIREAT", "myhash", DateTimeOffset.UtcNow.AddSeconds(3).ToUnixTimeMilliseconds().ToString(), "FIELDS", "2", "field4", "nonexistfield");
+            result = db.Execute("HPEXPIREAT", "myhash", DateTimeOffset.UtcNow.AddSeconds(4).ToUnixTimeMilliseconds().ToString(), "FIELDS", "2", "field4", "nonexistfield");
             results = (RedisResult[])result;
             ClassicAssert.AreEqual(2, results.Length);
             ClassicAssert.AreEqual(1, (long)results[0]);
@@ -1057,25 +1057,25 @@ namespace Garnet.test
 
             var ttl = (RedisResult[])db.Execute("HTTL", "myhash", "FIELDS", "2", "field1", "nonexistfield");
             ClassicAssert.AreEqual(2, ttl.Length);
-            ClassicAssert.LessOrEqual((long)ttl[0], 3);
+            ClassicAssert.LessOrEqual((long)ttl[0], 4);
             ClassicAssert.Greater((long)ttl[0], 1);
             ClassicAssert.AreEqual(-2, (long)results[1]);
 
             ttl = (RedisResult[])db.Execute("HPTTL", "myhash", "FIELDS", "2", "field1", "nonexistfield");
             ClassicAssert.AreEqual(2, ttl.Length);
-            ClassicAssert.LessOrEqual((long)ttl[0], 3000);
+            ClassicAssert.LessOrEqual((long)ttl[0], 4000);
             ClassicAssert.Greater((long)ttl[0], 1000);
             ClassicAssert.AreEqual(-2, (long)results[1]);
 
             ttl = (RedisResult[])db.Execute("HEXPIRETIME", "myhash", "FIELDS", "2", "field1", "nonexistfield");
             ClassicAssert.AreEqual(2, ttl.Length);
-            ClassicAssert.LessOrEqual((long)ttl[0], DateTimeOffset.UtcNow.AddSeconds(3).ToUnixTimeSeconds());
+            ClassicAssert.LessOrEqual((long)ttl[0], DateTimeOffset.UtcNow.AddSeconds(4).ToUnixTimeSeconds());
             ClassicAssert.Greater((long)ttl[0], DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeSeconds());
             ClassicAssert.AreEqual(-2, (long)results[1]);
 
             ttl = (RedisResult[])db.Execute("HPEXPIRETIME", "myhash", "FIELDS", "2", "field1", "nonexistfield");
             ClassicAssert.AreEqual(2, ttl.Length);
-            ClassicAssert.LessOrEqual((long)ttl[0], DateTimeOffset.UtcNow.AddSeconds(3).ToUnixTimeMilliseconds());
+            ClassicAssert.LessOrEqual((long)ttl[0], DateTimeOffset.UtcNow.AddSeconds(4).ToUnixTimeMilliseconds());
             ClassicAssert.Greater((long)ttl[0], DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeMilliseconds());
             ClassicAssert.AreEqual(-2, (long)results[1]);
 

--- a/test/Garnet.test/RespHashTests.cs
+++ b/test/Garnet.test/RespHashTests.cs
@@ -1030,7 +1030,7 @@ namespace Garnet.test
             var db = redis.GetDatabase(0);
             db.HashSet("myhash", [new HashEntry("field1", "hello"), new HashEntry("field2", "world"), new HashEntry("field3", "value3"), new HashEntry("field4", "value4"), new HashEntry("field5", "value5"), new HashEntry("field6", "value6")]);
 
-            var result = db.Execute("HEXPIRE", "myhash", "3", "FIELDS", "4", "field1", "field5", "nonexistfield");
+            var result = db.Execute("HEXPIRE", "myhash", "4", "FIELDS", "3", "field1", "field5", "nonexistfield");
             var results = (RedisResult[])result;
             ClassicAssert.AreEqual(3, results.Length);
             ClassicAssert.AreEqual(1, (long)results[0]);
@@ -1085,7 +1085,7 @@ namespace Garnet.test
             ClassicAssert.AreEqual(-1, (long)results[1]); // -1 if the field exists but has no associated expiration set.
             ClassicAssert.AreEqual(-2, (long)results[2]);
 
-            await Task.Delay(3500);
+            await Task.Delay(4500);
 
             var items = db.HashGetAll("myhash");
             ClassicAssert.AreEqual(2, items.Length);


### PR DESCRIPTION
Fixes: https://github.com/microsoft/garnet/actions/runs/13145028723/job/36681130931

The culprit is the `DateTimeOffset.UtcNow.ToUnixTimeSeconds() + expireAt` line as shown below. This line can return a time that is less than 1 sec from the current time, even it can be almost the same as the current time. Below is an example of when that can happen.

https://github.com/microsoft/garnet/blob/9fc685abae8985081226885781a2459e0b9a82c7/libs/server/Resp/Objects/HashCommands.cs#L608-L610

Current Time: 01:01:00.9980000
Current Time as Seconds: 01:01:00 (assume this timestamp as seconds)
Current Time as Seconds + 1 sec: 01:01:01 (this value is almost the same as current time)

This happens because `ToUnixTimeSeconds` method counts the number of full seconds in the provided time, basically it works like `Math.Floor` for seconds.

This works as expected, so I am increasing the expiration time in test file by 1 sec to avoid this issue in the test case