### PR TITLE
Fix Double Dispose Issue

### DIFF
--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -322,8 +322,6 @@ namespace Garnet.server
             // Cancel the async processor, if any
             asyncWaiterCancel?.Cancel();
             asyncWaiter?.Signal();
-
-            storageSession.Dispose();
         }
 
         public int StoreSessionID => storageSession.SessionID;


### PR DESCRIPTION
This PR fixes issue #1161 error. We were disposing twice the storage session and that created an assertion failure when disposing one of the SegmentAligned buffers