### PR TITLE
Keyspace Notifications #915

### DIFF
--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -183,6 +183,9 @@ namespace Garnet
         [Option("cluster-password", Required = false, HelpText = "Password to authenticate intra-cluster communication with.")]
         public string ClusterPassword { get; set; }
 
+        [Option("notify-keyspace-events-arguments", Required = false, HelpText = "Keyspace Notification argument string.")]
+        public string NotifiyKeyspaceEventsArguments { get; set; }
+
         [FilePathValidation(true, true, false)]
         [Option("acl-file", Required = false, HelpText = "External ACL user file.")]
         public string AclFile { get; set; }

--- a/libs/server/KeyspaceNotifications/IKeyspaceNotificationOptions.cs
+++ b/libs/server/KeyspaceNotifications/IKeyspaceNotificationOptions.cs
@@ -1,65 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 namespace Garnet.server.KeyspaceNotifications
 {
-    /// <summary>
-    /// Represents different types of notifications that can be received.
-    /// </summary>
-    [Flags]
-    public enum KeyspaceNotificationType
+    public interface IKeyspaceNotificationOptions
     {
-        /// <summary>Keyspace events, published with __keyspace@&lt;db&gt;__ prefix.</summary>
-        Keyspace = 1 << 0,    // K
-
-        /// <summary>Keyevent events, published with __keyevent@&lt;db&gt;__ prefix.</summary>
-        KeyEvent = 1 << 1,    // E
-
-        /// <summary>Generic commands (non-type specific) like DEL, EXPIRE, RENAME, etc.</summary>
-        Generic = 1 << 2,     // g
-
-        /// <summary>String commands.</summary>
-        String = 1 << 3,      // $
-
-        /// <summary>List commands.</summary>
-        List = 1 << 4,        // l
-
-        /// <summary>Set commands.</summary>
-        Set = 1 << 5,         // s
-
-        /// <summary>Hash commands.</summary>
-        Hash = 1 << 6,        // h
-
-        /// <summary>Sorted set commands.</summary>
-        ZSet = 1 << 7,        // z
-
-        /// <summary>Expired events (events generated every time a key expires).</summary>
-        Expired = 1 << 8,     // x
-
-        /// <summary>Evicted events (events generated when a key is evicted for maxmemory).</summary>
-        Evicted = 1 << 9,     // e
-
-        /// <summary>Stream commands.</summary>
-        Stream = 1 << 10,     // t
-
-        /// <summary>Key miss events (events generated when a key that doesn't exist is accessed).</summary>
-        KeyMiss = 1 << 11,    // m (Excluded from NOTIFY_ALL)
-
-        /// <summary>Module-only key space notification, indicating a key loaded from RDB.</summary>
-        Loaded = 1 << 12,     // module only key space notification
-
-        /// <summary>Module key type events.</summary>
-        Module = 1 << 13,     // d, module key space notification
-
-        /// <summary>New key events (Note: not included in the 'A' class).</summary>
-        New = 1 << 14,        // n, new key notification
-
-        /// <summary>
-        /// Alias for "g$lshztxed", meaning all events except "m" (KeyMiss) and "n" (New).
-        /// </summary>
-        All = Generic | String | List | Set | Hash | ZSet | Expired | Evicted | Stream | Module // A flag
+        KeyspaceNotificationType KeyspaceNotificationType { get; set; }
     }
 }

--- a/libs/server/KeyspaceNotifications/IKeyspaceNotificationOptions.cs
+++ b/libs/server/KeyspaceNotifications/IKeyspaceNotificationOptions.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Garnet.server.KeyspaceNotifications
+{
+    /// <summary>
+    /// Represents different types of notifications that can be received.
+    /// </summary>
+    [Flags]
+    public enum KeyspaceNotificationType
+    {
+        /// <summary>Keyspace events, published with __keyspace@&lt;db&gt;__ prefix.</summary>
+        Keyspace = 1 << 0,    // K
+
+        /// <summary>Keyevent events, published with __keyevent@&lt;db&gt;__ prefix.</summary>
+        KeyEvent = 1 << 1,    // E
+
+        /// <summary>Generic commands (non-type specific) like DEL, EXPIRE, RENAME, etc.</summary>
+        Generic = 1 << 2,     // g
+
+        /// <summary>String commands.</summary>
+        String = 1 << 3,      // $
+
+        /// <summary>List commands.</summary>
+        List = 1 << 4,        // l
+
+        /// <summary>Set commands.</summary>
+        Set = 1 << 5,         // s
+
+        /// <summary>Hash commands.</summary>
+        Hash = 1 << 6,        // h
+
+        /// <summary>Sorted set commands.</summary>
+        ZSet = 1 << 7,        // z
+
+        /// <summary>Expired events (events generated every time a key expires).</summary>
+        Expired = 1 << 8,     // x
+
+        /// <summary>Evicted events (events generated when a key is evicted for maxmemory).</summary>
+        Evicted = 1 << 9,     // e
+
+        /// <summary>Stream commands.</summary>
+        Stream = 1 << 10,     // t
+
+        /// <summary>Key miss events (events generated when a key that doesn't exist is accessed).</summary>
+        KeyMiss = 1 << 11,    // m (Excluded from NOTIFY_ALL)
+
+        /// <summary>Module-only key space notification, indicating a key loaded from RDB.</summary>
+        Loaded = 1 << 12,     // module only key space notification
+
+        /// <summary>Module key type events.</summary>
+        Module = 1 << 13,     // d, module key space notification
+
+        /// <summary>New key events (Note: not included in the 'A' class).</summary>
+        New = 1 << 14,        // n, new key notification
+
+        /// <summary>
+        /// Alias for "g$lshztxed", meaning all events except "m" (KeyMiss) and "n" (New).
+        /// </summary>
+        All = Generic | String | List | Set | Hash | ZSet | Expired | Evicted | Stream | Module // A flag
+    }
+}

--- a/libs/server/KeyspaceNotifications/KeyspaceNotificationPublisher.cs
+++ b/libs/server/KeyspaceNotifications/KeyspaceNotificationPublisher.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Garnet.server.KeyspaceNotifications;
+
+namespace Garnet.server
+{
+    internal sealed partial class RespServerSession : ServerSessionBase
+    {
+        public void PublishKeyspaceNotification(KeyspaceNotificationType keyspaceNotificationType, ref ArgSlice argSlice) 
+        {
+            if (!storeWrapper.serverOptions.AllowedKeyspaceNotifications.HasFlag(keyspaceNotificationType))
+            {
+                return;
+            }
+
+            if (storeWrapper.serverOptions.AllowedKeyspaceNotifications.HasFlag(KeyspaceNotificationType.Keyspace))
+            {
+                PublishKeyspace(ref argSlice);
+            }
+
+            if (storeWrapper.serverOptions.AllowedKeyspaceNotifications.HasFlag(KeyspaceNotificationType.Keyevent))
+            {
+                PublishKeyevent(ref argSlice);
+            }
+        }
+
+        public void PublishKeyevent(ref ArgSlice argSlice)
+        {
+            Publish(ArgSlice.FromPinnedSpan(KeyspaceNotificationStrings.KeyspacePrefix), argSlice);
+        }
+
+        public void PublishKeyspace(ref ArgSlice argSlice)
+        {
+            Publish(ArgSlice.FromPinnedSpan(KeyspaceNotificationStrings.KeyeventPrefix), argSlice);
+        }
+    }
+}

--- a/libs/server/KeyspaceNotifications/KeyspaceNotificationPublisher.cs
+++ b/libs/server/KeyspaceNotifications/KeyspaceNotificationPublisher.cs
@@ -30,12 +30,12 @@ namespace Garnet.server
 
         public void PublishKeyevent(ref ArgSlice argSlice)
         {
-            Publish(ArgSlice.FromPinnedSpan(KeyspaceNotificationStrings.KeyspacePrefix), argSlice);
+            subscribeBroker.Publish(ArgSlice.FromPinnedSpan(KeyspaceNotificationStrings.KeyspacePrefix), argSlice);
         }
 
         public void PublishKeyspace(ref ArgSlice argSlice)
         {
-            Publish(ArgSlice.FromPinnedSpan(KeyspaceNotificationStrings.KeyeventPrefix), argSlice);
+            subscribeBroker.Publish(ArgSlice.FromPinnedSpan(KeyspaceNotificationStrings.KeyeventPrefix), argSlice);
         }
     }
 }

--- a/libs/server/KeyspaceNotifications/KeyspaceNotificationPublisher.cs
+++ b/libs/server/KeyspaceNotifications/KeyspaceNotificationPublisher.cs
@@ -4,7 +4,7 @@ using Garnet.server.KeyspaceNotifications;
 
 namespace Garnet.server
 {
-    internal sealed partial class RespServerSession : ServerSessionBase
+    internal sealed unsafe partial class RespServerSession : ServerSessionBase
     {
         // TODO: use same parameter for key and keyevent; pass keyevent as ref; test performance; avoid concatSpans and remove concatenated Spans; check access modifiers
         internal void PublishKeyspaceNotification(KeyspaceNotificationType keyspaceNotificationType, ref ArgSlice key, ReadOnlySpan<byte> keyevent) 

--- a/libs/server/KeyspaceNotifications/KeyspaceNotificationPublisher.cs
+++ b/libs/server/KeyspaceNotifications/KeyspaceNotificationPublisher.cs
@@ -6,7 +6,7 @@ namespace Garnet.server
 {
     internal sealed partial class RespServerSession : ServerSessionBase
     {
-        // TODO: use same parameter for key and keyevent; pass keyevent as ref; test performance
+        // TODO: use same parameter for key and keyevent; pass keyevent as ref; test performance; avoid concatSpans and remove concatenated Spans; check access modifiers
         internal void PublishKeyspaceNotification(KeyspaceNotificationType keyspaceNotificationType, ref ArgSlice key, ReadOnlySpan<byte> keyevent) 
         {
             if (!storeWrapper.serverOptions.AllowedKeyspaceNotifications.HasFlag(keyspaceNotificationType))
@@ -39,7 +39,6 @@ namespace Garnet.server
             // TODO: see above
             subscribeBroker.Publish(ArgSlice.FromPinnedSpan(channel), key);
         }
-
 
         private static ReadOnlySpan<byte> ConcatSpans(ReadOnlySpan<byte> first, ReadOnlySpan<byte> second)
         {

--- a/libs/server/KeyspaceNotifications/KeyspaceNotificationStrings.cs
+++ b/libs/server/KeyspaceNotifications/KeyspaceNotificationStrings.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Garnet.server.KeyspaceNotifications
+{
+    /// <summary>
+    /// Keyspace Notification strings
+    /// </summary>
+    static partial class KeyspaceNotificationStrings
+    {
+        public static ReadOnlySpan<byte> KeyspacePrefix => "__keyspace@"u8;
+        public static ReadOnlySpan<byte> KeyeventPrefix => "__keyevent@"u8;
+        public static ReadOnlySpan<byte> Suffix => "__:"u8;
+    }
+}

--- a/libs/server/KeyspaceNotifications/KeyspaceNotificationStrings.cs
+++ b/libs/server/KeyspaceNotifications/KeyspaceNotificationStrings.cs
@@ -13,6 +13,6 @@ namespace Garnet.server.KeyspaceNotifications
     {
         public static ReadOnlySpan<byte> KeyspacePrefix => "__keyspace@"u8;
         public static ReadOnlySpan<byte> KeyeventPrefix => "__keyevent@"u8;
-        public static ReadOnlySpan<byte> Suffix => "__:"u8;
+        public static ReadOnlySpan<byte> Suffix => "0__:"u8;
     }
 }

--- a/libs/server/KeyspaceNotifications/KeyspaceNotificationStrings.cs
+++ b/libs/server/KeyspaceNotifications/KeyspaceNotificationStrings.cs
@@ -13,6 +13,7 @@ namespace Garnet.server.KeyspaceNotifications
     {
         public static ReadOnlySpan<byte> KeyspacePrefix => "__keyspace@"u8;
         public static ReadOnlySpan<byte> KeyeventPrefix => "__keyevent@"u8;
+        // TODO: dont use a hardcoded db id 
         public static ReadOnlySpan<byte> Suffix => "0__:"u8;
     }
 }

--- a/libs/server/KeyspaceNotifications/KeyspaceNotificationType.cs
+++ b/libs/server/KeyspaceNotifications/KeyspaceNotificationType.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Garnet.server.KeyspaceNotifications
+{
+    /// <summary>
+    /// Represents different types of notifications that can be received.
+    /// </summary>
+    [Flags]
+    public enum KeyspaceNotificationType
+    {
+        /// <summary>Keyspace events, published with __keyspace@&lt;db&gt;__ prefix.</summary>
+        Keyspace = 1 << 0,    // K
+
+        /// <summary>Keyevent events, published with __keyevent@&lt;db&gt;__ prefix.</summary>
+        KeyEvent = 1 << 1,    // E
+
+        /// <summary>Generic commands (non-type specific) like DEL, EXPIRE, RENAME, etc.</summary>
+        Generic = 1 << 2,     // g
+
+        /// <summary>String commands.</summary>
+        String = 1 << 3,      // $
+
+        /// <summary>List commands.</summary>
+        List = 1 << 4,        // l
+
+        /// <summary>Set commands.</summary>
+        Set = 1 << 5,         // s
+
+        /// <summary>Hash commands.</summary>
+        Hash = 1 << 6,        // h
+
+        /// <summary>Sorted set commands.</summary>
+        ZSet = 1 << 7,        // z
+
+        /// <summary>Expired events (events generated every time a key expires).</summary>
+        Expired = 1 << 8,     // x
+
+        /// <summary>Evicted events (events generated when a key is evicted for maxmemory).</summary>
+        Evicted = 1 << 9,     // e
+
+        /// <summary>Stream commands.</summary>
+        Stream = 1 << 10,     // t
+
+        /// <summary>Key miss events (events generated when a key that doesn't exist is accessed).</summary>
+        KeyMiss = 1 << 11,    // m (Excluded from NOTIFY_ALL)
+
+        /// <summary>Module-only key space notification, indicating a key loaded from RDB.</summary>
+        Loaded = 1 << 12,     // module only key space notification
+
+        /// <summary>Module key type events.</summary>
+        Module = 1 << 13,     // d, module key space notification
+
+        /// <summary>New key events (Note: not included in the 'A' class).</summary>
+        New = 1 << 14,        // n, new key notification
+
+        /// <summary>
+        /// Alias for "g$lshztxed", meaning all events except "m" (KeyMiss) and "n" (New).
+        /// </summary>
+        All = Generic | String | List | Set | Hash | ZSet | Expired | Evicted | Stream | Module // A flag
+    }
+}

--- a/libs/server/KeyspaceNotifications/KeyspaceNotificationType.cs
+++ b/libs/server/KeyspaceNotifications/KeyspaceNotificationType.cs
@@ -16,7 +16,7 @@ namespace Garnet.server.KeyspaceNotifications
         Keyspace = 1 << 0,    // K
 
         /// <summary>Keyevent events, published with __keyevent@&lt;db&gt;__ prefix.</summary>
-        KeyEvent = 1 << 1,    // E
+        Keyevent = 1 << 1,    // E
 
         /// <summary>Generic commands (non-type specific) like DEL, EXPIRE, RENAME, etc.</summary>
         Generic = 1 << 2,     // g

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Threading.Tasks;
 using Garnet.common;
+using Garnet.server.KeyspaceNotifications;
 using Microsoft.Extensions.Logging;
 using Tsavorite.core;
 
@@ -292,6 +293,8 @@ namespace Garnet.server
 
             while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
                 SendAndReset();
+
+            PublishKeyspaceNotification(KeyspaceNotificationType.Set, ref parseState.GetArgSliceByRef(0));
 
             return true;
         }

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -291,10 +291,10 @@ namespace Garnet.server
 
             storageApi.SET(ref key, ref value);
 
+            PublishKeyspaceNotification(KeyspaceNotificationType.Set, ref parseState.GetArgSliceByRef(0), CmdStrings.set);
+            
             while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
                 SendAndReset();
-
-            PublishKeyspaceNotification(KeyspaceNotificationType.Set, ref parseState.GetArgSliceByRef(0), CmdStrings.set);
 
             return true;
         }

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -294,7 +294,7 @@ namespace Garnet.server
             while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
                 SendAndReset();
 
-            PublishKeyspaceNotification(KeyspaceNotificationType.Set, ref parseState.GetArgSliceByRef(0));
+            PublishKeyspaceNotification(KeyspaceNotificationType.Set, ref parseState.GetArgSliceByRef(0), CmdStrings.set);
 
             return true;
         }

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -341,7 +341,7 @@ namespace Garnet.server
             var output = ArgSlice.FromPinnedSpan(outputBuffer);
 
             storageApi.SETRANGE(key, ref input, ref output);
-
+            PublishKeyspaceNotification(KeyspaceNotificationType.String, ref key, CmdStrings.setrange);
             while (!RespWriteUtils.TryWriteIntegerFromBytes(outputBuffer.Slice(0, output.Length), ref dcurr, dend))
                 SendAndReset();
 
@@ -766,6 +766,7 @@ namespace Garnet.server
                 case OperationError.SUCCESS:
                     while (!RespWriteUtils.TryWriteIntegerFromBytes(outputBuffer.Slice(0, output.Length), ref dcurr, dend))
                         SendAndReset();
+                    PublishKeyspaceNotification(KeyspaceNotificationType.String, ref key, CmdStrings.incrby);
                     break;
                 case OperationError.INVALID_TYPE:
                     while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_GENERIC_VALUE_IS_NOT_INTEGER, ref dcurr, dend))
@@ -809,6 +810,7 @@ namespace Garnet.server
                 case OperationError.SUCCESS:
                     while (!RespWriteUtils.TryWriteBulkString(outputBuffer.Slice(0, output.Length), ref dcurr, dend))
                         SendAndReset();
+                    PublishKeyspaceNotification(KeyspaceNotificationType.String, ref key, CmdStrings.incrbyfloat);
                     break;
                 case OperationError.INVALID_TYPE:
                     while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_NOT_VALID_FLOAT, ref dcurr,

--- a/libs/server/Resp/CmdStrings.cs
+++ b/libs/server/Resp/CmdStrings.cs
@@ -23,6 +23,7 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> get => "get"u8;
         public static ReadOnlySpan<byte> SET => "SET"u8;
         public static ReadOnlySpan<byte> set => "set"u8;
+        public static ReadOnlySpan<byte> del => "del"u8;
         public static ReadOnlySpan<byte> REWRITE => "REWRITE"u8;
         public static ReadOnlySpan<byte> rewrite => "rewrite"u8;
         public static ReadOnlySpan<byte> CONFIG => "CONFIG"u8;
@@ -150,6 +151,17 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> TIMEOUT => "TIMEOUT"u8;
         public static ReadOnlySpan<byte> ERROR => "ERROR"u8;
         public static ReadOnlySpan<byte> INCRBY => "INCRBY"u8;
+        public static ReadOnlySpan<byte> incrby => "incrby"u8;
+        public static ReadOnlySpan<byte> hincrby => "hincrby"u8;
+        public static ReadOnlySpan<byte> hincrbyfloat => "hincrbyfloat"u8;
+        public static ReadOnlySpan<byte> incrbyfloat => "incrbyfloat"u8;
+        public static ReadOnlySpan<byte> hpersist => "hpersist"u8;
+        public static ReadOnlySpan<byte> linsert => "linsert"u8;
+        public static ReadOnlySpan<byte> lset => "lset"u8;
+        public static ReadOnlySpan<byte> ltrim => "ltrim"u8;
+        public static ReadOnlySpan<byte> setrange => "setrange"u8;
+        public static ReadOnlySpan<byte> srem => "srem"u8;
+        public static ReadOnlySpan<byte> ssadd => "ssadd"u8;
         public static ReadOnlySpan<byte> NOGET => "NOGET"u8;
 
         /// <summary>

--- a/libs/server/Resp/CmdStrings.cs
+++ b/libs/server/Resp/CmdStrings.cs
@@ -30,6 +30,7 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> CertPassword => "cert-password"u8;
         public static ReadOnlySpan<byte> ClusterUsername => "cluster-username"u8;
         public static ReadOnlySpan<byte> ClusterPassword => "cluster-password"u8;
+        public static ReadOnlySpan<byte> NotifiyKeyspaceEvents => "notify-keyspace-events"u8;
         public static ReadOnlySpan<byte> ECHO => "ECHO"u8;
         public static ReadOnlySpan<byte> ACL => "ACL"u8;
         public static ReadOnlySpan<byte> AUTH => "AUTH"u8;

--- a/libs/server/Resp/CmdStrings.cs
+++ b/libs/server/Resp/CmdStrings.cs
@@ -151,6 +151,7 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> TIMEOUT => "TIMEOUT"u8;
         public static ReadOnlySpan<byte> ERROR => "ERROR"u8;
         public static ReadOnlySpan<byte> INCRBY => "INCRBY"u8;
+        // TODO: move to another file or region for example KeyspaceNotificationEventStrings
         public static ReadOnlySpan<byte> incrby => "incrby"u8;
         public static ReadOnlySpan<byte> hincrby => "hincrby"u8;
         public static ReadOnlySpan<byte> hincrbyfloat => "hincrbyfloat"u8;
@@ -162,6 +163,7 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> setrange => "setrange"u8;
         public static ReadOnlySpan<byte> srem => "srem"u8;
         public static ReadOnlySpan<byte> ssadd => "ssadd"u8;
+        // TODO: end
         public static ReadOnlySpan<byte> NOGET => "NOGET"u8;
 
         /// <summary>

--- a/libs/server/Resp/Objects/HashCommands.cs
+++ b/libs/server/Resp/Objects/HashCommands.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using Garnet.common;
+using Garnet.server.KeyspaceNotifications;
 using Tsavorite.core;
 
 namespace Garnet.server
@@ -566,6 +567,17 @@ namespace Garnet.server
                     break;
                 default:
                     ProcessOutputWithHeader(outputFooter.SpanByteAndMemory);
+                    switch (op)
+                    {
+                        case HashOperation.HINCRBY:
+                            PublishKeyspaceNotification(KeyspaceNotificationType.Hash, ref parseState.GetArgSliceByRef(0), CmdStrings.hincrby);
+                            break;
+                        case HashOperation.HINCRBYFLOAT:
+                            PublishKeyspaceNotification(KeyspaceNotificationType.Hash, ref parseState.GetArgSliceByRef(0), CmdStrings.hincrbyfloat);
+                            break;
+                        default:
+                            break;
+                    }
                     break;
             }
             return true;
@@ -820,6 +832,7 @@ namespace Garnet.server
                     }
                     break;
                 default:
+                    PublishKeyspaceNotification(KeyspaceNotificationType.Hash, ref parseState.GetArgSliceByRef(0), CmdStrings.hpersist);
                     ProcessOutputWithHeader(outputFooter.SpanByteAndMemory);
                     break;
             }

--- a/libs/server/Resp/Objects/ListCommands.cs
+++ b/libs/server/Resp/Objects/ListCommands.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using Garnet.common;
+using Garnet.server.KeyspaceNotifications;
 using Tsavorite.core;
 
 namespace Garnet.server
@@ -508,6 +509,7 @@ namespace Garnet.server
                     // no need to process output, just send OK
                     while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
                         SendAndReset();
+                    PublishKeyspaceNotification(KeyspaceNotificationType.List, ref parseState.GetArgSliceByRef(0), CmdStrings.ltrim);
                     break;
             }
 
@@ -667,6 +669,7 @@ namespace Garnet.server
                     //process output
                     while (!RespWriteUtils.TryWriteInt32(output.result1, ref dcurr, dend))
                         SendAndReset();
+                    PublishKeyspaceNotification(KeyspaceNotificationType.List, ref parseState.GetArgSliceByRef(0), CmdStrings.linsert);
                     break;
                 case GarnetStatus.NOTFOUND:
                     while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_RETURN_VAL_0, ref dcurr, dend))
@@ -895,6 +898,7 @@ namespace Garnet.server
                 case GarnetStatus.OK:
                     //process output
                     ProcessOutputWithHeader(outputFooter.SpanByteAndMemory);
+                    PublishKeyspaceNotification(KeyspaceNotificationType.List, ref parseState.GetArgSliceByRef(0), CmdStrings.lset);
                     break;
                 case GarnetStatus.NOTFOUND:
                     while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_GENERIC_NOSUCHKEY, ref dcurr, dend))

--- a/libs/server/Resp/Objects/ListCommands.cs
+++ b/libs/server/Resp/Objects/ListCommands.cs
@@ -505,11 +505,11 @@ namespace Garnet.server
                         SendAndReset();
                     break;
                 default:
+                    PublishKeyspaceNotification(KeyspaceNotificationType.List, ref parseState.GetArgSliceByRef(0), CmdStrings.ltrim);
                     //GarnetStatus.OK or NOTFOUND have same result
                     // no need to process output, just send OK
                     while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
                         SendAndReset();
-                    PublishKeyspaceNotification(KeyspaceNotificationType.List, ref parseState.GetArgSliceByRef(0), CmdStrings.ltrim);
                     break;
             }
 

--- a/libs/server/Resp/Objects/SetCommands.cs
+++ b/libs/server/Resp/Objects/SetCommands.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Text;
 using Garnet.common;
+using Garnet.server.KeyspaceNotifications;
 using Tsavorite.core;
 
 namespace Garnet.server
@@ -606,6 +607,8 @@ namespace Garnet.server
             switch (status)
             {
                 case GarnetStatus.OK:
+                    PublishKeyspaceNotification(KeyspaceNotificationType.Set, ref sourceKey, CmdStrings.srem);
+                    PublishKeyspaceNotification(KeyspaceNotificationType.Set, ref destinationKey, CmdStrings.ssadd);
                     while (!RespWriteUtils.TryWriteInt32(output, ref dcurr, dend))
                         SendAndReset();
                     break;

--- a/libs/server/Resp/Objects/SetCommands.cs
+++ b/libs/server/Resp/Objects/SetCommands.cs
@@ -607,6 +607,7 @@ namespace Garnet.server
             switch (status)
             {
                 case GarnetStatus.OK:
+                    // TODO: check usage of output var to send correct keyspace notification
                     PublishKeyspaceNotification(KeyspaceNotificationType.Set, ref sourceKey, CmdStrings.srem);
                     PublishKeyspaceNotification(KeyspaceNotificationType.Set, ref destinationKey, CmdStrings.ssadd);
                     while (!RespWriteUtils.TryWriteInt32(output, ref dcurr, dend))

--- a/libs/server/ServerConfig.cs
+++ b/libs/server/ServerConfig.cs
@@ -194,6 +194,10 @@ namespace Garnet.server
                         else errorMsg += " TLS is disabled.";
                     }
                 }
+                if (notifiyKeyspaceEventsArguments != null)
+                {
+                    storeWrapper.serverOptions.NotifiyKeyspaceEventsArguments = notifiyKeyspaceEventsArguments;
+                }
             }
 
             if (errorMsg == null)

--- a/libs/server/ServerConfig.cs
+++ b/libs/server/ServerConfig.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Garnet.common;
+using Garnet.server.KeyspaceNotifications;
 using Microsoft.Extensions.Logging;
 
 namespace Garnet.server
@@ -194,9 +195,11 @@ namespace Garnet.server
                         else errorMsg += " TLS is disabled.";
                     }
                 }
-                if (notifiyKeyspaceEventsArguments != null)
+
+                // TODO: Parse argument string into enum flags and remove second if statement
+                if (notifiyKeyspaceEventsArguments != null && notifiyKeyspaceEventsArguments.Equals("KEA"))
                 {
-                    storeWrapper.serverOptions.NotifiyKeyspaceEventsArguments = notifiyKeyspaceEventsArguments;
+                    storeWrapper.serverOptions.AllowedKeyspaceNotifications = KeyspaceNotificationType.All | KeyspaceNotificationType.Keyspace | KeyspaceNotificationType.Keyevent;
                 }
             }
 

--- a/libs/server/ServerConfig.cs
+++ b/libs/server/ServerConfig.cs
@@ -131,6 +131,7 @@ namespace Garnet.server
             string certPassword = null;
             string clusterUsername = null;
             string clusterPassword = null;
+            string notifiyKeyspaceEventsArguments = null;
             var unknownOption = false;
             var unknownKey = "";
 
@@ -147,6 +148,8 @@ namespace Garnet.server
                     clusterUsername = Encoding.ASCII.GetString(value);
                 else if (key.SequenceEqual(CmdStrings.ClusterPassword))
                     clusterPassword = Encoding.ASCII.GetString(value);
+                else if (key.SequenceEqual(CmdStrings.NotifiyKeyspaceEvents))
+                    notifiyKeyspaceEventsArguments = Encoding.ASCII.GetString(value);
                 else
                 {
                     if (!unknownOption)

--- a/libs/server/Servers/GarnetServerOptions.cs
+++ b/libs/server/Servers/GarnetServerOptions.cs
@@ -197,6 +197,11 @@ namespace Garnet.server
         public string ClusterPassword;
 
         /// <summary>
+        /// Argument string for keyspace notifications
+        /// </summary>
+        public string NotifiyKeyspaceEventsArguments;
+
+        /// <summary>
         /// Enable per command latency tracking for all commands
         /// </summary>
         public bool LatencyMonitor = false;

--- a/libs/server/Servers/GarnetServerOptions.cs
+++ b/libs/server/Servers/GarnetServerOptions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Garnet.server.Auth.Settings;
+using Garnet.server.KeyspaceNotifications;
 using Garnet.server.TLS;
 using Microsoft.Extensions.Logging;
 using Tsavorite.core;
@@ -197,9 +198,9 @@ namespace Garnet.server
         public string ClusterPassword;
 
         /// <summary>
-        /// Argument string for keyspace notifications
+        /// Keyspace notifications
         /// </summary>
-        public string NotifiyKeyspaceEventsArguments;
+        public KeyspaceNotificationType AllowedKeyspaceNotifications;
 
         /// <summary>
         /// Enable per command latency tracking for all commands


### PR DESCRIPTION
Hi, this is by no means finished—it's more about asking questions regarding the implementation:

I couldn't find a simple solution to access the publish functions from the storage session, so I publish them depending on the Garnet.Status from the RespServerSession. 
However, this comes with some limitations. For example:
![image](https://github.com/user-attachments/assets/e1be4913-bf30-4c5c-bc95-d2b851db8dd0)
I need to detect these changes and send a notification, but I would need to somehow publish from the HashObject itself when DeleteExpiredItems() is called otherwise i could only send an command i the HCOLLECT command is called. 

Does the approach still make sense, or do you think its entirely flawed and should be done differently (regarding where to publish from, please mind the open todos)?