### PR TITLE
Fix bug with Lua infallible allocations

### DIFF
--- a/libs/server/Lua/LuaStateWrapper.cs
+++ b/libs/server/Lua/LuaStateWrapper.cs
@@ -766,7 +766,7 @@ namespace Garnet.server
 
             var ret = customAllocator.TryExitInfallibleAllocationRegion();
 
-            if (ret)
+            if (!ret)
             {
                 NeedsDispose = true;
             }

--- a/test/Garnet.test/LuaScriptRunnerTests.cs
+++ b/test/Garnet.test/LuaScriptRunnerTests.cs
@@ -737,6 +737,30 @@ namespace Garnet.test
             ClassicAssert.AreEqual("nil", res);
         }
 
+        [Test]
+        public void NeedsDisposeCheck()
+        {
+            foreach (var mode in Enum.GetValues<LuaMemoryManagementMode>())
+            {
+                foreach (var limit in new[] { null, "1m" })
+                {
+                    if (limit != null && mode == LuaMemoryManagementMode.Native)
+                    {
+                        continue;
+                    }
+
+                    var opts = new LuaOptions(mode, limit, Timeout.InfiniteTimeSpan, LuaLoggingMode.Silent, []);
+
+                    using var runner = new LuaRunner(opts, "return 1");
+
+                    runner.CompileForRunner();
+                    _ = runner.RunForRunner([], []);
+
+                    ClassicAssert.IsFalse(runner.NeedsDispose);
+                }
+            }
+        }
+
         private sealed class FakeLogger : ILogger, IDisposable
         {
             private readonly List<string> logs = new();


### PR DESCRIPTION
Messed up an `if` and, for non-native allocators, `LuaRunners` are getting recreated on each invocation.

This is pretty rough on non-Native throughput and allocations, as demonstrated by failing `ScriptOperations` benchmarks.

Added a test to catch this regression in the future.

`main`, as of `524deebab4666b0908dbcacd1cd72c6678bc974f`

| Method            | Job    | Runtime  | Params        | Mean         | Error      | StdDev       | Median       | Gen0      | Gen1      | Gen2      | Allocated   |
|------------------ |------- |--------- |-------------- |-------------:|-----------:|-------------:|-------------:|----------:|----------:|----------:|------------:|
| ScriptLoad        | .NET 8 | .NET 8.0 | Managed,Limit |     80.02 us |   0.689 us |     0.611 us |     79.99 us |         - |         - |         - |      6400 B |
| ScriptExistsTrue  | .NET 8 | .NET 8.0 | Managed,Limit |     18.83 us |   0.122 us |     0.114 us |     18.79 us |         - |         - |         - |           - |
| ScriptExistsFalse | .NET 8 | .NET 8.0 | Managed,Limit |     17.93 us |   0.051 us |     0.045 us |     17.93 us |         - |         - |         - |           - |
| Eval              | .NET 8 | .NET 8.0 | Managed,Limit | 24,796.45 us | 314.284 us |   293.982 us | 24,764.59 us |  343.7500 |  343.7500 |  343.7500 | 209796022 B |
| EvalSha           | .NET 8 | .NET 8.0 | Managed,Limit | 24,181.26 us | 469.142 us |   576.148 us | 24,087.51 us |  343.7500 |  343.7500 |  343.7500 | 209801153 B |
| SmallScript       | .NET 8 | .NET 8.0 | Managed,Limit | 24,202.89 us | 472.456 us |   505.522 us | 24,198.80 us |  343.7500 |  343.7500 |  343.7500 | 209805385 B |
| LargeScript       | .NET 8 | .NET 8.0 | Managed,Limit | 29,322.15 us | 561.985 us |   551.945 us | 29,323.17 us |  281.2500 |  281.2500 |  281.2500 | 209887312 B |
| ArrayReturn       | .NET 8 | .NET 8.0 | Managed,Limit | 25,418.01 us | 483.970 us |   404.137 us | 25,386.37 us |  343.7500 |  343.7500 |  343.7500 | 209797048 B |
| ScriptLoad        | .NET 9 | .NET 9.0 | Managed,Limit |     81.74 us |   0.995 us |     0.930 us |     81.50 us |         - |         - |         - |      6400 B |
| ScriptExistsTrue  | .NET 9 | .NET 9.0 | Managed,Limit |     18.77 us |   0.098 us |     0.077 us |     18.79 us |         - |         - |         - |           - |
| ScriptExistsFalse | .NET 9 | .NET 9.0 | Managed,Limit |     17.07 us |   0.053 us |     0.045 us |     17.09 us |         - |         - |         - |           - |
| Eval              | .NET 9 | .NET 9.0 | Managed,Limit | 41,918.71 us | 692.085 us |   647.377 us | 41,858.54 us | 1333.3333 | 1333.3333 | 1333.3333 | 209805559 B |
| EvalSha           | .NET 9 | .NET 9.0 | Managed,Limit | 41,518.24 us | 710.531 us |   664.631 us | 41,366.55 us | 1307.6923 | 1307.6923 | 1307.6923 | 209809979 B |
| SmallScript       | .NET 9 | .NET 9.0 | Managed,Limit | 41,561.69 us | 740.630 us |   692.786 us | 41,684.86 us | 1333.3333 | 1333.3333 | 1333.3333 | 209814429 B |
| LargeScript       | .NET 9 | .NET 9.0 | Managed,Limit | 40,332.77 us | 798.256 us | 2,031.816 us | 40,993.16 us |  833.3333 |  833.3333 |  833.3333 | 209891509 B |
| ArrayReturn       | .NET 9 | .NET 9.0 | Managed,Limit | 41,398.05 us | 805.940 us |   753.877 us | 41,436.75 us | 1307.6923 | 1307.6923 | 1307.6923 | 209806244 B |
| ScriptLoad        | .NET 8 | .NET 8.0 | Managed,None  |     79.14 us |   0.610 us |     0.509 us |     79.20 us |         - |         - |         - |      6400 B |
| ScriptExistsTrue  | .NET 8 | .NET 8.0 | Managed,None  |     18.67 us |   0.138 us |     0.129 us |     18.70 us |         - |         - |         - |           - |
| ScriptExistsFalse | .NET 8 | .NET 8.0 | Managed,None  |     17.43 us |   0.060 us |     0.053 us |     17.43 us |         - |         - |         - |           - |
| Eval              | .NET 8 | .NET 8.0 | Managed,None  | 25,490.10 us | 368.722 us |   344.903 us | 25,430.10 us |  343.7500 |  343.7500 |  343.7500 | 209807200 B |
| EvalSha           | .NET 8 | .NET 8.0 | Managed,None  | 24,489.57 us | 443.916 us |   393.520 us | 24,493.22 us |  343.7500 |  343.7500 |  343.7500 | 209812332 B |
| SmallScript       | .NET 8 | .NET 8.0 | Managed,None  | 24,807.91 us | 474.204 us |   465.731 us | 24,795.29 us |  343.7500 |  343.7500 |  343.7500 | 209816332 B |
| LargeScript       | .NET 8 | .NET 8.0 | Managed,None  | 29,783.46 us | 590.280 us |   788.007 us | 29,625.73 us |  281.2500 |  281.2500 |  281.2500 | 209897882 B |
| ArrayReturn       | .NET 8 | .NET 8.0 | Managed,None  | 26,044.33 us | 461.185 us |   431.393 us | 26,087.75 us |  343.7500 |  343.7500 |  343.7500 | 209807542 B |
| ScriptLoad        | .NET 9 | .NET 9.0 | Managed,None  |     79.03 us |   0.861 us |     0.805 us |     78.93 us |         - |         - |         - |      6400 B |
| ScriptExistsTrue  | .NET 9 | .NET 9.0 | Managed,None  |     18.44 us |   0.113 us |     0.105 us |     18.48 us |         - |         - |         - |           - |
| ScriptExistsFalse | .NET 9 | .NET 9.0 | Managed,None  |     17.35 us |   0.210 us |     0.197 us |     17.32 us |         - |         - |         - |           - |
| Eval              | .NET 9 | .NET 9.0 | Managed,None  | 41,477.93 us | 816.730 us |   802.138 us | 41,454.12 us | 1230.7692 | 1230.7692 | 1230.7692 | 209815106 B |
| EvalSha           | .NET 9 | .NET 9.0 | Managed,None  | 41,614.17 us | 825.079 us |   882.825 us | 41,699.95 us | 1333.3333 | 1333.3333 | 1333.3333 | 209821687 B |
| SmallScript       | .NET 9 | .NET 9.0 | Managed,None  | 41,571.55 us | 788.310 us |   737.386 us | 41,671.18 us | 1333.3333 | 1333.3333 | 1333.3333 | 209825383 B |
| LargeScript       | .NET 9 | .NET 9.0 | Managed,None  | 41,892.13 us | 786.392 us | 1,958.388 us | 41,567.06 us |  833.3333 |  833.3333 |  833.3333 | 209902637 B |
| ArrayReturn       | .NET 9 | .NET 9.0 | Managed,None  | 41,677.87 us | 647.007 us |   573.555 us | 41,624.45 us | 1307.6923 | 1307.6923 | 1307.6923 | 209817174 B |
| ScriptLoad        | .NET 8 | .NET 8.0 | Native,None   |     79.72 us |   0.587 us |     0.520 us |     79.53 us |         - |         - |         - |      6400 B |
| ScriptExistsTrue  | .NET 8 | .NET 8.0 | Native,None   |     18.77 us |   0.072 us |     0.064 us |     18.78 us |         - |         - |         - |           - |
| ScriptExistsFalse | .NET 8 | .NET 8.0 | Native,None   |     17.61 us |   0.170 us |     0.159 us |     17.56 us |         - |         - |         - |           - |
| Eval              | .NET 8 | .NET 8.0 | Native,None   |     64.21 us |   0.556 us |     0.520 us |     64.22 us |         - |         - |         - |           - |
| EvalSha           | .NET 8 | .NET 8.0 | Native,None   |     28.85 us |   0.155 us |     0.145 us |     28.87 us |         - |         - |         - |           - |
| SmallScript       | .NET 8 | .NET 8.0 | Native,None   |     65.19 us |   0.647 us |     0.573 us |     65.18 us |         - |         - |         - |           - |
| LargeScript       | .NET 8 | .NET 8.0 | Native,None   |  4,192.16 us |  30.731 us |    25.662 us |  4,192.66 us |         - |         - |         - |         3 B |
| ArrayReturn       | .NET 8 | .NET 8.0 | Native,None   |    120.39 us |   0.771 us |     0.683 us |    120.09 us |         - |         - |         - |           - |
| ScriptLoad        | .NET 9 | .NET 9.0 | Native,None   |     78.81 us |   1.166 us |     1.090 us |     78.45 us |         - |         - |         - |      6400 B |
| ScriptExistsTrue  | .NET 9 | .NET 9.0 | Native,None   |     18.44 us |   0.105 us |     0.088 us |     18.43 us |         - |         - |         - |           - |
| ScriptExistsFalse | .NET 9 | .NET 9.0 | Native,None   |     17.16 us |   0.075 us |     0.070 us |     17.17 us |         - |         - |         - |           - |
| Eval              | .NET 9 | .NET 9.0 | Native,None   |     62.99 us |   0.567 us |     0.474 us |     63.01 us |         - |         - |         - |           - |
| EvalSha           | .NET 9 | .NET 9.0 | Native,None   |     29.11 us |   0.397 us |     0.352 us |     29.06 us |         - |         - |         - |           - |
| SmallScript       | .NET 9 | .NET 9.0 | Native,None   |     64.15 us |   0.705 us |     0.659 us |     64.02 us |         - |         - |         - |           - |
| LargeScript       | .NET 9 | .NET 9.0 | Native,None   |  4,193.67 us |  65.987 us |    55.102 us |  4,184.57 us |         - |         - |         - |         8 B |
| ArrayReturn       | .NET 9 | .NET 9.0 | Native,None   |    120.37 us |   0.434 us |     0.384 us |    120.24 us |         - |         - |         - |           - |
| ScriptLoad        | .NET 8 | .NET 8.0 | Tracked,Limit |     79.27 us |   0.758 us |     0.709 us |     78.94 us |         - |         - |         - |      6400 B |
| ScriptExistsTrue  | .NET 8 | .NET 8.0 | Tracked,Limit |     18.80 us |   0.162 us |     0.144 us |     18.79 us |         - |         - |         - |           - |
| ScriptExistsFalse | .NET 8 | .NET 8.0 | Tracked,Limit |     18.13 us |   0.161 us |     0.151 us |     18.15 us |         - |         - |         - |           - |
| Eval              | .NET 8 | .NET 8.0 | Tracked,Limit | 30,728.03 us | 372.046 us |   348.012 us | 30,607.14 us |   62.5000 |   62.5000 |   62.5000 |     75727 B |
| EvalSha           | .NET 8 | .NET 8.0 | Tracked,Limit | 29,653.78 us | 261.964 us |   245.041 us | 29,689.24 us |   62.5000 |   62.5000 |   62.5000 |     81264 B |
| SmallScript       | .NET 8 | .NET 8.0 | Tracked,Limit | 29,949.80 us | 400.541 us |   374.666 us | 29,821.92 us |   62.5000 |   62.5000 |   62.5000 |     85319 B |
| LargeScript       | .NET 8 | .NET 8.0 | Tracked,Limit | 36,146.18 us | 283.771 us |   251.555 us | 36,171.46 us |   71.4286 |   71.4286 |   71.4286 |    166981 B |
| ArrayReturn       | .NET 8 | .NET 8.0 | Tracked,Limit | 31,123.14 us | 224.621 us |   210.110 us | 31,166.54 us |   62.5000 |   62.5000 |   62.5000 |     76504 B |
| ScriptLoad        | .NET 9 | .NET 9.0 | Tracked,Limit |     78.84 us |   1.484 us |     1.316 us |     78.53 us |         - |         - |         - |      6400 B |
| ScriptExistsTrue  | .NET 9 | .NET 9.0 | Tracked,Limit |     18.57 us |   0.101 us |     0.089 us |     18.55 us |         - |         - |         - |           - |
| ScriptExistsFalse | .NET 9 | .NET 9.0 | Tracked,Limit |     17.36 us |   0.202 us |     0.179 us |     17.30 us |         - |         - |         - |           - |
| Eval              | .NET 9 | .NET 9.0 | Tracked,Limit | 30,283.54 us | 172.034 us |   152.503 us | 30,337.08 us |   62.5000 |   62.5000 |   62.5000 |           - |
| EvalSha           | .NET 9 | .NET 9.0 | Tracked,Limit | 29,677.74 us | 352.514 us |   294.365 us | 29,620.84 us |   62.5000 |   62.5000 |   62.5000 |     81346 B |
| SmallScript       | .NET 9 | .NET 9.0 | Tracked,Limit | 29,449.11 us | 319.402 us |   298.769 us | 29,447.21 us |   62.5000 |   62.5000 |   62.5000 |     85334 B |
| LargeScript       | .NET 9 | .NET 9.0 | Tracked,Limit | 35,286.79 us | 270.614 us |   239.892 us | 35,301.14 us |   71.4286 |   71.4286 |   71.4286 |    166832 B |
| ArrayReturn       | .NET 9 | .NET 9.0 | Tracked,Limit | 30,969.05 us | 395.495 us |   369.946 us | 30,848.72 us |   62.5000 |   62.5000 |   62.5000 |           - |
| ScriptLoad        | .NET 8 | .NET 8.0 | Tracked,None  |     80.00 us |   0.458 us |     0.428 us |     80.01 us |         - |         - |         - |      6400 B |
| ScriptExistsTrue  | .NET 8 | .NET 8.0 | Tracked,None  |     18.86 us |   0.070 us |     0.062 us |     18.86 us |         - |         - |         - |           - |
| ScriptExistsFalse | .NET 8 | .NET 8.0 | Tracked,None  |     17.68 us |   0.181 us |     0.169 us |     17.70 us |         - |         - |         - |           - |
| Eval              | .NET 8 | .NET 8.0 | Tracked,None  | 30,392.59 us | 349.197 us |   326.639 us | 30,366.33 us |   62.5000 |   62.5000 |   62.5000 |     75688 B |
| EvalSha           | .NET 8 | .NET 8.0 | Tracked,None  | 29,723.64 us | 546.659 us |   511.346 us | 29,568.36 us |   62.5000 |   62.5000 |   62.5000 |     81298 B |
| SmallScript       | .NET 8 | .NET 8.0 | Tracked,None  | 29,562.15 us | 159.826 us |   133.462 us | 29,563.64 us |   62.5000 |   62.5000 |   62.5000 |     85334 B |
| LargeScript       | .NET 8 | .NET 8.0 | Tracked,None  | 35,784.97 us | 357.513 us |   316.926 us | 35,669.78 us |   71.4286 |   71.4286 |   71.4286 |    167088 B |
| ArrayReturn       | .NET 8 | .NET 8.0 | Tracked,None  | 31,022.72 us | 321.254 us |   284.784 us | 31,036.70 us |   62.5000 |   62.5000 |   62.5000 |     76482 B |
| ScriptLoad        | .NET 9 | .NET 9.0 | Tracked,None  |     78.21 us |   0.473 us |     0.443 us |     78.23 us |         - |         - |         - |      6400 B |
| ScriptExistsTrue  | .NET 9 | .NET 9.0 | Tracked,None  |     18.67 us |   0.099 us |     0.088 us |     18.68 us |         - |         - |         - |           - |
| ScriptExistsFalse | .NET 9 | .NET 9.0 | Tracked,None  |     17.67 us |   0.262 us |     0.245 us |     17.62 us |         - |         - |         - |           - |
| Eval              | .NET 9 | .NET 9.0 | Tracked,None  | 30,396.23 us | 186.248 us |   174.216 us | 30,418.21 us |   62.5000 |   62.5000 |   62.5000 |     75768 B |
| EvalSha           | .NET 9 | .NET 9.0 | Tracked,None  | 29,336.89 us | 453.189 us |   423.913 us | 29,222.24 us |   62.5000 |   62.5000 |   62.5000 |           - |
| SmallScript       | .NET 9 | .NET 9.0 | Tracked,None  | 28,761.44 us | 343.339 us |   321.159 us | 28,747.20 us |   62.5000 |   62.5000 |   62.5000 |           - |
| LargeScript       | .NET 9 | .NET 9.0 | Tracked,None  | 34,996.96 us | 245.498 us |   229.639 us | 34,984.36 us |   71.4286 |   71.4286 |   71.4286 |    166901 B |
| ArrayReturn       | .NET 9 | .NET 9.0 | Tracked,None  | 30,618.64 us | 279.059 us |   247.378 us | 30,588.87 us |   62.5000 |   62.5000 |   62.5000 |           - |

`luaInfallibleFix` as of `2527660606a8427fd49be9ab7458cc18d6f29832`

| Method            | Job    | Runtime  | Params        | Mean        | Error     | StdDev     | Median      | Allocated |
|------------------ |------- |--------- |-------------- |------------:|----------:|-----------:|------------:|----------:|
| ScriptLoad        | .NET 8 | .NET 8.0 | Managed,Limit |    78.55 us |  0.374 us |   0.332 us |    78.51 us |    6400 B |
| ScriptExistsTrue  | .NET 8 | .NET 8.0 | Managed,Limit |    18.87 us |  0.307 us |   0.288 us |    18.75 us |         - |
| ScriptExistsFalse | .NET 8 | .NET 8.0 | Managed,Limit |    17.47 us |  0.094 us |   0.088 us |    17.44 us |         - |
| Eval              | .NET 8 | .NET 8.0 | Managed,Limit |    63.50 us |  0.901 us |   0.843 us |    63.17 us |         - |
| EvalSha           | .NET 8 | .NET 8.0 | Managed,Limit |    28.62 us |  0.156 us |   0.138 us |    28.61 us |         - |
| SmallScript       | .NET 8 | .NET 8.0 | Managed,Limit |    64.77 us |  0.394 us |   0.369 us |    64.72 us |         - |
| LargeScript       | .NET 8 | .NET 8.0 | Managed,Limit | 4,865.28 us | 96.452 us | 121.981 us | 4,816.84 us |       5 B |
| ArrayReturn       | .NET 8 | .NET 8.0 | Managed,Limit |   124.49 us |  4.199 us |  12.249 us |   120.26 us |         - |
| ScriptLoad        | .NET 9 | .NET 9.0 | Managed,Limit |    79.07 us |  0.311 us |   0.291 us |    79.05 us |    6400 B |
| ScriptExistsTrue  | .NET 9 | .NET 9.0 | Managed,Limit |    18.72 us |  0.143 us |   0.134 us |    18.68 us |         - |
| ScriptExistsFalse | .NET 9 | .NET 9.0 | Managed,Limit |    17.18 us |  0.112 us |   0.105 us |    17.15 us |         - |
| Eval              | .NET 9 | .NET 9.0 | Managed,Limit |    63.65 us |  0.289 us |   0.270 us |    63.68 us |         - |
| EvalSha           | .NET 9 | .NET 9.0 | Managed,Limit |    28.81 us |  0.426 us |   0.398 us |    28.75 us |         - |
| SmallScript       | .NET 9 | .NET 9.0 | Managed,Limit |    64.17 us |  0.417 us |   0.370 us |    64.11 us |         - |
| LargeScript       | .NET 9 | .NET 9.0 | Managed,Limit | 4,729.41 us | 47.284 us |  39.485 us | 4,739.96 us |      11 B |
| ArrayReturn       | .NET 9 | .NET 9.0 | Managed,Limit |   130.88 us |  5.268 us |  15.532 us |   126.95 us |         - |
| ScriptLoad        | .NET 8 | .NET 8.0 | Managed,None  |    79.28 us |  1.028 us |   0.961 us |    78.96 us |    6400 B |
| ScriptExistsTrue  | .NET 8 | .NET 8.0 | Managed,None  |    18.50 us |  0.147 us |   0.130 us |    18.46 us |         - |
| ScriptExistsFalse | .NET 8 | .NET 8.0 | Managed,None  |    17.31 us |  0.163 us |   0.144 us |    17.29 us |         - |
| Eval              | .NET 8 | .NET 8.0 | Managed,None  |    63.54 us |  0.281 us |   0.249 us |    63.46 us |         - |
| EvalSha           | .NET 8 | .NET 8.0 | Managed,None  |    28.46 us |  0.429 us |   0.380 us |    28.32 us |         - |
| SmallScript       | .NET 8 | .NET 8.0 | Managed,None  |    64.11 us |  0.545 us |   0.483 us |    64.11 us |         - |
| LargeScript       | .NET 8 | .NET 8.0 | Managed,None  | 4,998.60 us | 78.003 us |  65.136 us | 4,996.47 us |       5 B |
| ArrayReturn       | .NET 8 | .NET 8.0 | Managed,None  |   127.29 us |  3.719 us |  10.730 us |   122.95 us |         - |
| ScriptLoad        | .NET 9 | .NET 9.0 | Managed,None  |    79.47 us |  1.581 us |   1.401 us |    78.86 us |    6400 B |
| ScriptExistsTrue  | .NET 9 | .NET 9.0 | Managed,None  |    18.38 us |  0.109 us |   0.097 us |    18.35 us |         - |
| ScriptExistsFalse | .NET 9 | .NET 9.0 | Managed,None  |    17.43 us |  0.259 us |   0.230 us |    17.41 us |         - |
| Eval              | .NET 9 | .NET 9.0 | Managed,None  |    66.00 us |  0.217 us |   0.181 us |    66.00 us |         - |
| EvalSha           | .NET 9 | .NET 9.0 | Managed,None  |    28.75 us |  0.120 us |   0.094 us |    28.76 us |         - |
| SmallScript       | .NET 9 | .NET 9.0 | Managed,None  |    64.02 us |  0.554 us |   0.462 us |    63.92 us |         - |
| LargeScript       | .NET 9 | .NET 9.0 | Managed,None  | 4,963.01 us | 98.058 us | 127.503 us | 4,929.49 us |      23 B |
| ArrayReturn       | .NET 9 | .NET 9.0 | Managed,None  |   128.10 us |  4.188 us |  12.282 us |   124.15 us |         - |
| ScriptLoad        | .NET 8 | .NET 8.0 | Native,None   |    77.56 us |  0.368 us |   0.345 us |    77.59 us |    6400 B |
| ScriptExistsTrue  | .NET 8 | .NET 8.0 | Native,None   |    18.68 us |  0.054 us |   0.048 us |    18.68 us |         - |
| ScriptExistsFalse | .NET 8 | .NET 8.0 | Native,None   |    17.71 us |  0.099 us |   0.088 us |    17.71 us |         - |
| Eval              | .NET 8 | .NET 8.0 | Native,None   |    62.69 us |  0.211 us |   0.197 us |    62.62 us |         - |
| EvalSha           | .NET 8 | .NET 8.0 | Native,None   |    29.18 us |  0.283 us |   0.264 us |    29.14 us |         - |
| SmallScript       | .NET 8 | .NET 8.0 | Native,None   |    63.69 us |  0.338 us |   0.300 us |    63.79 us |         - |
| LargeScript       | .NET 8 | .NET 8.0 | Native,None   | 4,276.37 us | 80.674 us |  75.463 us | 4,269.20 us |       3 B |
| ArrayReturn       | .NET 8 | .NET 8.0 | Native,None   |   121.34 us |  1.339 us |   1.118 us |   121.66 us |         - |
| ScriptLoad        | .NET 9 | .NET 9.0 | Native,None   |    78.57 us |  0.514 us |   0.480 us |    78.46 us |    6400 B |
| ScriptExistsTrue  | .NET 9 | .NET 9.0 | Native,None   |    18.55 us |  0.081 us |   0.067 us |    18.55 us |         - |
| ScriptExistsFalse | .NET 9 | .NET 9.0 | Native,None   |    17.26 us |  0.214 us |   0.200 us |    17.23 us |         - |
| Eval              | .NET 9 | .NET 9.0 | Native,None   |    62.69 us |  0.475 us |   0.444 us |    62.75 us |         - |
| EvalSha           | .NET 9 | .NET 9.0 | Native,None   |    29.32 us |  0.303 us |   0.268 us |    29.32 us |         - |
| SmallScript       | .NET 9 | .NET 9.0 | Native,None   |    66.92 us |  1.205 us |   1.128 us |    66.89 us |         - |
| LargeScript       | .NET 9 | .NET 9.0 | Native,None   | 4,148.34 us | 29.998 us |  26.593 us | 4,145.36 us |      11 B |
| ArrayReturn       | .NET 9 | .NET 9.0 | Native,None   |   122.48 us |  1.729 us |   1.533 us |   121.81 us |         - |
| ScriptLoad        | .NET 8 | .NET 8.0 | Tracked,Limit |    78.79 us |  0.719 us |   0.637 us |    78.68 us |    6400 B |
| ScriptExistsTrue  | .NET 8 | .NET 8.0 | Tracked,Limit |    18.53 us |  0.054 us |   0.045 us |    18.52 us |         - |
| ScriptExistsFalse | .NET 8 | .NET 8.0 | Tracked,Limit |    17.10 us |  0.141 us |   0.132 us |    17.05 us |         - |
| Eval              | .NET 8 | .NET 8.0 | Tracked,Limit |    67.07 us |  0.690 us |   0.611 us |    67.19 us |         - |
| EvalSha           | .NET 8 | .NET 8.0 | Tracked,Limit |    28.60 us |  0.069 us |   0.054 us |    28.60 us |         - |
| SmallScript       | .NET 8 | .NET 8.0 | Tracked,Limit |    64.20 us |  0.309 us |   0.258 us |    64.24 us |         - |
| LargeScript       | .NET 8 | .NET 8.0 | Tracked,Limit | 4,963.83 us | 35.641 us |  31.595 us | 4,963.51 us |       4 B |
| ArrayReturn       | .NET 8 | .NET 8.0 | Tracked,Limit |   152.40 us |  1.971 us |   1.844 us |   152.02 us |         - |
| ScriptLoad        | .NET 9 | .NET 9.0 | Tracked,Limit |    77.81 us |  0.682 us |   0.605 us |    77.77 us |    6400 B |
| ScriptExistsTrue  | .NET 9 | .NET 9.0 | Tracked,Limit |    18.24 us |  0.084 us |   0.078 us |    18.25 us |         - |
| ScriptExistsFalse | .NET 9 | .NET 9.0 | Tracked,Limit |    17.23 us |  0.127 us |   0.106 us |    17.21 us |         - |
| Eval              | .NET 9 | .NET 9.0 | Tracked,Limit |    63.12 us |  0.273 us |   0.242 us |    63.12 us |         - |
| EvalSha           | .NET 9 | .NET 9.0 | Tracked,Limit |    28.34 us |  0.097 us |   0.091 us |    28.33 us |         - |
| SmallScript       | .NET 9 | .NET 9.0 | Tracked,Limit |    67.01 us |  1.207 us |   1.129 us |    67.44 us |         - |
| LargeScript       | .NET 9 | .NET 9.0 | Tracked,Limit | 4,953.66 us | 96.431 us |  85.484 us | 4,922.19 us |       8 B |
| ArrayReturn       | .NET 9 | .NET 9.0 | Tracked,Limit |   137.36 us |  1.024 us |   0.908 us |   137.21 us |         - |
| ScriptLoad        | .NET 8 | .NET 8.0 | Tracked,None  |    78.18 us |  0.492 us |   0.436 us |    78.14 us |    6400 B |
| ScriptExistsTrue  | .NET 8 | .NET 8.0 | Tracked,None  |    18.40 us |  0.098 us |   0.087 us |    18.37 us |         - |
| ScriptExistsFalse | .NET 8 | .NET 8.0 | Tracked,None  |    17.24 us |  0.075 us |   0.063 us |    17.24 us |         - |
| Eval              | .NET 8 | .NET 8.0 | Tracked,None  |    63.42 us |  0.799 us |   0.747 us |    63.10 us |         - |
| EvalSha           | .NET 8 | .NET 8.0 | Tracked,None  |    28.99 us |  0.242 us |   0.215 us |    28.92 us |         - |
| SmallScript       | .NET 8 | .NET 8.0 | Tracked,None  |    63.97 us |  0.504 us |   0.471 us |    63.89 us |         - |
| LargeScript       | .NET 8 | .NET 8.0 | Tracked,None  | 4,951.27 us | 46.167 us |  36.044 us | 4,948.84 us |       8 B |
| ArrayReturn       | .NET 8 | .NET 8.0 | Tracked,None  |   146.57 us |  1.331 us |   1.180 us |   146.39 us |         - |
| ScriptLoad        | .NET 9 | .NET 9.0 | Tracked,None  |    79.36 us |  0.800 us |   0.709 us |    79.38 us |    6400 B |
| ScriptExistsTrue  | .NET 9 | .NET 9.0 | Tracked,None  |    18.46 us |  0.074 us |   0.065 us |    18.45 us |         - |
| ScriptExistsFalse | .NET 9 | .NET 9.0 | Tracked,None  |    17.10 us |  0.077 us |   0.068 us |    17.11 us |         - |
| Eval              | .NET 9 | .NET 9.0 | Tracked,None  |    62.18 us |  0.370 us |   0.346 us |    61.99 us |         - |
| EvalSha           | .NET 9 | .NET 9.0 | Tracked,None  |    28.21 us |  0.117 us |   0.104 us |    28.19 us |         - |
| SmallScript       | .NET 9 | .NET 9.0 | Tracked,None  |    65.11 us |  0.313 us |   0.261 us |    65.18 us |         - |
| LargeScript       | .NET 9 | .NET 9.0 | Tracked,None  | 4,885.79 us | 43.496 us |  36.321 us | 4,878.74 us |      11 B |
| ArrayReturn       | .NET 9 | .NET 9.0 | Tracked,None  |   139.37 us |  1.455 us |   1.361 us |   139.40 us |         - |

Which is an, uh, 100% allocation improvement for `Managed` allocators.  This tempered by the fact I introduced the Infinity% regression in the first place 🫠.