### PR TITLE
Enforce Cluster Announce Parameters on Recovery

### DIFF
--- a/libs/cluster/Server/ClusterManager.cs
+++ b/libs/cluster/Server/ClusterManager.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Net;
 using System.Threading;
 using Garnet.common;
 using Garnet.server.TLS;
@@ -50,20 +49,7 @@ namespace Garnet.cluster
             clusterConfigDevice = deviceFactory.Get(new FileDescriptor(directoryName: "", fileName: "nodes.conf"));
             pool = new(1, (int)clusterConfigDevice.SectorSize);
 
-            IPEndPoint endpoint = null;
-            foreach (var endPoint in opts.EndPoints)
-            {
-                if (endPoint is IPEndPoint _endpoint)
-                {
-                    endpoint = _endpoint;
-                    break;
-                }
-            }
-
-            if (endpoint == null)
-                throw new GarnetException("No valid IPEndPoint found in endPoint list");
-
-            var address = clusterProvider.storeWrapper.GetIp();
+            var clusterEndpoint = clusterProvider.storeWrapper.GetClusterEndpoint();
 
             this.logger = logger;
             var recoverConfig = clusterConfigDevice.GetFileSize(0) > 0 && !opts.CleanClusterConfig;
@@ -80,14 +66,14 @@ namespace Garnet.cluster
                 var config = ClusterUtils.ReadDevice(clusterConfigDevice, pool, logger);
                 currentConfig = ClusterConfig.FromByteArray(config);
                 // Used to update endpoint if it change when running inside a container.
-                if (address != currentConfig.LocalNodeIp || endpoint.Port != currentConfig.LocalNodePort)
+                if (clusterEndpoint.Address.ToString() != currentConfig.LocalNodeIp || clusterEndpoint.Port != currentConfig.LocalNodePort)
                 {
                     logger?.LogInformation(
                         "Updating local Endpoint: From {currentConfig.GetLocalNodeIp()}:{currentConfig.GetLocalNodePort()} to {address}:{opts.Port}",
                         currentConfig.LocalNodeIp,
                         currentConfig.LocalNodePort,
-                        address,
-                        endpoint.Port);
+                        clusterEndpoint,
+                        clusterEndpoint.Port);
                 }
             }
             else
@@ -97,7 +83,7 @@ namespace Garnet.cluster
             }
 
             clusterConnectionStore = new GarnetClusterConnectionStore(logger: logger);
-            InitLocal(address, endpoint.Port, recoverConfig);
+            InitLocal(clusterEndpoint.Address.ToString(), clusterEndpoint.Port, recoverConfig);
             logger?.LogInformation("{NodeInfoStartup}", CurrentConfig.GetClusterInfo(clusterProvider).TrimEnd('\n'));
             gossipDelay = TimeSpan.FromSeconds(opts.GossipDelay);
             clusterTimeout = opts.ClusterTimeout <= 0 ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(opts.ClusterTimeout);

--- a/libs/cluster/Server/ClusterManager.cs
+++ b/libs/cluster/Server/ClusterManager.cs
@@ -69,11 +69,10 @@ namespace Garnet.cluster
                 if (clusterEndpoint.Address.ToString() != currentConfig.LocalNodeIp || clusterEndpoint.Port != currentConfig.LocalNodePort)
                 {
                     logger?.LogInformation(
-                        "Updating local Endpoint: From {currentConfig.GetLocalNodeIp()}:{currentConfig.GetLocalNodePort()} to {address}:{opts.Port}",
+                        "Updating local Endpoint: From {currentConfig.GetLocalNodeIp()}:{currentConfig.GetLocalNodePort()} to {endpoint}",
                         currentConfig.LocalNodeIp,
                         currentConfig.LocalNodePort,
-                        clusterEndpoint,
-                        clusterEndpoint.Port);
+                        clusterEndpoint);
                 }
             }
             else

--- a/libs/common/Format.cs
+++ b/libs/common/Format.cs
@@ -33,7 +33,11 @@ namespace Garnet.common
 #pragma warning disable format
     public static class Format
     {
-        static EndPoint[] defaultBindEndpoint(int port) => [new IPEndPoint(IPAddress.Any, port), new IPEndPoint(IPAddress.IPv6Any, port)];
+        static EndPoint[] defaultBindAny(int port)
+            => Socket.OSSupportsIPv6 ? [new IPEndPoint(IPAddress.Any, port), new IPEndPoint(IPAddress.IPv6Any, port)] : [new IPEndPoint(IPAddress.Any, port)];
+
+        static EndPoint[] defaultBindLoopBack(int port)
+            => Socket.OSSupportsIPv6 ? [new IPEndPoint(IPAddress.Loopback, port), new IPEndPoint(IPAddress.IPv6Loopback, port)] : [new IPEndPoint(IPAddress.Loopback, port)];
 
         /// <summary>
         /// Parse address list string containing address separated by whitespace
@@ -51,7 +55,7 @@ namespace Garnet.common
             // Check if input null or empty
             if (string.IsNullOrEmpty(addressList) || string.IsNullOrWhiteSpace(addressList))
             {
-                endpoints = defaultBindEndpoint(port);
+                endpoints = defaultBindAny(port);
                 return true;
             }
 
@@ -85,13 +89,13 @@ namespace Garnet.common
         public static async Task<EndPoint[]> TryCreateEndpoint(string singleAddressOrHostname, int port, bool tryConnect = false, ILogger logger = null)
         {
             if (string.IsNullOrEmpty(singleAddressOrHostname) || string.IsNullOrWhiteSpace(singleAddressOrHostname))
-                return defaultBindEndpoint(port);
+                return defaultBindAny(port);
 
             if (singleAddressOrHostname[0] == '-')
                 singleAddressOrHostname = singleAddressOrHostname.Substring(1);
 
             if (singleAddressOrHostname.Equals("localhost", StringComparison.CurrentCultureIgnoreCase))
-                return [new IPEndPoint(IPAddress.Loopback, port)];
+                return defaultBindLoopBack(port);
 
             if (IPAddress.TryParse(singleAddressOrHostname, out var ipAddress))
                 return [new IPEndPoint(ipAddress, port)];

--- a/libs/common/Format.cs
+++ b/libs/common/Format.cs
@@ -33,6 +33,8 @@ namespace Garnet.common
 #pragma warning disable format
     public static class Format
     {
+        static EndPoint[] defaultBindEndpoint(int port) => [new IPEndPoint(IPAddress.Any, port), new IPEndPoint(IPAddress.IPv6Any, port)];
+
         /// <summary>
         /// Parse address list string containing address separated by whitespace
         /// </summary>
@@ -49,7 +51,7 @@ namespace Garnet.common
             // Check if input null or empty
             if (string.IsNullOrEmpty(addressList) || string.IsNullOrWhiteSpace(addressList))
             {
-                endpoints = [new IPEndPoint(IPAddress.Any, port)];
+                endpoints = defaultBindEndpoint(port);
                 return true;
             }
 
@@ -83,7 +85,7 @@ namespace Garnet.common
         public static async Task<EndPoint[]> TryCreateEndpoint(string singleAddressOrHostname, int port, bool tryConnect = false, ILogger logger = null)
         {
             if (string.IsNullOrEmpty(singleAddressOrHostname) || string.IsNullOrWhiteSpace(singleAddressOrHostname))
-                return [new IPEndPoint(IPAddress.Any, port)];
+                return defaultBindEndpoint(port);
 
             if (singleAddressOrHostname[0] == '-')
                 singleAddressOrHostname = singleAddressOrHostname.Substring(1);

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -175,7 +175,7 @@ namespace Garnet
                 Console.WriteLine($"""
                     {red}    _________
                        /_||___||_\      {normal}Garnet {version} {(IntPtr.Size == 8 ? "64" : "32")} bit; {(opts.EnableCluster ? "cluster" : "standalone")} mode{red}
-                       '. \   / .'      {normal}Listening on: {(opts.EndPoints.Length > 1 ? opts.EndPoints[0] + ", ..." : opts.EndPoints[0])}{red}
+                       '. \   / .'      {normal}Listening on: {(opts.EndPoints.Length > 1 ? opts.EndPoints[0] + $" and {opts.EndPoints.Length} more" : opts.EndPoints[0])}{red}
                          '.\ /.'        {magenta}https://aka.ms/GetGarnet{red}
                            '.'
                     {normal}

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -175,7 +175,7 @@ namespace Garnet
                 Console.WriteLine($"""
                     {red}    _________
                        /_||___||_\      {normal}Garnet {version} {(IntPtr.Size == 8 ? "64" : "32")} bit; {(opts.EnableCluster ? "cluster" : "standalone")} mode{red}
-                       '. \   / .'      {normal}Listening on: {opts.EndPoints[0]}{red}
+                       '. \   / .'      {normal}Listening on: {(opts.EndPoints.Length > 1 ? opts.EndPoints[0] + ", ..." : opts.EndPoints[0])}{red}
                          '.\ /.'        {magenta}https://aka.ms/GetGarnet{red}
                            '.'
                     {normal}

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -175,7 +175,7 @@ namespace Garnet
                 Console.WriteLine($"""
                     {red}    _________
                        /_||___||_\      {normal}Garnet {version} {(IntPtr.Size == 8 ? "64" : "32")} bit; {(opts.EnableCluster ? "cluster" : "standalone")} mode{red}
-                       '. \   / .'      {normal}Listening on: {(opts.EndPoints.Length > 1 ? opts.EndPoints[0] + $" and {opts.EndPoints.Length} more" : opts.EndPoints[0])}{red}
+                       '. \   / .'      {normal}Listening on: {(opts.EndPoints.Length > 1 ? opts.EndPoints[0] + $" and {opts.EndPoints.Length - 1} more" : opts.EndPoints[0])}{red}
                          '.\ /.'        {magenta}https://aka.ms/GetGarnet{red}
                            '.'
                     {normal}

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -223,7 +223,7 @@ namespace Garnet.server
         /// Get IP
         /// </summary>
         /// <returns></returns>
-        public string GetIp()
+        public IPEndPoint GetClusterEndpoint()
         {
             IPEndPoint localEndPoint = null;
             if (serverOptions.ClusterAnnounceEndpoint == null)
@@ -253,7 +253,7 @@ namespace Garnet.server
                 {
                     socket.Connect("8.8.8.8", 65530);
                     var endPoint = socket.LocalEndPoint as IPEndPoint;
-                    return endPoint.Address.ToString();
+                    return endPoint;
                 }
             }
             else if (localEndPoint.Address.Equals(IPAddress.IPv6Any))
@@ -262,10 +262,10 @@ namespace Garnet.server
                 {
                     socket.Connect("2001:4860:4860::8888", 65530);
                     var endPoint = socket.LocalEndPoint as IPEndPoint;
-                    return endPoint.Address.ToString();
+                    return endPoint;
                 }
             }
-            return localEndPoint.Address.ToString();
+            return localEndPoint;
         }
 
         internal FunctionsState CreateFunctionsState()

--- a/test/Garnet.test.cluster/ClusterTestContext.cs
+++ b/test/Garnet.test.cluster/ClusterTestContext.cs
@@ -240,6 +240,7 @@ namespace Garnet.test.cluster
             bool useTLS = false,
             bool useAcl = false,
             bool asyncReplay = false,
+            EndPoint clusterAnnounceEndpoint = null,
             X509CertificateCollection certificates = null,
             ServerCredential clusterCreds = new ServerCredential())
         {
@@ -272,7 +273,8 @@ namespace Garnet.test.cluster
                 aclFile: credManager.aclFilePath,
                 authUsername: clusterCreds.user,
                 authPassword: clusterCreds.password,
-                certificates: certificates);
+                certificates: certificates,
+                clusterAnnounceEndpoint: clusterAnnounceEndpoint);
 
             return new GarnetServer(opts, loggerFactory);
         }

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -452,7 +452,8 @@ namespace Garnet.test
             bool enableDisklessSync = false,
             int replicaDisklessSyncDelay = 1,
             LuaMemoryManagementMode luaMemoryMode = LuaMemoryManagementMode.Native,
-            string luaMemoryLimit = "")
+            string luaMemoryLimit = "",
+            EndPoint clusterAnnounceEndpoint = null)
         {
             if (UseAzureStorage)
                 IgnoreIfNotRunningAzureTests();
@@ -498,7 +499,8 @@ namespace Garnet.test
                     enableDisklessSync: enableDisklessSync,
                     replicaDisklessSyncDelay: replicaDisklessSyncDelay,
                     luaMemoryMode: luaMemoryMode,
-                    luaMemoryLimit: luaMemoryLimit);
+                    luaMemoryLimit: luaMemoryLimit,
+                    clusterAnnounceEndpoint: clusterAnnounceEndpoint);
 
                 ClassicAssert.IsNotNull(opts);
 
@@ -559,7 +561,8 @@ namespace Garnet.test
             TimeSpan? luaTimeout = null,
             LuaLoggingMode luaLoggingMode = LuaLoggingMode.Enable,
             IEnumerable<string> luaAllowedFunctions = null,
-            string unixSocketPath = null)
+            string unixSocketPath = null,
+            EndPoint clusterAnnounceEndpoint = null)
         {
             if (useAzureStorage)
                 IgnoreIfNotRunningAzureTests();
@@ -665,7 +668,8 @@ namespace Garnet.test
                 LuaOptions = enableLua ? new LuaOptions(luaMemoryMode, luaMemoryLimit, luaTimeout ?? Timeout.InfiniteTimeSpan, luaLoggingMode, luaAllowedFunctions ?? [], logger) : null,
                 UnixSocketPath = unixSocketPath,
                 ReplicaDisklessSync = enableDisklessSync,
-                ReplicaDisklessSyncDelay = replicaDisklessSyncDelay
+                ReplicaDisklessSyncDelay = replicaDisklessSyncDelay,
+                ClusterAnnounceEndpoint = clusterAnnounceEndpoint,
             };
 
             if (lowMemory)

--- a/website/docs/getting-started/build.md
+++ b/website/docs/getting-started/build.md
@@ -48,6 +48,8 @@ dotnet run -c Release -f net8.0
 
 :::tip
 By default, Garnet listens to TCP port 6379, make sure to adjust your firewall settings when you need to access the server from remote machines.
+Also, note that Garnet by default listens to the IPAddress.Any and IPAddress.IPv6Any endpoints.
+Please make sure to adjust these based on your requirements.
 :::
 
 To see the configurable options and their defaults, run the below command. You can configure index size, memory size, page size, data file paths and checkpoint paths, IP address to bind to, port number to run on, etc.


### PR DESCRIPTION
This PR fixes issue #640 because now we support cluster-announce-ip and cluster-announce-port options