### PR TITLE
Fix subcribe and other typos

### DIFF
--- a/libs/resources/RespCommandsDocs.json
+++ b/libs/resources/RespCommandsDocs.json
@@ -5419,7 +5419,7 @@
             "Name": "NUMPARAMS",
             "DisplayText": "numParams",
             "Type": "Integer",
-            "Summary": "Numer of parameters of the command to register"
+            "Summary": "Number of parameters of the command to register"
           },
           {
             "TypeDiscriminator": "RespCommandBasicArgument",

--- a/libs/server/Resp/CmdStrings.cs
+++ b/libs/server/Resp/CmdStrings.cs
@@ -15,9 +15,9 @@ namespace Garnet.server
         /// </summary>
         public static ReadOnlySpan<byte> CLIENT => "CLIENT"u8;
         public static ReadOnlySpan<byte> SUBSCRIBE => "SUBSCRIBE"u8;
-        public static ReadOnlySpan<byte> subscribe => "subcribe"u8;
+        public static ReadOnlySpan<byte> subscribe => "subscribe"u8;
         public static ReadOnlySpan<byte> SSUBSCRIBE => "SSUBSCRIBE"u8;
-        public static ReadOnlySpan<byte> ssubscribe => "ssubcribe"u8;
+        public static ReadOnlySpan<byte> ssubscribe => "ssubscribe"u8;
         public static ReadOnlySpan<byte> RUNTXP => "RUNTXP"u8;
         public static ReadOnlySpan<byte> GET => "GET"u8;
         public static ReadOnlySpan<byte> get => "get"u8;

--- a/website/docs/commands/api-compatibility.md
+++ b/website/docs/commands/api-compatibility.md
@@ -397,7 +397,7 @@ Note that this list is subject to change as we continue to expand our API comman
 |  | [SETNX](raw-string.md#setnx) | ➕ |  |
 |  | [SETRANGE](raw-string.md#setrange) | ➕ |  |
 |  | [STRLEN](raw-string.md#strlen) | ➕ |  |
-|  | [SUBSTR](raw-string.md#substr) | ➖ | (Deprecated) |
+|  | [SUBSTR](raw-string.md#substr) | ➕ | (Deprecated) |
 | <span id="transactions">**TRANSACTIONS**</span> | [DISCARD](transactions.md#discard) | ➕ |  |
 |  | [EXEC](transactions.md#exec) | ➕ |  |
 |  | [MULTI](transactions.md#multi) | ➕ |  |


### PR DESCRIPTION
'subscribe' was spelled incorrectly and this was returned to the client.

While at it, fix a docs typo and website typo - SUBSTR is supported (redirectes to GETRANGE) even though it's marked as unsupported.