### PR TITLE
BITFIELD and BITFIELD_RO improvements

### DIFF
--- a/libs/server/Resp/Bitmap/BitmapCommands.cs
+++ b/libs/server/Resp/Bitmap/BitmapCommands.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -10,6 +9,8 @@ using Tsavorite.core;
 
 namespace Garnet.server
 {
+    using SecondaryCommandList = List<(RespCommand, ArgSlice[])>;
+
     ///  (1) , (2) , (3) 
     /// overflow check, ptr protection, and status not found implemented for below
     /// GETBIT, SETBIT, BITCOUNT, BITPOS (1),(2)
@@ -359,7 +360,7 @@ namespace Garnet.server
         /// <summary>
         /// Performs arbitrary bitfield integer operations on strings.
         /// </summary>
-        private bool StringBitField<TGarnetApi>(ref TGarnetApi storageApi, bool readOnly = false)
+        private bool StringBitField<TGarnetApi>(ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetApi
         {
             if (parseState.Count < 1)
@@ -371,12 +372,11 @@ namespace Garnet.server
             // Extract Key
             var sbKey = parseState.GetArgSliceByRef(0).SpanByte;
 
-            var currTokenIdx = 1;
-
             var isOverflowTypeSet = false;
             ArgSlice overflowTypeSlice = default;
-            var secondaryCommandArgs = new List<(RespCommand, ArgSlice[])>();
+            var secondaryCommandArgs = new SecondaryCommandList();
 
+            var currTokenIdx = 1;
             while (currTokenIdx < parseState.Count)
             {
                 // Get subcommand
@@ -384,80 +384,56 @@ namespace Garnet.server
                 var command = commandSlice.ReadOnlySpan;
 
                 // Process overflow command
-                if (!readOnly && command.EqualsUpperCaseSpanIgnoringCase("OVERFLOW"u8))
+                if (command.EqualsUpperCaseSpanIgnoringCase("OVERFLOW"u8))
                 {
-                    // Get overflow parameter
-                    overflowTypeSlice = parseState.GetArgSliceByRef(currTokenIdx);
-                    isOverflowTypeSet = true;
-
                     // Validate overflow type
-                    if (!parseState.TryGetBitFieldOverflow(currTokenIdx, out _))
+                    if (currTokenIdx >= parseState.Count || !parseState.TryGetBitFieldOverflow(currTokenIdx, out _))
                     {
-                        while (!RespWriteUtils.TryWriteError(
-                                   $"ERR Overflow type {parseState.GetString(currTokenIdx)} not supported",
-                                   ref dcurr, dend))
+                        while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_INVALID_OVERFLOW_TYPE, ref dcurr, dend))
                             SendAndReset();
                         return true;
                     }
 
-                    currTokenIdx++;
+                    // Get overflow parameter
+                    overflowTypeSlice = parseState.GetArgSliceByRef(currTokenIdx++);
+                    isOverflowTypeSet = true;
 
                     continue;
                 }
 
                 // [GET <encoding> <offset>] [SET <encoding> <offset> <value>] [INCRBY <encoding> <offset> <increment>]
                 // Process encoding argument
-                var encodingSlice = parseState.GetArgSliceByRef(currTokenIdx);
-                var offsetSlice = parseState.GetArgSliceByRef(currTokenIdx + 1);
-                var encodingArg = parseState.GetString(currTokenIdx);
-                var offsetArg = parseState.GetString(currTokenIdx + 1);
-                currTokenIdx += 2;
-
-                // Validate encoding
-                if (encodingArg.Length < 2 ||
-                    (encodingArg[0] != 'i' && encodingArg[0] != 'u') ||
-                    !int.TryParse(encodingArg.AsSpan(1), out var bitCount) ||
-                    bitCount > 64 ||
-                    (bitCount == 64 && encodingArg[0] == 'u'))
+                if ((currTokenIdx >= parseState.Count) || !parseState.TryGetBitfieldEncoding(currTokenIdx, out _, out _))
                 {
                     while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_INVALID_BITFIELD_TYPE, ref dcurr,
                                dend))
                         SendAndReset();
                     return true;
                 }
+                var encodingSlice = parseState.GetArgSliceByRef(currTokenIdx++);
 
-                // Validate offset
-                var isOffsetValid = offsetArg[0] == '#'
-                    ? long.TryParse(offsetArg.AsSpan(1), out _)
-                    : long.TryParse(offsetArg, out _);
-
-                if (!isOffsetValid)
+                // Process offset argument
+                if ((currTokenIdx >= parseState.Count) || !parseState.TryGetBitfieldOffset(currTokenIdx, out _, out _))
                 {
                     while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_GENERIC_BITOFFSET_IS_NOT_INTEGER, ref dcurr,
                                dend))
                         SendAndReset();
                     return true;
                 }
+                var offsetSlice = parseState.GetArgSliceByRef(currTokenIdx++);
 
-                // Subcommand takes 2 args, encoding and offset
-                if (command.EqualsUpperCaseSpanIgnoringCase("GET"u8))
+                // GET Subcommand takes 2 args, encoding and offset
+                if (command.EqualsUpperCaseSpanIgnoringCase(CmdStrings.GET))
                 {
                     secondaryCommandArgs.Add((RespCommand.GET, [commandSlice, encodingSlice, offsetSlice]));
                 }
                 else
                 {
-                    if (readOnly)
-                    {
-                        while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_SYNTAX_ERROR, ref dcurr, dend))
-                            SendAndReset();
-                        return true;
-                    }
-
                     RespCommand op;
                     // SET and INCRBY take 3 args, encoding, offset, and valueArg
-                    if (command.EqualsUpperCaseSpanIgnoringCase("SET"u8))
+                    if (command.EqualsUpperCaseSpanIgnoringCase(CmdStrings.SET))
                         op = RespCommand.SET;
-                    else if (command.EqualsUpperCaseSpanIgnoringCase("INCRBY"u8))
+                    else if (command.EqualsUpperCaseSpanIgnoringCase(CmdStrings.INCRBY))
                         op = RespCommand.INCRBY;
                     else
                     {
@@ -469,24 +445,96 @@ namespace Garnet.server
                     }
 
                     // Validate value
-                    var valueSlice = parseState.GetArgSliceByRef(currTokenIdx);
-                    if (!parseState.TryGetLong(currTokenIdx, out _))
+                    if (currTokenIdx >= parseState.Count || !parseState.TryGetLong(currTokenIdx, out _))
                     {
                         while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_GENERIC_VALUE_IS_NOT_INTEGER, ref dcurr,
                                    dend))
                             SendAndReset();
                         return true;
                     }
+                    var valueSlice = parseState.GetArgSliceByRef(currTokenIdx);
                     currTokenIdx++;
 
                     secondaryCommandArgs.Add((op, [commandSlice, encodingSlice, offsetSlice, valueSlice]));
                 }
             }
 
+            return StringBitFieldAction(ref storageApi, ref sbKey, RespCommand.BITFIELD,
+                                     secondaryCommandArgs, isOverflowTypeSet, overflowTypeSlice);
+        }
+
+        /// <summary>
+        /// Performs arbitrary read-only bitfield integer operations
+        /// </summary>
+        private bool StringBitFieldReadOnly<TGarnetApi>(ref TGarnetApi storageApi)
+            where TGarnetApi : IGarnetApi
+        {
+            if (parseState.Count < 1)
+            {
+                return AbortWithWrongNumberOfArguments(nameof(RespCommand.BITFIELD_RO));
+            }
+
+            // BITFIELD_RO key [GET encoding offset [GET encoding offset] ... ]
+            // Extract Key
+            var sbKey = parseState.GetArgSliceByRef(0).SpanByte;
+
+            var secondaryCommandArgs = new SecondaryCommandList();
+
+            var currTokenIdx = 1;
+            while (currTokenIdx < parseState.Count)
+            {
+                // Get subcommand
+                var commandSlice = parseState.GetArgSliceByRef(currTokenIdx++);
+                var command = commandSlice.ReadOnlySpan;
+
+                // Read-only variant supports only GET subcommand
+                if (!command.EqualsUpperCaseSpanIgnoringCase(CmdStrings.GET))
+                {
+                    while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_SYNTAX_ERROR, ref dcurr, dend))
+                        SendAndReset();
+                    return true;
+                }
+
+                // GET Subcommand takes 2 args, encoding and offset
+
+                // Process encoding argument
+                if ((currTokenIdx >= parseState.Count) || !parseState.TryGetBitfieldEncoding(currTokenIdx, out _, out _))
+                {
+                    while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_INVALID_BITFIELD_TYPE, ref dcurr,
+                               dend))
+                        SendAndReset();
+                    return true;
+                }
+                var encodingSlice = parseState.GetArgSliceByRef(currTokenIdx++);
+
+                // Process offset argument
+                if ((currTokenIdx >= parseState.Count) || !parseState.TryGetBitfieldOffset(currTokenIdx, out _, out _))
+                {
+                    while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_GENERIC_BITOFFSET_IS_NOT_INTEGER, ref dcurr,
+                               dend))
+                        SendAndReset();
+                    return true;
+                }
+                var offsetSlice = parseState.GetArgSliceByRef(currTokenIdx++);
+
+                secondaryCommandArgs.Add((RespCommand.GET, [commandSlice, encodingSlice, offsetSlice]));
+            }
+
+            return StringBitFieldAction(ref storageApi, ref sbKey, RespCommand.BITFIELD_RO, secondaryCommandArgs);
+        }
+
+        private bool StringBitFieldAction<TGarnetApi>(ref TGarnetApi storageApi,
+                                                      ref SpanByte sbKey,
+                                                      RespCommand cmd,
+                                                      SecondaryCommandList secondaryCommandArgs,
+                                                      bool isOverflowTypeSet = false,
+                                                      ArgSlice overflowTypeSlice = default)
+            where TGarnetApi : IGarnetApi
+        {
             while (!RespWriteUtils.TryWriteArrayLength(secondaryCommandArgs.Count, ref dcurr, dend))
                 SendAndReset();
 
-            var input = new RawStringInput(RespCommand.BITFIELD);
+            var input = new RawStringInput(cmd);
 
             for (var i = 0; i < secondaryCommandArgs.Count; i++)
             {
@@ -512,7 +560,7 @@ namespace Garnet.server
 
                 if (status == GarnetStatus.NOTFOUND && opCode == RespCommand.GET)
                 {
-                    while (!RespWriteUtils.TryWriteArrayItem(0, ref dcurr, dend))
+                    while (!RespWriteUtils.TryWriteInt32(0, ref dcurr, dend))
                         SendAndReset();
                 }
                 else
@@ -525,16 +573,6 @@ namespace Garnet.server
             }
 
             return true;
-        }
-
-        /// <summary>
-        /// Performs arbitrary read-only bitfield integer operations
-        /// </summary>
-        private bool StringBitFieldReadOnly<TGarnetApi>(ref TGarnetApi storageApi)
-            where TGarnetApi : IGarnetApi
-        {
-            // BITFIELD_RO key [GET encoding offset [GET encoding offset] ... ]
-            return StringBitField(ref storageApi, true);
         }
     }
 }

--- a/libs/server/Resp/Bitmap/BitmapManagerBitfield.cs
+++ b/libs/server/Resp/Bitmap/BitmapManagerBitfield.cs
@@ -441,5 +441,24 @@ namespace Garnet.server
                 _ => throw new GarnetException("BITFIELD secondary op not supported"),
             };
         }
+
+        /// <summary>
+        /// Execute readonly bitfield operation described at input on bitmap stored within value.
+        /// </summary>
+        /// <param name="args"></param>
+        /// <param name="value"></param>
+        /// <param name="valLen"></param>
+        /// <returns></returns>
+        public static long BitFieldExecute_RO(BitFieldCmdArgs args, byte* value, int valLen)
+        {
+            var bitCount = (byte)(args.typeInfo & 0x7F);
+            var signed = (args.typeInfo & (byte)BitFieldSign.SIGNED) > 0;
+
+            return args.secondaryCommand switch
+            {
+                RespCommand.GET => GetBitfield(value, valLen, args.offset, bitCount, signed),
+                _ => throw new GarnetException("BITFIELD secondary op not supported"),
+            };
+        }
     }
 }

--- a/libs/server/Resp/CmdStrings.cs
+++ b/libs/server/Resp/CmdStrings.cs
@@ -148,6 +148,7 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> FIELDS => "FIELDS"u8;
         public static ReadOnlySpan<byte> TIMEOUT => "TIMEOUT"u8;
         public static ReadOnlySpan<byte> ERROR => "ERROR"u8;
+        public static ReadOnlySpan<byte> INCRBY => "INCRBY"u8;
         public static ReadOnlySpan<byte> NOGET => "NOGET"u8;
 
         /// <summary>
@@ -244,6 +245,7 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> RESP_ERR_GT_LT_NX_NOT_COMPATIBLE => "ERR GT, LT, and/or NX options at the same time are not compatible"u8;
         public static ReadOnlySpan<byte> RESP_ERR_INCR_SUPPORTS_ONLY_SINGLE_PAIR => "ERR INCR option supports a single increment-element pair"u8;
         public static ReadOnlySpan<byte> RESP_ERR_INVALID_BITFIELD_TYPE => "ERR Invalid bitfield type. Use something like i16 u8. Note that u64 is not supported but i64 is"u8;
+        public static ReadOnlySpan<byte> RESP_ERR_INVALID_OVERFLOW_TYPE => "ERR Invalid OVERFLOW type specified"u8;
         public static ReadOnlySpan<byte> RESP_ERR_SCRIPT_FLUSH_OPTIONS => "ERR SCRIPT FLUSH only support SYNC|ASYNC option"u8;
         public static ReadOnlySpan<byte> RESP_ERR_BUSSYKEY => "BUSYKEY Target key name already exists."u8;
         public static ReadOnlySpan<byte> RESP_ERR_LENGTH_AND_INDEXES => "If you want both the length and indexes, please just use IDX."u8;

--- a/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
@@ -207,11 +207,21 @@ namespace Garnet.server
 
                 case RespCommand.BITFIELD:
                     var bitFieldArgs = GetBitFieldArguments(ref input);
-                    var (retValue, overflow) = BitmapManager.BitFieldExecute(bitFieldArgs, value.ToPointer() + functionsState.etagState.etagSkippedStart, value.Length - functionsState.etagState.etagSkippedStart);
+                    var (retValue, overflow) = BitmapManager.BitFieldExecute(bitFieldArgs,
+                                                value.ToPointer() + functionsState.etagState.etagSkippedStart,
+                                                value.Length - functionsState.etagState.etagSkippedStart);
                     if (!overflow)
                         CopyRespNumber(retValue, ref dst);
                     else
                         CopyDefaultResp(CmdStrings.RESP_ERRNOTFOUND, ref dst);
+                    return;
+
+                case RespCommand.BITFIELD_RO:
+                    var bitFieldArgs_RO = GetBitFieldArguments(ref input);
+                    var retValue_RO = BitmapManager.BitFieldExecute_RO(bitFieldArgs_RO,
+                                                value.ToPointer() + functionsState.etagState.etagSkippedStart,
+                                                value.Length - functionsState.etagState.etagSkippedStart);
+                    CopyRespNumber(retValue_RO, ref dst);
                     return;
 
                 case RespCommand.PFCOUNT:
@@ -756,15 +766,23 @@ namespace Garnet.server
             // Get secondary command. Legal commands: GET, SET & INCRBY.
             var cmd = RespCommand.NONE;
             var sbCmd = input.parseState.GetArgSliceByRef(currTokenIdx++).ReadOnlySpan;
-            if (sbCmd.EqualsUpperCaseSpanIgnoringCase("GET"u8))
+            if (sbCmd.EqualsUpperCaseSpanIgnoringCase(CmdStrings.GET))
                 cmd = RespCommand.GET;
-            else if (sbCmd.EqualsUpperCaseSpanIgnoringCase("SET"u8))
+            else if (sbCmd.EqualsUpperCaseSpanIgnoringCase(CmdStrings.SET))
                 cmd = RespCommand.SET;
-            else if (sbCmd.EqualsUpperCaseSpanIgnoringCase("INCRBY"u8))
+            else if (sbCmd.EqualsUpperCaseSpanIgnoringCase(CmdStrings.INCRBY))
                 cmd = RespCommand.INCRBY;
 
-            var encodingArg = input.parseState.GetString(currTokenIdx++);
-            var offsetArg = input.parseState.GetString(currTokenIdx++);
+            var bitfieldEncodingParsed = input.parseState.TryGetBitfieldEncoding(
+                                                currTokenIdx++, out var bitCount, out var isSigned);
+            Debug.Assert(bitfieldEncodingParsed);
+            var sign = isSigned ? (byte)BitFieldSign.SIGNED : (byte)BitFieldSign.UNSIGNED;
+
+            // Calculate number offset from bitCount if offsetArg starts with #
+            var offsetParsed = input.parseState.TryGetBitfieldOffset(currTokenIdx++, out var offset, out var multiplyOffset);
+            Debug.Assert(offsetParsed);
+            if (multiplyOffset)
+                offset *= bitCount;
 
             long value = default;
             if (cmd == RespCommand.SET || cmd == RespCommand.INCRBY)
@@ -780,14 +798,9 @@ namespace Garnet.server
                 overflowType = (byte)overflowTypeValue;
             }
 
-            var sign = encodingArg[0] == 'i' ? (byte)BitFieldSign.SIGNED : (byte)BitFieldSign.UNSIGNED;
             // Number of bits in signed number
-            var bitCount = (byte)int.Parse(encodingArg.AsSpan(1));
             // At most 64 bits can fit into encoding info
             var typeInfo = (byte)(sign | bitCount);
-
-            // Calculate number offset from bitCount if offsetArg starts with #
-            var offset = offsetArg[0] == '#' ? long.Parse(offsetArg.AsSpan(1)) * bitCount : long.Parse(offsetArg);
 
             return new BitFieldCmdArgs(cmd, typeInfo, offset, value, overflowType);
         }

--- a/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
@@ -76,6 +76,7 @@ namespace Garnet.server
                     var bOffset = input.arg1;
                     return sizeof(int) + BitmapManager.Length(bOffset);
                 case RespCommand.BITFIELD:
+                case RespCommand.BITFIELD_RO:
                     var bitFieldArgs = GetBitFieldArguments(ref input);
                     return sizeof(int) + BitmapManager.LengthFromType(bitFieldArgs);
                 case RespCommand.PFADD:
@@ -178,6 +179,7 @@ namespace Garnet.server
                         var bOffset = input.arg1;
                         return sizeof(int) + BitmapManager.NewBlockAllocLength(t.Length, bOffset);
                     case RespCommand.BITFIELD:
+                    case RespCommand.BITFIELD_RO:
                         var bitFieldArgs = GetBitFieldArguments(ref input);
                         return sizeof(int) + BitmapManager.NewBlockAllocLengthFromType(bitFieldArgs, t.Length);
                     case RespCommand.PFADD:

--- a/test/Garnet.test/GarnetBitmapTests.cs
+++ b/test/Garnet.test/GarnetBitmapTests.cs
@@ -2521,13 +2521,153 @@ namespace Garnet.test
             bit = db.StringSetBit(key, offset: 8, bit: true);
             ClassicAssert.AreEqual(expected: false, actual: bit);
 
-            _ = db.Execute("BITFIELD", (RedisKey)key, "SET", "u8", 0, 1);
-            _ = db.Execute("BITFIELD", (RedisKey)key, "SET", "u8", 0, 128);
-            _ = db.Execute("BITFIELD", (RedisKey)key, "SET", "u8", 8, 1);
+            var ret = db.Execute("BITFIELD", (RedisKey)key, "SET", "u8", 0, 1);
+            ClassicAssert.AreEqual(1, ((string[])ret).Length);
+            ClassicAssert.AreEqual("128", ret[0].ToString());
 
+            ret = db.Execute("BITFIELD", (RedisKey)key, "SET", "u8", 0, 128);
+            ClassicAssert.AreEqual(1, ((string[])ret).Length);
+            ClassicAssert.AreEqual("1", ret[0].ToString());
+
+            ret = db.Execute("BITFIELD", (RedisKey)key, "SET", "u8", 8, 1);
+            ClassicAssert.AreEqual(1, ((string[])ret).Length);
+            ClassicAssert.AreEqual("128", ret[0].ToString());
 
             var result = (byte[])db.StringGet(key);
             ClassicAssert.AreEqual(expected: new byte[] { 0x80, 0x01 }, actual: result);
+
+            ret = db.Execute("BITFIELD", (RedisKey)key, "SET", "u8", 8, 128, "GET", "u8", 8);
+            ClassicAssert.AreEqual(2, ((string[])ret).Length);
+            ClassicAssert.AreEqual("1", ret[0].ToString());
+            ClassicAssert.AreEqual("128", ret[1].ToString());
+
+            result = (byte[])db.StringGet(key);
+            ClassicAssert.AreEqual(expected: new byte[] { 0x80, 0x80 }, actual: result);
+        }
+
+        [Order(41)]
+        [Test]
+        [Category("BITFIELD")]
+        public void BitmapBitFieldInvalidOptionsTest([Values(RespCommand.BITFIELD, RespCommand.BITFIELD_RO)] RespCommand testCmd)
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+            var key = "BitmapBitFieldInvalidOptionsTest";
+
+            try
+            {
+                db.Execute(testCmd.ToString(), key, "GET");
+                Assert.Fail("Should be unreachable, arguments are incorrect");
+            }
+            catch (RedisServerException ex)
+            {
+                ClassicAssert.AreEqual("ERR Invalid bitfield type. Use something like i16 u8. Note that u64 is not supported but i64 is",
+                                       ex.Message);
+            }
+
+            try
+            {
+                db.Execute(testCmd.ToString(), key, "GET", "u64", "0");
+                Assert.Fail("Should be unreachable, arguments are incorrect");
+            }
+            catch (RedisServerException ex)
+            {
+                ClassicAssert.AreEqual("ERR Invalid bitfield type. Use something like i16 u8. Note that u64 is not supported but i64 is",
+                                       ex.Message);
+            }
+
+            try
+            {
+                db.Execute(testCmd.ToString(), key, "GET", "i-1", "0");
+                Assert.Fail("Should be unreachable, arguments are incorrect");
+            }
+            catch (RedisServerException ex)
+            {
+                ClassicAssert.AreEqual("ERR Invalid bitfield type. Use something like i16 u8. Note that u64 is not supported but i64 is",
+                                       ex.Message);
+            }
+
+            try
+            {
+                db.Execute(testCmd.ToString(), key, "GET", "u8", @"""");
+                Assert.Fail("Should be unreachable, arguments are incorrect");
+            }
+            catch (RedisServerException ex)
+            {
+                ClassicAssert.AreEqual("ERR bit offset is not an integer or out of range",
+                                       ex.Message);
+            }
+
+            try
+            {
+                db.Execute(testCmd.ToString(), key, "GET", "i16", "#");
+                Assert.Fail("Should be unreachable, arguments are incorrect");
+            }
+            catch (RedisServerException ex)
+            {
+                ClassicAssert.AreEqual("ERR bit offset is not an integer or out of range",
+                                       ex.Message);
+            }
+
+            try
+            {
+                db.Execute(testCmd.ToString(), key, "GET", "32", "1");
+                Assert.Fail("Should be unreachable, arguments are incorrect");
+            }
+            catch (RedisServerException ex)
+            {
+                ClassicAssert.AreEqual("ERR Invalid bitfield type. Use something like i16 u8. Note that u64 is not supported but i64 is",
+                                       ex.Message);
+            }
+
+            try
+            {
+                db.Execute(testCmd.ToString(), key, "GET", "u32", @"-1");
+                Assert.Fail("Should be unreachable, arguments are incorrect");
+            }
+            catch (RedisServerException ex)
+            {
+                ClassicAssert.AreEqual("ERR bit offset is not an integer or out of range",
+                                       ex.Message);
+            }
+
+            if (testCmd == RespCommand.BITFIELD)
+            {
+                try
+                {
+                    db.Execute(testCmd.ToString(), key, "SET", "i32", "0");
+                    Assert.Fail("Should be unreachable, arguments are incorrect");
+                }
+                catch (RedisServerException ex)
+                {
+                    ClassicAssert.AreEqual("ERR value is not an integer or out of range.",
+                                           ex.Message);
+                }
+
+                try
+                {
+                    db.Execute(testCmd.ToString(), key, "OVERFLOW", "NONE");
+                    Assert.Fail("Should be unreachable, arguments are incorrect");
+                }
+                catch (RedisServerException ex)
+                {
+                    ClassicAssert.AreEqual("ERR Invalid OVERFLOW type specified",
+                                           ex.Message);
+                }
+            }
+            else
+            {
+                try
+                {
+                    db.Execute(testCmd.ToString(), key, "SET", "i64", "0");
+                    Assert.Fail("Should be unreachable, arguments are incorrect");
+                }
+                catch (RedisServerException ex)
+                {
+                    ClassicAssert.AreEqual("ERR syntax error",
+                                           ex.Message);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
It's very easy to get a parsing exception with either:

BITFIELD a SET i8
BITFIELD a GET i8 ""

(I managed to get crashes but it didn't replicate later. I guess it depends on build settings).

Error messages can be confusing:

bitfield_ro a OVERFLOW fail GET i8 1
ERR Invalid bitfield type. Use something like i16 u8. Note that u64 is not supported but i64 is

Return type is wrong when key was not found:

BITFIELD nx GET i8 0
1) "0"
(should be an integer).

----

First commit cleans up the parsing and separates the '_RO' version so both sides are simplified and give decent messages. Adds a test.

Next commit continues the _RO separation to the storage layer.
It's very mechanical (we know only the GET operation can activate and therefore overflow is false and then edit accordingly). I suspect the _RO part can be reduced a bit more but didn't want to risk it.