### PR TITLE
Remove spaces from INFO section names to increase compatibility with buggy clients

### DIFF
--- a/libs/server/Metrics/Info/GarnetInfoMetrics.cs
+++ b/libs/server/Metrics/Info/GarnetInfoMetrics.cs
@@ -383,6 +383,8 @@ namespace Garnet.server
 
         public static string GetSectionHeader(InfoMetricsType infoType, int dbId)
         {
+            // No word separators inside section names, some clients will then fail to process INFO output.
+            // https://github.com/microsoft/garnet/pull/1019#issuecomment-2660752028
             return infoType switch
             {
                 InfoMetricsType.SERVER => "Server",
@@ -390,13 +392,13 @@ namespace Garnet.server
                 InfoMetricsType.CLUSTER => "Cluster",
                 InfoMetricsType.REPLICATION => "Replication",
                 InfoMetricsType.STATS => "Stats",
-                InfoMetricsType.STORE => $"MainStore (DB {dbId})",
-                InfoMetricsType.OBJECTSTORE => $"ObjectStore (DB {dbId})",
-                InfoMetricsType.STOREHASHTABLE => $"MainStoreHashTableDistribution (DB {dbId})",
-                InfoMetricsType.OBJECTSTOREHASHTABLE => $"ObjectStoreHashTableDistribution (DB {dbId})",
-                InfoMetricsType.STOREREVIV => $"MainStoreDeletedRecordRevivification (DB {dbId})",
-                InfoMetricsType.OBJECTSTOREREVIV => $"ObjectStoreDeletedRecordRevivification (DB {dbId})",
-                InfoMetricsType.PERSISTENCE => $"Persistence (DB {dbId})",
+                InfoMetricsType.STORE => $"MainStore_DB_{dbId}",
+                InfoMetricsType.OBJECTSTORE => $"ObjectStore_DB_{dbId}",
+                InfoMetricsType.STOREHASHTABLE => $"MainStoreHashTableDistribution_DB_{dbId}",
+                InfoMetricsType.OBJECTSTOREHASHTABLE => $"ObjectStoreHashTableDistribution_DB_{dbId}",
+                InfoMetricsType.STOREREVIV => $"MainStoreDeletedRecordRevivification_DB_{dbId}",
+                InfoMetricsType.OBJECTSTOREREVIV => $"ObjectStoreDeletedRecordRevivification_DB_{dbId}",
+                InfoMetricsType.PERSISTENCE => $"Persistence_DB_{dbId}",
                 InfoMetricsType.CLIENTS => "Clients",
                 InfoMetricsType.KEYSPACE => "Keyspace",
                 InfoMetricsType.MODULES => "Modules",


### PR DESCRIPTION
Clients like predis have parsing for INFO, which fails when section names have spaces or other word separator. 

https://github.com/predis/predis/blob/ac933cc5481eb4c7cc2132c1013ad3bbb780847a/src/Command/Redis/INFO.php#L59

Change names to increase compatibility and add a comment to remind of this in the future.