### PR TITLE
Fixed security SHA for Deploy to Github pages

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -50,7 +50,7 @@ jobs:
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@aa83d0c2cfc3d813560e13068d3152aa21490171    #v4 - for security reasons have pinned tag (commit SHA) for 3rd party
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e    #v4 - for security reasons have pinned tag (commit SHA) for 3rd party
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:


### PR DESCRIPTION
For some reason, the previous SHA did not work. I think this was a bug on my part by using the most recent build instead of the blessed release. I changed it to the blessed release and it now passes.  All the other ones used the blessed release so not sure why I used "most recent" on this one.