### PR TITLE
fix overflow based error from long to int casting

### DIFF
--- a/libs/storage/Tsavorite/cs/src/core/Allocator/MallocFixedPageSize.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/MallocFixedPageSize.cs
@@ -468,9 +468,9 @@ namespace Tsavorite.core
                 Allocate();
             }
 
-            int numRecords = (int)numBytesToRead / RecordSize;
-            int recordsCountInLastLevel = numRecords & PageSizeMask;
-            int numCompleteLevels = numRecords >> PageSizeBits;
+            ulong numRecords = numBytesToRead / (ulong)RecordSize;
+            int recordsCountInLastLevel = checked((int)numRecords) & PageSizeMask;
+            int numCompleteLevels = checked((int)(numRecords >> PageSizeBits));
             int numLevels = numCompleteLevels + (recordsCountInLastLevel > 0 ? 1 : 0);
 
             recoveryCountdown = new CountdownWrapper(numLevels, isAsync);

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/MallocFixedPageSize.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/MallocFixedPageSize.cs
@@ -468,9 +468,9 @@ namespace Tsavorite.core
                 Allocate();
             }
 
-            ulong numRecords = numBytesToRead / (ulong)RecordSize;
-            int recordsCountInLastLevel = checked((int)numRecords) & PageSizeMask;
-            int numCompleteLevels = checked((int)(numRecords >> PageSizeBits));
+            int numRecords = (int)(numBytesToRead / (ulong)RecordSize);
+            int recordsCountInLastLevel = numRecords & PageSizeMask;
+            int numCompleteLevels = numRecords >> PageSizeBits;
             int numLevels = numCompleteLevels + (recordsCountInLastLevel > 0 ? 1 : 0);
 
             recoveryCountdown = new CountdownWrapper(numLevels, isAsync);


### PR DESCRIPTION
Currently ulong to int casting can result in exception in countdown wrapper because of negative numbers, this PR reorders casting after calculating so now the limit is on numRecords being more than int.MaxValue