### PR TITLE
Validate SETBIT offset is not negative

### DIFF
--- a/libs/server/Resp/Bitmap/BitmapCommands.cs
+++ b/libs/server/Resp/Bitmap/BitmapCommands.cs
@@ -178,7 +178,7 @@ namespace Garnet.server
             var sbKey = parseState.GetArgSliceByRef(0).SpanByte;
 
             // Validate offset
-            if (!parseState.TryGetLong(1, out _))
+            if (!parseState.TryGetLong(1, out var offset) || (offset < 0))
             {
                 while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_GENERIC_BITOFFSET_IS_NOT_INTEGER, ref dcurr,
                            dend))
@@ -186,7 +186,7 @@ namespace Garnet.server
                 return true;
             }
 
-            var input = new RawStringInput(RespCommand.GETBIT, ref parseState, startIdx: 1);
+            var input = new RawStringInput(RespCommand.GETBIT, ref parseState, startIdx: 1, arg1: offset);
 
             var o = new SpanByteAndMemory(dcurr, (int)(dend - dcurr));
             var status = storageApi.StringGetBit(ref sbKey, ref input, ref o);

--- a/libs/server/Resp/Bitmap/BitmapCommands.cs
+++ b/libs/server/Resp/Bitmap/BitmapCommands.cs
@@ -132,7 +132,7 @@ namespace Garnet.server
             var sbKey = parseState.GetArgSliceByRef(0).SpanByte;
 
             // Validate offset
-            if (!parseState.TryGetLong(1, out _))
+            if (!parseState.TryGetLong(1, out var offset) || (offset < 0))
             {
                 while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_GENERIC_BITOFFSET_IS_NOT_INTEGER, ref dcurr,
                            dend))
@@ -150,7 +150,7 @@ namespace Garnet.server
                 return true;
             }
 
-            var input = new RawStringInput(RespCommand.SETBIT, ref parseState, startIdx: 1);
+            var input = new RawStringInput(RespCommand.SETBIT, ref parseState, startIdx: 1, arg1: offset);
 
             var o = new SpanByteAndMemory(dcurr, (int)(dend - dcurr));
             var status = storageApi.StringSetBit(

--- a/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
@@ -134,7 +134,7 @@ namespace Garnet.server
                     break;
 
                 case RespCommand.GETBIT:
-                    var offset = input.parseState.GetLong(0);
+                    var offset = input.arg1;
                     var oldValSet = BitmapManager.GetBit(offset, value.ToPointer() + functionsState.etagState.etagSkippedStart, value.Length - functionsState.etagState.etagSkippedStart);
                     if (oldValSet == 0)
                         CopyDefaultResp(CmdStrings.RESP_RETURN_VAL_0, ref dst);

--- a/libs/server/Storage/Functions/MainStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/RMWMethods.cs
@@ -138,7 +138,7 @@ namespace Garnet.server
                     throw new Exception();
 
                 case RespCommand.SETBIT:
-                    var bOffset = input.parseState.GetLong(0);
+                    var bOffset = input.arg1;
                     var bSetVal = (byte)(input.parseState.GetArgSliceByRef(1).ReadOnlySpan[0] - '0');
 
                     value.ShrinkSerializedLength(BitmapManager.Length(bOffset));
@@ -591,7 +591,7 @@ namespace Garnet.server
 
                 case RespCommand.SETBIT:
                     var v = value.ToPointer() + functionsState.etagState.etagSkippedStart;
-                    var bOffset = input.parseState.GetLong(0);
+                    var bOffset = input.arg1;
                     var bSetVal = (byte)(input.parseState.GetArgSliceByRef(1).ReadOnlySpan[0] - '0');
 
                     if (!BitmapManager.IsLargeEnough(functionsState.etagState.etagAccountedLength, bOffset)) return false;
@@ -1120,7 +1120,7 @@ namespace Garnet.server
                     break;
 
                 case RespCommand.SETBIT:
-                    var bOffset = input.parseState.GetLong(0);
+                    var bOffset = input.arg1;
                     var bSetVal = (byte)(input.parseState.GetArgSliceByRef(1).ReadOnlySpan[0] - '0');
                     Buffer.MemoryCopy(oldValue.ToPointer(), newValue.ToPointer(), newValue.Length, oldValue.Length);
                     var oldValSet = BitmapManager.UpdateBitmap(newValue.ToPointer(), bOffset, bSetVal);

--- a/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
@@ -73,7 +73,7 @@ namespace Garnet.server
             switch (cmd)
             {
                 case RespCommand.SETBIT:
-                    var bOffset = input.parseState.GetLong(0);
+                    var bOffset = input.arg1;
                     return sizeof(int) + BitmapManager.Length(bOffset);
                 case RespCommand.BITFIELD:
                     var bitFieldArgs = GetBitFieldArguments(ref input);
@@ -175,7 +175,7 @@ namespace Garnet.server
 
                         return sizeof(int) + ndigits + t.MetadataSize + functionsState.etagState.etagOffsetForVarlen;
                     case RespCommand.SETBIT:
-                        var bOffset = input.parseState.GetLong(0);
+                        var bOffset = input.arg1;
                         return sizeof(int) + BitmapManager.NewBlockAllocLength(t.Length, bOffset);
                     case RespCommand.BITFIELD:
                         var bitFieldArgs = GetBitFieldArguments(ref input);

--- a/libs/server/Storage/Session/MainStore/BitmapOps.cs
+++ b/libs/server/Storage/Session/MainStore/BitmapOps.cs
@@ -50,7 +50,8 @@ namespace Garnet.server
 
             parseState.InitializeWithArgument(offset);
 
-            var input = new RawStringInput(RespCommand.GETBIT, ref parseState);
+            var input = new RawStringInput(RespCommand.GETBIT, ref parseState,
+                                           arg1: ParseUtils.ReadLong(ref offset));
 
             SpanByteAndMemory output = new(null);
             var keySp = key.SpanByte;

--- a/libs/server/Storage/Session/MainStore/BitmapOps.cs
+++ b/libs/server/Storage/Session/MainStore/BitmapOps.cs
@@ -30,7 +30,8 @@ namespace Garnet.server
 
             parseState.InitializeWithArguments(offset, setValSlice);
 
-            var input = new RawStringInput(RespCommand.SETBIT, ref parseState);
+            var input = new RawStringInput(RespCommand.SETBIT, ref parseState,
+                                           arg1: ParseUtils.ReadLong(ref offset));
 
             SpanByteAndMemory output = new(null);
             var keySp = key.SpanByte;

--- a/test/Garnet.test/GarnetBitmapTests.cs
+++ b/test/Garnet.test/GarnetBitmapTests.cs
@@ -123,6 +123,17 @@ namespace Garnet.test
             {
                 ClassicAssert.IsFalse(db.StringGetBit(key, i));
             }
+
+            try
+            {
+                db.Execute("GETBIT", key, "-1");
+                Assert.Fail("Should be unreachable, arguments are incorrect");
+            }
+            catch (RedisServerException ex)
+            {
+                ClassicAssert.AreEqual("ERR bit offset is not an integer or out of range",
+                                       ex.Message);
+            }
         }
 
         [Test, Order(3)]

--- a/test/Garnet.test/GarnetBitmapTests.cs
+++ b/test/Garnet.test/GarnetBitmapTests.cs
@@ -98,6 +98,17 @@ namespace Garnet.test
             ClassicAssert.IsFalse(db.StringGetBit(key, 7999));
             ClassicAssert.IsFalse(db.StringGetBit(key, 8999));
             ClassicAssert.IsTrue(db.StringGetBit(key, 9999));
+
+            try
+            {
+                db.Execute("SETBIT", key, "-1", "1");
+                Assert.Fail("Should be unreachable, arguments are incorrect");
+            }
+            catch (RedisServerException ex)
+            {
+                ClassicAssert.AreEqual("ERR bit offset is not an integer or out of range",
+                                       ex.Message);
+            }
         }
 
         [Test, Order(2)]


### PR DESCRIPTION
SETBIT k -1 1

SETBIT command doesn't try to validate offset and the predictable results (crash or allocating a huge string) happen. 
This PR adds the check. Since we need to get the offset for it, might as well pass it via arg1.