### PR TITLE
Install Lua 5.4 on Container Images

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -34,7 +34,7 @@ RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contain
 FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine AS runtime
 
 # Install dependencies
-RUN apk update && apk add --upgrade libaio gcompat
+RUN apk update && apk add --upgrade libaio gcompat lua5.4 && ln -sf /usr/lib/liblua-5.4.so.0 /usr/lib/liblua54.so
 
 RUN mkdir /data /app \
     && chown -R $APP_UID:$APP_UID /data /app


### PR DESCRIPTION
Fixes #1098

I did debug the source code and found we have following error when we run the server on a container, which I interpret it as lua54 not being installed on the container. 

The error is not visible since we ignore the error in sessionScriptCache.TryLoad method.

https://github.com/microsoft/garnet/blob/3efcc0579149287f14f7c2f3aff7e38efe7322ce/libs/server/Lua/LuaCommands.cs#L116


### Error on container

```
 Unable to load shared library 'lua54' or one of its dependencies. In order to help diagnose loading problems, consider using a tool like strace. If you're using glibc, consider setting the LD_DEBUG environment variable:
/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.14/lua54.so: cannot open shared object file: No such file or directory
/app/lua54.so: cannot open shared object file: No such file or directory
/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.14/liblua54.so: cannot open shared object file: No such file or directory
/app/liblua54.so: cannot open shared object file: No such file or directory
/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.14/lua54: cannot open shared object file: No such file or directory
/app/lua54: cannot open shared object file: No such file or directory
/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.14/liblua54: cannot open shared object file: No such file or directory
/app/liblua54: cannot open shared object file: No such file or directory
```

_I'll change the other images when we agree this is the right fix._