### PR TITLE
Use RESP3 Null in a lot of places where it's appropriate given right protocol version and fix PUNSUBSCRIBE

### DIFF
--- a/libs/server/Resp/ACLCommands.cs
+++ b/libs/server/Resp/ACLCommands.cs
@@ -432,8 +432,7 @@ namespace Garnet.server
 
                 if (user is null)
                 {
-                    while (!RespWriteUtils.TryWriteNull(ref dcurr, dend))
-                        SendAndReset();
+                    WriteNull();
                 }
                 else
                 {

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -1161,8 +1161,7 @@ namespace Garnet.server
                     }
                     else
                     {
-                        while (!RespWriteUtils.TryWriteNull(ref dcurr, dend))
-                            SendAndReset();
+                        WriteNull();
                     }
                 }
             }

--- a/libs/server/Resp/ClientCommands.cs
+++ b/libs/server/Resp/ClientCommands.cs
@@ -501,8 +501,7 @@ namespace Garnet.server
 
             if (string.IsNullOrEmpty(this.clientName))
             {
-                while (!RespWriteUtils.TryWriteNull(ref dcurr, dend))
-                    SendAndReset();
+                WriteNull();
             }
             else
             {

--- a/libs/server/Resp/Objects/ListCommands.cs
+++ b/libs/server/Resp/Objects/ListCommands.cs
@@ -407,8 +407,7 @@ namespace Garnet.server
 
             if (!result.Found)
             {
-                while (!RespWriteUtils.TryWriteNull(ref dcurr, dend))
-                    SendAndReset();
+                WriteNull();
             }
             else
             {
@@ -779,8 +778,7 @@ namespace Garnet.server
                     }
                     else
                     {
-                        while (!RespWriteUtils.TryWriteNull(ref dcurr, dend))
-                            SendAndReset();
+                        WriteNull();
                     }
 
                     break;
@@ -823,8 +821,7 @@ namespace Garnet.server
                     }
                     else
                     {
-                        while (!RespWriteUtils.TryWriteNull(ref dcurr, dend))
-                            SendAndReset();
+                        WriteNull();
                     }
 
                     break;
@@ -994,8 +991,7 @@ namespace Garnet.server
 
             if (!result.Found)
             {
-                while (!RespWriteUtils.TryWriteNull(ref dcurr, dend))
-                    SendAndReset();
+                WriteNull();
                 return true;
             }
 

--- a/libs/server/Resp/Objects/SortedSetCommands.cs
+++ b/libs/server/Resp/Objects/SortedSetCommands.cs
@@ -483,8 +483,7 @@ namespace Garnet.server
                     if (pairs == null || pairs.Length == 0)
                     {
                         // No elements found
-                        while (!RespWriteUtils.TryWriteNull(ref dcurr, dend))
-                            SendAndReset();
+                        WriteNull();
                     }
                     else
                     {
@@ -1568,8 +1567,7 @@ namespace Garnet.server
 
             if (!result.Found)
             {
-                while (!RespWriteUtils.TryWriteNull(ref dcurr, dend))
-                    SendAndReset();
+                WriteNull();
             }
             else
             {
@@ -1675,8 +1673,7 @@ namespace Garnet.server
 
             if (!result.Found)
             {
-                while (!RespWriteUtils.TryWriteNull(ref dcurr, dend))
-                    SendAndReset();
+                WriteNull();
                 return true;
             }
 

--- a/libs/server/Resp/PubSubCommands.cs
+++ b/libs/server/Resp/PubSubCommands.cs
@@ -284,8 +284,9 @@ namespace Garnet.server
                         SendAndReset();
                     while (!RespWriteUtils.TryWriteBulkString("unsubscribe"u8, ref dcurr, dend))
                         SendAndReset();
-                    while (!RespWriteUtils.TryWriteNull(ref dcurr, dend))
-                        SendAndReset();
+
+                    WriteNull();
+
                     while (!RespWriteUtils.TryWriteInt32(numActiveChannels, ref dcurr, dend))
                         SendAndReset();
                 }

--- a/libs/server/Resp/PubSubCommands.cs
+++ b/libs/server/Resp/PubSubCommands.cs
@@ -361,6 +361,20 @@ namespace Garnet.server
                         SendAndReset();
                 }
 
+                if (channels.Count == 0)
+                {
+                    while (!RespWriteUtils.TryWriteArrayLength(3, ref dcurr, dend))
+                        SendAndReset();
+
+                    while (!RespWriteUtils.TryWriteBulkString("punsubscribe"u8, ref dcurr, dend))
+                        SendAndReset();
+
+                    WriteNull();
+
+                    while (!RespWriteUtils.TryWriteInt32(0, ref dcurr, dend))
+                        SendAndReset();
+                }
+
                 if (numActiveChannels == 0)
                     isSubscriptionSession = false;
 

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -1193,6 +1193,21 @@ namespace Garnet.server
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteNull()
+        {
+            if (respProtocolVersion == 3)
+            {
+                while (!RespWriteUtils.TryWriteResp3Null(ref dcurr, dend))
+                    SendAndReset();
+            }
+            else
+            {
+                while (!RespWriteUtils.TryWriteNull(ref dcurr, dend))
+                    SendAndReset();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void Send(byte* d)
         {
             // Note: This SEND method may be called for responding to multiple commands in a single message (pipelining),


### PR DESCRIPTION
In a lot of places, Garnet writes a RESP2 Null where it already should know RESP3 Null is allowed. Add a function to RespServerSession to allow writing the right value easily and use it.  This does not solve cases closer to storage layer, only where the session is available.

In addition, PUNSUBSCRIBE should send a response where it's called when no channels are active, otherwise the client just waits. The code already existed on UNSUBSCRIBE, just need to be copied over.