### PR TITLE
Use Loopback (IPv4+IPv6) as the default end points, rather than IPv4 Any

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,4 @@ USER $APP_UID
 # For inter-container communication.
 EXPOSE 6379
 
-ENTRYPOINT ["/app/GarnetServer"]
+ENTRYPOINT ["/app/GarnetServer", "--bind", "0.0.0.0"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -50,4 +50,4 @@ USER $APP_UID
 # For inter-container communication.
 EXPOSE 6379
 
-ENTRYPOINT ["/app/GarnetServer"]
+ENTRYPOINT ["/app/GarnetServer", "--bind", "0.0.0.0"]

--- a/Dockerfile.cbl-mariner
+++ b/Dockerfile.cbl-mariner
@@ -50,4 +50,4 @@ USER $APP_UID
 # For inter-container communication.
 EXPOSE 6379
 
-ENTRYPOINT ["/app/GarnetServer"]
+ENTRYPOINT ["/app/GarnetServer", "--bind", "0.0.0.0"]

--- a/Dockerfile.chiseled
+++ b/Dockerfile.chiseled
@@ -46,4 +46,4 @@ VOLUME /data
 # For inter-container communication.
 EXPOSE 6379
 
-ENTRYPOINT ["/app/GarnetServer"]
+ENTRYPOINT ["/app/GarnetServer", "--bind", "0.0.0.0"]

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -22,4 +22,4 @@ COPY --from=build /app .
 # For inter-container communication.
 EXPOSE 6379
 
-ENTRYPOINT ["/app/GarnetServer.exe"]
+ENTRYPOINT ["/app/GarnetServer.exe", "--bind", "0.0.0.0"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -54,4 +54,4 @@ USER $APP_UID
 # For inter-container communication.
 EXPOSE 6379
 
-ENTRYPOINT ["/app/GarnetServer"]
+ENTRYPOINT ["/app/GarnetServer", "--bind", "0.0.0.0"]

--- a/libs/common/Format.cs
+++ b/libs/common/Format.cs
@@ -49,7 +49,7 @@ namespace Garnet.common
             // Check if input null or empty
             if (string.IsNullOrEmpty(addressList) || string.IsNullOrWhiteSpace(addressList))
             {
-                endpoints = [new IPEndPoint(IPAddress.Loopback, port), new IPEndPoint(IPAddress.IPv6Loopback, port)];
+                endpoints = Socket.OSSupportsIPv6 ? [new IPEndPoint(IPAddress.Loopback, port), new IPEndPoint(IPAddress.IPv6Loopback, port)] : [new IPEndPoint(IPAddress.Loopback, port)];
                 return true;
             }
 
@@ -83,13 +83,13 @@ namespace Garnet.common
         public static async Task<EndPoint[]> TryCreateEndpoint(string singleAddressOrHostname, int port, bool tryConnect = false, ILogger logger = null)
         {
             if (string.IsNullOrEmpty(singleAddressOrHostname) || string.IsNullOrWhiteSpace(singleAddressOrHostname))
-                return [new IPEndPoint(IPAddress.Loopback, port), new IPEndPoint(IPAddress.IPv6Loopback, port)];
+                return Socket.OSSupportsIPv6 ? [new IPEndPoint(IPAddress.Loopback, port), new IPEndPoint(IPAddress.IPv6Loopback, port)] : [new IPEndPoint(IPAddress.Loopback, port)];
 
             if (singleAddressOrHostname[0] == '-')
                 singleAddressOrHostname = singleAddressOrHostname.Substring(1);
 
             if (singleAddressOrHostname.Equals("localhost", StringComparison.CurrentCultureIgnoreCase))
-                return [new IPEndPoint(IPAddress.Loopback, port), new IPEndPoint(IPAddress.IPv6Loopback, port)];
+                return Socket.OSSupportsIPv6 ? [new IPEndPoint(IPAddress.Loopback, port), new IPEndPoint(IPAddress.IPv6Loopback, port)] : [new IPEndPoint(IPAddress.Loopback, port)];
 
             if (IPAddress.TryParse(singleAddressOrHostname, out var ipAddress))
                 return [new IPEndPoint(ipAddress, port)];

--- a/libs/common/Format.cs
+++ b/libs/common/Format.cs
@@ -49,7 +49,7 @@ namespace Garnet.common
             // Check if input null or empty
             if (string.IsNullOrEmpty(addressList) || string.IsNullOrWhiteSpace(addressList))
             {
-                endpoints = [new IPEndPoint(IPAddress.Any, port)];
+                endpoints = [new IPEndPoint(IPAddress.Loopback, port), new IPEndPoint(IPAddress.IPv6Loopback, port)];
                 return true;
             }
 
@@ -83,13 +83,13 @@ namespace Garnet.common
         public static async Task<EndPoint[]> TryCreateEndpoint(string singleAddressOrHostname, int port, bool tryConnect = false, ILogger logger = null)
         {
             if (string.IsNullOrEmpty(singleAddressOrHostname) || string.IsNullOrWhiteSpace(singleAddressOrHostname))
-                return [new IPEndPoint(IPAddress.Any, port)];
+                return [new IPEndPoint(IPAddress.Loopback, port), new IPEndPoint(IPAddress.IPv6Loopback, port)];
 
             if (singleAddressOrHostname[0] == '-')
                 singleAddressOrHostname = singleAddressOrHostname.Substring(1);
 
             if (singleAddressOrHostname.Equals("localhost", StringComparison.CurrentCultureIgnoreCase))
-                return [new IPEndPoint(IPAddress.Loopback, port)];
+                return [new IPEndPoint(IPAddress.Loopback, port), new IPEndPoint(IPAddress.IPv6Loopback, port)];
 
             if (IPAddress.TryParse(singleAddressOrHostname, out var ipAddress))
                 return [new IPEndPoint(ipAddress, port)];

--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -40,7 +40,7 @@ namespace Garnet
         public int Port { get; set; }
 
         [IpAddressValidation(false)]
-        [Option("bind", Required = false, HelpText = "Whitespace or comma separated string of IP addresses to bind server to (default: any)")]
+        [Option("bind", Required = false, HelpText = "Whitespace or comma separated string of IP addresses to bind server to (default: loopback)")]
         public string Address { get; set; }
 
         [IntRangeValidation(0, 65535)]

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -171,11 +171,12 @@ namespace Garnet
                 var red = "\u001b[31m";
                 var magenta = "\u001b[35m";
                 var normal = "\u001b[0m";
+                var endpoints = string.Join(", ", opts.EndPoints.Select(x => x.ToString()));
 
                 Console.WriteLine($"""
                     {red}    _________
                        /_||___||_\      {normal}Garnet {version} {(IntPtr.Size == 8 ? "64" : "32")} bit; {(opts.EnableCluster ? "cluster" : "standalone")} mode{red}
-                       '. \   / .'      {normal}Listening on: {opts.EndPoints[0]}{red}
+                       '. \   / .'      {normal}Listening on: {endpoints}{red}
                          '.\ /.'        {magenta}https://aka.ms/GetGarnet{red}
                            '.'
                     {normal}

--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -6,7 +6,7 @@
 	/* Port to run server on */
 	"Port" : 6379,
 
-	/* Whitespace or comma separated string of IP addresses to bind server to (default: any) */
+	/* Whitespace or comma separated string of IP addresses to bind server to (default: loopback) */
 	"Address" : null,
 
 	/* Port that this node advertises to other nodes to connect to for gossiping. */

--- a/libs/server/Servers/ServerOptions.cs
+++ b/libs/server/Servers/ServerOptions.cs
@@ -17,7 +17,7 @@ namespace Garnet.server
         /// <summary>
         /// Endpoints to bind server to.
         /// </summary>
-        public EndPoint[] EndPoints { get; set; } = [new IPEndPoint(IPAddress.Loopback, 6379)];
+        public EndPoint[] EndPoints { get; set; } = [new IPEndPoint(IPAddress.Loopback, 6379), new IPEndPoint(IPAddress.IPv6Loopback, 6379)];
 
         /// <summary>
         /// Cluster announce Endpoint


### PR DESCRIPTION
- Render all endpoints during startup
- If localhost is specified as the address, explicitly add v4 and v6, modern Windows uses IPv6 for 'localhost', macos and linux use IPv4 currently
- Makes the defaults on the Options objects consistent with what is assigned during parsing of addresses

Discussed in https://github.com/microsoft/garnet/pull/1083#issuecomment-2766761513

Main drivers for change:
- Increased security for defaults, prevent uses unknowingly exposing their instances to the network accidentally
- Bind to both IPv4 and IPv6 stacks to localhost works consistently between OSs