### PR TITLE
Website update - copyright to 2025 and short meta tag description.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -149,7 +149,7 @@ const config = {
           style="color: white;">Terms of Use</a> |
           <a href="
           https://www.microsoft.com/trademarks"
-          style="color: white;">Trademarks</a> | © 2024
+          style="color: white;">Trademarks</a> | © 2025
           </p>`,
       },
       prism: {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -33,7 +33,7 @@ export default function Home() {
   return (
     <Layout
       title={`Hello from ${siteConfig.title}`}
-          description="Garnet is a high-performance remote cache-store from Microsoft Research, that works with existing Redis clients.">
+      description="Garnet is a high-performance remote cache-store from Microsoft Research, that works with existing Redis clients.">
       <HomepageHeader />
       <main>
         <HomepageFeatures />

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -33,7 +33,7 @@ export default function Home() {
   return (
     <Layout
       title={`Hello from ${siteConfig.title}`}
-          description="Garnet is a new remote cache-store from Microsoft Research">
+          description="Garnet is a high-performance remote cache-store from Microsoft Research, that works with existing Redis clients.">
       <HomepageHeader />
       <main>
         <HomepageFeatures />

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -33,7 +33,7 @@ export default function Home() {
   return (
     <Layout
       title={`Hello from ${siteConfig.title}`}
-          description="Garnet is a new remote cache-store from Microsoft Research. <head />">
+          description="Garnet is a new remote cache-store from Microsoft Research">
       <HomepageHeader />
       <main>
         <HomepageFeatures />

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -33,7 +33,7 @@ export default function Home() {
   return (
     <Layout
       title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
+          description="Garnet is a new remote cache-store from Microsoft Research. <head />">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
I updated the copyright at the bottom of the web page to 2025.

I also added short description for the Meta Tag ("Garnet is a new remote cache-store from Microsoft Research.").  This replaced the default of "Description will go into a meta tag in"