### PR TITLE
Fix bind address

### DIFF
--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -610,10 +610,18 @@ namespace Garnet
             }
             else
             {
-                var address = string.IsNullOrEmpty(Address) || Address.Equals("localhost", StringComparison.CurrentCultureIgnoreCase)
-                    ? IPAddress.Loopback
-                    : IPAddress.Parse(Address);
-
+                IPAddress address;
+                if (string.IsNullOrEmpty(Address))
+                {
+                    address = IPAddress.Any;
+                }
+                else
+                {
+                    if (Address.Equals("localhost", StringComparison.CurrentCultureIgnoreCase))
+                        address = IPAddress.Loopback;
+                    else
+                        address = IPAddress.Parse(Address);
+                }
                 endpoint = new IPEndPoint(address, Port);
             }
 


### PR DESCRIPTION
Set bind address to IPAddress.Any when address is null (default) to restore older semantics. Fixes https://github.com/microsoft/garnet/issues/993