### PR TITLE
BITPOS bit search on the last byte should account for the byte's position.

### DIFF
--- a/libs/server/Resp/Bitmap/BitmapManagerBitPos.cs
+++ b/libs/server/Resp/Bitmap/BitmapManagerBitPos.cs
@@ -126,7 +126,14 @@ namespace Garnet.server
 
             // Search suffix
             var _spos = BitPosIndexBitSearch(value, setVal, endOffset);
-            return _spos;
+            if (_spos != -1)
+            {
+                var retpos = (endByte * 8) + _spos;
+                if (retpos <= endOffset)
+                    return retpos;
+            }
+
+            return -1;
         }
 
         /// <summary>

--- a/test/Garnet.test/GarnetBitmapTests.cs
+++ b/test/Garnet.test/GarnetBitmapTests.cs
@@ -694,6 +694,7 @@ namespace Garnet.test
         }
 
         [Test, Order(15)]
+        [Category("BITPOS")]
         [TestCase(10)]
         [TestCase(20)]
         [TestCase(30)]
@@ -2282,6 +2283,9 @@ namespace Garnet.test
 
             pos = db.StringBitPosition(key, false, 0, 0, StringIndexType.Byte);
             ClassicAssert.AreEqual(0, pos);
+
+            pos = db.StringBitPosition(key, true, 7, 15, StringIndexType.Bit);
+            ClassicAssert.AreEqual(8, pos);
 
             value = [0xf8, 0x6f, 0xf0];
             db.StringSet(key, value);


### PR DESCRIPTION
The code In question is clearly wrong. The return value is defined relative to start of string. However, the called function returns bit offset relative to start of byte - it should add the byte's offset in the result like it already does for the starting byte. Fix this by adding the offset. Add a test.

Existing faulty code:
```
            // Search prefix and terminate if found position of bit
            var _ppos = BitPosIndexBitSearch(value, setVal, startOffset);
            if (_ppos != -1) return startOffset + _ppos;

            ....

            // Search suffix
            var _spos = BitPosIndexBitSearch(value, setVal, endOffset); // should add here too like it does for start!
            return _spos;
```

(I have some doubts regarding over other parts of the bit path, but these require more careful consideration. It's best to push a clearly right fix now and consider from there),