### PR TITLE
[TestSuit] Use consistent assertion for lightClient responses.

### DIFF
--- a/test/Garnet.test/GarnetBitmapTests.cs
+++ b/test/Garnet.test/GarnetBitmapTests.cs
@@ -174,11 +174,11 @@ namespace Garnet.test
 
             var expectedResponse = ":0\r\n";
             var response = lightClientRequest.SendCommandChunks("SETBIT mykey 7 1", bytesPerSend);
-            ClassicAssert.AreEqual(response.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             expectedResponse = ":1\r\n";
             response = lightClientRequest.SendCommandChunks("GETBIT mykey 7", bytesPerSend);
-            ClassicAssert.AreEqual(response.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test, Order(5)]

--- a/test/Garnet.test/HyperLogLogTests.cs
+++ b/test/Garnet.test/HyperLogLogTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Garnet.server;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;

--- a/test/Garnet.test/HyperLogLogTests.cs
+++ b/test/Garnet.test/HyperLogLogTests.cs
@@ -203,7 +203,7 @@ namespace Garnet.test
             {
                 response = lightClientRequest.SendCommandChunks("PFADD mykey " + data[i], bytesPerSend);
                 expectedResponse = i == 0 || data[i - 1] != data[i] ? ":1\r\n" : ":0\r\n";
-                ClassicAssert.AreEqual(response.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
             }
             lightClientRequest.Dispose();
         }
@@ -222,50 +222,42 @@ namespace Garnet.test
             //1. PFADD mykey
             response = lightClientRequest.SendCommandChunks("PFADD mykey h e l l o", bytesPerSend);
             expectedResponse = ":1\r\n";
-            var actualResponse = Encoding.ASCII.GetString(response.AsSpan().Slice(0, expectedResponse.Length));
-            ClassicAssert.AreEqual(expectedResponse, actualResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //2. PFCOUNT mykey
             response = lightClientRequest.SendCommandChunks("PFCOUNT mykey", bytesPerSend);
             expectedResponse = ":4\r\n";
-            actualResponse = Encoding.ASCII.GetString(response.AsSpan().Slice(0, expectedResponse.Length));
-            ClassicAssert.AreEqual(expectedResponse, actualResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //3. PFADD mykey2
             response = lightClientRequest.SendCommandChunks("PFADD mykey2 w o r l d", bytesPerSend);
             expectedResponse = ":1\r\n";
-            actualResponse = Encoding.ASCII.GetString(response.AsSpan().Slice(0, expectedResponse.Length));
-            ClassicAssert.AreEqual(expectedResponse, actualResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //4. PFCOUNT mykey mykey2
             response = lightClientRequest.SendCommandChunks("PFCOUNT mykey mykey2", bytesPerSend);
             expectedResponse = ":7\r\n";
-            actualResponse = Encoding.ASCII.GetString(response.AsSpan().Slice(0, expectedResponse.Length));
-            ClassicAssert.AreEqual(expectedResponse, actualResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //5. PFMERGE mykey3
             response = lightClientRequest.SendCommandChunks("PFMERGE mykey3 mykey", bytesPerSend);
             expectedResponse = "+OK\r\n";
-            actualResponse = Encoding.ASCII.GetString(response.AsSpan().Slice(0, expectedResponse.Length));
-            ClassicAssert.AreEqual(expectedResponse, actualResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //6. PFCOUNT mykey3
             response = lightClientRequest.SendCommandChunks("PFCOUNT mykey3", bytesPerSend);
             expectedResponse = ":4\r\n";
-            actualResponse = Encoding.ASCII.GetString(response.AsSpan().Slice(0, expectedResponse.Length));
-            ClassicAssert.AreEqual(expectedResponse, actualResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //7. PFMERGE mykey4 mykey mykey2
             response = lightClientRequest.SendCommandChunks("PFMERGE mykey4 mykey mykey2", bytesPerSend);
             expectedResponse = "+OK\r\n";
-            actualResponse = Encoding.ASCII.GetString(response.AsSpan().Slice(0, expectedResponse.Length));
-            ClassicAssert.AreEqual(expectedResponse, actualResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //8. PFCOUNT mykey4
             response = lightClientRequest.SendCommandChunks("PFCOUNT mykey4", bytesPerSend);
             expectedResponse = ":7\r\n";
-            actualResponse = Encoding.ASCII.GetString(response.AsSpan().Slice(0, expectedResponse.Length));
-            ClassicAssert.AreEqual(expectedResponse, actualResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         private static unsafe ulong MurmurHash2x64A(byte* bString, int len, uint seed = 0)

--- a/test/Garnet.test/LuaScriptTests.cs
+++ b/test/Garnet.test/LuaScriptTests.cs
@@ -452,7 +452,8 @@ namespace Garnet.test
             var valueKey = "valueKey-";
             using var lightClientRequest = TestUtils.CreateRequest();
             var stringCmd = "*3\r\n$6\r\nSCRIPT\r\n$4\r\nLOAD\r\n$40\r\nreturn redis.call('set',KEYS[1],ARGV[1])\r\n";
-            var sha1SetScript = Encoding.ASCII.GetString(lightClientRequest.SendCommand(Encoding.ASCII.GetBytes(stringCmd), 1)).Substring(5, 40);
+            var response = lightClientRequest.SendCommand(Encoding.ASCII.GetBytes(stringCmd), 1);
+            var sha1SetScript = Encoding.ASCII.GetString(response, 5, 40);
 
             ClassicAssert.AreEqual("c686f316aaf1eb01d5a4de1b0b63cd233010e63d", sha1SetScript);
             for (var i = 0; i < 5000; i++)
@@ -460,14 +461,21 @@ namespace Garnet.test
                 var randPostFix = rnd.Next(1, 1000);
                 valueKey = $"{valueKey}{randPostFix}";
 
-                var r = lightClientRequest.SendCommand($"EVALSHA {sha1SetScript} 1 {nameKey}{randPostFix} {valueKey}", 1);
+                response = lightClientRequest.SendCommand($"EVALSHA {sha1SetScript} 1 {nameKey}{randPostFix} {valueKey}", 1);
                 // Check for error reply
-                ClassicAssert.IsTrue(r[0] != '-');
+                ClassicAssert.IsTrue(response[0] != '-');
 
-                var g = Encoding.ASCII.GetString(lightClientRequest.SendCommand($"get {nameKey}{randPostFix}", 1));
-                var fstEndOfLine = g.IndexOf('\n', StringComparison.OrdinalIgnoreCase) + 1;
-                var strKeyValue = g.Substring(fstEndOfLine, valueKey.Length);
-                ClassicAssert.IsTrue(strKeyValue == valueKey);
+                response = lightClientRequest.SendCommand($"get {nameKey}{randPostFix}", 1);
+
+                var fstEndOfLine = 0;
+                foreach (var chr in response)
+                {
+                    ++fstEndOfLine;
+                    if (chr == '\n')
+                        break;
+                }
+                var strKeyValue = Encoding.ASCII.GetString(response, fstEndOfLine, valueKey.Length);
+                ClassicAssert.AreEqual(valueKey, strKeyValue);
             }
         }
 

--- a/test/Garnet.test/Resp/ACL/SetUserTests.cs
+++ b/test/Garnet.test/Resp/ACL/SetUserTests.cs
@@ -30,10 +30,9 @@ namespace Garnet.test.Resp.ACL
             using var lightClientRequest = TestUtils.CreateRequest();
             var expectedResponse = "+default\r\n";
             var response = lightClientRequest.SendCommand("ACL WHOAMI");
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
 
             // Correctness check
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         /// <summary>

--- a/test/Garnet.test/Resp/ACL/SetUserTests.cs
+++ b/test/Garnet.test/Resp/ACL/SetUserTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;

--- a/test/Garnet.test/RespAdminCommandsTests.cs
+++ b/test/Garnet.test/RespAdminCommandsTests.cs
@@ -42,8 +42,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var expectedResponse = "+PONG\r\n";
             var response = lightClientRequest.SendCommand("PING");
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -52,8 +51,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var expectedResponse = "$5\r\nHELLO\r\n";
             var response = lightClientRequest.SendCommand("PING HELLO");
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -62,8 +60,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var expectedResponse = $"-{string.Format(CmdStrings.GenericErrWrongNumArgs, $"{nameof(RespCommand.PING)}")}\r\n";
             var response = lightClientRequest.SendCommand("PING HELLO WORLD", 1);
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -72,10 +69,8 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var expectedResponse = $"-{string.Format(CmdStrings.GenericErrWrongNumArgs, $"{nameof(RespCommand.ECHO)}")}\r\n";
             var response = lightClientRequest.SendCommand("ECHO", 1);
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
 
         [Test]
         public void EchoWithMessagesReturnErrorTest()
@@ -83,11 +78,10 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var expectedResponse = $"-{string.Format(CmdStrings.GenericErrWrongNumArgs, $"{nameof(RespCommand.ECHO)}")}\r\n";
             var response = lightClientRequest.SendCommand("ECHO HELLO WORLD", 1);
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
             response = lightClientRequest.SendCommand("ECHO HELLO WORLD WORLD2", 1);
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -96,8 +90,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var expectedResponse = "$5\r\nHELLO\r\n";
             var response = lightClientRequest.SendCommand("ECHO HELLO", 1);
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -107,10 +100,8 @@ namespace Garnet.test
             var wrongNumMessage = string.Format(CmdStrings.GenericErrWrongNumArgs, $"{nameof(RespCommand.ECHO)}");
             var expectedResponse = $"-{wrongNumMessage}\r\n$5\r\nHELLO\r\n";
             var response = lightClientRequest.SendCommands("ECHO HELLO WORLD WORLD2", "ECHO HELLO", 1, 1);
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
 
         [Test]
         public void TimeCommandTest()
@@ -119,10 +110,9 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var expectedResponse = "*2\r\n$10\r\n1626282789\r\n$6\r\n621362\r\n";
             var response = lightClientRequest.SendCommand("TIME", 3);
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
+            var actualValue = Encoding.ASCII.GetString(response, 0, expectedResponse.Length);
             ClassicAssert.AreEqual(expectedResponse.Length, actualValue.Length);
         }
-
 
         [Test]
         public void TimeWithReturnErrorTest()
@@ -130,8 +120,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var expectedResponse = $"-{string.Format(CmdStrings.GenericErrWrongNumArgs, nameof(RespCommand.TIME))}\r\n";
             var response = lightClientRequest.SendCommand("TIME HELLO");
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         #endregion

--- a/test/Garnet.test/RespAdminCommandsTests.cs
+++ b/test/Garnet.test/RespAdminCommandsTests.cs
@@ -111,7 +111,7 @@ namespace Garnet.test
             var expectedResponse = "*2\r\n$10\r\n1626282789\r\n$6\r\n621362\r\n";
             var response = lightClientRequest.SendCommand("TIME", 3);
             var actualValue = Encoding.ASCII.GetString(response, 0, expectedResponse.Length);
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+            ClassicAssert.AreEqual(expectedResponse.Length, actualValue.Length);
         }
 
         [Test]

--- a/test/Garnet.test/RespAdminCommandsTests.cs
+++ b/test/Garnet.test/RespAdminCommandsTests.cs
@@ -111,7 +111,7 @@ namespace Garnet.test
             var expectedResponse = "*2\r\n$10\r\n1626282789\r\n$6\r\n621362\r\n";
             var response = lightClientRequest.SendCommand("TIME", 3);
             var actualValue = Encoding.ASCII.GetString(response, 0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse.Length, actualValue.Length);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]

--- a/test/Garnet.test/RespBlockingCollectionTests.cs
+++ b/test/Garnet.test/RespBlockingCollectionTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Text;
 using System.Threading.Tasks;
 using Garnet.server;
 using NUnit.Framework;

--- a/test/Garnet.test/RespBlockingCollectionTests.cs
+++ b/test/Garnet.test/RespBlockingCollectionTests.cs
@@ -43,21 +43,18 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand($"LPUSH {key} {value}");
             var expectedResponse = ":1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand($"{blockingCmd} {key} 10", 3);
             expectedResponse = $"*2\r\n${key.Length}\r\n{key}\r\n${value.Length}\r\n{value}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             var blockingTask = taskFactory.StartNew(() =>
             {
                 using var lcr = TestUtils.CreateRequest();
                 var btResponse = lcr.SendCommand($"{blockingCmd} {key2} 30", 3);
                 var btExpectedResponse = $"*2\r\n${key2.Length}\r\n{key2}\r\n${value2.Length}\r\n{value2}\r\n";
-                var btActualValue = Encoding.ASCII.GetString(btResponse).Substring(0, btExpectedResponse.Length);
-                ClassicAssert.AreEqual(btExpectedResponse, btActualValue);
+                TestUtils.AssertEqualUpToExpectedLength(btExpectedResponse, btResponse);
             });
 
             var releasingTask = taskFactory.StartNew(() =>
@@ -95,31 +92,26 @@ namespace Garnet.test
 
             var response = lightClientRequest.SendCommand($"LPUSH {srcKey1} {value1}");
             var expectedResponse = ":1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand($"BLMOVE {srcKey1} {dstKey1} {OperationDirection.Right} {OperationDirection.Left} 10");
             expectedResponse = $"${value1.Length}\r\n{value1}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand($"LRANGE {srcKey1} 0 -1");
             expectedResponse = $"*0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand($"LRANGE {dstKey1} 0 -1", 2);
             expectedResponse = $"*1\r\n${value1.Length}\r\n{value1}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             var blockingTask = taskFactory.StartNew(() =>
             {
                 using var lcr = TestUtils.CreateRequest();
                 var btResponse = lcr.SendCommand($"BLMOVE {srcKey2} {dstKey2} {OperationDirection.Left} {OperationDirection.Right} 0");
                 var btExpectedResponse = $"${value2.Length}\r\n{value2}\r\n";
-                var btActualValue = Encoding.ASCII.GetString(btResponse).Substring(0, btExpectedResponse.Length);
-                ClassicAssert.AreEqual(btExpectedResponse, btActualValue);
+                TestUtils.AssertEqualUpToExpectedLength(btExpectedResponse, btResponse);
             });
 
             var releasingTask = taskFactory.StartNew(() =>
@@ -144,13 +136,11 @@ namespace Garnet.test
 
             response = lightClientRequest.SendCommand($"LRANGE {srcKey2} 0 -1");
             expectedResponse = $"*0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand($"LRANGE {dstKey2} 0 -1", 2);
             expectedResponse = $"*1\r\n${value2.Length}\r\n{value2}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -163,23 +153,20 @@ namespace Garnet.test
 
             byte[] response;
             string expectedResponse;
-            string actualValue;
 
             using var lightClientRequest = TestUtils.CreateRequest();
             for (var i = 0; i < keys.Length; i++)
             {
                 response = lightClientRequest.SendCommand($"LPUSH {keys[i]} {values[i]}");
                 expectedResponse = ":1\r\n";
-                actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-                ClassicAssert.AreEqual(expectedResponse, actualValue);
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
             }
 
             for (var i = 0; i < keys.Length; i++)
             {
                 response = lightClientRequest.SendCommand($"{blockingCmd} {string.Join(' ', keys)} 10", 3);
                 expectedResponse = $"*2\r\n${keys[i].Length}\r\n{keys[i]}\r\n${values[i].Length}\r\n{values[i]}\r\n";
-                actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-                ClassicAssert.AreEqual(expectedResponse, actualValue);
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
             }
         }
 
@@ -197,18 +184,15 @@ namespace Garnet.test
                 using var lcr = TestUtils.CreateRequest();
                 var response = lcr.SendCommands($"{blockingCmd} {key} 30", $"LPUSH {key} {value1}", 3, 1);
                 var expectedResponse = $"*2\r\n${key.Length}\r\n{key}\r\n${value2.Length}\r\n{value2}\r\n:1\r\n";
-                var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-                ClassicAssert.AreEqual(expectedResponse, actualValue);
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
                 response = lcr.SendCommand($"LLEN {key}");
                 expectedResponse = ":1\r\n";
-                actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-                ClassicAssert.AreEqual(expectedResponse, actualValue);
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
                 response = lcr.SendCommand($"LPOP {key}");
                 expectedResponse = $"${value1.Length}\r\n{value1}\r\n";
-                actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-                ClassicAssert.AreEqual(expectedResponse, actualValue);
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
             });
 
             var releasingTask = taskFactory.StartNew(() =>
@@ -246,31 +230,26 @@ namespace Garnet.test
 
             var response = lightClientRequest.SendCommand($"LPUSH {srcKey1} {value1}");
             var expectedResponse = ":1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand($"BRPOPLPUSH {srcKey1} {dstKey1} 10");
             expectedResponse = $"${value1.Length}\r\n{value1}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand($"LRANGE {srcKey1} 0 -1");
             expectedResponse = $"*0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand($"LRANGE {dstKey1} 0 -1", 2);
             expectedResponse = $"*1\r\n${value1.Length}\r\n{value1}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             var blockingTask = taskFactory.StartNew(() =>
             {
                 using var lcr = TestUtils.CreateRequest();
                 var btResponse = lcr.SendCommand($"BRPOPLPUSH {srcKey2} {dstKey2} 0");
                 var btExpectedResponse = $"${value2.Length}\r\n{value2}\r\n";
-                var btActualValue = Encoding.ASCII.GetString(btResponse).Substring(0, btExpectedResponse.Length);
-                ClassicAssert.AreEqual(btExpectedResponse, btActualValue);
+                TestUtils.AssertEqualUpToExpectedLength(btExpectedResponse, btResponse);
             });
 
             var releasingTask = taskFactory.StartNew(() =>
@@ -295,13 +274,11 @@ namespace Garnet.test
 
             response = lightClientRequest.SendCommand($"LRANGE {srcKey2} 0 -1");
             expectedResponse = $"*0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand($"LRANGE {dstKey2} 0 -1", 2);
             expectedResponse = $"*1\r\n${value2.Length}\r\n{value2}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -315,8 +292,7 @@ namespace Garnet.test
             lightClientRequest.SendCommand($"RPUSH {key} value1 value2 value3");
             var response = lightClientRequest.SendCommand($"BLMPOP 1 1 {key} {direction}");
             var expectedResponse = $"*2\r\n${key.Length}\r\n{key}\r\n*1\r\n${expectedValue.Length}\r\n{expectedValue}\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -330,8 +306,7 @@ namespace Garnet.test
             lightClientRequest.SendCommand($"RPUSH {keys[valueKeyIndex - 1]} {expectedValue}");
             var response = lightClientRequest.SendCommand($"BLMPOP 1 {keys.Length} {string.Join(" ", keys)} LEFT");
             var expectedResponse = $"*2\r\n${expectedKey.Length}\r\n{expectedKey}\r\n*1\r\n${expectedValue.Length}\r\n{expectedValue}\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -340,8 +315,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("BLMPOP 1 1 nonexistentkey LEFT");
             var expectedResponse = "$-1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -355,8 +329,7 @@ namespace Garnet.test
                 using var lcr = TestUtils.CreateRequest();
                 var response = lcr.SendCommand($"BLMPOP 30 1 {key} LEFT");
                 var expectedResponse = $"*2\r\n${key.Length}\r\n{key}\r\n*1\r\n${value.Length}\r\n{value}\r\n";
-                var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-                ClassicAssert.AreEqual(expectedResponse, actualValue);
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
             });
 
             var pushingTask = taskFactory.StartNew(() =>
@@ -382,8 +355,7 @@ namespace Garnet.test
                 using var lcr = TestUtils.CreateRequest();
                 var response = lcr.SendCommand($"BLMPOP 30 1 {key} LEFT COUNT 3");
                 var expectedResponse = $"*2\r\n${key.Length}\r\n{key}\r\n*3\r\n$6\r\nvalue1\r\n$6\r\nvalue2\r\n$6\r\nvalue3\r\n";
-                var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-                ClassicAssert.AreEqual(expectedResponse, actualValue);
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
             });
 
             var pushingTask = taskFactory.StartNew(() =>
@@ -409,8 +381,7 @@ namespace Garnet.test
             lightClientRequest.SendCommand($"ZADD {key} 1.5 value1 2.5 value2 3.5 value3");
             var response = lightClientRequest.SendCommand($"BZMPOP 1 1 {key} {mode}");
             var expectedResponse = $"*2\r\n${key.Length}\r\n{key}\r\n*1\r\n*2\r\n${expectedValue.Length}\r\n{expectedValue}\r\n${expectedScore.ToString().Length}\r\n{expectedScore}\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -424,8 +395,7 @@ namespace Garnet.test
             lightClientRequest.SendCommand($"ZADD {keys[valueKeyIndex - 1]} {expectedScore} {expectedValue}");
             var response = lightClientRequest.SendCommand($"BZMPOP 1 {keys.Length} {string.Join(" ", keys)} MIN");
             var expectedResponse = $"*2\r\n${expectedKey.Length}\r\n{expectedKey}\r\n*1\r\n*2\r\n${expectedValue.Length}\r\n{expectedValue}\r\n${expectedScore.ToString().Length}\r\n{expectedScore}\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -434,8 +404,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("BZMPOP 1 1 nonexistentkey MIN");
             var expectedResponse = "$-1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -450,8 +419,7 @@ namespace Garnet.test
                 using var lcr = TestUtils.CreateRequest();
                 var response = lcr.SendCommand($"BZMPOP 30 1 {key} MIN COUNT 2");
                 var expectedResponse = $"*2\r\n${key.Length}\r\n{key}\r\n*1\r\n*2\r\n${value.Length}\r\n{value}\r\n${score.ToString().Length}\r\n{score}\r\n";
-                var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-                ClassicAssert.AreEqual(expectedResponse, actualValue);
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
             });
 
             var pushingTask = taskFactory.StartNew(() =>
@@ -478,8 +446,7 @@ namespace Garnet.test
             lightClientRequest.SendCommand($"ZADD {key} 1.5 value1 2.5 value2 3.5 value3");
             var response = lightClientRequest.SendCommand($"{command} {key} 1");
             var expectedResponse = $"*3\r\n${key.Length}\r\n{key}\r\n${expectedValue.Length}\r\n{expectedValue}\r\n${expectedScore.ToString().Length}\r\n{expectedScore}\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -493,8 +460,7 @@ namespace Garnet.test
             lightClientRequest.SendCommand($"ZADD {keys[valueKeyIndex - 1]} {expectedScore} {expectedValue}");
             var response = lightClientRequest.SendCommand($"{command} {string.Join(" ", keys)} 1");
             var expectedResponse = $"*3\r\n${expectedKey.Length}\r\n{expectedKey}\r\n${expectedValue.Length}\r\n{expectedValue}\r\n${expectedScore.ToString().Length}\r\n{expectedScore}\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -511,8 +477,7 @@ namespace Garnet.test
                 using var lcr = TestUtils.CreateRequest();
                 var response = lcr.SendCommand($"{command} {key} 30");
                 var expectedResponse = $"*3\r\n${key.Length}\r\n{key}\r\n${value.Length}\r\n{value}\r\n${score.ToString().Length}\r\n{score}\r\n";
-                var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-                ClassicAssert.AreEqual(expectedResponse, actualValue);
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
             });
 
             var pushingTask = taskFactory.StartNew(() =>
@@ -535,8 +500,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand($"{command} nonexistentkey 1");
             var expectedResponse = "$-1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
     }
 }

--- a/test/Garnet.test/RespHashTests.cs
+++ b/test/Garnet.test/RespHashTests.cs
@@ -1332,7 +1332,7 @@ namespace Garnet.test
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // multiple get
-            var result = lightClientRequest.SendCommand("HMGET myhash field1 field2", 3);
+            response = lightClientRequest.SendCommand("HMGET myhash field1 field2", 3);
             expectedResponse = "*2\r\n$11\r\nfield1value\r\n$11\r\nfield2value\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
@@ -1378,7 +1378,7 @@ namespace Garnet.test
 
             // only update one field
             lightClientRequest.SendCommand("HSET myhash field1 field1valueupdated");
-            var result = lightClientRequest.SendCommand("HGET myhash field1");
+            response = lightClientRequest.SendCommand("HGET myhash field1");
             expectedResponse = "$18\r\nfield1valueupdated\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
@@ -1395,7 +1395,7 @@ namespace Garnet.test
             expectedResponse = ":408\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            var result = lightClientRequest.SendCommand("HDEL myhash field1");
+            response = lightClientRequest.SendCommand("HDEL myhash field1");
             expectedResponse = ":1\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
@@ -1404,7 +1404,7 @@ namespace Garnet.test
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //HDEL with nonexisting key
-            result = lightClientRequest.SendCommand("HDEL foo bar");
+            response = lightClientRequest.SendCommand("HDEL foo bar");
             expectedResponse = ":0\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
@@ -1419,7 +1419,7 @@ namespace Garnet.test
 
             //get all keys
             expectedResponse = "*8\r\n$6\r\nfield1\r\n$11\r\nfield1value\r\n$6\r\nfield2\r\n$11\r\nfield2value\r\n$6\r\nfield3\r\n$11\r\nfield3value\r\n$6\r\nfield4\r\n$11\r\nfield4value\r\n";
-            var result = lightClientRequest.SendCommand("HGETALL myhash", 9);
+            response = lightClientRequest.SendCommand("HGETALL myhash", 9);
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
@@ -1619,12 +1619,11 @@ namespace Garnet.test
         public async Task CanFailWhenUseMultiWatchTest()
         {
             var lightClientRequest = TestUtils.CreateRequest();
-            byte[] response;
 
-            string key = "myhash";
+            var key = "myhash";
 
-            response = lightClientRequest.SendCommand($"HSET {key} field1 1");
-            string expectedResponse = ":1\r\n";
+            var response = lightClientRequest.SendCommand($"HSET {key} field1 1");
+            var expectedResponse = ":1\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand($"WATCH {key}");
@@ -1677,8 +1676,8 @@ namespace Garnet.test
         private static void UpdateHashMap(string keyName)
         {
             using var lightClientRequest = TestUtils.CreateRequest();
-            byte[] response = lightClientRequest.SendCommand($"HSET {keyName} field3 3");
-            string expectedResponse = ":1\r\n";
+            var response = lightClientRequest.SendCommand($"HSET {keyName} field3 3");
+            var expectedResponse = ":1\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 

--- a/test/Garnet.test/RespHashTests.cs
+++ b/test/Garnet.test/RespHashTests.cs
@@ -1313,8 +1313,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommandChunks("HSET myhash field1 myvalue", bytesSent);
             var expectedResponse = ":1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1326,21 +1325,17 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommandChunks("HSET myhash field1 field1value field2 field2value field3 field3value field4 field4value", bytesSent);
             var expectedResponse = ":4\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("MEMORY USAGE myhash");
             expectedResponse = ":680\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // multiple get
             var result = lightClientRequest.SendCommand("HMGET myhash field1 field2", 3);
             expectedResponse = "*2\r\n$11\r\nfield1value\r\n$11\r\nfield2value\r\n";
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
 
         [Test]
         [TestCase(10)]
@@ -1351,34 +1346,26 @@ namespace Garnet.test
 
             var response = lightClientRequest.SendCommandChunks("HSET myhashone field1 field1value field2 field2value", bytesPerSend);
             var expectedResponse = ":2\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            var result = lightClientRequest.SendCommandChunks("HGET myhashone field1", bytesPerSend);
+            response = lightClientRequest.SendCommandChunks("HGET myhashone field1", bytesPerSend);
             expectedResponse = "$11\r\nfield1value\r\n";
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("HSET myhash field1 field1value field2 field2value field3 field3value field4 field4value", bytesPerSend);
             expectedResponse = ":4\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //get all keys
+            response = lightClientRequest.SendCommandChunks("HGETALL myhash", bytesPerSend, 9);
             expectedResponse = "*8\r\n$6\r\nfield1\r\n$11\r\nfield1value\r\n$6\r\nfield2\r\n$11\r\nfield2value\r\n$6\r\nfield3\r\n$11\r\nfield3value\r\n$6\r\nfield4\r\n$11\r\nfield4value\r\n";
-            result = lightClientRequest.SendCommandChunks("HGETALL myhash", bytesPerSend, 9);
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //get only keys
+            response = lightClientRequest.SendCommandChunks("HKEYS myhash", bytesPerSend, 5);
             expectedResponse = "*4\r\n$6\r\nfield1\r\n$6\r\nfield2\r\n$6\r\nfield3\r\n$6\r\nfield4\r\n";
-            result = lightClientRequest.SendCommandChunks("HKEYS myhash", bytesPerSend, 5);
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
-
-
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
 
         [Test]
         public void CanSetAndGetMultiplePairsSecondUseCaseLC()
@@ -1387,15 +1374,13 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("HSET myhash field1 field1value field2 field2value");
             var expectedResponse = ":2\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // only update one field
             lightClientRequest.SendCommand("HSET myhash field1 field1valueupdated");
             var result = lightClientRequest.SendCommand("HGET myhash field1");
             expectedResponse = "$18\r\nfield1valueupdated\r\n";
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1404,31 +1389,25 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("HSET myhash field1 field1value field2 field2value");
             var expectedResponse = ":2\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("MEMORY USAGE myhash");
             expectedResponse = ":408\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             var result = lightClientRequest.SendCommand("HDEL myhash field1");
             expectedResponse = ":1\r\n";
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("MEMORY USAGE myhash");
             expectedResponse = ":272\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //HDEL with nonexisting key
             result = lightClientRequest.SendCommand("HDEL foo bar");
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
 
         [Test]
         public void CanDoGetAllLC()
@@ -1436,13 +1415,12 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("HSET myhash field1 field1value field2 field2value field3 field3value field4 field4value");
             var expectedResponse = ":4\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
             //get all keys
             expectedResponse = "*8\r\n$6\r\nfield1\r\n$11\r\nfield1value\r\n$6\r\nfield2\r\n$11\r\nfield2value\r\n$6\r\nfield3\r\n$11\r\nfield3value\r\n$6\r\nfield4\r\n$11\r\nfield4value\r\n";
             var result = lightClientRequest.SendCommand("HGETALL myhash", 9);
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1451,32 +1429,27 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("HSET myhash field1 myvalue");
             var expectedResponse = ":1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // get an existing field
             response = lightClientRequest.SendCommand("HEXISTS myhash field1");
             expectedResponse = ":1\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // get an nonexisting field
             response = lightClientRequest.SendCommand("HEXISTS myhash field0");
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //non existing hash
             response = lightClientRequest.SendCommand("HEXISTS foo field0");
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //missing paramenters
             response = lightClientRequest.SendCommand("HEXISTS foo");
             expectedResponse = FormatWrongNumOfArgsError("HEXISTS");
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1485,38 +1458,32 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("HSET myhash field1 myvalue");
             var expectedResponse = ":1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // get an existing field
             response = lightClientRequest.SendCommand("HSTRLEN myhash field1");
             expectedResponse = ":7\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // get an nonexisting field
             response = lightClientRequest.SendCommand("HSTRLEN myhash field0");
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //non existing hash
             response = lightClientRequest.SendCommand("HSTRLEN foo field0");
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //missing paramenters
             response = lightClientRequest.SendCommand("HSTRLEN foo");
             expectedResponse = FormatWrongNumOfArgsError("HSTRLEN");
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //too many paramenters
             response = lightClientRequest.SendCommand("HSTRLEN foo field0 field1");
             expectedResponse = FormatWrongNumOfArgsError("HSTRLEN");
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1525,26 +1492,21 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("HSET myhash field1 1");
             var expectedResponse = ":1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("MEMORY USAGE myhash");
             expectedResponse = ":264\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // do hincrby
             response = lightClientRequest.SendCommand("HINCRBY myhash field1 4");
             expectedResponse = ":5\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("MEMORY USAGE myhash");
             expectedResponse = ":264\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
 
         [Test]
         public void CanDoIncrByFloatLC()
@@ -1552,44 +1514,36 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("HSET myhash field 10.50");
             var expectedResponse = ":1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("MEMORY USAGE myhash");
             expectedResponse = ":264\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("HINCRBYFLOAT myhash field 0.1");
             expectedResponse = "$4\r\n10.6\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("MEMORY USAGE myhash");
             expectedResponse = ":264\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // exponential notation
             response = lightClientRequest.SendCommand("HSET myhash field2 5.0e3");
             expectedResponse = ":1\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("MEMORY USAGE myhash");
             expectedResponse = ":392\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommands("HINCRBYFLOAT myhash field2 2.0e2", "PING HELLO");
             expectedResponse = "$4\r\n5200\r\n$5\r\nHELLO\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("MEMORY USAGE myhash");
             expectedResponse = ":392\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1598,31 +1552,26 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("HMSET coin heads obverse tails reverse edge null");
             var expectedResponse = "+OK\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Check correct case when not an integer value in COUNT parameter
             response = lightClientRequest.SendCommand("HRANDFIELD coin A WITHVALUES");
             expectedResponse = "-ERR value is not an integer or out of range.\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Check correct error message when incorrect number of parameters
             response = lightClientRequest.SendCommand("HRANDFIELD");
             expectedResponse = FormatWrongNumOfArgsError("HRANDFIELD");
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-
-            for (int i = 0; i < 3; i++)
+            for (var i = 0; i < 3; i++)
             {
                 response = lightClientRequest.SendCommand("HRANDFIELD coin 3 WITHVALUES", 7);
                 expectedResponse = "*6\r\n"; // 3 keyvalue pairs
-                actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-                ClassicAssert.AreEqual(expectedResponse, actualValue);
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
             }
 
-            for (int i = 0; i < 3; i++)
+            for (var i = 0; i < 3; i++)
             {
                 string s = Encoding.ASCII.GetString(lightClientRequest.SendCommand("HRANDFIELD coin", 1));
                 int startIndexField = s.IndexOf('\n') + 1;
@@ -1636,8 +1585,7 @@ namespace Garnet.test
             {
                 response = lightClientRequest.SendCommand("HRANDFIELD coin -5 WITHVALUES", 11);
                 expectedResponse = "*10\r\n"; // 5 keyvalue pairs
-                actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-                ClassicAssert.AreEqual(expectedResponse, actualValue);
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
             }
         }
 
@@ -1647,13 +1595,11 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("HMSET coin heads obverse tails reverse edge null");
             var expectedResponse = "+OK\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommands("HGET coin nokey", "PING", 1, 1);
             expectedResponse = "$-1\r\n+PONG\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1662,10 +1608,8 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommands("HGET foo bar", "PING", 1, 1);
             var expectedResponse = "$-1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
         #endregion
 
 
@@ -1675,68 +1619,67 @@ namespace Garnet.test
         public async Task CanFailWhenUseMultiWatchTest()
         {
             var lightClientRequest = TestUtils.CreateRequest();
-            byte[] res;
+            byte[] response;
 
             string key = "myhash";
 
-            res = lightClientRequest.SendCommand($"HSET {key} field1 1");
+            response = lightClientRequest.SendCommand($"HSET {key} field1 1");
             string expectedResponse = ":1\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand($"WATCH {key}");
+            response = lightClientRequest.SendCommand($"WATCH {key}");
             expectedResponse = "+OK\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("MULTI");
+            response = lightClientRequest.SendCommand("MULTI");
             expectedResponse = "+OK\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand($"HINCRBY {key} field1 2");
+            response = lightClientRequest.SendCommand($"HINCRBY {key} field1 2");
             expectedResponse = "+QUEUED\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             await Task.Run(() => UpdateHashMap(key));
 
-            res = lightClientRequest.SendCommand("EXEC");
+            response = lightClientRequest.SendCommand("EXEC");
             expectedResponse = "*-1";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // This sequence should work
-            res = lightClientRequest.SendCommand("MULTI");
+            response = lightClientRequest.SendCommand("MULTI");
             expectedResponse = "+OK\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand($"HSET {key} field2 2");
+            response = lightClientRequest.SendCommand($"HSET {key} field2 2");
             expectedResponse = "+QUEUED\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // This should commit
-            res = lightClientRequest.SendCommand("EXEC", 2);
+            response = lightClientRequest.SendCommand("EXEC", 2);
             expectedResponse = "*1\r\n:1\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // HMSET within MULTI/EXEC
-            res = lightClientRequest.SendCommand("MULTI");
+            response = lightClientRequest.SendCommand("MULTI");
             expectedResponse = "+OK\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand($"HMSET {key} field4 4");
+            response = lightClientRequest.SendCommand($"HMSET {key} field4 4");
             expectedResponse = "+QUEUED\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // This should commit
-            res = lightClientRequest.SendCommand("EXEC", 2);
+            response = lightClientRequest.SendCommand("EXEC", 2);
             expectedResponse = "*1\r\n+OK\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
 
         private static void UpdateHashMap(string keyName)
         {
             using var lightClientRequest = TestUtils.CreateRequest();
-            byte[] res = lightClientRequest.SendCommand($"HSET {keyName} field3 3");
+            byte[] response = lightClientRequest.SendCommand($"HSET {keyName} field3 3");
             string expectedResponse = ":1\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         #endregion
@@ -1749,8 +1692,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommands("HRANDFIELD foo -5 WITHVALUES", "PING", 1, 1);
             var expectedResponse = "*0\r\n+PONG\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1759,8 +1701,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommands("HRANDFIELD foo", "PING", 1, 1);
             var expectedResponse = "$-1\r\n+PONG\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1769,8 +1710,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommands("HVALS foo", "PING HELLO", 1, 1);
             var expectedResponse = "*0\r\n$5\r\nHELLO\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1779,8 +1719,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommands("HINCRBY foo", "PING HELLO", 1, 1);
             var expectedResponse = $"{FormatWrongNumOfArgsError("HINCRBY")}$5\r\nHELLO\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1789,8 +1728,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommands("HINCRBYFLOAT foo", "PING HELLO", 1, 1);
             var expectedResponse = $"{FormatWrongNumOfArgsError("HINCRBYFLOAT")}$5\r\nHELLO\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1799,13 +1737,11 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand($"HSET myhash int64 {1L + int.MaxValue}");
             var expectedResponse = ":1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("HINCRBY myhash int64 1");
             expectedResponse = $":{2L + int.MaxValue}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
         #endregion
 

--- a/test/Garnet.test/RespListTests.cs
+++ b/test/Garnet.test/RespListTests.cs
@@ -851,13 +851,11 @@ namespace Garnet.test
 
             var response = lightClientRequest.SendCommands("LRANGE mylist 0 -1", "PING", 4, 1);
             var expectedResponse = "*3\r\n$5\r\nHello\r\n$3\r\nfoo\r\n$3\r\nbar\r\n+PONG\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommands("LRANGE mylist 5 10", "PING", 1, 1);
             expectedResponse = "*0\r\n+PONG\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -867,8 +865,7 @@ namespace Garnet.test
             var response = lightClientRequest.SendCommands("LINSERT mykey BEFORE \"hola\" \"bye\"", "PING", 1, 1);
             //0 if key does not exist
             var expectedResponse = ":0\r\n+PONG\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -877,8 +874,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommands("LINSERT mykey", "PING", 1, 1);
             var expectedResponse = $"-{string.Format(CmdStrings.GenericErrWrongNumArgs, "LINSERT")}\r\n+PONG\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -889,18 +885,15 @@ namespace Garnet.test
             lightClientRequest.SendCommand("RPUSH mylist two");
             var response = lightClientRequest.SendCommand("RPUSH mylist three");
             var expectedResponse = ":3\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("LTRIM mylist 1 -1");
             expectedResponse = "+OK\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("LRANGE mylist 0 -1", 3);
             expectedResponse = "*2\r\n$3\r\ntwo\r\n$5\r\nthree\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -912,24 +905,20 @@ namespace Garnet.test
             // Use Before
             var response = lightClientRequest.SendCommand("LINSERT mylist BEFORE World There");
             var expectedResponse = ":3\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("LRANGE mylist 0 -1", 4);
             expectedResponse = "*3\r\n$5\r\nHello\r\n$5\r\nThere\r\n$5\r\nWorld\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Use After
             response = lightClientRequest.SendCommand("LINSERT mylist AFTER World Bye");
             expectedResponse = ":4\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("LRANGE mylist 0 -1", 5);
             expectedResponse = "*4\r\n$5\r\nHello\r\n$5\r\nThere\r\n$5\r\nWorld\r\n$3\r\nBye\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -941,8 +930,7 @@ namespace Garnet.test
             // Use Before
             var response = lightClientRequest.SendCommand("LINSERT mylist BEFORE There Today");
             var expectedResponse = ":-1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -952,8 +940,7 @@ namespace Garnet.test
             var response = lightClientRequest.SendCommand("HSET myhash onekey onepair");
             lightClientRequest.SendCommand("LINSERT myhash BEFORE one two");
             var expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_WRONG_TYPE)}\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -963,8 +950,7 @@ namespace Garnet.test
             _ = lightClientRequest.SendCommand("RPUSH mylist one two three");
             var response = lightClientRequest.SendCommand("LSET mylist 0 four");
             var expectedResponse = "+OK\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -973,8 +959,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("LSET mylist 0 four");
             var expectedResponse = "-ERR no such key\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -984,8 +969,7 @@ namespace Garnet.test
             _ = lightClientRequest.SendCommand("RPUSH mylist one two three");
             var response = lightClientRequest.SendCommand("LSET mylist a four");
             var expectedResponse = "-ERR value is not an integer or out of range.\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -996,13 +980,11 @@ namespace Garnet.test
             var response = lightClientRequest.SendCommand("LSET mylist 10 four");
             // 
             var expectedResponse = "-ERR index out of range";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("LSET mylist -100 four");
             expectedResponse = "-ERR index out of range";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1012,8 +994,7 @@ namespace Garnet.test
             _ = lightClientRequest.SendCommand("RPUSH mylist one two three");
             var response = lightClientRequest.SendCommand("LSET mylist a");
             var expectedResponse = "-ERR wrong number of arguments for 'LSET'";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         #endregion
@@ -1159,13 +1140,11 @@ namespace Garnet.test
 
             var expectedResponse = "$11\r\nvalue-three\r\n";
             var response = lightClientRequest.SendCommandChunks("RPOPLPUSH mylist myotherlist", bytesPerSend);
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             expectedResponse = "*2\r\n$9\r\nvalue-one\r\n$9\r\nvalue-two\r\n";
             response = lightClientRequest.SendCommandChunks("LRANGE mylist 0 -1", bytesPerSend, 3);
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1294,8 +1273,7 @@ namespace Garnet.test
             var len = lightClientRequest.SendCommand("LLEN mylist");
 
             var expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_WRONG_TYPE)}\r\n";
-            var actualValue = Encoding.ASCII.GetString(len).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, len);
         }
 
         [Test]
@@ -1416,8 +1394,7 @@ namespace Garnet.test
 
             var response = lightClientRequest.SendCommands("LRANGE mylist 0 -1", "PING", 4, 1);
             var expectedResponse = "*3\r\n$1\r\na\r\n$1\r\nb\r\n$1\r\nc\r\n+PONG\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]

--- a/test/Garnet.test/RespListTests.cs
+++ b/test/Garnet.test/RespListTests.cs
@@ -1270,10 +1270,10 @@ namespace Garnet.test
             //this operation should affect only if key already exists and holds a list.
             lightClientRequest.SendCommand("LPUSHX mylist value-two");
             lightClientRequest.SendCommand("RPUSHX mylist value-one");
-            var len = lightClientRequest.SendCommand("LLEN mylist");
+            response = lightClientRequest.SendCommand("LLEN mylist");
 
             var expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_WRONG_TYPE)}\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, len);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]

--- a/test/Garnet.test/RespScanCommandsTests.cs
+++ b/test/Garnet.test/RespScanCommandsTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Garnet.server;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;

--- a/test/Garnet.test/RespScanCommandsTests.cs
+++ b/test/Garnet.test/RespScanCommandsTests.cs
@@ -601,8 +601,7 @@ namespace Garnet.test
 
             var expectedResponse = "*3\r\n$6\r\nkeyone\r\n$6\r\nkeytwo\r\n$8\r\nkeythree\r\n+PONG\r\n";
             var response = lightClientRequest.SendCommands("KEYS *", "PING", 4);
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         #endregion

--- a/test/Garnet.test/RespSetTest.cs
+++ b/test/Garnet.test/RespSetTest.cs
@@ -956,8 +956,8 @@ namespace Garnet.test
 
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SPOP myset");
-            var strLen = Encoding.ASCII.GetString(response).Substring(1, 1);
-            var item = Encoding.ASCII.GetString(response).Substring(4, Int32.Parse(strLen));
+            var strLen = Encoding.ASCII.GetString(response, 1, 1);
+            var item = Encoding.ASCII.GetString(response, 4, int.Parse(strLen));
             ClassicAssert.IsTrue(myset.Contains(item));
 
             response = lightClientRequest.SendCommand("SCARD myset");
@@ -972,29 +972,29 @@ namespace Garnet.test
 
             var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SPOP myset 3", 3);
-            var strResponse = Encoding.ASCII.GetString(response);
-            ClassicAssert.AreEqual('*', strResponse[0]);
+            TestUtils.AssertEqualUpToExpectedLength("*", response);
 
+            var strResponse = Encoding.ASCII.GetString(response);
             var arrLenEndIdx = strResponse.IndexOf("\r\n", StringComparison.InvariantCultureIgnoreCase);
             ClassicAssert.IsTrue(arrLenEndIdx > 1);
 
-            var strArrLen = Encoding.ASCII.GetString(response).Substring(1, arrLenEndIdx - 1);
+            var strArrLen = Encoding.ASCII.GetString(response, 1, arrLenEndIdx - 1);
             ClassicAssert.IsTrue(int.TryParse(strArrLen, out var arrLen));
             ClassicAssert.AreEqual(3, arrLen);
 
-            var secondResponse = lightClientRequest.SendCommands("SCARD myset", "PING", 1, 1);
+            response = lightClientRequest.SendCommands("SCARD myset", "PING", 1, 1);
             var expectedResponse = ":2\r\n+PONG\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, secondResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Test for popping set until empty
             response = lightClientRequest.SendCommand("SPOP myset 2", 2);
-            strResponse = Encoding.ASCII.GetString(response);
-            ClassicAssert.AreEqual('*', strResponse[0]);
+            TestUtils.AssertEqualUpToExpectedLength("*", response);
 
+            strResponse = Encoding.ASCII.GetString(response);
             arrLenEndIdx = strResponse.IndexOf("\r\n", StringComparison.InvariantCultureIgnoreCase);
             ClassicAssert.IsTrue(arrLenEndIdx > 1);
 
-            strArrLen = Encoding.ASCII.GetString(response).Substring(1, arrLenEndIdx - 1);
+            strArrLen = Encoding.ASCII.GetString(response, 1, arrLenEndIdx - 1);
             ClassicAssert.IsTrue(int.TryParse(strArrLen, out arrLen));
             ClassicAssert.AreEqual(2, arrLen);
         }
@@ -1007,10 +1007,9 @@ namespace Garnet.test
             var lightClientRequest = TestUtils.CreateRequest();
 
             var response = lightClientRequest.SendCommand("SPOP myset 10", 5);
+            TestUtils.AssertEqualUpToExpectedLength("*", response);
 
             var strResponse = Encoding.ASCII.GetString(response);
-            ClassicAssert.AreEqual('*', strResponse[0]);
-
             var arrLenEndIdx = strResponse.IndexOf("\r\n", StringComparison.InvariantCultureIgnoreCase);
             ClassicAssert.IsTrue(arrLenEndIdx > 1);
 
@@ -1019,13 +1018,13 @@ namespace Garnet.test
             ClassicAssert.IsTrue(arrLen == 5);
 
             var lightClientRequest2 = TestUtils.CreateRequest();
-            var response2 = lightClientRequest2.SendCommand("SADD myset one");
+            response = lightClientRequest2.SendCommand("SADD myset one");
             var expectedResponse = ":1\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response2);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            response2 = lightClientRequest2.SendCommand("SCARD myset");
+            response = lightClientRequest2.SendCommand("SCARD myset");
             expectedResponse = ":1\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response2);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1136,25 +1135,23 @@ namespace Garnet.test
         public void MultiWithNonExistingSet()
         {
             var lightClientRequest = TestUtils.CreateRequest();
-            byte[] res;
 
-            string expectedResponse = "+OK\r\n";
-
-            res = lightClientRequest.SendCommand("MULTI");
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            var response = lightClientRequest.SendCommand("MULTI");
+            var expectedResponse = "+OK\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //create set
-            res = lightClientRequest.SendCommand("SADD MySet ItemOne");
+            response = lightClientRequest.SendCommand("SADD MySet ItemOne");
             expectedResponse = "+QUEUED\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("EXEC", 2);
+            response = lightClientRequest.SendCommand("EXEC", 2);
             expectedResponse = "*1\r\n:1\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("SMEMBERS MySet", 2);
+            response = lightClientRequest.SendCommand("SMEMBERS MySet", 2);
             expectedResponse = "*1\r\n$7\r\nItemOne\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1201,9 +1198,9 @@ namespace Garnet.test
             var expectedResponse = ":5\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            var membersResponse = lightClientRequest.SendCommand("SMEMBERS key");
+            response = lightClientRequest.SendCommand("SMEMBERS key");
             expectedResponse = "*5\r\n$1\r\na\r\n$1\r\nb\r\n$1\r\nc\r\n$1\r\nd\r\n$1\r\ne\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, membersResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1267,22 +1264,22 @@ namespace Garnet.test
             var lightClientRequest = TestUtils.CreateRequest();
             lightClientRequest.SendCommand("SADD key a");
 
-            var SINTERSTOREResponse = lightClientRequest.SendCommand("SINTERSTORE key key1 key2 key3");
-            var expectedSINTERSTOREResponse = ":0\r\n";
-            ClassicAssert.AreEqual(expectedSINTERSTOREResponse, SINTERSTOREResponse.AsSpan().Slice(0, expectedSINTERSTOREResponse.Length).ToArray());
+            var response = lightClientRequest.SendCommand("SINTERSTORE key key1 key2 key3");
+            var expectedResponse = ":0\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            var membersResponse = lightClientRequest.SendCommand("SMEMBERS key");
-            var expectedResponse = "*0\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, membersResponse);
+            response = lightClientRequest.SendCommand("SMEMBERS key");
+            expectedResponse = "*0\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
         public void IntersectAndStoreWithNoSetsReturnErrWrongNumArgs()
         {
             var lightClientRequest = TestUtils.CreateRequest();
-            var SINTERSTOREResponse = lightClientRequest.SendCommand("SINTERSTORE key");
-            var expectedSINTERSTOREResponse = $"-{string.Format(CmdStrings.GenericErrWrongNumArgs, "SINTERSTORE")}\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedSINTERSTOREResponse, SINTERSTOREResponse);
+            var response = lightClientRequest.SendCommand("SINTERSTORE key");
+            var expectedResponse = $"-{string.Format(CmdStrings.GenericErrWrongNumArgs, "SINTERSTORE")}\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1296,9 +1293,9 @@ namespace Garnet.test
             var expectedResponse = ":1\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            var membersResponse = lightClientRequest.SendCommand("SMEMBERS key");
+            response = lightClientRequest.SendCommand("SMEMBERS key");
             expectedResponse = "*1\r\n$1\r\nc\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, membersResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1314,9 +1311,9 @@ namespace Garnet.test
             var expectedResponse = ":2\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            var membersResponse = lightClientRequest.SendCommand($"SMEMBERS {key}");
+            response = lightClientRequest.SendCommand($"SMEMBERS {key}");
             expectedResponse = "*2\r\n$1\r\nb\r\n$1\r\nd\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, membersResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1399,9 +1396,9 @@ namespace Garnet.test
             var expectedResponse = ":0\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            var membersResponse = lightClientRequest.SendCommand("SMEMBERS key");
+            response = lightClientRequest.SendCommand("SMEMBERS key");
             expectedResponse = "*0\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, membersResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1412,9 +1409,9 @@ namespace Garnet.test
             var expectedResponse = ":0\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            var membersResponse = lightClientRequest.SendCommand("SMEMBERS key");
+            response = lightClientRequest.SendCommand("SMEMBERS key");
             expectedResponse = "*0\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, membersResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1425,9 +1422,9 @@ namespace Garnet.test
             var expectedResponse = ":0\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            var membersResponse = lightClientRequest.SendCommand("SMEMBERS key");
+            response = lightClientRequest.SendCommand("SMEMBERS key");
             expectedResponse = "*0\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, membersResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]

--- a/test/Garnet.test/RespSetTest.cs
+++ b/test/Garnet.test/RespSetTest.cs
@@ -784,22 +784,18 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SADD myset \"Hello\"");
             var expectedResponse = ":1\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("SADD myset \"World\"");
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             expectedResponse = ":0\r\n";
             response = lightClientRequest.SendCommand("SADD myset \"World\"");
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("SMEMBERS myset", 3);
             expectedResponse = "*2\r\n$7\r\n\"Hello\"\r\n$7\r\n\"World\"\r\n";
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -809,38 +805,31 @@ namespace Garnet.test
 
             var response = lightClientRequest.SendCommand("SADD myset \"Hello\"");
             var expectedResponse = ":1\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("SADD myset \"World\"");
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("SISMEMBER myset \"Hello\"");
             expectedResponse = ":1\r\n";
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("SISMEMBER myset \"NonExistingMember\"");
             expectedResponse = ":0\r\n";
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("SISMEMBER NonExistingSet \"AnyMember\"");
             expectedResponse = ":0\r\n";
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Missing arguments
             response = lightClientRequest.SendCommand("SISMEMBER myset");
             expectedResponse = $"-{string.Format(CmdStrings.GenericErrWrongNumArgs, "SISMEMBER")}\r\n";
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Extra arguments
             response = lightClientRequest.SendCommand("SISMEMBER myset \"Hello\" \"ExtraArg\"");
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -850,10 +839,8 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SCARD myset");
             var expectedResponse = ":2\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
 
         [Test]
         public void CanReturnEmptySetLC()
@@ -863,8 +850,7 @@ namespace Garnet.test
 
             // Empty array
             var expectedResponse = "*0\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -873,23 +859,19 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SADD myset ItemOne ItemTwo ItemThree ItemFour");
             var expectedResponse = ":4\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("SREM myset World");
             expectedResponse = ":0\r\n";
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("SREM myset ItemOne");
             expectedResponse = ":1\r\n";
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("SREM myset ItemTwo ItemThree");
             expectedResponse = ":2\r\n";
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -898,8 +880,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommands("SCARD fooset", "PING", 1, 1);
             var expectedResponse = ":0\r\n+PONG\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -911,14 +892,12 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SRANDMEMBER myset");
             var expectedResponse = "$-1\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Check SRANDMEMBER with non-existing key and count
             response = lightClientRequest.SendCommand("SRANDMEMBER myset 3");
             expectedResponse = "*0\r\n";
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             CreateLongSet();
 
@@ -929,7 +908,7 @@ namespace Garnet.test
 
             // Get three random members
             response = lightClientRequest.SendCommand("SRANDMEMBER myset 3", 3);
-            strResponse = Encoding.ASCII.GetString(response);
+            var strResponse = Encoding.ASCII.GetString(response);
             ClassicAssert.AreEqual('*', strResponse[0]);
 
             var arrLenEndIdx = strResponse.IndexOf("\r\n", StringComparison.InvariantCultureIgnoreCase);
@@ -983,8 +962,7 @@ namespace Garnet.test
 
             response = lightClientRequest.SendCommand("SCARD myset");
             var expectedResponse = ":4\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1006,8 +984,7 @@ namespace Garnet.test
 
             var secondResponse = lightClientRequest.SendCommands("SCARD myset", "PING", 1, 1);
             var expectedResponse = ":2\r\n+PONG\r\n";
-            strResponse = Encoding.ASCII.GetString(secondResponse).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, secondResponse);
 
             // Test for popping set until empty
             response = lightClientRequest.SendCommand("SPOP myset 2", 2);
@@ -1044,13 +1021,11 @@ namespace Garnet.test
             var lightClientRequest2 = TestUtils.CreateRequest();
             var response2 = lightClientRequest2.SendCommand("SADD myset one");
             var expectedResponse = ":1\r\n";
-            strResponse = Encoding.ASCII.GetString(response2).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response2);
 
             response2 = lightClientRequest2.SendCommand("SCARD myset");
             expectedResponse = ":1\r\n";
-            strResponse = Encoding.ASCII.GetString(response2).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response2);
         }
 
         [Test]
@@ -1091,37 +1066,31 @@ namespace Garnet.test
 
             // Source set doesn't exist
             response = lightClientRequest.SendCommand("SMOVE \"someRandomSet\" \"mySourceSet\" \"twoS\"");
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedFailureResponse.Length);
-            ClassicAssert.AreEqual(expectedFailureResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedFailureResponse, response);
 
             // Destination set doesn't exist
             response = lightClientRequest.SendCommand("SMOVE \"mySourceSet\" \"someRandomSet\" \"twoS\"");
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedSuccessfulResponse.Length);
-            ClassicAssert.AreEqual(expectedSuccessfulResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedSuccessfulResponse, response);
 
             // Value not in source
             response = lightClientRequest.SendCommand("SMOVE \"mySourceSet\" \"mySourceSet\" \"notAValue\"");
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedFailureResponse.Length);
-            ClassicAssert.AreEqual(expectedFailureResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedFailureResponse, response);
 
             // Move into self
             response = lightClientRequest.SendCommand("SMOVE \"mySourceSet\" \"mySourceSet\" \"twoS\"");
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedFailureResponse.Length);
-            ClassicAssert.AreEqual(expectedFailureResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedFailureResponse, response);
 
             // Common value
             response = lightClientRequest.SendCommand("SMOVE \"mySourceSet\" \"myDestinationSet\" \"common\"");
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedSuccessfulResponse.Length);
-            ClassicAssert.AreEqual(expectedSuccessfulResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedSuccessfulResponse, response);
 
+            // Source set contains member
             response = lightClientRequest.SendCommand("SISMEMBER \"mySourceSet\" \"common\"");
-            mySourceSetContainsMember = Encoding.ASCII.GetString(response).Substring(0, expectedFailureResponse.Length);
+            TestUtils.AssertEqualUpToExpectedLength(expectedFailureResponse, response);
 
+            // Destination set contains member
             response = lightClientRequest.SendCommand("SISMEMBER \"myDestinationSet\" \"common\"");
-            myDestinationSetContainsMember = Encoding.ASCII.GetString(response).Substring(0, expectedSuccessfulResponse.Length);
-
-            ClassicAssert.AreEqual(expectedFailureResponse, mySourceSetContainsMember);
-            ClassicAssert.AreEqual(expectedSuccessfulResponse, myDestinationSetContainsMember);
+            TestUtils.AssertEqualUpToExpectedLength(expectedSuccessfulResponse, response);
         }
 
         [Test]
@@ -1172,20 +1141,20 @@ namespace Garnet.test
             string expectedResponse = "+OK\r\n";
 
             res = lightClientRequest.SendCommand("MULTI");
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             //create set
             res = lightClientRequest.SendCommand("SADD MySet ItemOne");
             expectedResponse = "+QUEUED\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             res = lightClientRequest.SendCommand("EXEC", 2);
             expectedResponse = "*1\r\n:1\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             res = lightClientRequest.SendCommand("SMEMBERS MySet", 2);
             expectedResponse = "*1\r\n$7\r\nItemOne\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
         }
 
         [Test]
@@ -1194,39 +1163,32 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SADD myset ItemOne ItemTwo ItemThree ItemFour");
             var expectedResponse = ":4\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("SUNION myset another_set", 5);
             expectedResponse = "*4\r\n";
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             lightClientRequest.SendCommand("SADD another_set ItemOne ItemFive ItemTwo ItemSix ItemSeven");
             response = lightClientRequest.SendCommand("SUNION myset another_set", 8);
             expectedResponse = "*7\r\n";
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("SUNION myset no_exist_set", 5);
             expectedResponse = "*4\r\n";
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("SUNION no_exist_set myset no_exist_set another_set", 8);
             expectedResponse = "*7\r\n";
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("SUNION myset", 5);
             expectedResponse = "*4\r\n";
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("SUNION");
             expectedResponse = $"-{string.Format(CmdStrings.GenericErrWrongNumArgs, "SUNION")}\r\n";
-            strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1237,11 +1199,11 @@ namespace Garnet.test
             _ = lightClientRequest.SendCommand("SADD key2 c d e");
             var response = lightClientRequest.SendCommand("SUNIONSTORE key key1 key2");
             var expectedResponse = ":5\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             var membersResponse = lightClientRequest.SendCommand("SMEMBERS key");
             expectedResponse = "*5\r\n$1\r\na\r\n$1\r\nb\r\n$1\r\nc\r\n$1\r\nd\r\n$1\r\ne\r\n";
-            ClassicAssert.AreEqual(expectedResponse, membersResponse.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, membersResponse);
         }
 
         [Test]
@@ -1253,7 +1215,7 @@ namespace Garnet.test
             lightClientRequest.SendCommand("SADD key3 a c e");
             var response = lightClientRequest.SendCommand("SDIFF key1 key2 key3");
             var expectedResponse = "*2\r\n$1\r\nb\r\n$1\r\nd\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
 
@@ -1266,7 +1228,7 @@ namespace Garnet.test
             lightClientRequest.SendCommand("SADD key3 a c e");
             var response = lightClientRequest.SendCommand("SINTER key1 key2 key3");
             var expectedResponse = "*1\r\n$1\r\nc\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1277,7 +1239,7 @@ namespace Garnet.test
 
             var response = lightClientRequest.SendCommand("SINTER key1 key2");
             var expectedResponse = "*0\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1286,7 +1248,7 @@ namespace Garnet.test
             var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SINTER");
             var expectedResponse = "-ERR wrong number of arguments for 'SINTER' command\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1295,7 +1257,7 @@ namespace Garnet.test
             var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SINTERSTORE");
             var expectedResponse = "-ERR wrong number of arguments for 'SINTERSTORE' command\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
 
@@ -1311,7 +1273,7 @@ namespace Garnet.test
 
             var membersResponse = lightClientRequest.SendCommand("SMEMBERS key");
             var expectedResponse = "*0\r\n";
-            ClassicAssert.AreEqual(expectedResponse, membersResponse.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, membersResponse);
         }
 
         [Test]
@@ -1320,9 +1282,8 @@ namespace Garnet.test
             var lightClientRequest = TestUtils.CreateRequest();
             var SINTERSTOREResponse = lightClientRequest.SendCommand("SINTERSTORE key");
             var expectedSINTERSTOREResponse = $"-{string.Format(CmdStrings.GenericErrWrongNumArgs, "SINTERSTORE")}\r\n";
-            ClassicAssert.AreEqual(expectedSINTERSTOREResponse, SINTERSTOREResponse.AsSpan().Slice(0, expectedSINTERSTOREResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedSINTERSTOREResponse, SINTERSTOREResponse);
         }
-
 
         [Test]
         public void CanDoSinterStoreLC()
@@ -1333,11 +1294,11 @@ namespace Garnet.test
             lightClientRequest.SendCommand("SADD key3 a c e");
             var response = lightClientRequest.SendCommand("SINTERSTORE key key1 key2 key3");
             var expectedResponse = ":1\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             var membersResponse = lightClientRequest.SendCommand("SMEMBERS key");
             expectedResponse = "*1\r\n$1\r\nc\r\n";
-            ClassicAssert.AreEqual(expectedResponse, membersResponse.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, membersResponse);
         }
 
         [Test]
@@ -1351,11 +1312,11 @@ namespace Garnet.test
             _ = lightClientRequest.SendCommand("SADD key3 a c e");
             var response = lightClientRequest.SendCommand($"SDIFFSTORE {key} key1 key2 key3");
             var expectedResponse = ":2\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             var membersResponse = lightClientRequest.SendCommand($"SMEMBERS {key}");
             expectedResponse = "*2\r\n$1\r\nb\r\n$1\r\nd\r\n";
-            ClassicAssert.AreEqual(expectedResponse, membersResponse.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, membersResponse);
         }
 
         [Test]
@@ -1382,12 +1343,12 @@ namespace Garnet.test
 
             var response = lightClientRequest.SendCommand("SINTERCARD 2 key1 key2");
             var expectedResponse = $":{expectedCount}\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Test with non-existing keys
             response = lightClientRequest.SendCommand("SINTERCARD 2 nonexistent1 nonexistent2");
             expectedResponse = ":0\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
         #endregion
 
@@ -1400,8 +1361,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SCARD fooset");
             var expectedResponse = ":0\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1410,8 +1370,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SPOP fooset");
             var expectedResponse = "$-1\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1420,8 +1379,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SMEMBERS foo");
             var expectedResponse = "*0\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1430,8 +1388,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SDIFF foo");
             var expectedResponse = "*0\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1440,13 +1397,11 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SDIFFSTORE key key1 key2 key3");
             var expectedResponse = ":0\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             var membersResponse = lightClientRequest.SendCommand("SMEMBERS key");
             expectedResponse = "*0\r\n";
-            strResponse = Encoding.ASCII.GetString(membersResponse).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, membersResponse);
         }
 
         [Test]
@@ -1455,13 +1410,11 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SUNIONSTORE key key1 key2 key3");
             var expectedResponse = ":0\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             var membersResponse = lightClientRequest.SendCommand("SMEMBERS key");
             expectedResponse = "*0\r\n";
-            strResponse = Encoding.ASCII.GetString(membersResponse).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, membersResponse);
         }
 
         [Test]
@@ -1470,13 +1423,11 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("SINTERSTORE key key1 key2 key3");
             var expectedResponse = ":0\r\n";
-            var strResponse = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             var membersResponse = lightClientRequest.SendCommand("SMEMBERS key");
             expectedResponse = "*0\r\n";
-            strResponse = Encoding.ASCII.GetString(membersResponse).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, strResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, membersResponse);
         }
 
         [Test]

--- a/test/Garnet.test/RespSetTest.cs
+++ b/test/Garnet.test/RespSetTest.cs
@@ -908,9 +908,9 @@ namespace Garnet.test
 
             // Get three random members
             response = lightClientRequest.SendCommand("SRANDMEMBER myset 3", 3);
-            var strResponse = Encoding.ASCII.GetString(response);
-            ClassicAssert.AreEqual('*', strResponse[0]);
+            TestUtils.AssertEqualUpToExpectedLength("*", response);
 
+            var strResponse = Encoding.ASCII.GetString(response);
             var arrLenEndIdx = strResponse.IndexOf("\r\n", StringComparison.InvariantCultureIgnoreCase);
             ClassicAssert.IsTrue(arrLenEndIdx > 1);
 

--- a/test/Garnet.test/RespSortedSetGeoTests.cs
+++ b/test/Garnet.test/RespSortedSetGeoTests.cs
@@ -425,13 +425,13 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var responseBuf = lightClientRequest.SendCommands("GEOSEARCH cities FROMMEMBER Washington BYBOX 800 800 km WITHCOORD WITHDIST", "PING");
             var expectedResponse = "*3\r\n*3\r\n$10\r\nWashington\r\n$1\r\n0\r\n*2\r\n$17\r\n-77.0368704199791\r\n$17\r\n38.90719190239906\r\n*3\r\n$12\r\nPhiladelphia\r\n$17\r\n198.4242996738795\r\n*2\r\n$18\r\n-75.16521960496902\r\n$18\r\n39.952582865953445\r\n*3\r\n$8\r\nNew York\r\n$18\r\n327.67645879712575\r\n*2\r\n$17\r\n-74.0059420466423\r\n$18\r\n40.712782591581345\r\n+PONG\r\n";
-            var actualValue = Encoding.ASCII.GetString(responseBuf).Substring(0, expectedResponse.Length);
+            var actualValue = Encoding.ASCII.GetString(responseBuf, 0, expectedResponse.Length);
             ClassicAssert.IsTrue(actualValue.IndexOf("Washington") != -1);
 
             //Send command in chunks
             responseBuf = lightClientRequest.SendCommandChunks("GEOSEARCH cities FROMMEMBER Washington BYBOX 800 800 km COUNT 3 ANY WITHCOORD WITHDIST", bytesSent, 16);
             expectedResponse = "*3\r\n*3\r\n$10\r\nWashington\r\n$1\r\n0\r\n*2\r\n$17\r\n-77.0368704199791\r\n$17\r\n38.90719190239906\r\n*3\r\n$12\r\nPhiladelphia\r\n$17\r\n198.4242996738795\r\n*2\r\n$18\r\n-75.16521960496902\r\n$18\r\n39.952582865953445\r\n*3\r\n$8\r\nNew York\r\n$18\r\n327.67645879712575\r\n*2\r\n$17\r\n-74.0059420466423\r\n$18\r\n40.712782591581345\r\n+PONG\r\n";
-            actualValue = Encoding.ASCII.GetString(responseBuf).Substring(0, expectedResponse.Length);
+            actualValue = Encoding.ASCII.GetString(responseBuf, 0, expectedResponse.Length);
             ClassicAssert.IsTrue(actualValue.IndexOf("Washington") != -1);
         }
 
@@ -447,27 +447,22 @@ namespace Garnet.test
             // Check GEOADD without members
             var response = lightClientRequest.SendCommandChunks("GEOADD Sicily NX", bytesSent);
             var expectedResponse = $"-{string.Format(CmdStrings.GenericErrWrongNumArgs, nameof(SortedSetOperation.GEOADD))}\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("GEOADD Sicily NX 13.361389 38.115556 Palermo 15.087269 37.502669 Catania", bytesSent);
             expectedResponse = ":2\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Add new elements, return only the elements changed
             response = lightClientRequest.SendCommandChunks("GEOADD Sicily NX CH 14.361389 39.115556 Palermo 15.087269 37.502669 Catania 38.0350 14.0212 Cefalu 37.8545 15.2889 Taormina", bytesSent);
             expectedResponse = ":2\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Only update elements, return only the elements changed
             response = lightClientRequest.SendCommandChunks("GEOADD Sicily XX CH 15.361389 39.115556 Palermo 15.087269 37.502669 Catania", bytesSent);
             expectedResponse = ":1\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
 
         [Test]
         [TestCase(10)]
@@ -479,14 +474,12 @@ namespace Garnet.test
             //only Catania pair is added
             var response = lightClientRequest.SendCommands("GEOADD Sicily 113.361389 338.115556 Palermo 15.087269 37.502669 Catania", "PING");
             var expectedResponse = ":1\r\n+PONG\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //no pairs are added
             response = lightClientRequest.SendCommandChunks("GEOADD Sicily 113.361389 338.115556 Palermo 15.087269 37.502669 Catania", bytesSent);
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -562,18 +555,15 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommandChunks("GEOADD Sicily 13.361389 38.115556 Palermo 15.087269 37.502669 Catania", bytesSent);
             var expectedResponse = ":2\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommands("GEODIST Sicily Palermo Unknown", "PING");
             expectedResponse = "$-1\r\n+PONG\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("GEODIST Sicily Palermo Unknown", bytesSent);
             expectedResponse = "$-1\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -611,13 +601,11 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommands("GEOADD Sicily 13.361389 38.115556", "PING");
             var expectedResponse = $"-{string.Format(CmdStrings.GenericErrWrongNumArgs, "GEOADD")}\r\n+PONG\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("GEOADD Sicily 13.361389 38.115556", bytesSent);
             expectedResponse = $"-{string.Format(CmdStrings.GenericErrWrongNumArgs, "GEOADD")}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
         #endregion
     }

--- a/test/Garnet.test/RespSortedSetTests.cs
+++ b/test/Garnet.test/RespSortedSetTests.cs
@@ -617,18 +617,15 @@ namespace Garnet.test
 
             var response = lightClientRequest.SendCommands("ZMSCORE zmscore", "PING");
             var expectedResponse = $"{FormatWrongNumOfArgsError("ZMSCORE")}+PONG\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommands("ZMSCORE nokey a b c", "PING", 4, 1);
             expectedResponse = "*3\r\n$-1\r\n$-1\r\n$-1\r\n+PONG\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommands("ZMSCORE zmscore a z b", "PING", 4, 1);
             expectedResponse = "*3\r\n$1\r\n0\r\n$-1\r\n$1\r\n1\r\n+PONG\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1794,18 +1791,15 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommandChunks("ZADD board 340 Dave 400 Kendra 560 Tom 650 Barbara 690 Jennifer 690 Peter", bytesPerSend);
             var expectedResponse = ":6\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommands("ZCOUNT board 500 700", "PING");
             expectedResponse = ":4\r\n+PONG\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZCOUNT board 500 700", bytesPerSend);
             expectedResponse = ":4\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1822,63 +1816,51 @@ namespace Garnet.test
 
             response = lightClientRequest.SendCommandChunks("ZRANGE board 0 -1", bytesSent, 4);
             var expectedResponse = "*3\r\n$3\r\none\r\n$3\r\ntwo\r\n$5\r\nthree\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // get a range by index with scores
             response = lightClientRequest.SendCommandChunks("ZRANGE board 0 -1 WITHSCORES", bytesSent, 7);
             expectedResponse = "*6\r\n$3\r\none\r\n$1\r\n1\r\n$3\r\ntwo\r\n$1\r\n2\r\n$5\r\nthree\r\n$1\r\n3\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZRANGE board 2 3", 2);
             expectedResponse = "*1\r\n$5\r\nthree\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZRANGE board -2 -1", 3);
             expectedResponse = "*2\r\n$3\r\ntwo\r\n$5\r\nthree\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZRANGE board -2 -1 WITHSCORES", 5);
             expectedResponse = "*4\r\n$3\r\ntwo\r\n$1\r\n2\r\n$5\r\nthree\r\n$1\r\n3\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZRANGE board -50 -1 WITHSCORES", 7);
             expectedResponse = "*6\r\n$3\r\none\r\n$1\r\n1\r\n$3\r\ntwo\r\n$1\r\n2\r\n$5\r\nthree\r\n$1\r\n3\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZRANGE board -50 -10 WITHSCORES", 1);
             expectedResponse = "*0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZRANGE board 2 1 WITHSCORES", 1);
             expectedResponse = "*0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZRANGE board -1 -2 WITHSCORES", 1);
             expectedResponse = "*0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZRANGE board 50 60 WITHSCORES", 1);
             expectedResponse = "*0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZRANGE board (1 +inf BYSCORE LIMIT 1 1", 2);
             expectedResponse = "*1\r\n$5\r\nthree\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZRANGE board (1 +inf BYSCORE LIMIT 1 1", bytesSent, 2);
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         // ZRANGEBSTORE
@@ -1897,25 +1879,26 @@ namespace Garnet.test
                 var addCommand = $"ZADD {key} " + string.Join(" ", elements.Zip(scores, (e, s) => $"{s} {e}"));
                 var response = lightClientRequest.SendCommand(addCommand);
                 var expectedResponse = $":{elements.Length}\r\n";
-                var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-                ClassicAssert.AreEqual(expectedResponse, actualValue);
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
             }
 
             // Execute ZRANGESTORE
             var rangeStoreCommand = $"ZRANGESTORE {destinationKey} {key} {start} {stop}";
             var response2 = lightClientRequest.SendCommand(rangeStoreCommand);
             var expectedResponse2 = $":{expectedElements.Length}\r\n";
-            var actualValue2 = Encoding.ASCII.GetString(response2).Substring(0, expectedResponse2.Length);
-            ClassicAssert.AreEqual(expectedResponse2, actualValue2);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse2, response2);
 
             // Verify stored result using ZRANGE
             if (expectedElements.Length > 0)
             {
                 var verifyCommand = $"ZRANGE {destinationKey} 0 -1 WITHSCORES";
                 var response3 = lightClientRequest.SendCommand(verifyCommand, expectedElements.Length * 2 + 1);
-                var expectedItems = new List<string>();
-                expectedItems.Add($"*{expectedElements.Length * 2}");
-                for (int i = 0; i < expectedElements.Length; i++)
+                var expectedItems = new List<string>
+                {
+                    $"*{expectedElements.Length * 2}"
+                };
+
+                for (var i = 0; i < expectedElements.Length; i++)
                 {
                     expectedItems.Add($"${expectedElements[i].Length}");
                     expectedItems.Add(expectedElements[i]);
@@ -1923,16 +1906,14 @@ namespace Garnet.test
                     expectedItems.Add(expectedScores[i].ToString());
                 }
                 var expectedResponse3 = string.Join("\r\n", expectedItems) + "\r\n";
-                var actualValue3 = Encoding.ASCII.GetString(response3).Substring(0, expectedResponse3.Length);
-                ClassicAssert.AreEqual(expectedResponse3, actualValue3);
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse3, response3);
             }
             else
             {
                 var verifyCommand = $"ZRANGE {destinationKey} 0 -1";
                 var response3 = lightClientRequest.SendCommand(verifyCommand);
                 var expectedResponse3 = "*0\r\n";
-                var actualValue3 = Encoding.ASCII.GetString(response3).Substring(0, expectedResponse3.Length);
-                ClassicAssert.AreEqual(expectedResponse3, actualValue3);
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse3, response3);
             }
         }
 
@@ -1951,14 +1932,12 @@ namespace Garnet.test
             // 1 < score <= 5
             response = lightClientRequest.SendCommandChunks("ZRANGEBYSCORE board (1 5", bytesSent, 3);
             var expectedResponse = "*2\r\n$3\r\ntwo\r\n$5\r\nthree\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // 1 < score <= 5
             response = lightClientRequest.SendCommands("ZRANGEBYSCORE board (1 5", "PING", 3, 1);
             expectedResponse = "*2\r\n$3\r\ntwo\r\n$5\r\nthree\r\n+PONG\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1976,20 +1955,17 @@ namespace Garnet.test
             // 5 < score <= 1
             response = lightClientRequest.SendCommandChunks("ZRANGE board 2 5 BYSCORE REV", bytesSent, 1);
             var expectedResponse = "*0\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // 1 < score <= 5
             response = lightClientRequest.SendCommandChunks("ZRANGE board 5 2 BYSCORE REV", bytesSent, 3);
             expectedResponse = "*2\r\n$5\r\nthree\r\n$3\r\ntwo\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // 1 < score <= 5
             response = lightClientRequest.SendCommands("ZRANGE board 5 2 BYSCORE REV", "PING", 3, 1);
             expectedResponse = "*2\r\n$5\r\nthree\r\n$3\r\ntwo\r\n+PONG\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2024,7 +2000,6 @@ namespace Garnet.test
             ClassicAssert.AreEqual(expectedResponse, response);
         }
 
-
         [Test]
         public void CanDoZRangeByLex()
         {
@@ -2041,26 +2016,22 @@ namespace Garnet.test
             // get a range by lex order
             response = lightClientRequest.SendCommand("ZRANGE board (a (d BYLEX", 3);
             var expectedResponse = "*2\r\n$1\r\nb\r\n$1\r\nc\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //by lex with different range
             response = lightClientRequest.SendCommand("ZRANGE board [aaa (g BYLEX", 6);
             expectedResponse = "*5\r\n$1\r\nb\r\n$1\r\nc\r\n$1\r\nd\r\n$1\r\ne\r\n$1\r\nf\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //by lex with different range
             response = lightClientRequest.SendCommand("ZRANGE board - [c BYLEX", 4);
             expectedResponse = "*3\r\n$1\r\na\r\n$1\r\nb\r\n$1\r\nc\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // ZRANGEBYLEX Synonym
             response = lightClientRequest.SendCommand("ZRANGEBYLEX board - [c", 4);
             //expectedResponse = "*3\r\n$1\r\na\r\n$1\r\nb\r\n$1\r\nc\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2079,32 +2050,27 @@ namespace Garnet.test
             // get a range by lex order
             response = lightClientRequest.SendCommand("ZRANGE board (a (d BYLEX REV", 1);
             var expectedResponse = "*0\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // get a range by lex order
             response = lightClientRequest.SendCommand("ZRANGE board (d (a BYLEX REV", 3);
             expectedResponse = "*2\r\n$1\r\nc\r\n$1\r\nb\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //by lex with different range
             response = lightClientRequest.SendCommand("ZRANGE board [g (aaa BYLEX REV", 6);
             expectedResponse = "*5\r\n$1\r\nf\r\n$1\r\ne\r\n$1\r\nd\r\n$1\r\nc\r\n$1\r\nb\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //by lex with different range
             response = lightClientRequest.SendCommand("ZRANGE board [c - BYLEX REV", 4);
             expectedResponse = "*3\r\n$1\r\nc\r\n$1\r\nb\r\n$1\r\na\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // ZREVRANGEBYLEX Synonym
             response = lightClientRequest.SendCommand("ZREVRANGEBYLEX board [c - REV", 4);
             //expectedResponse = "*3\r\n$1\r\nc\r\n$1\r\nb\r\n$1\r\na\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2114,21 +2080,17 @@ namespace Garnet.test
             var response = lightClientRequest.SendCommand("ZADD mycity 0 Delhi 0 London 0 Paris 0 Tokyo 0 NewYork 0 Seoul");
             response = lightClientRequest.SendCommand("ZRANGE mycity (London + BYLEX", 5);
             var expectedResponse = "*4\r\n$7\r\nNewYork\r\n$5\r\nParis\r\n$5\r\nSeoul\r\n$5\r\nTokyo\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZRANGE mycity - + BYLEX LIMIT 2 3", 4);
             expectedResponse = "*3\r\n$7\r\nNewYork\r\n$5\r\nParis\r\n$5\r\nSeoul\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // ZRANGEBYLEX Synonym
             response = lightClientRequest.SendCommand("ZRANGEBYLEX mycity - + LIMIT 2 3", 4);
             //expectedResponse = "*3\r\n$7\r\nNewYork\r\n$5\r\nParis\r\n$5\r\nSeoul\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
 
         [Test]
         [TestCase(10)]
@@ -2149,8 +2111,7 @@ namespace Garnet.test
             response = lightClientRequest.SendCommandChunks("ZRANGE board 0 -1 REV", bytesSent, 7);
 
             var expectedResponse = "*6\r\n$1\r\nf\r\n$1\r\ne\r\n$1\r\nd\r\n$1\r\nc\r\n$1\r\nb\r\n$1\r\na\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZRANGE board 0 -1 REV", 7);
         }
@@ -2164,13 +2125,11 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommandChunks("ZADD cities 100000 Delhi 850000 Mumbai 700000 Hyderabad 800000 Kolkata", bytesSent);
             var expectedResponse = ":4\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZREVRANGE cities -2 -1 WITHSCORES", bytesSent, 5);
             expectedResponse = "*4\r\n$9\r\nHyderabad\r\n$6\r\n700000\r\n$5\r\nDelhi\r\n$6\r\n100000\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2186,14 +2145,12 @@ namespace Garnet.test
             // Basic ZUNION
             var response = lightClientRequest.SendCommandChunks("ZUNION 2 zset1 zset2", bytesSent, 7);
             var expectedResponse = "*6\r\n$3\r\nuno\r\n$3\r\ndue\r\n$3\r\ntre\r\n$7\r\nquattro\r\n$6\r\ncinque\r\n$3\r\nsei\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // ZUNION with WITHSCORES
             response = lightClientRequest.SendCommandChunks("ZUNION 2 zset1 zset2 WITHSCORES", bytesSent, 13);
             expectedResponse = "*12\r\n$3\r\nuno\r\n$1\r\n2\r\n$3\r\ndue\r\n$1\r\n4\r\n$3\r\ntre\r\n$1\r\n6\r\n$7\r\nquattro\r\n$1\r\n8\r\n$6\r\ncinque\r\n$1\r\n5\r\n$3\r\nsei\r\n$1\r\n6\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2209,14 +2166,12 @@ namespace Garnet.test
             // Basic ZUNIONSTORE
             var response = lightClientRequest.SendCommandChunks("ZUNIONSTORE destset 2 zset1 zset2", bytesSent);
             var expectedResponse = ":6\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Verify stored result
             response = lightClientRequest.SendCommandChunks("ZRANGE destset 0 -1 WITHSCORES", bytesSent, 13);
             expectedResponse = "*12\r\n$3\r\nuno\r\n$1\r\n2\r\n$3\r\ndue\r\n$1\r\n4\r\n$6\r\ncinque\r\n$1\r\n5\r\n$3\r\nsei\r\n$1\r\n6\r\n$3\r\ntre\r\n$1\r\n6\r\n$7\r\nquattro\r\n$1\r\n8\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2228,8 +2183,7 @@ namespace Garnet.test
             lightClientRequest.SendCommand("ZADD board 1 one 2 two 3 three 4 four 5 five");
 
             var response = lightClientRequest.SendCommandChunks($"ZMPOP 1 board {direction} COUNT {count}", bytesSent);
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2242,8 +2196,7 @@ namespace Garnet.test
 
             var response = lightClientRequest.SendCommand($"ZMPOP 1 board MIN {invalidArg}");
             var expectedResponse = "-ERR syntax error\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2255,8 +2208,7 @@ namespace Garnet.test
 
             var response = lightClientRequest.SendCommand("ZMPOP 2 board1 board2 MIN");
             var expectedResponse = "*2\r\n$6\r\nboard1\r\n*1\r\n*2\r\n$3\r\none\r\n$1\r\n1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
 
@@ -2270,8 +2222,7 @@ namespace Garnet.test
             // Test WEIGHTS and AGGREGATE together
             var response = lightClientRequest.SendCommand("ZUNION 2 zset1 zset2 WEIGHTS 2 3 AGGREGATE MAX WITHSCORES");
             var expectedResponse = "*8\r\n$3\r\nuno\r\n$2\r\n12\r\n$3\r\ndue\r\n$2\r\n15\r\n$3\r\ntre\r\n$1\r\n6\r\n$7\r\nquattro\r\n$2\r\n18\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         #endregion
@@ -2299,7 +2250,6 @@ namespace Garnet.test
             ClassicAssert.AreEqual(expectedResponse, response);
         }
 
-
         [Test]
         [TestCase(10)]
         [TestCase(30)]
@@ -2309,37 +2259,30 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommands("ZCOUNT nokey 12 232 4343 5454", "PING");
             var expectedResponse = $"{FormatWrongNumOfArgsError("ZCOUNT")}+PONG\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZCOUNT nokey 12 232 4343 5454", bytesSent);
             expectedResponse = FormatWrongNumOfArgsError("ZCOUNT");
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // no arguments
             response = lightClientRequest.SendCommandChunks("ZCOUNT nokey", bytesSent);
             expectedResponse = FormatWrongNumOfArgsError("ZCOUNT");
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // not found key
             response = lightClientRequest.SendCommandChunks("ZCOUNT nokey", bytesSent);
             expectedResponse = FormatWrongNumOfArgsError("ZCOUNT");
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZCOUNT nokey 1 2", bytesSent);
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommands("ZCOUNT nokey 1 2", "PING");
             expectedResponse = ":0\r\n+PONG\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
 
         [Test]
         [TestCase(10)]
@@ -2350,13 +2293,11 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommandChunks("ZINCRBY newboard 200 Tom", bytesSent);
             var expectedResponse = "$3\r\n200\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZCARD newboard", bytesSent);
             expectedResponse = ":1\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2380,7 +2321,6 @@ namespace Garnet.test
             ClassicAssert.AreEqual(leaderBoard.Length, card);
         }
 
-
         [Test]
         [TestCase(10)]
         [TestCase(50)]
@@ -2390,17 +2330,14 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommandChunks("ZADD board 340 Dave 400 Kendra 560 Tom 650 Barbara 690 Jennifer 690 Peter", bytesSent);
             var expectedResponse = ":6\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //get the number of elements in the Sorted Set
             response = lightClientRequest.SendCommand("ZCARD board");
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZCARD board", bytesSent);
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2417,30 +2354,24 @@ namespace Garnet.test
 
             response = lightClientRequest.SendCommandChunks("ZINCRBY board 10 Tom", bytesSent);
             var expectedResponse = "$3\r\n570\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZINCRBY board -590 Tom");
             expectedResponse = "$3\r\n-20\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZINCRBY board -590", bytesSent);
             expectedResponse = FormatWrongNumOfArgsError("ZINCRBY");
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //using key exists but non existing member
             response = lightClientRequest.SendCommandChunks("ZINCRBY board 10 Julia", bytesSent);
             expectedResponse = "$2\r\n10\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZCARD board", bytesSent);
             expectedResponse = ":4\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
-
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2449,8 +2380,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommands("ZINCRBY nokey", "PING");
             var expectedResponse = $"{FormatWrongNumOfArgsError("ZINCRBY")}+PONG\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2466,8 +2396,7 @@ namespace Garnet.test
             //do zincrby
             var response = lightClientRequest.SendCommandChunks("ZINCRBY myboard 1 field1", bytesSent);
             var expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_WRONG_TYPE)}\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2485,20 +2414,16 @@ namespace Garnet.test
             // get a range by lex order
             response = lightClientRequest.SendCommand("ZREVRANGE board 0 -1", 7);
             var expectedResponse = "*6\r\n$1\r\nf\r\n$1\r\ne\r\n$1\r\nd\r\n$1\r\nc\r\n$1\r\nb\r\n$1\r\na\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
-
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // including scores
             response = lightClientRequest.SendCommand("ZREVRANGE board 0 -1 WITHSCORES", 13);
             expectedResponse = "*12\r\n$1\r\nf\r\n$2\r\n60\r\n$1\r\ne\r\n$2\r\n50\r\n$1\r\nd\r\n$2\r\n40\r\n$1\r\nc\r\n$2\r\n30\r\n$1\r\nb\r\n$2\r\n20\r\n$1\r\na\r\n$2\r\n10\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZREVRANGE board 0 1", 3);
             expectedResponse = "*2\r\n$1\r\nf\r\n$1\r\ne\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2516,24 +2441,20 @@ namespace Garnet.test
             // get a reverse range by score order
             response = lightClientRequest.SendCommand("ZREVRANGEBYSCORE board 70 0", 7);
             var expectedResponse = "*6\r\n$1\r\nf\r\n$1\r\ne\r\n$1\r\nd\r\n$1\r\nc\r\n$1\r\nb\r\n$1\r\na\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // including scores
             response = lightClientRequest.SendCommand("ZREVRANGEBYSCORE board 60 10 WITHSCORES", 13);
             expectedResponse = "*12\r\n$1\r\nf\r\n$2\r\n60\r\n$1\r\ne\r\n$2\r\n50\r\n$1\r\nd\r\n$2\r\n40\r\n$1\r\nc\r\n$2\r\n30\r\n$1\r\nb\r\n$2\r\n20\r\n$1\r\na\r\n$2\r\n10\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZREVRANGEBYSCORE board +inf 45", 3);
             expectedResponse = "*2\r\n$1\r\nf\r\n$1\r\ne\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZREVRANGEBYSCORE board 70 45 LIMIT 0 1", 2);
             expectedResponse = "*1\r\n$1\r\nf\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2550,23 +2471,19 @@ namespace Garnet.test
 
             response = lightClientRequest.SendCommandChunks("ZRANK board Jon", bytesSent);
             var expectedResponse = "$-1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZRANK board Tom INVALIDOPTION", bytesSent);
             expectedResponse = "-ERR syntax error\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZRANK board Tom", bytesSent);
             expectedResponse = ":2\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZRANK board Tom withscore", bytesSent);
             expectedResponse = "*2\r\n:2\r\n$3\r\n560\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2583,33 +2500,27 @@ namespace Garnet.test
 
             response = lightClientRequest.SendCommandChunks("ZREVRANK board Jon", bytesSent);
             var expectedResponse = "$-1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZREVRANK board Tom INVALIDOPTION", bytesSent);
             expectedResponse = "-ERR syntax error\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZREVRANK board Tom", bytesSent);
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZREVRANK board Kendra", bytesSent);
             expectedResponse = ":1\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZREVRANK board Dave", bytesSent);
             expectedResponse = ":2\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZREVRANK board Dave WITHSCORE", bytesSent);
             expectedResponse = "*2\r\n:2\r\n$3\r\n340\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2624,18 +2535,15 @@ namespace Garnet.test
             lightClientRequest.SendCommand("ZADD myzset 0 foo 0 zap 0 zip 0 ALPHA 0 alpha");
             response = lightClientRequest.SendCommand("ZRANGE myzset 0 -1", 11);
             var expectedResponse = "*10\r\n$5\r\nALPHA\r\n$4\r\naaaa\r\n$5\r\nalpha\r\n$1\r\nb\r\n$1\r\nc\r\n$1\r\nd\r\n$1\r\ne\r\n$3\r\nfoo\r\n$3\r\nzap\r\n$3\r\nzip\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZREMRANGEBYLEX myzset [alpha [omega", bytesSent);
             expectedResponse = ":6\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZRANGE myzset 0 -1", bytesSent, 5);
             expectedResponse = "*4\r\n$5\r\nALPHA\r\n$4\r\naaaa\r\n$3\r\nzap\r\n$3\r\nzip\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2654,40 +2562,32 @@ namespace Garnet.test
             lightClientRequest.SendCommand("ZADD myzset 0 foo 0 zap 0 zip 0 ALPHA 0 alpha");
             response = lightClientRequest.SendCommand("ZRANGE myzset 0 -1", 11);
             var expectedResponse = "*10\r\n$5\r\nALPHA\r\n$4\r\naaaa\r\n$5\r\nalpha\r\n$1\r\nb\r\n$1\r\nc\r\n$1\r\nd\r\n$1\r\ne\r\n$3\r\nfoo\r\n$3\r\nzap\r\n$3\r\nzip\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZREMRANGEBYLEX myzset [alpha [omega", bytesSent);
             expectedResponse = ":6\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZREMRANGEBYLEX myzset =a .", bytesSent);
             expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_MIN_MAX_NOT_VALID_STRING)}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZRANGE myzset 0 -1", bytesSent, 5);
             expectedResponse = "*4\r\n$5\r\nALPHA\r\n$4\r\naaaa\r\n$3\r\nzap\r\n$3\r\nzip\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZREMRANGEBYRANK board a b", bytesSent);
             expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_GENERIC_VALUE_IS_NOT_INTEGER)}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZREMRANGEBYRANK board 0 1", bytesSent);
             expectedResponse = ":2\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommands("ZREMRANGEBYRANK board 0 1", "PING");
             expectedResponse = ":1\r\n+PONG\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
 
         [Test]
         [TestCase(10)]
@@ -2703,18 +2603,15 @@ namespace Garnet.test
 
             response = lightClientRequest.SendCommandChunks("ZREMRANGEBYSCORE board -inf (500", bytesSent);
             var expectedResponse = ":2\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZCARD board", bytesSent);
             expectedResponse = ":1\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZREMRANGEBYSCORE board a b", bytesSent);
             expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_MIN_MAX_NOT_VALID_FLOAT)}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2730,10 +2627,8 @@ namespace Garnet.test
 
             response = lightClientRequest.SendCommandChunks("ZRANGE board 0 -1 LIMIT 1 1", bytesSent);
             var expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_LIMIT_NOT_SUPPORTED)}\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
 
         [Test]
         [TestCase(10)]
@@ -2746,18 +2641,15 @@ namespace Garnet.test
 
             response = lightClientRequest.SendCommandChunks("ZLEXCOUNT board - +", bytesSent);
             var expectedResponse = ":7\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZLEXCOUNT board [b [f", bytesSent);
             expectedResponse = ":5\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZLEXCOUNT board *d 8", bytesSent);
             expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_MIN_MAX_NOT_VALID_STRING)}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2771,13 +2663,11 @@ namespace Garnet.test
 
             response = lightClientRequest.SendCommandChunks("ZPOPMIN board", bytesSent);
             var expectedResponse = "*2\r\n$3\r\none\r\n$1\r\n1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZPOPMIN board 3", bytesSent, 5);
             expectedResponse = "*4\r\n$3\r\ntwo\r\n$1\r\n2\r\n$5\r\nthree\r\n$1\r\n3\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -2801,24 +2691,20 @@ namespace Garnet.test
             // ZRANDMEMBER count
             var response = lightClientRequest.SendCommandChunks("ZRANDMEMBER dadi 5", bytesSent, 6);
             var expectedResponse = "*5\r\n"; // 5 values
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // ZRANDMEMBER [count [WITHSCORES]]
             response = lightClientRequest.SendCommandChunks("ZRANDMEMBER dadi 3 WITHSCORES", bytesSent, 7);
             expectedResponse = "*6\r\n"; // 3 keyvalue pairs
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZRANDMEMBER dadi 1 WITHSCORES", bytesSent, 3);
             expectedResponse = "*2\r\n"; // 2 elements
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommandChunks("ZRANDMEMBER dadi 0 WITHSCORES", bytesSent);
             expectedResponse = "*0\r\n"; // Empty List
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
 
@@ -2919,13 +2805,11 @@ namespace Garnet.test
             //zdiff withscores
             var zdiffResult = lightClientRequest.SendCommandChunks("ZDIFF 2 dadi seconddadi WITHSCORES", bytesSent, 5);
             var expectedResponse = "*4\r\n$6\r\ncinque\r\n$1\r\n5\r\n$3\r\nsei\r\n$1\r\n6\r\n";
-            var actualValue = Encoding.ASCII.GetString(zdiffResult).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, zdiffResult);
 
             zdiffResult = lightClientRequest.SendCommandChunks("ZDIFF 2 dadi seconddadi", bytesSent, 3);
             expectedResponse = "*2\r\n$6\r\ncinque\r\n$3\r\nsei\r\n";
-            actualValue = Encoding.ASCII.GetString(zdiffResult).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, zdiffResult);
         }
 
         [Test]
@@ -2939,15 +2823,14 @@ namespace Garnet.test
             //zdiff withscores
             var zdiffResult = lightClientRequest.SendCommandChunks("ZDIFFSTORE desKey 2 dadi seconddadi", bytesSent);
             var expectedResponse = ":0\r\n";
-            var actualValue = Encoding.ASCII.GetString(zdiffResult).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, zdiffResult);
 
             lightClientRequest.SendCommand("ZADD dadi 1 uno 2 due 3 tre 4 quattro 5 cinque 6 sei");
             lightClientRequest.SendCommand("ZADD seconddadi 1 uno 2 due 3 tre 4 quattro");
 
             zdiffResult = lightClientRequest.SendCommandChunks("ZDIFFSTORE desKey 2 dadi seconddadi", bytesSent);
-            expectedResponse = "1\r\n";
-            actualValue = Encoding.ASCII.GetString(zdiffResult).Substring(0, expectedResponse.Length);
+            expectedResponse = ":2\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, zdiffResult);
         }
 
         [Test]
@@ -2963,14 +2846,12 @@ namespace Garnet.test
 
             var zdiffResult = lightClientRequest.SendCommandChunks("ZDIFF 3 zset1 zset2 zset3", bytesSent, 3);
             var expectedResponse = "*2\r\n$6\r\ncinque\r\n$3\r\nsei\r\n";
-            var actualValue = Encoding.ASCII.GetString(zdiffResult).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, zdiffResult);
 
             // Zdiff withscores
             zdiffResult = lightClientRequest.SendCommandChunks("ZDIFF 3 zset1 zset2 zset3 WITHSCORES", bytesSent, 5);
             expectedResponse = "*4\r\n$6\r\ncinque\r\n$1\r\n5\r\n$3\r\nsei\r\n$1\r\n6\r\n";
-            actualValue = Encoding.ASCII.GetString(zdiffResult).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, zdiffResult);
         }
 
         [Test]
@@ -2980,13 +2861,11 @@ namespace Garnet.test
             lightClientRequest.SendCommand("ZADD zset1 1 uno 2 due 3 tre 4 quattro 5 cinque 6 sei");
             var zdiffResult = lightClientRequest.SendCommand("ZDIFF 2 zsetnotfound zset1");
             var expectedResponse = "*0\r\n";
-            var actualValue = Encoding.ASCII.GetString(zdiffResult).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, zdiffResult);
 
             zdiffResult = lightClientRequest.SendCommand("ZDIFF 2 zsetnotfound zset1notfound");
             expectedResponse = "*0\r\n";
-            actualValue = Encoding.ASCII.GetString(zdiffResult).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, zdiffResult);
         }
 
         [Test]
@@ -2994,73 +2873,60 @@ namespace Garnet.test
         {
             using var lightClientRequest = TestUtils.CreateRequest();
 
-            var result = lightClientRequest.SendCommand("ZCARD nokey");
+            var response = lightClientRequest.SendCommand("ZCARD nokey");
             var expectedResponse = ":0\r\n";
-            var actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZSCORE nokey a");
+            response = lightClientRequest.SendCommand("ZSCORE nokey a");
             expectedResponse = "$-1\r\n"; // NULL
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZRANK noboard a");
+            response = lightClientRequest.SendCommand("ZRANK noboard a");
             expectedResponse = "$-1\r\n";
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZRANGE unekey 0 1");
+            response = lightClientRequest.SendCommand("ZRANGE unekey 0 1");
             expectedResponse = "*0\r\n"; //empty array
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZRANGEBYSCORE nonekey 0 1");
+            response = lightClientRequest.SendCommand("ZRANGEBYSCORE nonekey 0 1");
             expectedResponse = "*0\r\n"; //empty array
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZREVRANGE nonekey 0 1");
+            response = lightClientRequest.SendCommand("ZREVRANGE nonekey 0 1");
             expectedResponse = "*0\r\n"; //empty array
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZREVRANK nonekey 0");
+            response = lightClientRequest.SendCommand("ZREVRANK nonekey 0");
             expectedResponse = "$-1\r\n"; // NULL
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZREVRANGE nonekey 0 1");
+            response = lightClientRequest.SendCommand("ZREVRANGE nonekey 0 1");
             expectedResponse = "*0\r\n"; //empty array
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZLEXCOUNT nonekey [a [f");
+            response = lightClientRequest.SendCommand("ZLEXCOUNT nonekey [a [f");
             expectedResponse = ":0\r\n"; //integer reply
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //without the additional count argument, the command returns nil when key does not exist.
-            result = lightClientRequest.SendCommand("ZRANDMEMBER nonekey");
+            response = lightClientRequest.SendCommand("ZRANDMEMBER nonekey");
             expectedResponse = "$-1\r\n"; //nil when key does not exist.
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //when the additional count argument is passed, the command returns an array of elements,
             //or an empty array when key does not exist.
-            result = lightClientRequest.SendCommand("ZRANDMEMBER nonekey 1");
+            response = lightClientRequest.SendCommand("ZRANDMEMBER nonekey 1");
             expectedResponse = "*0\r\n"; //empty array
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZDIFF 2 i i");
+            response = lightClientRequest.SendCommand("ZDIFF 2 i i");
             expectedResponse = "*0\r\n"; //empty array
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZDIFF 1 nonekey");
+            response = lightClientRequest.SendCommand("ZDIFF 1 nonekey");
             expectedResponse = "*0\r\n"; //empty array
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -3068,59 +2934,48 @@ namespace Garnet.test
         {
             using var lightClientRequest = TestUtils.CreateRequest();
 
-            var result = lightClientRequest.SendCommand("ZPOPMAX nokey");
+            var response = lightClientRequest.SendCommand("ZPOPMAX nokey");
             var expectedResponse = "*0\r\n";
-            var actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZREM nokey a");
+            response = lightClientRequest.SendCommand("ZREM nokey a");
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //for this case the boundaries arguments are wrong, in redis this validation occurs
             //before the validation of a non existing key, but we are not executing the backend until
             //the key is validated first.
-            result = lightClientRequest.SendCommand("ZREMRANGEBYLEX nokey 0 1");
+            response = lightClientRequest.SendCommand("ZREMRANGEBYLEX nokey 0 1");
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             //testing out only a nonexisting key
-            result = lightClientRequest.SendCommand("ZREMRANGEBYLEX nokey [a [b");
+            response = lightClientRequest.SendCommand("ZREMRANGEBYLEX nokey [a [b");
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZREMRANGEBYLEX iii [a [b");
+            response = lightClientRequest.SendCommand("ZREMRANGEBYLEX iii [a [b");
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZREM nokey a");
+            response = lightClientRequest.SendCommand("ZREM nokey a");
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZREMRANGEBYRANK nokey 0 1");
+            response = lightClientRequest.SendCommand("ZREMRANGEBYRANK nokey 0 1");
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZREMRANGEBYSCORE nokey 0 1");
+            response = lightClientRequest.SendCommand("ZREMRANGEBYSCORE nokey 0 1");
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             lightClientRequest.SendCommand("ZADD zset1 1 uno 2 due 3 tre 4 quattro 5 cinque 6 sei");
 
-            result = lightClientRequest.SendCommand("ZREMRANGEBYLEX zset1 0 1");
+            response = lightClientRequest.SendCommand("ZREMRANGEBYLEX zset1 0 1");
             expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_MIN_MAX_NOT_VALID_STRING)}\r\n"; ;
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
-
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
 
         /// <summary>
         /// This test executes an RMW followed by a Read method which none
@@ -3132,22 +2987,19 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
 
             // Executing an RMW method first
-            var result = lightClientRequest.SendCommand("ZPOPMAX nokey");
+            var response = lightClientRequest.SendCommand("ZPOPMAX nokey");
             var expectedResponse = "*0\r\n";
-            var actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // When the additional count argument is passed, the command returns an array of elements,
             // Or an empty array when key does not exist.
-            result = lightClientRequest.SendCommand("ZRANDMEMBER nokey 1");
+            response = lightClientRequest.SendCommand("ZRANDMEMBER nokey 1");
             expectedResponse = "*0\r\n"; //empty array
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            result = lightClientRequest.SendCommand("ZCARD nokey");
+            response = lightClientRequest.SendCommand("ZCARD nokey");
             expectedResponse = ":0\r\n";
-            actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
 
@@ -3157,29 +3009,24 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommandChunks("ZADD board 340 Dave 400 Kendra 560 Tom 650 Barbara 690 Jennifer 690 Peter", 100);
             var expectedResponse = ":6\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZPOPMAX board", 3);
             expectedResponse = "*2\r\n$5\r\nPeter\r\n$3\r\n690\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZPOPMAX board 2", 5);
             expectedResponse = "*4\r\n$8\r\nJennifer\r\n$3\r\n690\r\n$7\r\nBarbara\r\n$3\r\n650\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommands("DEL board", "PING");
             expectedResponse = ":1\r\n+PONG\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Check the key is null or empty
             response = lightClientRequest.SendCommand("ZPOPMAX board");
             expectedResponse = "*0\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = redis.GetDatabase(0);
@@ -3211,71 +3058,71 @@ namespace Garnet.test
         public async Task CanFailWhenUseMultiWatchTest()
         {
             var lightClientRequest = TestUtils.CreateRequest();
-            string key = "MySSKey";
-            byte[] res;
+            var key = "MySSKey";
+            byte[] response;
 
-            res = lightClientRequest.SendCommand($"ZADD {key} 1 a 2 b 3 c");
-            string expectedResponse = ":3\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            response = lightClientRequest.SendCommand($"ZADD {key} 1 a 2 b 3 c");
+            var expectedResponse = ":3\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand($"WATCH {key}");
+            response = lightClientRequest.SendCommand($"WATCH {key}");
             expectedResponse = "+OK\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("MULTI");
+            response = lightClientRequest.SendCommand("MULTI");
             expectedResponse = "+OK\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand($"ZREM {key} a");
+            response = lightClientRequest.SendCommand($"ZREM {key} a");
             expectedResponse = "+QUEUED\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             await Task.Run(() => UpdateSortedSetKey(key));
 
-            res = lightClientRequest.SendCommand("EXEC");
+            response = lightClientRequest.SendCommand("EXEC");
             expectedResponse = "*-1";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // This sequence should work
-            res = lightClientRequest.SendCommand("MULTI");
+            response = lightClientRequest.SendCommand("MULTI");
             expectedResponse = "+OK\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand($"ZADD {key} 7 g");
+            response = lightClientRequest.SendCommand($"ZADD {key} 7 g");
             expectedResponse = "+QUEUED\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // This should commit
-            res = lightClientRequest.SendCommand("EXEC", 2);
+            response = lightClientRequest.SendCommand("EXEC", 2);
             expectedResponse = "*1\r\n:1\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
         public void CanUseMultiTest()
         {
             var lightClientRequest = TestUtils.CreateRequest();
-            byte[] res;
+            byte[] response;
 
-            res = lightClientRequest.SendCommand("ZADD MySSKey 1 a 2 b 3 c");
-            string expectedResponse = ":3\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            response = lightClientRequest.SendCommand("ZADD MySSKey 1 a 2 b 3 c");
+            var expectedResponse = ":3\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("MULTI");
+            response = lightClientRequest.SendCommand("MULTI");
             expectedResponse = "+OK\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("ZREM MySSKey a");
+            response = lightClientRequest.SendCommand("ZREM MySSKey a");
             expectedResponse = "+QUEUED\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("ZADD MySSKey 7 g");
+            response = lightClientRequest.SendCommand("ZADD MySSKey 7 g");
             expectedResponse = "+QUEUED\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("EXEC", 3);
+            response = lightClientRequest.SendCommand("EXEC", 3);
             expectedResponse = "*2\r\n:1\r\n:1\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -3284,21 +3131,17 @@ namespace Garnet.test
             var lightClientRequest = TestUtils.CreateRequest();
             var response = lightClientRequest.SendCommand("ZSCORE foo bar foo bar foo");
             var expectedResponse = FormatWrongNumOfArgsError("ZSCORE");
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Add a large number
             response = lightClientRequest.SendCommand("ZADD zset1 -9007199254740992 uno");
             expectedResponse = ":1\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("ZSCORE zset1 uno");
             expectedResponse = $"$17\r\n-9007199254740992\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
-
 
         [Test]
         public void CanDoZaddWithInvalidInput()
@@ -3307,18 +3150,15 @@ namespace Garnet.test
             var key = "zset1";
             var response = lightClientRequest.SendCommand($"ZADD {key} 1 uno 2 due 3 tre 4 quattro 5 cinque foo bar");
             var expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_NOT_VALID_FLOAT)}\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             key = "zset2";
             response = lightClientRequest.SendCommand($"ZADD {key} 1 uno 2 due 3 tre foo bar 4 quattro 5 cinque");
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             key = "zset3";
             response = lightClientRequest.SendCommand($"ZADD {key} foo bar 1 uno 2 due 3 tre 4 quattro 5 cinque");
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -3341,37 +3181,31 @@ namespace Garnet.test
             // ZRANGE
             var response = lightClientRequest.SendCommand($"ZRANGE {keys[0]} 0 -1");
             var expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_WRONG_TYPE)}\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
-
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // ZREVRANGE
             response = lightClientRequest.SendCommand($"ZREVRANGE {keys[0]} 0 -1");
             expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_WRONG_TYPE)}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // ZREMRANGEBYLEX
             response = lightClientRequest.SendCommand($"ZREMRANGEBYLEX {keys[0]} {values[1][0]} {values[1][1]}");
             expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_WRONG_TYPE)}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // ZREVRANGEBYSCORE
             response = lightClientRequest.SendCommand($"ZREVRANGEBYSCORE {keys[0]} 0 -1");
             expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_WRONG_TYPE)}\r\n";
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         #endregion
 
         private static void SendCommandWithoutKey(string command, LightClientRequest lightClientRequest)
         {
-            var result = lightClientRequest.SendCommand(command);
+            var response = lightClientRequest.SendCommand(command);
             var expectedResponse = FormatWrongNumOfArgsError(command);
-            var actualValue = Encoding.ASCII.GetString(result).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         private static void UpdateSortedSetKey(string keyName)
@@ -3379,7 +3213,7 @@ namespace Garnet.test
             using var lightClientRequest = TestUtils.CreateRequest();
             byte[] res = lightClientRequest.SendCommand($"ZADD {keyName} 4 d");
             string expectedResponse = ":1\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
         }
 
         private static string FormatWrongNumOfArgsError(string commandName) => $"-{string.Format(CmdStrings.GenericErrWrongNumArgs, commandName)}\r\n";
@@ -3403,8 +3237,7 @@ namespace Garnet.test
                 if (numKeys == 2)
                 {
                     var expectedResponse = "*4\r\n$3\r\none\r\n$1\r\n2\r\n$3\r\ntwo\r\n$1\r\n4\r\n";
-                    var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-                    ClassicAssert.AreEqual(expectedResponse, actualValue);
+                    TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
                 }
             }
             else
@@ -3412,14 +3245,12 @@ namespace Garnet.test
                 if (numKeys == 2)
                 {
                     var expectedResponse = "*2\r\n$3\r\none\r\n$3\r\ntwo\r\n";
-                    var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-                    ClassicAssert.AreEqual(expectedResponse, actualValue);
+                    TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
                 }
                 else if (numKeys == 3)
                 {
                     var expectedResponse = "*1\r\n$3\r\none\r\n";
-                    var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-                    ClassicAssert.AreEqual(expectedResponse, actualValue);
+                    TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
                 }
             }
         }
@@ -3439,8 +3270,7 @@ namespace Garnet.test
 
             var response = lightClientRequest.SendCommand(command);
             var expectedResponse = $":{expectedCount}\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -3458,8 +3288,7 @@ namespace Garnet.test
 
             var response = lightClientRequest.SendCommand(command);
             var expectedResponse = $":{expectedCount}\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Verify stored results
             response = lightClientRequest.SendCommand("ZRANGE dest 0 -1 WITHSCORES");
@@ -3479,8 +3308,7 @@ namespace Garnet.test
             {
                 expectedResponse = "*4\r\n$3\r\none\r\n$1\r\n2\r\n$3\r\ntwo\r\n$1\r\n4\r\n";
             }
-            actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
     }
 

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -568,35 +568,35 @@ namespace Garnet.test
             // Set keys
             var response = lightClientRequest.SendCommand("MSETNX key1 5 key2 6");
             var expectedResponse = ":1\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // MSETNX command should fail since key exists
             response = lightClientRequest.SendCommand("MSETNX key3 7 key1 8");
             expectedResponse = ":0\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Verify values
             response = lightClientRequest.SendCommand("GET key1");
             expectedResponse = "$1\r\n5\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("GET key2");
             expectedResponse = "$1\r\n6\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Should not be set even though it was 'before' existing key1.
             response = lightClientRequest.SendCommand("GET key3");
             expectedResponse = "$-1\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("HSET key4 first 1");
             expectedResponse = ":1\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // MSETNX command should fail since key exists even if it's an object.
             response = lightClientRequest.SendCommand("MSETNX key3 7 key4 8");
             expectedResponse = ":0\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -4705,17 +4705,17 @@ namespace Garnet.test
             // Set key
             var response = lightClientRequest.SendCommand("SETNX key1 2");
             var expectedResponse = ":1\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Setnx command should fail since key exists
             response = lightClientRequest.SendCommand("SETNX key1 3");
             expectedResponse = ":0\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // Be sure key wasn't modified
             response = lightClientRequest.SendCommand("GET key1");
             expectedResponse = "$1\r\n2\r\n";
-            ClassicAssert.AreEqual(expectedResponse, response.AsSpan().Slice(0, expectedResponse.Length).ToArray());
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
         #endregion
 

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
@@ -90,6 +91,12 @@ namespace Garnet.test
                 }
                 return false;
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void AssertEqualUpToExpectedLength(string expectedResponse, byte[] response)
+        {
+            ClassicAssert.AreEqual(expectedResponse, Encoding.ASCII.GetString(response, 0, expectedResponse.Length));
         }
 
         /// <summary>

--- a/test/Garnet.test/TransactionTests.cs
+++ b/test/Garnet.test/TransactionTests.cs
@@ -207,25 +207,25 @@ namespace Garnet.test
 
             res = lightClientRequest.SendCommand("SET key1 value1");
             string expectedResponse = "+OK\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             res = lightClientRequest.SendCommand("WATCH key1");
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             res = lightClientRequest.SendCommand("MULTI");
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             res = lightClientRequest.SendCommand("GET key1");
             expectedResponse = "+QUEUED\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
             res = lightClientRequest.SendCommand("SET key2 value2");
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             await Task.Run(() => updateKey("key1", "value1_updated"));
 
             res = lightClientRequest.SendCommand("EXEC");
             expectedResponse = "*-1";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             // This one should Commit
             lightClientRequest.SendCommand("MULTI");
@@ -234,10 +234,7 @@ namespace Garnet.test
             res = lightClientRequest.SendCommand("EXEC");
 
             expectedResponse = "*2\r\n$14\r\nvalue1_updated\r\n+OK\r\n";
-
-            ClassicAssert.AreEqual(
-                expectedResponse,
-                Encoding.ASCII.GetString(res.AsSpan().Slice(0, expectedResponse.Length)));
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
         }
 
         [Test]
@@ -248,21 +245,21 @@ namespace Garnet.test
 
             string expectedResponse = ":1\r\n";
             res = lightClientRequest.SendCommand("SET key1 value1 WITHETAG");
-            var debug = res.AsSpan().Slice(0, expectedResponse.Length).ToArray();
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             expectedResponse = "+OK\r\n";
             res = lightClientRequest.SendCommand("WATCH key1");
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             res = lightClientRequest.SendCommand("MULTI");
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             res = lightClientRequest.SendCommand("GET key1");
             expectedResponse = "+QUEUED\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+
             res = lightClientRequest.SendCommand("SET key2 value2");
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             await Task.Run(() =>
             {
@@ -273,7 +270,7 @@ namespace Garnet.test
 
             res = lightClientRequest.SendCommand("EXEC");
             expectedResponse = "*-1";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             // This one should Commit
             lightClientRequest.SendCommand("MULTI");
@@ -290,15 +287,13 @@ namespace Garnet.test
             res = lightClientRequest.SendCommand("EXEC");
 
             expectedResponse = "*7\r\n$14\r\nvalue1_updated\r\n+OK\r\n:1\r\n*2\r\n:1\r\n$6\r\nvalue2\r\n*2\r\n:1\r\n$-1\r\n*2\r\n:2\r\n$-1\r\n:3\r\n";
-            string response = Encoding.ASCII.GetString(res.AsSpan().Slice(0, expectedResponse.Length));
-            ClassicAssert.AreEqual(expectedResponse, response);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             // check if we still have the appropriate etag on the key we had set
             var otherLighClientRequest = TestUtils.CreateRequest();
             res = otherLighClientRequest.SendCommand("GETWITHETAG key1");
             expectedResponse = "*2\r\n:2\r\n$14\r\nvalue1_updated\r\n";
-            response = Encoding.ASCII.GetString(res.AsSpan().Slice(0, expectedResponse.Length));
-            ClassicAssert.AreEqual(response, expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
         }
 
         [Test]
@@ -310,25 +305,26 @@ namespace Garnet.test
             string expectedResponse = "+OK\r\n";
 
             res = lightClientRequest.SendCommand("SET key2 value2");
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             res = lightClientRequest.SendCommand("WATCH key1");
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             res = lightClientRequest.SendCommand("MULTI");
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             res = lightClientRequest.SendCommand("GET key2");
             expectedResponse = "+QUEUED\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+
             res = lightClientRequest.SendCommand("SET key3 value3");
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             await Task.Run(() => updateKey("key1", "value1"));
 
             res = lightClientRequest.SendCommand("EXEC");
             expectedResponse = "*-1";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             // This one should Commit
             lightClientRequest.SendCommand("MULTI");
@@ -337,8 +333,7 @@ namespace Garnet.test
             res = lightClientRequest.SendCommand("EXEC");
 
             expectedResponse = "*2\r\n$6\r\nvalue1\r\n+OK\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
-
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
         }
 
         [Test]
@@ -359,22 +354,23 @@ namespace Garnet.test
             // this key should be in the disk
             res = lightClientRequest.SendCommand("WATCH key1");
             string expectedResponse = "+OK\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             res = lightClientRequest.SendCommand("MULTI");
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             res = lightClientRequest.SendCommand("GET key900");
             expectedResponse = "+QUEUED\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+
             res = lightClientRequest.SendCommand("SET key901 value901_updated");
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             await Task.Run(() => updateKey("key1", "value1_updated"));
 
             res = lightClientRequest.SendCommand("EXEC");
             expectedResponse = "*-1";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
 
             // This one should Commit
             lightClientRequest.SendCommand("MULTI");
@@ -385,16 +381,17 @@ namespace Garnet.test
             var buffer_str = System.Text.Encoding.Default.GetString(res);
 
             expectedResponse = "*2\r\n$8\r\nvalue900\r\n+OK\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
         }
 
         private static void updateKey(string key, string value)
         {
             using var lightClientRequest = TestUtils.CreateRequest();
-            string command = $"SET {key} {value}";
-            byte[] res = lightClientRequest.SendCommand(command);
-            string expectedResponse = "+OK\r\n";
-            ClassicAssert.AreEqual(res.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
+            var command = $"SET {key} {value}";
+            var res = lightClientRequest.SendCommand(command);
+
+            var expectedResponse = "+OK\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
         }
     }
 }

--- a/test/Garnet.test/TransactionTests.cs
+++ b/test/Garnet.test/TransactionTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System;
-using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
@@ -203,63 +201,61 @@ namespace Garnet.test
         public async Task SimpleWatchTest()
         {
             var lightClientRequest = TestUtils.CreateRequest();
-            byte[] res;
 
-            res = lightClientRequest.SendCommand("SET key1 value1");
-            string expectedResponse = "+OK\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            var response = lightClientRequest.SendCommand("SET key1 value1");
+            var expectedResponse = "+OK\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("WATCH key1");
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            response = lightClientRequest.SendCommand("WATCH key1");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("MULTI");
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            response = lightClientRequest.SendCommand("MULTI");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("GET key1");
+            response = lightClientRequest.SendCommand("GET key1");
             expectedResponse = "+QUEUED\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
-            res = lightClientRequest.SendCommand("SET key2 value2");
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+            response = lightClientRequest.SendCommand("SET key2 value2");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             await Task.Run(() => updateKey("key1", "value1_updated"));
 
-            res = lightClientRequest.SendCommand("EXEC");
+            response = lightClientRequest.SendCommand("EXEC");
             expectedResponse = "*-1";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // This one should Commit
             lightClientRequest.SendCommand("MULTI");
             lightClientRequest.SendCommand("GET key1");
             lightClientRequest.SendCommand("SET key2 value2");
-            res = lightClientRequest.SendCommand("EXEC");
+            response = lightClientRequest.SendCommand("EXEC");
 
             expectedResponse = "*2\r\n$14\r\nvalue1_updated\r\n+OK\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
         public async Task WatchTestWithSetWithEtag()
         {
             var lightClientRequest = TestUtils.CreateRequest();
-            byte[] res;
 
-            string expectedResponse = ":1\r\n";
-            res = lightClientRequest.SendCommand("SET key1 value1 WITHETAG");
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            var expectedResponse = ":1\r\n";
+            var response = lightClientRequest.SendCommand("SET key1 value1 WITHETAG");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             expectedResponse = "+OK\r\n";
-            res = lightClientRequest.SendCommand("WATCH key1");
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            response = lightClientRequest.SendCommand("WATCH key1");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("MULTI");
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            response = lightClientRequest.SendCommand("MULTI");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("GET key1");
+            response = lightClientRequest.SendCommand("GET key1");
             expectedResponse = "+QUEUED\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("SET key2 value2");
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            response = lightClientRequest.SendCommand("SET key2 value2");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             await Task.Run(() =>
             {
@@ -268,9 +264,9 @@ namespace Garnet.test
                 lightClientRequestCopy.SendCommand(command);
             });
 
-            res = lightClientRequest.SendCommand("EXEC");
+            response = lightClientRequest.SendCommand("EXEC");
             expectedResponse = "*-1";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // This one should Commit
             lightClientRequest.SendCommand("MULTI");
@@ -284,56 +280,54 @@ namespace Garnet.test
             lightClientRequest.SendCommand("SETIFMATCH key3 anotherVal 1");
             lightClientRequest.SendCommand("SET key3 arandomval WITHETAG");
 
-            res = lightClientRequest.SendCommand("EXEC");
+            response = lightClientRequest.SendCommand("EXEC");
 
             expectedResponse = "*7\r\n$14\r\nvalue1_updated\r\n+OK\r\n:1\r\n*2\r\n:1\r\n$6\r\nvalue2\r\n*2\r\n:1\r\n$-1\r\n*2\r\n:2\r\n$-1\r\n:3\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // check if we still have the appropriate etag on the key we had set
             var otherLighClientRequest = TestUtils.CreateRequest();
-            res = otherLighClientRequest.SendCommand("GETWITHETAG key1");
+            response = otherLighClientRequest.SendCommand("GETWITHETAG key1");
             expectedResponse = "*2\r\n:2\r\n$14\r\nvalue1_updated\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
         public async Task WatchNonExistentKey()
         {
             var lightClientRequest = TestUtils.CreateRequest();
-            byte[] res;
 
-            string expectedResponse = "+OK\r\n";
+            var expectedResponse = "+OK\r\n";
+            var response = lightClientRequest.SendCommand("SET key2 value2");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("SET key2 value2");
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            response = lightClientRequest.SendCommand("WATCH key1");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("WATCH key1");
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            response = lightClientRequest.SendCommand("MULTI");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("MULTI");
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
-
-            res = lightClientRequest.SendCommand("GET key2");
+            response = lightClientRequest.SendCommand("GET key2");
             expectedResponse = "+QUEUED\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("SET key3 value3");
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            response = lightClientRequest.SendCommand("SET key3 value3");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             await Task.Run(() => updateKey("key1", "value1"));
 
-            res = lightClientRequest.SendCommand("EXEC");
+            response = lightClientRequest.SendCommand("EXEC");
             expectedResponse = "*-1";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // This one should Commit
             lightClientRequest.SendCommand("MULTI");
             lightClientRequest.SendCommand("GET key1");
             lightClientRequest.SendCommand("SET key2 value2");
-            res = lightClientRequest.SendCommand("EXEC");
+            response = lightClientRequest.SendCommand("EXEC");
 
             expectedResponse = "*2\r\n$6\r\nvalue1\r\n+OK\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -348,50 +342,46 @@ namespace Garnet.test
             }
 
             var lightClientRequest = TestUtils.CreateRequest();
-            byte[] res;
-
 
             // this key should be in the disk
-            res = lightClientRequest.SendCommand("WATCH key1");
-            string expectedResponse = "+OK\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            var response = lightClientRequest.SendCommand("WATCH key1");
+            var expectedResponse = "+OK\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("MULTI");
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            response = lightClientRequest.SendCommand("MULTI");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("GET key900");
+            response = lightClientRequest.SendCommand("GET key900");
             expectedResponse = "+QUEUED\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            res = lightClientRequest.SendCommand("SET key901 value901_updated");
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            response = lightClientRequest.SendCommand("SET key901 value901_updated");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             await Task.Run(() => updateKey("key1", "value1_updated"));
 
-            res = lightClientRequest.SendCommand("EXEC");
+            response = lightClientRequest.SendCommand("EXEC");
             expectedResponse = "*-1";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             // This one should Commit
             lightClientRequest.SendCommand("MULTI");
             lightClientRequest.SendCommand("GET key900");
             lightClientRequest.SendCommand("SET key901 value901_updated");
-            res = lightClientRequest.SendCommand("EXEC");
-
-            var buffer_str = System.Text.Encoding.Default.GetString(res);
+            response = lightClientRequest.SendCommand("EXEC");
 
             expectedResponse = "*2\r\n$8\r\nvalue900\r\n+OK\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         private static void updateKey(string key, string value)
         {
             using var lightClientRequest = TestUtils.CreateRequest();
             var command = $"SET {key} {value}";
-            var res = lightClientRequest.SendCommand(command);
+            var response = lightClientRequest.SendCommand(command);
 
             var expectedResponse = "+OK\r\n";
-            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, res);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
     }
 }


### PR DESCRIPTION
LightClient is used for a lot of the testsuit. It uses a large fixed array, which is trimmed to compare a fixed expected responsed. There are at least 4 separate ways this is done in the testsuit**. Also the comparison is sometimes wrong in the argument order (doesn't use expected response as expected) or very rarely just wrong (CanUseZDiffSTORE test). 

This PR introduces a standard TestUtils methods for this assertion, changes almost all relevant locations to use it, and fixes the few cases when it's done incorrectly.

**

1. There's this:
Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length).

(Runs GetString + allocation over the entire fixed array).

2. There's also:
Encoding.ASCII.GetString(response, 0, expectedResponse.Length)

(Reasonable, but allocates. Maybe could be improved)

3. And also:
  ClassicAssert.AreEqual(response.AsSpan().Slice(0, expectedResponse.Length).ToArray(), expectedResponse);
  
(Order of arguments is wrong. Otherwise, it's interesting to note NUnit can handle the different types, not clear if that is better or worse).

4. Lastly there are calls to lightclient's Execute() method which just does the second under the hood. These aren't modified for now.

This diff uses the Encoding.ASCII.GetString(response, 0, expectedResponse.Length) method. It would be easy the try the latter method (in the correct argument order) if it's useful.

(Re #1063 comments: I don't view this as 'improving lightClient' but as improving the testsuit. If we are stuck with some use for now, might as well test the assertion in a consistent and safe way.)