### PR TITLE
Fix Checkpoint Version Shift for Diskless Replication

### DIFF
--- a/libs/cluster/Server/Replication/PrimaryOps/DisklessReplication/ReplicationSnapshotIterator.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/DisklessReplication/ReplicationSnapshotIterator.cs
@@ -26,7 +26,6 @@ namespace Garnet.cluster
         long currentFlushEventCount = 0;
         long lastFlushEventCount = 0;
 
-
         public long CheckpointCoveredAddress { get; private set; }
 
         public SnapshotIteratorManager(ReplicationSyncManager replicationSyncManager, CancellationToken cancellationToken, ILogger logger = null)
@@ -194,6 +193,10 @@ namespace Garnet.cluster
 
             // Wait for flush and response to complete
             replicationSyncManager.WaitForFlush().GetAwaiter().GetResult();
+
+            // Enqueue commit end marker
+            var entryType = isMainStore ? AofEntryType.MainStoreStreamingCheckpointEndCommit : AofEntryType.ObjectStoreStreamingCheckpointEndCommit;
+            replicationSyncManager.ClusterProvider.storeWrapper.EnqueueCommit(entryType, targetVersion);
 
             logger?.LogTrace("{OnStop} {store} {numberOfRecords} {targetVersion}",
                 nameof(OnStop), isMainStore ? "MAIN STORE" : "OBJECT STORE", numberOfRecords, targetVersion);

--- a/libs/cluster/Server/Replication/PrimaryOps/DisklessReplication/ReplicationSnapshotIterator.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/DisklessReplication/ReplicationSnapshotIterator.cs
@@ -195,9 +195,6 @@ namespace Garnet.cluster
             // Wait for flush and response to complete
             replicationSyncManager.WaitForFlush().GetAwaiter().GetResult();
 
-            // Enqueue version change commit
-            replicationSyncManager.ClusterProvider.storeWrapper.EnqueueCommit(isMainStore, targetVersion);
-
             logger?.LogTrace("{OnStop} {store} {numberOfRecords} {targetVersion}",
                 nameof(OnStop), isMainStore ? "MAIN STORE" : "OBJECT STORE", numberOfRecords, targetVersion);
 

--- a/libs/cluster/Server/Replication/ReplicationManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationManager.cs
@@ -156,7 +156,7 @@ namespace Garnet.cluster
         {
             if (clusterProvider.clusterManager.CurrentConfig.LocalNodeRole == NodeRole.REPLICA)
                 return;
-            storeWrapper.EnqueueCommit(isMainStore, newVersion, streaming: true);
+            storeWrapper.EnqueueCommit(isMainStore, newVersion, streaming: clusterProvider.serverOptions.ReplicaDisklessSync);
         }
 
         /// <summary>

--- a/libs/cluster/Server/Replication/ReplicationManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationManager.cs
@@ -156,7 +156,10 @@ namespace Garnet.cluster
         {
             if (clusterProvider.clusterManager.CurrentConfig.LocalNodeRole == NodeRole.REPLICA)
                 return;
-            storeWrapper.EnqueueCommit(isMainStore, newVersion, diskless: clusterProvider.serverOptions.ReplicaDisklessSync);
+            var entryType = clusterProvider.serverOptions.ReplicaDisklessSync ?
+                (isMainStore ? AofEntryType.MainStoreStreamingCheckpointStartCommit : AofEntryType.ObjectStoreStreamingCheckpointStartCommit) :
+                (isMainStore ? AofEntryType.MainStoreCheckpointStartCommit : AofEntryType.ObjectStoreCheckpointStartCommit);
+            storeWrapper.EnqueueCommit(entryType, newVersion);
         }
 
         /// <summary>

--- a/libs/cluster/Server/Replication/ReplicationManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationManager.cs
@@ -156,7 +156,7 @@ namespace Garnet.cluster
         {
             if (clusterProvider.clusterManager.CurrentConfig.LocalNodeRole == NodeRole.REPLICA)
                 return;
-            storeWrapper.EnqueueCommit(isMainStore, newVersion, streaming: clusterProvider.serverOptions.ReplicaDisklessSync);
+            storeWrapper.EnqueueCommit(isMainStore, newVersion, diskless: clusterProvider.serverOptions.ReplicaDisklessSync);
         }
 
         /// <summary>

--- a/libs/server/AOF/AofEntryType.cs
+++ b/libs/server/AOF/AofEntryType.cs
@@ -3,21 +3,79 @@
 
 namespace Garnet.server
 {
-    enum AofEntryType : byte
+    public enum AofEntryType : byte
     {
+        /// <summary>
+        /// Store upsert
+        /// </summary>
         StoreUpsert = 0x00,
+        /// <summary>
+        /// Store RMW
+        /// </summary>
         StoreRMW = 0x01,
+        /// <summary>
+        /// Store delete
+        /// </summary>
         StoreDelete = 0x02,
+        /// <summary>
+        /// Object store upsert
+        /// </summary>
         ObjectStoreUpsert = 0x10,
+        /// <summary>
+        /// Object store RMW
+        /// </summary>
         ObjectStoreRMW = 0x11,
+        /// <summary>
+        /// Object store delete
+        /// </summary>
         ObjectStoreDelete = 0x12,
+        /// <summary>
+        /// Transaction start
+        /// </summary>
         TxnStart = 0x20,
+        /// <summary>
+        /// Transaction commit
+        /// </summary>
         TxnCommit = 0x21,
+        /// <summary>
+        /// Transaction abort
+        /// </summary>
         TxnAbort = 0x22,
+        /// <summary>
+        /// Checkpoint for main store start
+        /// </summary>
         MainStoreCheckpointStartCommit = 0x30,
+        /// <summary>
+        /// Checkpoint for object store start
+        /// </summary>
         ObjectStoreCheckpointStartCommit = 0x31,
+        /// <summary>
+        /// Checkpoint for main store end
+        /// </summary>
+        MainStoreCheckpointEndCommit = 0x32,
+        /// <summary>
+        /// Checkpoint for object store end
+        /// </summary>
+        ObjectStoreCheckpointEndCommit = 0x33,
+        /// <summary>
+        /// Streaming checkpoint for main store start
+        /// </summary>
         MainStoreStreamingCheckpointStartCommit = 0x40,
+        /// <summary>
+        /// Streaming checkpoint for object store start
+        /// </summary>
         ObjectStoreStreamingCheckpointStartCommit = 0x41,
+        /// <summary>
+        /// Streaming checkpoint for main store end
+        /// </summary>
+        MainStoreStreamingCheckpointEndCommit = 0x42,
+        /// <summary>
+        /// Streaming checkpoint for object store end
+        /// </summary>
+        ObjectStoreStreamingCheckpointEndCommit = 0x43,
+        /// <summary>
+        /// StoredProcedure
+        /// </summary>
         StoredProcedure = 0x50,
     }
 

--- a/libs/server/AOF/AofEntryType.cs
+++ b/libs/server/AOF/AofEntryType.cs
@@ -14,10 +14,10 @@ namespace Garnet.server
         TxnStart = 0x20,
         TxnCommit = 0x21,
         TxnAbort = 0x22,
-        MainStoreCheckpointCommit = 0x30,
-        ObjectStoreCheckpointCommit = 0x31,
-        MainStoreStreamingCheckpointCommit = 0x40,
-        ObjectStoreStreamingCheckpointCommit = 0x41,
+        MainStoreCheckpointStartCommit = 0x30,
+        ObjectStoreCheckpointStartCommit = 0x31,
+        MainStoreStreamingCheckpointStartCommit = 0x40,
+        ObjectStoreStreamingCheckpointStartCommit = 0x41,
         StoredProcedure = 0x50,
     }
 

--- a/libs/server/AOF/AofProcessor.cs
+++ b/libs/server/AOF/AofProcessor.cs
@@ -200,7 +200,7 @@ namespace Garnet.server
             switch (header.opType)
             {
                 case AofEntryType.TxnStart:
-                    inflightTxns[header.sessionID] = new List<byte[]>();
+                    inflightTxns[header.sessionID] = [];
                     break;
                 case AofEntryType.TxnAbort:
                 case AofEntryType.TxnCommit:
@@ -209,32 +209,31 @@ namespace Garnet.server
                     // be ignored.
                     break;
                 case AofEntryType.MainStoreCheckpointStartCommit:
-                    if (asReplica)
-                    {
-                        if (header.storeVersion > storeWrapper.store.CurrentVersion)
-                        {
-                            storeWrapper.TakeCheckpoint(false, StoreType.Main, logger);
-                        }
-                    }
+                    if (asReplica && header.storeVersion > storeWrapper.store.CurrentVersion)
+                        _ = storeWrapper.TakeCheckpoint(false, StoreType.Main, logger);
                     break;
                 case AofEntryType.ObjectStoreCheckpointStartCommit:
-                    if (asReplica)
-                    {
-                        if (header.storeVersion > storeWrapper.objectStore.CurrentVersion)
-                        {
-                            storeWrapper.TakeCheckpoint(false, StoreType.Object, logger);
-                        }
-                    }
+                    if (asReplica && header.storeVersion > storeWrapper.objectStore.CurrentVersion)
+                        _ = storeWrapper.TakeCheckpoint(false, StoreType.Object, logger);
+                    break;
+                case AofEntryType.MainStoreCheckpointEndCommit:
+                case AofEntryType.ObjectStoreCheckpointEndCommit:
                     break;
                 case AofEntryType.MainStoreStreamingCheckpointStartCommit:
                     Debug.Assert(storeWrapper.serverOptions.ReplicaDisklessSync);
-                    if (header.storeVersion > storeWrapper.store.CurrentVersion)
+                    if (asReplica && header.storeVersion > storeWrapper.store.CurrentVersion)
                         storeWrapper.store.SetVersion(header.storeVersion);
+                    break;
+                case AofEntryType.MainStoreStreamingCheckpointEndCommit:
+                    Debug.Assert(storeWrapper.serverOptions.ReplicaDisklessSync);
                     break;
                 case AofEntryType.ObjectStoreStreamingCheckpointStartCommit:
                     Debug.Assert(storeWrapper.serverOptions.ReplicaDisklessSync);
-                    if (header.storeVersion > storeWrapper.store.CurrentVersion)
+                    if (asReplica && header.storeVersion > storeWrapper.store.CurrentVersion)
                         storeWrapper.objectStore.SetVersion(header.storeVersion);
+                    break;
+                case AofEntryType.ObjectStoreStreamingCheckpointEndCommit:
+                    Debug.Assert(storeWrapper.serverOptions.ReplicaDisklessSync);
                     break;
                 default:
                     ReplayOp(ptr);
@@ -423,7 +422,8 @@ namespace Garnet.server
                 AofEntryType.StoreUpsert or AofEntryType.StoreRMW or AofEntryType.StoreDelete => AofStoreType.MainStoreType,
                 AofEntryType.ObjectStoreUpsert or AofEntryType.ObjectStoreRMW or AofEntryType.ObjectStoreDelete => AofStoreType.ObjectStoreType,
                 AofEntryType.TxnStart or AofEntryType.TxnCommit or AofEntryType.TxnAbort or AofEntryType.StoredProcedure => AofStoreType.TxnType,
-                AofEntryType.MainStoreCheckpointStartCommit or AofEntryType.ObjectStoreCheckpointStartCommit => AofStoreType.CheckpointType,
+                AofEntryType.MainStoreCheckpointStartCommit or AofEntryType.ObjectStoreCheckpointStartCommit or AofEntryType.MainStoreStreamingCheckpointStartCommit or AofEntryType.ObjectStoreStreamingCheckpointStartCommit => AofStoreType.CheckpointType,
+                AofEntryType.MainStoreCheckpointEndCommit or AofEntryType.ObjectStoreCheckpointEndCommit or AofEntryType.MainStoreStreamingCheckpointEndCommit or AofEntryType.ObjectStoreStreamingCheckpointEndCommit => AofStoreType.CheckpointType,
                 _ => throw new GarnetException($"Conversion to AofStoreType not possible for {type}"),
             };
         }

--- a/libs/server/AOF/AofProcessor.cs
+++ b/libs/server/AOF/AofProcessor.cs
@@ -208,7 +208,7 @@ namespace Garnet.server
                     // after a checkpoint, and the transaction belonged to the previous version. It can safely
                     // be ignored.
                     break;
-                case AofEntryType.MainStoreCheckpointCommit:
+                case AofEntryType.MainStoreCheckpointStartCommit:
                     if (asReplica)
                     {
                         if (header.storeVersion > storeWrapper.store.CurrentVersion)
@@ -217,7 +217,7 @@ namespace Garnet.server
                         }
                     }
                     break;
-                case AofEntryType.ObjectStoreCheckpointCommit:
+                case AofEntryType.ObjectStoreCheckpointStartCommit:
                     if (asReplica)
                     {
                         if (header.storeVersion > storeWrapper.objectStore.CurrentVersion)
@@ -226,12 +226,12 @@ namespace Garnet.server
                         }
                     }
                     break;
-                case AofEntryType.MainStoreStreamingCheckpointCommit:
+                case AofEntryType.MainStoreStreamingCheckpointStartCommit:
                     Debug.Assert(storeWrapper.serverOptions.ReplicaDisklessSync);
                     if (header.storeVersion > storeWrapper.store.CurrentVersion)
                         storeWrapper.store.SetVersion(header.storeVersion);
                     break;
-                case AofEntryType.ObjectStoreStreamingCheckpointCommit:
+                case AofEntryType.ObjectStoreStreamingCheckpointStartCommit:
                     Debug.Assert(storeWrapper.serverOptions.ReplicaDisklessSync);
                     if (header.storeVersion > storeWrapper.store.CurrentVersion)
                         storeWrapper.objectStore.SetVersion(header.storeVersion);
@@ -423,7 +423,7 @@ namespace Garnet.server
                 AofEntryType.StoreUpsert or AofEntryType.StoreRMW or AofEntryType.StoreDelete => AofStoreType.MainStoreType,
                 AofEntryType.ObjectStoreUpsert or AofEntryType.ObjectStoreRMW or AofEntryType.ObjectStoreDelete => AofStoreType.ObjectStoreType,
                 AofEntryType.TxnStart or AofEntryType.TxnCommit or AofEntryType.TxnAbort or AofEntryType.StoredProcedure => AofStoreType.TxnType,
-                AofEntryType.MainStoreCheckpointCommit or AofEntryType.ObjectStoreCheckpointCommit => AofStoreType.CheckpointType,
+                AofEntryType.MainStoreCheckpointStartCommit or AofEntryType.ObjectStoreCheckpointStartCommit => AofStoreType.CheckpointType,
                 _ => throw new GarnetException($"Conversion to AofStoreType not possible for {type}"),
             };
         }

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -506,7 +506,7 @@ namespace Garnet.server
 
             AofHeader header = new()
             {
-                opType = isMainStore ? AofEntryType.MainStoreCheckpointCommit : AofEntryType.ObjectStoreCheckpointCommit,
+                opType = opType,
                 storeVersion = version,
                 sessionID = -1
             };

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -501,8 +501,8 @@ namespace Garnet.server
         public void EnqueueCommit(bool isMainStore, long version, bool streaming = false)
         {
             var opType = streaming ?
-                isMainStore ? AofEntryType.MainStoreStreamingCheckpointCommit : AofEntryType.ObjectStoreStreamingCheckpointCommit :
-                isMainStore ? AofEntryType.MainStoreCheckpointCommit : AofEntryType.ObjectStoreCheckpointCommit;
+                (isMainStore ? AofEntryType.MainStoreStreamingCheckpointCommit : AofEntryType.ObjectStoreStreamingCheckpointCommit) :
+                (isMainStore ? AofEntryType.MainStoreCheckpointCommit : AofEntryType.ObjectStoreCheckpointCommit);
 
             AofHeader header = new()
             {

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -497,10 +497,10 @@ namespace Garnet.server
         /// </summary>
         /// <param name="isMainStore"></param>
         /// <param name="version"></param>
-        /// <param name="streaming"></param>
-        public void EnqueueCommit(bool isMainStore, long version, bool streaming = false)
+        /// <param name="diskless"></param>
+        public void EnqueueCommit(bool isMainStore, long version, bool diskless)
         {
-            var opType = streaming ?
+            var opType = diskless ?
                 (isMainStore ? AofEntryType.MainStoreStreamingCheckpointCommit : AofEntryType.ObjectStoreStreamingCheckpointCommit) :
                 (isMainStore ? AofEntryType.MainStoreCheckpointCommit : AofEntryType.ObjectStoreCheckpointCommit);
 

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -495,18 +495,13 @@ namespace Garnet.server
         /// <summary>
         /// Append a checkpoint commit to the AOF
         /// </summary>
-        /// <param name="isMainStore"></param>
+        /// <param name="entryType"></param>
         /// <param name="version"></param>
-        /// <param name="diskless"></param>
-        public void EnqueueCommit(bool isMainStore, long version, bool diskless)
+        public void EnqueueCommit(AofEntryType entryType, long version)
         {
-            var opType = diskless ?
-                (isMainStore ? AofEntryType.MainStoreStreamingCheckpointStartCommit : AofEntryType.ObjectStoreStreamingCheckpointStartCommit) :
-                (isMainStore ? AofEntryType.MainStoreCheckpointStartCommit : AofEntryType.ObjectStoreCheckpointStartCommit);
-
             AofHeader header = new()
             {
-                opType = opType,
+                opType = entryType,
                 storeVersion = version,
                 sessionID = -1
             };
@@ -849,18 +844,30 @@ namespace Garnet.server
             if (full)
             {
                 if (storeType is StoreType.Main or StoreType.All)
+                {
                     storeCheckpointResult = await store.TakeFullCheckpointAsync(checkpointType);
+                    if (clusterProvider.IsPrimary()) EnqueueCommit(AofEntryType.MainStoreCheckpointEndCommit, store.CurrentVersion);
+                }
 
                 if (objectStore != null && (storeType == StoreType.Object || storeType == StoreType.All))
+                {
                     objectStoreCheckpointResult = await objectStore.TakeFullCheckpointAsync(checkpointType);
+                    if (clusterProvider.IsPrimary()) EnqueueCommit(AofEntryType.ObjectStoreCheckpointEndCommit, objectStore.CurrentVersion);
+                }
             }
             else
             {
                 if (storeType is StoreType.Main or StoreType.All)
+                {
                     storeCheckpointResult = await store.TakeHybridLogCheckpointAsync(checkpointType, tryIncremental);
+                    if (clusterProvider.IsPrimary()) EnqueueCommit(AofEntryType.MainStoreCheckpointEndCommit, store.CurrentVersion);
+                }
 
                 if (objectStore != null && (storeType == StoreType.Object || storeType == StoreType.All))
+                {
                     objectStoreCheckpointResult = await objectStore.TakeHybridLogCheckpointAsync(checkpointType, tryIncremental);
+                    if (clusterProvider.IsPrimary()) EnqueueCommit(AofEntryType.ObjectStoreCheckpointEndCommit, objectStore.CurrentVersion);
+                }
             }
 
             // If cluster is enabled the replication manager is responsible for truncating AOF

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -846,13 +846,13 @@ namespace Garnet.server
                 if (storeType is StoreType.Main or StoreType.All)
                 {
                     storeCheckpointResult = await store.TakeFullCheckpointAsync(checkpointType);
-                    if (clusterProvider.IsPrimary()) EnqueueCommit(AofEntryType.MainStoreCheckpointEndCommit, store.CurrentVersion);
+                    if (serverOptions.EnableCluster && clusterProvider.IsPrimary()) EnqueueCommit(AofEntryType.MainStoreCheckpointEndCommit, store.CurrentVersion);
                 }
 
                 if (objectStore != null && (storeType == StoreType.Object || storeType == StoreType.All))
                 {
                     objectStoreCheckpointResult = await objectStore.TakeFullCheckpointAsync(checkpointType);
-                    if (clusterProvider.IsPrimary()) EnqueueCommit(AofEntryType.ObjectStoreCheckpointEndCommit, objectStore.CurrentVersion);
+                    if (serverOptions.EnableCluster && clusterProvider.IsPrimary()) EnqueueCommit(AofEntryType.ObjectStoreCheckpointEndCommit, objectStore.CurrentVersion);
                 }
             }
             else
@@ -860,13 +860,13 @@ namespace Garnet.server
                 if (storeType is StoreType.Main or StoreType.All)
                 {
                     storeCheckpointResult = await store.TakeHybridLogCheckpointAsync(checkpointType, tryIncremental);
-                    if (clusterProvider.IsPrimary()) EnqueueCommit(AofEntryType.MainStoreCheckpointEndCommit, store.CurrentVersion);
+                    if (serverOptions.EnableCluster && clusterProvider.IsPrimary()) EnqueueCommit(AofEntryType.MainStoreCheckpointEndCommit, store.CurrentVersion);
                 }
 
                 if (objectStore != null && (storeType == StoreType.Object || storeType == StoreType.All))
                 {
                     objectStoreCheckpointResult = await objectStore.TakeHybridLogCheckpointAsync(checkpointType, tryIncremental);
-                    if (clusterProvider.IsPrimary()) EnqueueCommit(AofEntryType.ObjectStoreCheckpointEndCommit, objectStore.CurrentVersion);
+                    if (serverOptions.EnableCluster && clusterProvider.IsPrimary()) EnqueueCommit(AofEntryType.ObjectStoreCheckpointEndCommit, objectStore.CurrentVersion);
                 }
             }
 

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -501,8 +501,8 @@ namespace Garnet.server
         public void EnqueueCommit(bool isMainStore, long version, bool diskless)
         {
             var opType = diskless ?
-                (isMainStore ? AofEntryType.MainStoreStreamingCheckpointCommit : AofEntryType.ObjectStoreStreamingCheckpointCommit) :
-                (isMainStore ? AofEntryType.MainStoreCheckpointCommit : AofEntryType.ObjectStoreCheckpointCommit);
+                (isMainStore ? AofEntryType.MainStoreStreamingCheckpointStartCommit : AofEntryType.ObjectStoreStreamingCheckpointStartCommit) :
+                (isMainStore ? AofEntryType.MainStoreCheckpointStartCommit : AofEntryType.ObjectStoreCheckpointStartCommit);
 
             AofHeader header = new()
             {


### PR DESCRIPTION
This PR fixes a bug related to enqueuing a checkpoint version shift marker when Diskless Replication is enabled