### PR TITLE
Fix Single Threaded Client Usage Issues in Parallel ACL SETUSER Tests

### DIFF
--- a/test/Garnet.test/Resp/ACL/ParallelTests.cs
+++ b/test/Garnet.test/Resp/ACL/ParallelTests.cs
@@ -74,8 +74,8 @@ namespace Garnet.test.Resp.ACL
         /// <summary>
         /// Tests that ACL SETUSER works in parallel without corrupting the user's ACL.
         ///
-        /// Test launches multiple clients that apply two simple ACL changes to the same user many times in parallel.
-        /// Validates that ACL result after each execution is one of the possible valid responses.
+        /// Test launches multiple single-threaded clients that apply two simple ACL changes to the same user many times
+        /// in parallel. Validates that ACL result after each execution is one of the possible valid responses.
         ///
         /// Race conditions are not deterministic so test uses repeat.
         ///
@@ -90,6 +90,7 @@ namespace Garnet.test.Resp.ACL
             // This is a combination of the two commands above indicative of threading issues.
             string inactiveUserWithGet = $"user {TestUserA} off #{DummyPasswordHash} +get";
 
+            // Use client with support for single thread.
             using var c = TestUtils.GetGarnetClientSession();
             c.Connect();
             _ = await c.ExecuteAsync(activeUserWithGetCommand.Split(" "));
@@ -101,9 +102,8 @@ namespace Garnet.test.Resp.ACL
 
                 for (uint i = 0; i < iterationsPerSession; i++)
                 {
-                    await Task.WhenAll(
-                        c.ExecuteAsync(activeUserWithGetCommand.Split(" ")),
-                        c.ExecuteAsync(inactiveUserWithoutGetCommand.Split(" ")));
+                    await c.ExecuteAsync(activeUserWithGetCommand.Split(" "));
+                    await c.ExecuteAsync(inactiveUserWithoutGetCommand.Split(" "));
 
                     var aclListResponse = await c.ExecuteForArrayAsync("ACL", "LIST");
 
@@ -119,8 +119,9 @@ namespace Garnet.test.Resp.ACL
         /// <summary>
         /// Tests that ACL SETUSER works in parallel without fatal contention on user in ACL map.
         ///
-        /// Test launches multiple clients that apply the same ACL change to the same user. Creates race to become the
-        /// the first client to add the user to the ACL. Throws after initial insert into ACL if threading issues exist.
+        /// Test uses a multi-threaded client that applies the same ACL change to the same user. Creates race to
+        /// become the first command invocation to add the user to the ACL. Throws after initial insert into ACL if
+        /// threading issues exist.
         ///
         /// Race conditions are not deterministic so test uses repeat.
         ///
@@ -129,18 +130,17 @@ namespace Garnet.test.Resp.ACL
         [Repeat(5)]
         public async Task ParallelAclSetUserAvoidsMapContentionTest(int degreeOfParallelism, int iterationsPerSession)
         {
-            string command1 = $"ACL SETUSER {TestUserA} on >{DummyPassword}";
-
             await Parallel.ForAsync(0, degreeOfParallelism, async (t, state) =>
             {
-                using var c = TestUtils.GetGarnetClientSession();
+                // Use client with multi-threaded support.
+                using var c = TestUtils.GetGarnetClient();
                 c.Connect();
 
                 List<Task> tasks = new();
                 for (uint i = 0; i < iterationsPerSession; i++)
                 {
                     // Creates race between threads contending for first insert into ACL. Throws after first ACL insert.
-                    tasks.Add(c.ExecuteAsync(command1.Split(" ")));
+                    tasks.Add(c.ExecuteForStringResultAsync("ACL", ["SETUSER", $"{TestUserA}", "on", $">{DummyPassword}"]));
                 }
 
                 await Task.WhenAll(tasks);

--- a/test/Garnet.test/Resp/ACL/ParallelTests.cs
+++ b/test/Garnet.test/Resp/ACL/ParallelTests.cs
@@ -119,8 +119,8 @@ namespace Garnet.test.Resp.ACL
         /// <summary>
         /// Tests that ACL SETUSER works in parallel without fatal contention on user in ACL map.
         ///
-        /// Test launches multiple clients that apply the same ACL change to the same user. Creates race to become the
-        /// the first client to add the user to the ACL. Throws after initial insert into ACL if threading issues exist.
+        /// Test launches multiple single-threaded clients that apply the same ACL change to the same user. Creates race
+        /// to become the first client to add the user to the ACL. Throws after initial insert into ACL if threading issues exist.
         ///
         /// Race conditions are not deterministic so test uses repeat.
         ///
@@ -133,7 +133,7 @@ namespace Garnet.test.Resp.ACL
 
             await Parallel.ForAsync(0, degreeOfParallelism, async (t, state) =>
             {
-                // Use client with multi-threaded support.
+                // Use client with support for single thread.
                 using var c = TestUtils.GetGarnetClientSession();
                 c.Connect();
                 await c.ExecuteAsync(setUserCommand.Split(" "));


### PR DESCRIPTION
# Summary
The `ParallelTests#ParallelAclSetUserTest` and `ParallelTests#ParallelAclSetUserAvoidsMapContentionTest` have issues surrounding the client selected for the test and how the client is used within the test. This misuse can lead to sporadic thread safety and memory access violation issues when executing tests.

## ParallelAclSetUserTest

The `ParallelAclSetUserTest` uses the single threaded `GarnetClientSession`, however it launches concurrent tasks using `Task.WhenAll`. This violates the contract of the single threaded client causing sporadic issues with the test. To fix this problem unnecessary usage of `Task.WhenAll` was removed and each individual async command executed by the client was awaited.

## ParallelAclSetUserAvoidsMapContentionTest

The `ParallelAclSetUserAvoidsMapContentionTest` uses the single threaded `GarnetClientSession` to start many tasks concurrently using `Task.WhenAll`. The goal is to create a close race between the first successful task and the runner up, causing contention on the ACL map. However, it launches the concurrent tasks using `Task.WhenAll`, violating the contract of the ingle threaded client. To fix this problem, the test was updated to use the `GarnetClient`, which has support for multiple threads.
