### PR TITLE
UnixDomainSocketEndPoint - improve error message if the user doesn't also specify the UnixSocketPath

### DIFF
--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -259,6 +259,8 @@ namespace Garnet
                 {
                     if (opts.EndPoints[i] is UnixDomainSocketEndPoint)
                     {
+                        ArgumentException.ThrowIfNullOrWhiteSpace(opts.UnixSocketPath, nameof(opts.UnixSocketPath));
+
                         // Delete existing unix socket file, if it exists.
                         File.Delete(opts.UnixSocketPath);
                     }

--- a/test/Garnet.test/UnixSocketTests.cs
+++ b/test/Garnet.test/UnixSocketTests.cs
@@ -89,5 +89,19 @@ namespace Garnet.test
 
             ArrayPool<byte>.Shared.Return(buffer);
         }
+
+        [Test]
+        public void Helpful_Exception_For_Missing_Path([Values] bool useTls)
+        {
+            var unixSocketPath = "./unix-socket-ping-test.sock";
+            var unixSocketEndpoint = new UnixDomainSocketEndPoint(unixSocketPath);
+
+            // Given the reasonable expectation that the UnixDomainSocketEndPoint already has the path in it, make sure caller is aware the path must also be specified in unixSocketPath
+            _ = Assert.Throws<ArgumentNullException>(() => 
+            {
+                using var server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, [unixSocketEndpoint], enableTLS: useTls /*, unixSocketPath: unixSocketPath */);
+            }, "Value cannot be null. (Parameter 'UnixSocketPath')");
+        }
+
     }
 }

--- a/test/Garnet.test/UnixSocketTests.cs
+++ b/test/Garnet.test/UnixSocketTests.cs
@@ -97,7 +97,7 @@ namespace Garnet.test
             var unixSocketEndpoint = new UnixDomainSocketEndPoint(unixSocketPath);
 
             // Given the reasonable expectation that the UnixDomainSocketEndPoint already has the path in it, make sure caller is aware the path must also be specified in unixSocketPath
-            _ = Assert.Throws<ArgumentNullException>(() => 
+            _ = Assert.Throws<ArgumentNullException>(() =>
             {
                 using var server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, [unixSocketEndpoint], enableTLS: useTls /*, unixSocketPath: unixSocketPath */);
             }, "Value cannot be null. (Parameter 'UnixSocketPath')");


### PR DESCRIPTION
The current error is confusing because the parameter name is actually the underlying parameter name of File.Delete.
I came across this when testing with UnixDomainSocketEndPoint, as to why I needed to specify the path twice, but can see that UnixDomainSocketEndPoint doesn't expose the path it's created with.

`System.ArgumentNullException : Value cannot be null. (Parameter 'path')` => `System.ArgumentNullException : Value cannot be null. (Parameter 'UnixSocketPath')`
