### PR TITLE
Blocking functions: Check key type first, and expire empty keys.

### DIFF
--- a/libs/server/Objects/ItemBroker/CollectionItemResult.cs
+++ b/libs/server/Objects/ItemBroker/CollectionItemResult.cs
@@ -8,30 +8,39 @@ namespace Garnet.server
     /// </summary>
     internal readonly struct CollectionItemResult
     {
+        public CollectionItemResult(GarnetStatus status)
+        {
+            Status = status;
+        }
+
         public CollectionItemResult(byte[] key, byte[] item)
         {
             Key = key;
             Item = item;
+            Status = key == default ? GarnetStatus.NOTFOUND : GarnetStatus.OK;
         }
 
         public CollectionItemResult(byte[] key, byte[][] items)
         {
             Key = key;
             Items = items;
+            Status = key == default ? GarnetStatus.NOTFOUND : GarnetStatus.OK;
         }
 
         public CollectionItemResult(byte[] key, double score, byte[] item)
         {
             Key = key;
-            Score = score;
             Item = item;
+            Score = score;
+            Status = key == default ? GarnetStatus.NOTFOUND : GarnetStatus.OK;
         }
 
         public CollectionItemResult(byte[] key, double[] scores, byte[][] items)
         {
             Key = key;
-            Scores = scores;
             Items = items;
+            Scores = scores;
+            Status = key == default ? GarnetStatus.NOTFOUND : GarnetStatus.OK;
         }
 
         private CollectionItemResult(bool isForceUnblocked)
@@ -40,9 +49,9 @@ namespace Garnet.server
         }
 
         /// <summary>
-        /// True if item was found
+        /// Result status
         /// </summary>
-        internal bool Found => Key != default;
+        internal GarnetStatus Status { get; }
 
         /// <summary>
         /// Key of collection from which item was retrieved

--- a/test/Garnet.test/RespBlockingCollectionTests.cs
+++ b/test/Garnet.test/RespBlockingCollectionTests.cs
@@ -656,16 +656,16 @@ namespace Garnet.test
             response = lightClientRequest.SendCommand("BLMOVE set foo RIGHT RIGHT 0");
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            response = lightClientRequest.SendCommand("BLMOVE foo key LEFT LEFT 0");
+            response = lightClientRequest.SendCommand("BLMOVE list set LEFT LEFT 0");
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            response = lightClientRequest.SendCommand("BLMOVE foo set LEFT LEFT 0");
+            response = lightClientRequest.SendCommand("BLMOVE list key LEFT LEFT 0");
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("BRPOPLPUSH key foo 0");
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
-            response = lightClientRequest.SendCommand("BRPOPLPUSH foo key 0");
+            response = lightClientRequest.SendCommand("BRPOPLPUSH list key 0");
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
             response = lightClientRequest.SendCommand("BLPOP key 0");

--- a/test/Garnet.test/RespBlockingCollectionTests.cs
+++ b/test/Garnet.test/RespBlockingCollectionTests.cs
@@ -414,6 +414,11 @@ namespace Garnet.test
             Task.WaitAll([blockingTask, pushingTask], TimeSpan.FromSeconds(10));
             ClassicAssert.IsTrue(blockingTask.IsCompletedSuccessfully);
             ClassicAssert.IsTrue(pushingTask.IsCompletedSuccessfully);
+
+            using var lightClientRequest = TestUtils.CreateRequest();
+            var response = lightClientRequest.SendCommand($"EXISTS {key}");
+            var expectedResponse = ":1\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -470,6 +475,9 @@ namespace Garnet.test
             ClassicAssert.AreEqual(2, pop[1][1].Length);
             ClassicAssert.AreEqual("two", pop[1][1][0].ToString());
             ClassicAssert.AreEqual(2, (int)(RedisValue)pop[1][1][1]);
+
+            ClassicAssert.IsFalse(db.KeyExists("a"));
+            ClassicAssert.IsTrue(db.KeyExists("b"));
         }
 
         [Test]
@@ -685,6 +693,10 @@ namespace Garnet.test
             Task.WaitAll([blockingLTask, blockingZTask], TimeSpan.FromSeconds(5));
             ClassicAssert.IsTrue(blockingLTask.IsCompletedSuccessfully);
             ClassicAssert.IsTrue(blockingZTask.IsCompletedSuccessfully);
+
+            response = lightClientRequest.SendCommand("EXISTS list");
+            expectedResponse = ":0\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
     }
 }


### PR DESCRIPTION
Whenever Redis gets a blocking pop command, it tries to pop the value first, and if the value is of the wrong type, it aborts with a WRONGTYPE error. Note that setting the key with the wrong type afterwards (while the timeout is on), will not emit a WRONGTYPE error.

This is arguably in 'bug compatible' category - but blocking when the client may not expect it is best avoided.