### PR TITLE
Enhance file logging to include exception details

### DIFF
--- a/libs/common/Logging/FileLoggerProvider.cs
+++ b/libs/common/Logging/FileLoggerProvider.cs
@@ -79,6 +79,11 @@ namespace Garnet.common
                 categoryName,
                 formatter(state, exception));
 
+            if (exception != null)
+            {
+                msg += Environment.NewLine + exception.ToString();
+            }
+
             lock (lockObj)
             {
                 streamWriter.WriteLine(msg);


### PR DESCRIPTION
Added a conditional check in `FileLoggerProvider.cs` to append the string representation of an `exception` to the log message if it is not null. This improvement provides better context for debugging by ensuring that exceptions encountered during logging are captured in the output.