### PR TITLE
[TestSuit] Fix CanDoSRANDMEMBERWithCountCommandLC test

### DIFF
--- a/test/Garnet.test/GarnetServerConfigTests.cs
+++ b/test/Garnet.test/GarnetServerConfigTests.cs
@@ -866,6 +866,7 @@ namespace Garnet.test
             var hostname = TestUtils.GetHostName();
             var addresses = Dns.GetHostAddresses(hostname);
             addresses = [.. addresses, IPAddress.IPv6Loopback, IPAddress.Loopback];
+            addresses = [.. addresses.Distinct()];
 
             var endpoints = addresses.Select(address => new IPEndPoint(address, TestUtils.TestPort)).ToArray();
             var server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, endpoints: endpoints);

--- a/test/Garnet.test/Resp/TestSimpleReadRESP.cs
+++ b/test/Garnet.test/Resp/TestSimpleReadRESP.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Garnet.common.Parsing;
+
+namespace Garnet.test
+{
+    public static class TestSimpleReadRESP
+    {
+        public static object[] ReadRESP(byte[] inputArray)
+        {
+            var pos = 0;
+            var input = Encoding.ASCII.GetString(inputArray);
+
+            return Read(input, ref pos);
+        }
+
+        public static object[] ReadRESP(string input)
+        {
+            var pos = 0;
+            return Read(input, ref pos);
+        }
+
+        static object[] Read(string input, ref int pos)
+        {
+            if (input.Length < 3)
+                return default;
+
+            switch (input[pos])
+            {
+                case '+':
+                    pos++;
+                    var resultString = ReadSimpleString(input, ref pos);
+                    return [resultString];
+
+                case ':':
+                    pos++;
+                    var resultInt = ReadIntegerAsString(input, ref pos);
+                    return [resultInt];
+
+                case '-':
+                    pos++;
+                    var errorString = ReadErrorAsString(input, ref pos);
+                    return [errorString];
+
+                case '$':
+                    pos++;
+                    var resultBulk = ReadStringWithLengthHeader(input, ref pos);
+                    return [resultBulk];
+
+                case '*':
+                    pos++;
+                    var resultArray = ReadStringArrayWithLengthHeader(input, ref pos);
+                    return resultArray;
+
+                default:
+                    RespParsingException.Throw($"Unexpected character {input[0]}");
+                    throw new NotImplementedException();
+            }
+        }
+
+        private static object[] ReadStringArrayWithLengthHeader(string input, ref int loc)
+        {
+            var pos = input.IndexOf("\r\n", loc);
+            if (pos == -1)
+                RespParsingException.Throw("No newline");
+
+            var arraylen = int.Parse(input[loc..pos]);
+            loc = pos + 2;
+
+            if (arraylen < 0)
+                RespParsingException.ThrowInvalidLength(arraylen);
+
+            List<object> lo = new();
+            for (var i = 0; i < arraylen; i++)
+            {
+                var res = Read(input, ref loc);
+                lo.AddRange(res);
+            }
+
+            return [.. lo];
+        }
+
+        private static string ReadStringWithLengthHeader(string input, ref int loc)
+        {
+            var pos = input.IndexOf("\r\n", loc);
+            if (pos == -1)
+                RespParsingException.Throw("No newline");
+
+            var len = int.Parse(input[loc..pos]);
+            if (len < -1)
+                RespParsingException.ThrowInvalidStringLength(len);
+
+            loc = input.IndexOf("\r\n", pos + 2) + 2;
+            if (loc < 0)
+                RespParsingException.Throw("No newline!");
+
+            if (len == -1)
+            {
+                return null;
+            }
+
+            if (loc != pos + 2 + len + 2)
+                RespParsingException.Throw("Invalid length!");
+
+            return input[(pos + 2)..(pos + 2 + len)];
+        }
+
+        private static string ReadErrorAsString(string input, ref int loc)
+        {
+            var pos = input.IndexOf("\r\n", loc);
+            if (pos == -1)
+                RespParsingException.Throw("No newline");
+
+            var ret = input[loc..pos];
+            loc = pos + 2;
+
+            return ret;
+        }
+
+        private static long ReadIntegerAsString(string input, ref int loc)
+        {
+            var pos = input.IndexOf("\r\n", loc);
+            if (pos == -1)
+                RespParsingException.Throw("No newline");
+
+            var ret = long.Parse(input[loc..pos]);
+            loc = pos + 2;
+
+            return ret;
+        }
+
+        private static string ReadSimpleString(string input, ref int loc)
+        {
+            var pos = input.IndexOf("\r\n", loc);
+            if (pos == -1)
+                RespParsingException.Throw("No newline");
+
+            var ret = input[loc..pos];
+            loc = pos + 2;
+
+            return ret;
+        }
+    }
+}

--- a/test/Garnet.test/Resp/TestSimpleReadRESP.cs
+++ b/test/Garnet.test/Resp/TestSimpleReadRESP.cs
@@ -124,7 +124,7 @@ namespace Garnet.test
 
             return ret;
         }
-        
+
         private static double ReadDoubleAsString(string input, ref int loc)
         {
             var pos = input.IndexOf("\r\n", loc);

--- a/test/Garnet.test/RespBlockingCollectionTests.cs
+++ b/test/Garnet.test/RespBlockingCollectionTests.cs
@@ -961,8 +961,7 @@ namespace Garnet.test
             using var lcr = TestUtils.CreateRequest();
             var response = lcr.SendCommand($"BZMPOP 1 1 {key} {mode}");
             var expectedResponse = "$-1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -1079,8 +1078,7 @@ namespace Garnet.test
             using var lcr = TestUtils.CreateRequest();
             var response = lcr.SendCommand($"{command} {key} 1");
             var expectedResponse = "$-1\r\n";
-            var actualValue = Encoding.ASCII.GetString(response).Substring(0, expectedResponse.Length);
-            ClassicAssert.AreEqual(expectedResponse, actualValue);
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]

--- a/test/Garnet.test/RespSetTest.cs
+++ b/test/Garnet.test/RespSetTest.cs
@@ -1007,7 +1007,7 @@ namespace Garnet.test
         }
 
         [Test]
-        public unsafe void CanDoSRANDMEMBERWithCountCommandLC()
+        public void CanDoSRANDMEMBERWithCountCommandLC()
         {
             var myset = new HashSet<string> { "one", "two", "three", "four", "five" };
 
@@ -1041,7 +1041,7 @@ namespace Garnet.test
 
             ClassicAssert.IsTrue(results.All(a => myset.Contains((string)a)));
             ClassicAssert.IsTrue(results.Distinct().Count() != results.Length,
-                                 "At least two members are repeated.");
+                                 "At least two members must be repeated.");
         }
 
         [Test]

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -5024,7 +5024,7 @@ namespace Garnet.test
                 {
                     var startTime = Stopwatch.GetTimestamp();
                     var response = blockingClient.SendCommand("BLMPOP 10 1 keyA LEFT");
-                    if (Encoding.ASCII.GetString(response).Substring(0, "-UNBLOCKED".Length) == "-UNBLOCKED")
+                    if (Encoding.ASCII.GetString(response, 0, "-UNBLOCKED".Length) == "-UNBLOCKED")
                     {
                         isError = true;
                     }
@@ -5077,6 +5077,7 @@ namespace Garnet.test
             using var blockingClient = TestUtils.CreateRequest();
             var clientIdResponse = Encoding.ASCII.GetString(blockingClient.SendCommand("CLIENT ID"));
             var clientId = clientIdResponse.Substring(1, clientIdResponse.IndexOf("\r\n") - 1);
+            ClassicAssert.IsTrue(long.TryParse(clientId, out _));
 
             string blockingResult = null;
             var blockingTask = Task.Run(() =>


### PR DESCRIPTION
The test didn't really test for duplicate members, because it didn't update arrLenEndIdx, so the next loop run just compared against the previous - passing regardless of actual behaviour (which happened to be per spec, but the test should still work).

Also fix remaining Encoding.ASCII.GetString usages.