### PR TITLE
Bugfix: Retain Expiration at IPU for SETIFGREATER and SETIFMATCH

### DIFF
--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -1,4 +1,4 @@
-ARG TAG=ltsc2022
+ARG TAG=ltsc2025
 FROM mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-$TAG AS build
 
 WORKDIR /source
@@ -7,11 +7,10 @@ WORKDIR /source
 COPY . .
 WORKDIR /source/main/GarnetServer
 
-RUN dotnet restore
-RUN dotnet build -c Release -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false
-
-# Copy and publish app and libraries
-RUN dotnet publish -c Release -o /app -r win-x64 --self-contained false -f net8.0 -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false
+# Restore, build, and publish
+RUN dotnet restore && \
+    dotnet build -c Release -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false && \
+    dotnet publish -c Release -o /app -r win-x64 --self-contained false -f net8.0 -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false
 
 # Final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:8.0-nanoserver-$TAG AS runtime

--- a/libs/server/Storage/Functions/MainStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/RMWMethods.cs
@@ -398,7 +398,7 @@ namespace Garnet.server
                     recordInfo.SetHasETag();
 
                     long newEtag = cmd is RespCommand.SETIFMATCH ? (functionsState.etagState.etag + 1) : (etagFromClient + 1);
-                    
+
                     long oldExtraMetadata = value.ExtraMetadata;
 
                     rmwInfo.ClearExtraValueLength(ref recordInfo, ref value, value.TotalSize);

--- a/libs/server/Storage/Functions/MainStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/RMWMethods.cs
@@ -398,6 +398,8 @@ namespace Garnet.server
                     recordInfo.SetHasETag();
 
                     long newEtag = cmd is RespCommand.SETIFMATCH ? (functionsState.etagState.etag + 1) : (etagFromClient + 1);
+                    
+                    long oldExtraMetadata = value.ExtraMetadata;
 
                     rmwInfo.ClearExtraValueLength(ref recordInfo, ref value, value.TotalSize);
                     value.UnmarkExtraMetadata();
@@ -407,6 +409,10 @@ namespace Garnet.server
                     if (input.arg1 != 0)
                     {
                         value.ExtraMetadata = input.arg1;
+                    }
+                    else if (oldExtraMetadata != 0)
+                    {
+                        value.ExtraMetadata = oldExtraMetadata;
                     }
 
                     value.SetEtagInPayload(newEtag);

--- a/test/Garnet.test/RespEtagTests.cs
+++ b/test/Garnet.test/RespEtagTests.cs
@@ -208,6 +208,17 @@ namespace Garnet.test
             // confirm expiration retained -> TTL should exist
             ttl = db.KeyTimeToLive(key);
             ClassicAssert.IsTrue(ttl.HasValue);
+
+
+            // Scenario: smaller length update (IPU) of a key with existing etag should increment the ETAG and retain the expiration
+            res = db.Execute("SET", key, "oneofusoneofus", "EX", 10000);
+            // when no etag then count 0 as it's existing etag
+            updatedEtagRes = long.Parse(db.Execute("SETIFMATCH", key, "i", 0)[0].ToString());
+            ClassicAssert.AreEqual(1, updatedEtagRes);
+
+            // confirm expiration retained -> TTL should exist
+            ttl = db.KeyTimeToLive(key);
+            ClassicAssert.IsTrue(ttl.HasValue);
         }
 
         #endregion


### PR DESCRIPTION
IPU removes existing expiration currently. This PR adds the retention to be consistent with RCU for the same commands.