### PR TITLE
Less annoying lightClient request builder

### DIFF
--- a/libs/common/LightClientRequest.cs
+++ b/libs/common/LightClientRequest.cs
@@ -202,7 +202,20 @@ namespace Garnet.common
                 {
                     sb = sb.Append(to - tokenStart - hadEscapedChar);
                     sb = sb.Append("\r\n");
-                    sb = sb.Append(cmd[tokenStart..to].Replace("\\", ""));
+
+                    for (var j = tokenStart; j < to; ++j)
+                    {
+                        if (escapedChar)
+                        {
+                            escapedChar = false;
+                        }
+                        else if (cmd[j] == '\\')
+                        {
+                            escapedChar = true;
+                            continue;
+                        }
+                        sb = sb.Append(cmd[j]);
+                    }
                     hadEscapedChar = 0;
                 }
                 sb = sb.Append("\r\n");

--- a/test/Garnet.test/RespSetTest.cs
+++ b/test/Garnet.test/RespSetTest.cs
@@ -782,17 +782,17 @@ namespace Garnet.test
         public void CanAddAndListMembersLC()
         {
             using var lightClientRequest = TestUtils.CreateRequest();
-            var response = lightClientRequest.SendCommand("SADD myset \"Hello\"");
+            var response = lightClientRequest.SendCommand(@"SADD myset \""Hello\""");
             var expectedResponse = ":1\r\n";
             var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
             ClassicAssert.AreEqual(expectedResponse, strResponse);
 
-            response = lightClientRequest.SendCommand("SADD myset \"World\"");
+            response = lightClientRequest.SendCommand(@"SADD myset \""World\""");
             strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
             ClassicAssert.AreEqual(expectedResponse, strResponse);
 
             expectedResponse = ":0\r\n";
-            response = lightClientRequest.SendCommand("SADD myset \"World\"");
+            response = lightClientRequest.SendCommand(@"SADD myset \""World\""");
             strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
             ClassicAssert.AreEqual(expectedResponse, strResponse);
 
@@ -1345,7 +1345,7 @@ namespace Garnet.test
         [TestCase("key")]
         public void CanDoSdiffStoreLC(string key)
         {
-            var lightClientRequest = TestUtils.CreateRequest();
+            var lightClientRequest = TestUtils.CreateRequest(extraWhiteSpaceIsEmptyParameter: true);
             _ = lightClientRequest.SendCommand("SADD key1 a b c d");
             _ = lightClientRequest.SendCommand("SADD key2 c");
             _ = lightClientRequest.SendCommand("SADD key3 a c e");

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -746,7 +746,10 @@ namespace Garnet.test
             return new GarnetClientSession(EndPoint, new(), tlsOptions: sslOptions);
         }
 
-        public static LightClientRequest CreateRequest(LightClient.OnResponseDelegateUnsafe onReceive = null, bool useTLS = false, CountResponseType countResponseType = CountResponseType.Tokens)
+        public static LightClientRequest CreateRequest(LightClient.OnResponseDelegateUnsafe onReceive = null,
+                                                       bool useTLS = false,
+                                                       CountResponseType countResponseType = CountResponseType.Tokens,
+                                                       bool extraWhiteSpaceIsEmptyParameter = false)
         {
             SslClientAuthenticationOptions sslOptions = null;
             if (useTLS)
@@ -759,7 +762,10 @@ namespace Garnet.test
                     RemoteCertificateValidationCallback = ValidateServerCertificate,
                 };
             }
-            return new LightClientRequest(EndPoint, 0, onReceive, sslOptions, countResponseType);
+
+            return new LightClientRequest(EndPoint, 0, onReceive,
+                                          sslOptions, countResponseType,
+                                          extraWhiteSpaceIsEmptyParameter);
         }
 
         public static string GetHostName(ILogger logger = null)


### PR DESCRIPTION
Lightclient does very naive parsing, which is reasonable except it does things like 'interpret extra spaces as an empty argument'. For example, accidentally trying to send 

```
GET  a
``` 
 sends '*3$3GET$0$1a' which is unexpected.

This PR teaches lightClientRequest to do slightly less naive parsing, so extra spaces don't usually turn into empty arguments. While at it, teach it a bit of quotes and escaping. Quotes are useful to be able to do 'get "A B"' (sends '*2$3GET$3A B').

There was a test actually depending on the empty argument behaviour so I left an option to enable it.