### PR TITLE
Some timing issues with CIs that run in ADO as they were timing out

### DIFF
--- a/.azure/pipelines/azure-pipelines-tsavorite.yml
+++ b/.azure/pipelines/azure-pipelines-tsavorite.yml
@@ -12,7 +12,7 @@ jobs:
   pool:
     vmImage: windows-latest
   displayName: 'C# (Windows)'
-  timeoutInMinutes: 125
+  timeoutInMinutes: '175'
 
   strategy:
     maxParallel: 2
@@ -113,7 +113,7 @@ jobs:
   pool:
     vmImage: ubuntu-latest
   displayName: 'C# (Linux)'
-  timeoutInMinutes: 125
+  timeoutInMinutes: '175'
 
   strategy:
     maxParallel: 2

--- a/.azure/pipelines/azure-pipelines.yml
+++ b/.azure/pipelines/azure-pipelines.yml
@@ -12,10 +12,10 @@ jobs:
   pool:
     vmImage: windows-latest
   displayName: 'C# (Windows)'
-  timeoutInMinutes: 75 
+  timeoutInMinutes: '120'
 
   strategy:
-    maxParallel: 2
+    maxParallel: '2'
     matrix:
       AnyCPU-Debug:
         buildPlatform: 'Any CPU'
@@ -106,7 +106,7 @@ jobs:
   pool:
     vmImage: ubuntu-latest
   displayName: 'C# (Linux)'
-  timeoutInMinutes: 75
+  timeoutInMinutes: '120'
 
   strategy:
     maxParallel: 2


### PR DESCRIPTION
This is kind of a secondary check that happens when mirrored to the ADO repo so it would be good to have these running. There is a dotnet fail but that might be related to the time out. 

First things first is to see if we can run this without a timeout. Unfortunately, we can't run these pipelines on the branch as we don't want to be creating branches on the ADO repo. 