### PR TITLE
Dispose GarnetClientSession in Parallel ACL SETUSER Test

### DIFF
--- a/test/Garnet.test/Resp/ACL/ParallelTests.cs
+++ b/test/Garnet.test/Resp/ACL/ParallelTests.cs
@@ -90,7 +90,7 @@ namespace Garnet.test.Resp.ACL
             // This is a combination of the two commands above indicative of threading issues.
             string inactiveUserWithGet = $"user {TestUserA} off #{DummyPasswordHash} +get";
 
-            var c = TestUtils.GetGarnetClientSession();
+            using var c = TestUtils.GetGarnetClientSession();
             c.Connect();
             _ = await c.ExecuteAsync(activeUserWithGetCommand.Split(" "));
 


### PR DESCRIPTION
In the `ParallelTests#ParallelAclSetUser` test one of the `GarnetClientSession`s was not being disposed of properly. This pull request adds the `using` statement to properly dispose of the client.