### PR TITLE
Update KeraLua version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.12" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="JsonPath.Net" Version="1.1.6" />
-    <PackageVersion Include="KeraLua" Version="1.4.1" />
+    <PackageVersion Include="KeraLua" Version="1.4.4" />
     <PackageVersion Include="NUnit" Version="4.1.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.13.0" />


### PR DESCRIPTION
This should add Linux/ARM64 lua support, and truly close #1098 (#1133 in practice too, even if there are uncommon archs that Garnet could run on theoretically and KeraLua may not supply binaries for).