### PR TITLE
Add ability to disable intrinsics for tests

### DIFF
--- a/main/GarnetServer/GarnetServer.csproj
+++ b/main/GarnetServer/GarnetServer.csproj
@@ -9,8 +9,15 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\..\test\testcerts\testcert.pfx" Link="testcert.pfx">
+	<PropertyGroup>
+		<SignAssembly>true</SignAssembly>
+		<AssemblyOriginatorKeyFile>../../Garnet.snk</AssemblyOriginatorKeyFile>
+		<DelaySign>false</DelaySign>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<InternalsVisibleTo Include="Garnet.test" Key="0024000004800000940000000602000000240000525341310004000001000100011b1661238d3d3c76232193c8aa2de8c05b8930d6dfe8cd88797a8f5624fdf14a1643141f31da05c0f67961b0e3a64c7120001d2f8579f01ac788b0ff545790d44854abe02f42bfe36a056166a75c6a694db8c5b6609cff8a2dbb429855a1d9f79d4d8ec3e145c74bfdd903274b7344beea93eab86b422652f8dd8eecf530d2" />
+		<None Include="..\..\test\testcerts\testcert.pfx" Link="testcert.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/main/GarnetServer/Program.cs
+++ b/main/GarnetServer/Program.cs
@@ -10,7 +10,7 @@ namespace Garnet
     /// <summary>
     /// Garnet server entry point
     /// </summary>
-    class Program
+    public class Program
     {
         static void Main(string[] args)
         {

--- a/test/Garnet.test/Garnet.test.csproj
+++ b/test/Garnet.test/Garnet.test.csproj
@@ -12,20 +12,6 @@
 
   <ItemGroup>
     <Compile Include="..\..\benchmark\BDN.benchmark\Embedded\EmbeddedNetworkSender.cs" Link="EmbeddedNetworkSender.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\DeleteIfMatch.cs" Link="DeleteIfMatch.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\MGetIfPM.cs" Link="MGetIfPM.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\MSetPx.cs" Link="MSetPx.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\MyDictObject.cs" Link="MyDictObject.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\MyDictSet.cs" Link="MyDictSet.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\MyDictGet.cs" Link="MyDictGet.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\GetTwoKeysNoTxn.cs" Link="GetTwoKeysNoTxn.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\ReadWriteTxn.cs" Link="ReadWriteTxn.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\SampleUpdateTxn.cs" Link="SampleUpdateTxn.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\SampleDeleteTxn.cs" Link="SampleDeleteTxn.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\SetIfPM.cs" Link="SetIfPM.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\SetWPIfPGT.cs" Link="SetWPIFPGT.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\Sum.cs" Link="Sum.cs" />
-    <Compile Include="..\..\main\GarnetServer\Extensions\SetStringAndList.cs" Link="SetStringAndList.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -56,6 +42,7 @@
     <ProjectReference Include="..\..\libs\host\Garnet.host.csproj" />
     <ProjectReference Include="..\..\libs\server\Garnet.server.csproj" />
     <ProjectReference Include="..\..\libs\storage\Tsavorite\cs\src\devices\AzureStorageDevice\Tsavorite.devices.AzureStorageDevice.csproj" />
+    <ProjectReference Include="..\..\main\GarnetServer\GarnetServer.csproj" />
     <ProjectReference Include="..\..\playground\GarnetJSON\GarnetJSON.csproj" />
     <ProjectReference Include="..\..\playground\NoOpModule\NoOpModule.csproj" />
   </ItemGroup>

--- a/test/Garnet.test/TestProcess.cs
+++ b/test/Garnet.test/TestProcess.cs
@@ -36,11 +36,10 @@ namespace Garnet.test
             var endPoint = new IPEndPoint(IPAddress.Loopback, port);
             opts = TestUtils.GetConfig([endPoint]);
 
-            var psi = new ProcessStartInfo(name, ["--bind", "127.0.0.1",
-                                                  "--port", port.ToString(),
-                                                  "--enable-debug-command", "local",
-                                                  // For faster startup
-                                                  "--no-pubsub", "--no-obj"])
+            var psi = new ProcessStartInfo(name,
+["--bind", "127.0.0.1", "--port", port.ToString(), "--enable-debug-command", "local",
+// For faster startup
+"--no-pubsub", "--no-obj"])
             {
                 CreateNoWindow = true,
                 RedirectStandardInput = true,

--- a/test/Garnet.test/TestProcess.cs
+++ b/test/Garnet.test/TestProcess.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Garnet.common;
+using NUnit.Framework.Legacy;
+using StackExchange.Redis;
+
+namespace Garnet.test
+{
+    internal class GarnetServerTestProcess : IDisposable
+    {
+        private readonly Process p = default;
+        private readonly Stopwatch stopWatch = default;
+        private readonly LightClientRequest lightClientRequest = default;
+
+        internal GarnetServerTestProcess(out ConfigurationOptions opts,
+                                         Dictionary<string, string> env = default,
+                                         int port = 7000)
+        {
+            var a = Assembly.GetAssembly(typeof(Garnet.Program));
+            var name = a.Location;
+            var pos = name.LastIndexOf('.');
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                name = name.AsSpan().Slice(0, pos).ToString() + ".exe";
+            }
+            else
+            {
+                name = name.AsSpan().Slice(0, pos).ToString();
+            }
+
+            var endPoint = new IPEndPoint(IPAddress.Loopback, port);
+            opts = TestUtils.GetConfig([endPoint]);
+
+            var psi = new ProcessStartInfo(name, ["--bind", "127.0.0.1",
+                                                  "--port", port.ToString(),
+                                                  "--enable-debug-command", "local",
+                                                  // For faster startup
+                                                  "--no-pubsub", "--no-obj"])
+            {
+                CreateNoWindow = true,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true
+            };
+
+            if (env != default)
+            {
+                foreach (var e in env)
+                    psi.Environment.Add(e.Key, e.Value);
+            }
+
+            p = Process.Start(psi);
+            ClassicAssert.NotNull(p);
+
+            lightClientRequest = new LightClientRequest(endPoint, 0);
+
+            // Block until the startup message to ensure process is up.
+            var dummy = new char[1];
+            _ = p.StandardOutput.ReadBlock(dummy, 0, 1);
+
+            stopWatch = Stopwatch.StartNew();
+        }
+
+        public void Dispose()
+        {
+            if (stopWatch != default)
+            {
+                stopWatch.Stop();
+                Console.WriteLine(stopWatch.ElapsedMilliseconds);
+            }
+
+            if (p != default)
+            {
+                // We want to be sure the process is down, otherwise it may conflict
+                // with a future run. First, we'll ask nicely and then kill it.
+                try
+                {
+                    // More reliable than QUIT.
+                    _ = lightClientRequest.SendCommand("DEBUG PANIC");
+                    lightClientRequest.Dispose();
+                }
+                catch { }
+
+                try { p.Kill(); }
+                catch { }
+
+                p.Close();
+            }
+        }
+    }
+}

--- a/test/Garnet.test/TestProcess.cs
+++ b/test/Garnet.test/TestProcess.cs
@@ -53,11 +53,11 @@ namespace Garnet.test
             p = Process.Start(psi);
             ClassicAssert.NotNull(p);
 
-            lightClientRequest = new LightClientRequest(endPoint, 0);
-
             // Block until the startup message to ensure process is up.
             var dummy = new char[1];
             _ = p.StandardOutput.ReadBlock(dummy, 0, 1);
+
+            lightClientRequest = new LightClientRequest(endPoint, 0);
 
             stopWatch = Stopwatch.StartNew();
         }

--- a/test/Garnet.test/TestProcess.cs
+++ b/test/Garnet.test/TestProcess.cs
@@ -36,10 +36,8 @@ namespace Garnet.test
             var endPoint = new IPEndPoint(IPAddress.Loopback, port);
             opts = TestUtils.GetConfig([endPoint]);
 
-            var psi = new ProcessStartInfo(name,
-["--bind", "127.0.0.1", "--port", port.ToString(), "--enable-debug-command", "local",
-// For faster startup
-"--no-pubsub", "--no-obj"])
+            // We don't have to disable objects, it's done to improve startup time a bit.
+            var psi = new ProcessStartInfo(name, ["--bind", "127.0.0.1", "--port", port.ToString(), "--enable-debug-command", "local", "--no-pubsub", "--no-obj"])
             {
                 CreateNoWindow = true,
                 RedirectStandardInput = true,

--- a/test/Garnet.test/TestProcess.cs
+++ b/test/Garnet.test/TestProcess.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Garnet.common;
 using NUnit.Framework.Legacy;
 using StackExchange.Redis;
@@ -57,6 +58,8 @@ namespace Garnet.test
             var dummy = new char[1];
             _ = p.StandardOutput.ReadBlock(dummy, 0, 1);
 
+            // Give it a bit more time
+            Thread.Sleep(100);
             lightClientRequest = new LightClientRequest(endPoint, 0);
 
             stopWatch = Stopwatch.StartNew();


### PR DESCRIPTION
This adds a DEBUG INTRINSICS command so the fallback can be tested. The command allows turning off their use even when the runner supports the intrinsics. Use this with some BITCOUNT tests.