### PR TITLE
Set the Compliance-Security Compliance-Policheck to NOT run on continuousbenchmark branch

### DIFF
--- a/.azure/pipelines/azure-pipelines-compliance-policheck.yml
+++ b/.azure/pipelines/azure-pipelines-compliance-policheck.yml
@@ -1,3 +1,11 @@
+trigger:
+  branches:
+    exclude:
+      - continuousbenchmark
+pr:
+  branches:
+    exclude:
+      - continuousbenchmark
 resources:
   repositories:
   - repository: self

--- a/.azure/pipelines/azure-pipelines-compliance.yml
+++ b/.azure/pipelines/azure-pipelines-compliance.yml
@@ -1,3 +1,11 @@
+trigger:
+  branches:
+    exclude:
+      - continuousbenchmark
+pr:
+  branches:
+    exclude:
+      - continuousbenchmark
 variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'


### PR DESCRIPTION
Every time a single data point is pushed to the charts data in continuousbenchmark branch, the compliance-security and compliance-policheck pipelines are ran. This causes A LOT of pipeline runs that don't even really matter.  We should not be running these two pipelines on the continuousbenchmark branch.