### PR TITLE
Fix Hostname CLUSTER MEET

### DIFF
--- a/libs/cluster/Server/Gossip.cs
+++ b/libs/cluster/Server/Gossip.cs
@@ -161,7 +161,7 @@ namespace Garnet.cluster
 
                 if (gsn == null)
                 {
-                    var endpoint = await Format.TryParseEndpoint(address, port, logger);
+                    var endpoint = await Format.TryCreateEndpoint(address, port, tryConnect: true, logger: logger);
                     if (endpoint == null)
                     {
                         logger?.LogError("Could not parse endpoint {address} {port}", address, port);

--- a/libs/cluster/Server/Gossip.cs
+++ b/libs/cluster/Server/Gossip.cs
@@ -161,7 +161,12 @@ namespace Garnet.cluster
 
                 if (gsn == null)
                 {
-                    gsn = new GarnetServerNode(clusterProvider, new IPEndPoint(IPAddress.Parse(address), port), tlsOptions?.TlsClientOptions, logger: logger);
+                    var endpoint = await Format.TryParseEndpoint(address, port, logger);
+                    if (endpoint == null)
+                    {
+                        logger?.LogError("Could not parse endpoint {address} {port}", address, port);
+                    }
+                    gsn = new GarnetServerNode(clusterProvider, endpoint, tlsOptions?.TlsClientOptions, logger: logger);
                     created = true;
                 }
 

--- a/libs/cluster/Server/Gossip.cs
+++ b/libs/cluster/Server/Gossip.cs
@@ -161,7 +161,7 @@ namespace Garnet.cluster
 
                 if (gsn == null)
                 {
-                    var endpoint = await Format.TryCreateEndpoint(address, port, tryConnect: true, logger: logger);
+                    var endpoint = await Format.TryCreateEndpoint(address, port, useForBind: true, logger: logger);
                     if (endpoint == null)
                     {
                         logger?.LogError("Could not parse endpoint {address} {port}", address, port);

--- a/libs/common/Format.cs
+++ b/libs/common/Format.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
@@ -33,119 +31,82 @@ namespace Garnet.common
 #pragma warning disable format
     public static class Format
     {
-        /// <summary>
-        /// Parse Endpoint in the form address:port
-        /// </summary>
-        /// <param name="addressWithPort"></param>
-        /// <param name="endpoint"></param>
-        /// <returns></returns>
-        /// <exception cref="PlatformNotSupportedException"></exception>
-#nullable enable
-        public static bool TryParseEndPoint(string addressWithPort, [NotNullWhen(true)] out EndPoint? endpoint)
-#nullable disable
+        public static async Task<EndPoint> TryCreateEndpoint(string addressOrHostname, int port, bool tryConnect = false, ILogger logger = null)
         {
-            string addressPart;
-#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
-            string portPart = null;
-#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
-            if (addressWithPort.IsNullOrEmpty())
-            {
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-                endpoint = null;
-#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
-                return false;
-            }
+            IPEndPoint endpoint = null;
+            if (string.IsNullOrEmpty(addressOrHostname) || string.IsNullOrWhiteSpace(addressOrHostname))
+                return new IPEndPoint(IPAddress.Any, port);
 
-            if (addressWithPort[0] == '!')
+            if (IPAddress.TryParse(addressOrHostname, out var ipAddress))
+                return new IPEndPoint(ipAddress, port);
+
+            // Sanity check, there should be at least one ip address available
+            try
             {
-                if (addressWithPort.Length == 1)
+                var ipAddresses = Dns.GetHostAddresses(addressOrHostname);
+                if (ipAddresses.Length == 0)
                 {
-                    endpoint = null;
-                    return false;
+                    logger?.LogError("No IP address found for hostname:{hostname}", addressOrHostname);
+                    return null;
                 }
 
-#if UNIX_SOCKET
-                endpoint = new UnixDomainSocketEndPoint(addressWithPort.Substring(1));
-                return true;
-#else
-                throw new PlatformNotSupportedException("Unix domain sockets require .NET Core 3 or above");
-#endif
-            }
-            var lastColonIndex = addressWithPort.LastIndexOf(':');
-            if (lastColonIndex > 0)
-            {
-                // IPv4 with port or IPv6
-                var closingIndex = addressWithPort.LastIndexOf(']');
-                if (closingIndex > 0)
+
+                if (tryConnect)
                 {
-                    // IPv6 with brackets
-                    addressPart = addressWithPort.Substring(1, closingIndex - 1);
-                    if (closingIndex < lastColonIndex)
+                    foreach (var entry in ipAddresses)
                     {
-                        // IPv6 with port [::1]:80
-                        portPart = addressWithPort.Substring(lastColonIndex + 1);
+                        endpoint = new IPEndPoint(entry, port);
+                        var IsListening = await IsReachable(endpoint);
+                        if (IsListening) break;
                     }
                 }
                 else
                 {
-                    // IPv6 without port or IPv4
-                    var firstColonIndex = addressWithPort.IndexOf(':');
-                    if (firstColonIndex != lastColonIndex)
-                    {
-                        // IPv6 ::1
-                        addressPart = addressWithPort;
-                    }
-                    else
-                    {
-                        // IPv4 with port 127.0.0.1:123
-                        addressPart = addressWithPort.Substring(0, firstColonIndex);
-                        portPart = addressWithPort.Substring(firstColonIndex + 1);
-                    }
-                }
-            }
-            else
-            {
-                // IPv4 without port
-                addressPart = addressWithPort;
-            }
+                    var machineHostname = GetHostName();
 
-            int? port = 0;
-            if (portPart != null)
-            {
-                if (TryParseInt32(portPart, out var portVal))
-                {
-                    port = portVal;
-                }
-                else
-                {
-                    // Invalid port, return
-                    endpoint = null;
-                    return false;
-                }
-            }
+                    // Hostname does match the one acquired from machine name
+                    if (!addressOrHostname.Equals(machineHostname, StringComparison.OrdinalIgnoreCase))
+                        throw new GarnetException($"Provided hostname does not much acquired machine name {addressOrHostname} {machineHostname}!");
 
-            if (IPAddress.TryParse(addressPart, out IPAddress address))
-            {
-                endpoint = new IPEndPoint(address, port ?? 0);
-                return true;
+                    // Listen to any address since we were given a valid hostname
+                    return new IPEndPoint(IPAddress.Any, port);
+                }
+                logger?.LogError("No reachable IP address found for hostname:{hostname}", addressOrHostname);
             }
-            else
+            catch (Exception ex)
             {
-                IPHostEntry host = Dns.GetHostEntryAsync(addressPart).Result;
-                var ip = host.AddressList.First(x => x.AddressFamily == AddressFamily.InterNetwork);
-                endpoint = new IPEndPoint(ip, port ?? 0);
-                return true;
+                logger?.LogError(ex, "Error while trying to resolve hostname:{hostname}", addressOrHostname);
+            }            
+
+            return endpoint;
+
+            async Task<bool> IsReachable(IPEndPoint endpoint)
+            {
+                using (var tcpClient = new TcpClient())
+                {
+                    try
+                    {
+                        await tcpClient.ConnectAsync(endpoint.Address, endpoint.Port);
+                        logger?.LogTrace("Reachable {ip} {port}", endpoint.Address, endpoint.Port);
+                        return true;
+                    }
+                    catch
+                    {
+                        logger?.LogTrace("Unreachable {ip} {port}", endpoint.Address, endpoint.Port);
+                        return false;
+                    }
+                }
             }
         }
 
         /// <summary>
-        /// Try to parse endpoint from address and port
+        /// Try to
         /// </summary>
         /// <param name="address"></param>
         /// <param name="port"></param>
         /// <param name="logger"></param>
         /// <returns></returns>
-        public static async Task<IPEndPoint> TryParseEndpoint(string address, int port, ILogger logger = null)
+        public static async Task<IPEndPoint> TryValidateAndConnectAddress2(string address, int port, ILogger logger = null)
         {
             IPEndPoint endpoint = null;
             if (!IPAddress.TryParse(address, out var ipAddress))
@@ -156,8 +117,7 @@ namespace Garnet.common
                 {
                     endpoint = new IPEndPoint(entry, port);
                     var IsListening = await IsReachable(endpoint);
-                    if (IsListening)
-                        break;
+                    if (IsListening) break;
                 }
             }
             else
@@ -188,27 +148,55 @@ namespace Garnet.common
         }
 
         /// <summary>
-        /// TryParseInt32
+        /// Parse address (hostname) and port to endpoint
         /// </summary>
-        /// <param name="s"></param>
-        /// <param name="value"></param>
+        /// <param name="address"></param>
+        /// <param name="port"></param>
+        /// <param name="endpoint"></param>
         /// <returns></returns>
-        public static bool TryParseInt32(string s, out int value) =>
-            int.TryParse(s, NumberStyles.Integer, NumberFormatInfo.InvariantInfo, out value);
+        public static bool TryValidateAddress(string address, int port, out EndPoint endpoint)
+        {
+            endpoint = null;
+
+            if (string.IsNullOrWhiteSpace(address))
+            {
+                endpoint = new IPEndPoint(IPAddress.Any, port);
+                return true;
+            }
+
+            if (IPAddress.TryParse(address, out var ipAddress))
+            {
+                endpoint = new IPEndPoint(ipAddress, port);
+                return true;
+            }
+
+            var machineHostname = GetHostName();
+
+            // Hostname does match then one acquired from machine name
+            if (!address.Equals(machineHostname, StringComparison.OrdinalIgnoreCase))                
+                return false;
+
+            // Sanity check, there should be at least one ip address available
+            var ipAddresses = Dns.GetHostAddresses(address);
+            if (ipAddresses.Length == 0)
+                return false;
+
+            // Listen to any since we were given a valid hostname
+            endpoint = new IPEndPoint(IPAddress.Any, port);
+            return true;
+        }
 
         /// <summary>
         /// Resolve host from Ip
         /// </summary>
         /// <param name="logger"></param>
         /// <returns></returns>
-#nullable enable
-        public static string GetHostName(ILogger? logger = null)
-#nullable disable
+        public static string GetHostName(ILogger logger = null)
         {
             try
             {
-                var serverName = Environment.MachineName; //host name sans domain
-                var fqhn = Dns.GetHostEntry(serverName).HostName; //fully qualified hostname
+                var serverName = Environment.MachineName; // host name sans domain
+                var fqhn = Dns.GetHostEntry(serverName).HostName; // fully qualified hostname
                 return fqhn;
             }
             catch (SocketException ex)

--- a/libs/common/Format.cs
+++ b/libs/common/Format.cs
@@ -155,8 +155,8 @@ namespace Garnet.common
                 foreach (var entry in hostEntry.AddressList)
                 {
                     endpoint = new IPEndPoint(entry, port);
-                    var IsValid = await IsReachable(endpoint);
-                    if (await IsReachable(endpoint))
+                    var IsListening = await IsReachable(endpoint);
+                    if (IsListening)
                         break;
                 }
             }

--- a/libs/common/Format.cs
+++ b/libs/common/Format.cs
@@ -58,7 +58,6 @@ namespace Garnet.common
                     return null;
                 }
 
-
                 if (useForBind)
                 {
                     foreach (var entry in ipAddresses)
@@ -74,10 +73,15 @@ namespace Garnet.common
 
                     // Hostname does match the one acquired from machine name
                     if (!addressOrHostname.Equals(machineHostname, StringComparison.OrdinalIgnoreCase))
-                        throw new GarnetException($"Provided hostname does not much acquired machine name {addressOrHostname} {machineHostname}!");
+                    {
+                        logger?.LogError("Provided hostname does not much acquired machine name {addressOrHostname} {machineHostname}!", addressOrHostname, machineHostname);
+                        return null;
+                    }
 
-                    if(ipAddresses.Length > 1)
-                        throw new GarnetException("Error hostname resolved to multiple endpoints.");
+                    if (ipAddresses.Length > 1) {
+                        logger?.LogError("Error hostname resolved to multiple endpoints. Garnet does not support multiple endpoints!");
+                        return null;
+                    }
 
                     return new IPEndPoint(ipAddresses[0], port);
                 }
@@ -86,7 +90,7 @@ namespace Garnet.common
             catch (Exception ex)
             {
                 logger?.LogError(ex, "Error while trying to resolve hostname:{hostname}", addressOrHostname);
-            }            
+            }
 
             return endpoint;
 

--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -632,7 +632,7 @@ namespace Garnet
             }
             else
             {
-                endpoint = Format.TryCreateEndpoint(Address, Port, tryConnect: false).Result;
+                endpoint = Format.TryCreateEndpoint(Address, Port, useForBind: false).Result;
                 if (endpoint == null)
                     throw new GarnetException($"Invalid endpoint format {Address} {Port}.");
             }

--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -574,18 +574,27 @@ namespace Garnet
         public IList<string> UnparsedArguments { get; set; }
 
         /// <summary>
+        /// Logger instance used for runtime option validation
+        /// </summary>
+        public ILogger runtimeLogger { get; set; }
+
+        /// <summary>
         /// Check the validity of all options with an explicit ValidationAttribute
         /// </summary>
         /// <param name="invalidOptions">List of invalid options</param>
         /// <param name="logger">Logger</param>
         /// <returns>True if all property values are valid</returns>
-        public bool IsValid(out List<string> invalidOptions, ILogger logger)
+        public bool IsValid(out List<string> invalidOptions, ILogger logger = null)
         {
-            invalidOptions = new List<string>();
-            bool isValid = true;
+            invalidOptions = [];
+            var isValid = true;
 
-            foreach (PropertyInfo prop in typeof(Options).GetProperties())
+            this.runtimeLogger = logger;
+            foreach (var prop in typeof(Options).GetProperties())
             {
+                if (prop.Name.Equals("runtimeLogger"))
+                    continue;
+
                 // Ignore if property is not decorated with the OptionsAttribute or the ValidationAttribute
                 var validationAttr = prop.GetCustomAttributes(typeof(ValidationAttribute)).FirstOrDefault();
                 if (!Attribute.IsDefined(prop, typeof(OptionAttribute)) || validationAttr == null)

--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -13,6 +13,7 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using CommandLine;
+using Garnet.common;
 using Garnet.server;
 using Garnet.server.Auth.Aad;
 using Garnet.server.Auth.Settings;
@@ -631,19 +632,9 @@ namespace Garnet
             }
             else
             {
-                IPAddress address;
-                if (string.IsNullOrEmpty(Address))
-                {
-                    address = IPAddress.Any;
-                }
-                else
-                {
-                    if (Address.Equals("localhost", StringComparison.CurrentCultureIgnoreCase))
-                        address = IPAddress.Loopback;
-                    else
-                        address = IPAddress.Parse(Address);
-                }
-                endpoint = new IPEndPoint(address, Port);
+                endpoint = Format.TryCreateEndpoint(Address, Port, tryConnect: false).Result;
+                if (endpoint == null)
+                    throw new GarnetException($"Invalid endpoint format {Address} {Port}.");
             }
 
             // Unix file permission octal to UnixFileMode

--- a/libs/host/Configuration/OptionsValidators.cs
+++ b/libs/host/Configuration/OptionsValidators.cs
@@ -354,7 +354,7 @@ namespace Garnet
             if (TryInitialValidation<string>(value, validationContext, out var initValidationResult, out var ipAddress))
                 return initValidationResult;
 
-            if (ipAddress.Equals(Localhost, StringComparison.CurrentCultureIgnoreCase) || Format.TryCreateEndpoint(ipAddress, 0, tryConnect: false).Result != null)
+            if (ipAddress.Equals(Localhost, StringComparison.CurrentCultureIgnoreCase) || Format.TryCreateEndpoint(ipAddress, 0, useForBind: false).Result != null)
                 return ValidationResult.Success;
 
             var baseError = validationContext.MemberName != null ? base.FormatErrorMessage(validationContext.MemberName) : string.Empty;

--- a/libs/host/Configuration/OptionsValidators.cs
+++ b/libs/host/Configuration/OptionsValidators.cs
@@ -6,12 +6,11 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
 using System.Text.RegularExpressions;
+using Garnet.common;
 
 namespace Garnet
 {
@@ -355,11 +354,11 @@ namespace Garnet
             if (TryInitialValidation<string>(value, validationContext, out var initValidationResult, out var ipAddress))
                 return initValidationResult;
 
-            if (ipAddress.Equals(Localhost, StringComparison.CurrentCultureIgnoreCase) || IPAddress.TryParse(ipAddress, out _))
+            if (ipAddress.Equals(Localhost, StringComparison.CurrentCultureIgnoreCase) || Format.TryCreateEndpoint(ipAddress, 0, tryConnect: false).Result != null)
                 return ValidationResult.Success;
 
             var baseError = validationContext.MemberName != null ? base.FormatErrorMessage(validationContext.MemberName) : string.Empty;
-            var errorMessage = $"{baseError} Expected string in IPv4 / IPv6 format (e.g. 127.0.0.1 / 0:0:0:0:0:0:0:1) or 'localhost'. Actual value: {ipAddress}";
+            var errorMessage = $"{baseError} Expected string in IPv4 / IPv6 format (e.g. 127.0.0.1 / 0:0:0:0:0:0:0:1) or 'localhost' or valid hostname. Actual value: {ipAddress}";
             return new ValidationResult(errorMessage, [validationContext.MemberName]);
         }
     }

--- a/libs/host/Configuration/OptionsValidators.cs
+++ b/libs/host/Configuration/OptionsValidators.cs
@@ -11,6 +11,7 @@ using System.Security;
 using System.Text;
 using System.Text.RegularExpressions;
 using Garnet.common;
+using Microsoft.Extensions.Logging;
 
 namespace Garnet
 {
@@ -21,6 +22,11 @@ namespace Garnet
     [AttributeUsage(AttributeTargets.Property)]
     internal class OptionValidationAttribute : ValidationAttribute
     {
+        /// <summary>
+        /// Logger to use for validation
+        /// </summary>
+        public ILogger Logger { get; set; }
+
         /// <summary>
         /// Determines if current property is required to have a value
         /// </summary>
@@ -354,7 +360,9 @@ namespace Garnet
             if (TryInitialValidation<string>(value, validationContext, out var initValidationResult, out var ipAddress))
                 return initValidationResult;
 
-            if (ipAddress.Equals(Localhost, StringComparison.CurrentCultureIgnoreCase) || Format.TryCreateEndpoint(ipAddress, 0, useForBind: false).Result != null)
+            var logger = ((Options)validationContext.ObjectInstance).runtimeLogger;
+            if (ipAddress.Equals(Localhost, StringComparison.CurrentCultureIgnoreCase) ||
+                Format.TryCreateEndpoint(ipAddress, 0, useForBind: false, logger: logger).Result != null)
                 return ValidationResult.Success;
 
             var baseError = validationContext.MemberName != null ? base.FormatErrorMessage(validationContext.MemberName) : string.Empty;

--- a/libs/host/ServerSettingsManager.cs
+++ b/libs/host/ServerSettingsManager.cs
@@ -11,7 +11,6 @@ using CommandLine;
 using CommandLine.Text;
 using Garnet.common;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Garnet
 {
@@ -37,13 +36,10 @@ namespace Garnet
         /// <returns>True if parsing succeeded</returns>
         internal static bool TryParseCommandLineArguments(string[] args, out Options options, out List<string> invalidOptions, out bool exitGracefully, ILogger logger = null)
         {
-            if (logger == null)
-                logger = NullLogger.Instance;
-
             options = null;
-            invalidOptions = new List<string>();
+            invalidOptions = [];
 
-            if (args == null) args = [];
+            args ??= [];
 
             // Initialize command line parser
             var parser = new Parser(settings =>
@@ -55,7 +51,7 @@ namespace Garnet
 
             // Create an Options object and initialize it with default options,
             // then override them with options deserialized from ConfigImportPath (if specified)
-            Options initOptions = new Options();
+            var initOptions = new Options();
 
             // Initialize options with defaults
             var importSuccessful = TryImportServerOptions(DefaultOptionsEmbeddedFileName,
@@ -80,7 +76,7 @@ namespace Garnet
                 {
                     for (var i = dashDashIdx + 1; i < consolidatedArgs.Length; i++)
                     {
-                        unparsedArguments.Remove(consolidatedArgs[i]);
+                        _ = unparsedArguments.Remove(consolidatedArgs[i]);
                     }
                 }
 

--- a/test/Garnet.test.cluster/ClusterManagementTests.cs
+++ b/test/Garnet.test.cluster/ClusterManagementTests.cs
@@ -762,17 +762,17 @@ namespace Garnet.test.cluster
         }
 
         [Test, Order(13)]
-        public void ClusterMeetHostname()
+        public void ClusterMeetHostname([Values] bool localhost)
         {
             var node_count = 3;
-            context.CreateInstances(node_count, enableAOF: true, useLocalIp: true);
+            context.CreateInstances(node_count, enableAOF: true, useLocalIp: !localhost);
             context.CreateConnection();
 
             for (var i = 0; i < node_count; i++)
                 context.clusterTestUtils.SetConfigEpoch(i, i + 1, context.logger);
 
             var config = context.clusterTestUtils.ClusterNodes(0, context.logger);
-            var hostname = config.Nodes.First().Raw.Split(" ")[1].Split(",")[1];
+            var hostname = localhost ? "localhost" : config.Nodes.First().Raw.Split(" ")[1].Split(",")[1];
             ClassicAssert.IsNotNull(hostname);
 
             for (var i = 1; i < node_count; i++)

--- a/test/Garnet.test.cluster/ClusterManagementTests.cs
+++ b/test/Garnet.test.cluster/ClusterManagementTests.cs
@@ -762,18 +762,19 @@ namespace Garnet.test.cluster
         }
 
         [Test, Order(13)]
-        public void ClusterMeetHostname([Values] bool localhost)
+        public void ClusterMeetHostname([Values] bool useLoopback)
         {
+            var hostname = useLoopback ? "localhost" : TestUtils.GetHostName(context.logger);
+            ClassicAssert.IsNotNull(hostname);
+            ClassicAssert.IsNotEmpty(hostname);
+
             var node_count = 3;
-            context.CreateInstances(node_count, enableAOF: true, useLocalIp: !localhost);
+            context.CreateInstances(node_count, enableAOF: true, useHostname: !useLoopback);
             context.CreateConnection();
 
             for (var i = 0; i < node_count; i++)
                 context.clusterTestUtils.SetConfigEpoch(i, i + 1, context.logger);
 
-            var config = context.clusterTestUtils.ClusterNodes(0, context.logger);
-            var hostname = localhost ? "localhost" : config.Nodes.First().Raw.Split(" ")[1].Split(",")[1];
-            ClassicAssert.IsNotNull(hostname);
 
             for (var i = 1; i < node_count; i++)
                 context.clusterTestUtils.Meet(0, i, hostname, context.logger);

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -1152,6 +1152,24 @@ namespace Garnet.test.cluster
             }
         }
 
+        public void Meet(int sourceNodeIndex, int meetNodeIndex, string hostname, ILogger logger = null)
+            => Meet((IPEndPoint)endpoints[sourceNodeIndex], (IPEndPoint)endpoints[meetNodeIndex], hostname, logger);
+
+        public void Meet(IPEndPoint source, IPEndPoint target, string hostname, ILogger logger = null)
+        {
+            try
+            {
+                var server = redis.GetServer(source);
+                var resp = server.Execute("cluster", "meet", $"{hostname}", $"{target.Port}");
+                ClassicAssert.AreEqual((string)resp, "OK");
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "An error has occurred");
+                Assert.Fail(ex.Message);
+            }
+        }
+
         public string[] BanList(int sourceNodeIndex, ILogger logger = null)
             => BanList((IPEndPoint)endpoints[sourceNodeIndex], logger);
 
@@ -1304,7 +1322,7 @@ namespace Garnet.test.cluster
             while (true)
             {
                 var configs = new List<ClusterConfiguration>();
-                for (int i = 0; i < endpoints.Count; i++)
+                for (var i = 0; i < endpoints.Count; i++)
                 {
                     if (i == nodeIndex) continue;
                     configs.Add(ClusterNodes(i, logger));

--- a/test/Garnet.test/GarnetServerConfigTests.cs
+++ b/test/Garnet.test/GarnetServerConfigTests.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading;
 using CommandLine;
 using Garnet.common;
 using Garnet.server;
@@ -18,7 +16,6 @@ using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using Tsavorite.core;
-using Tsavorite.devices;
 
 namespace Garnet.test
 {
@@ -473,8 +470,6 @@ namespace Garnet.test
                 }
             }
         }
-
-
 
         /// <summary>
         /// Import a garnet.conf file with the given contents

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -762,10 +762,26 @@ namespace Garnet.test
             return new LightClientRequest(EndPoint, 0, onReceive, sslOptions, countResponseType);
         }
 
+        public static string GetHostName(ILogger logger = null)
+        {
+            try
+            {
+                var serverName = Environment.MachineName; // host name sans domain
+                var fqhn = Dns.GetHostEntry(serverName).HostName; // fully qualified hostname
+                return fqhn;
+            }
+            catch (SocketException ex)
+            {
+                logger?.LogError(ex, "GetHostName threw an error");
+            }
+
+            return "";
+        }
+
         public static EndPointCollection GetShardEndPoints(int shards, IPAddress address, int port)
         {
             EndPointCollection endPoints = [];
-            for (int i = 0; i < shards; i++)
+            for (var i = 0; i < shards; i++)
                 endPoints.Add(address, port + i);
             return endPoints;
         }


### PR DESCRIPTION
This PR fixes #1042. In hindsight, it fixes also #1036 as now users should be able to use localhost in CLUSTER MEET.
The fix probes all IP addresses returned by Dns.GetHostEntry to see which one is actively listening on the corresponding port.

This PR adds the following

- [x]  Allow support of hostnames when calling cluster meet 
- [x]  Allow for Garnet to bind to a hostname with --bind option

NOTES:

1. It seems CLUSTER MEET accepts only IP address and not hostnames
2. After Redis version 6.2, redis-cli will perform hostname resolution and issue CLUSTER MEET to a specific address, while for version 6.2 and earlier (did not test it for previous versions but I assume it holds) it will not resolve the hostname. Similarly, the redis server cannot be bound to a hostname using bind option in the configuration.
3. Currently, Garnet did not support binding on a hostname.
