### PR TITLE
Correct index calculation when recreating KEYS and ARGV

### DIFF
--- a/libs/server/Lua/LuaRunner.cs
+++ b/libs/server/Lua/LuaRunner.cs
@@ -1412,8 +1412,8 @@ namespace Garnet.server
             Debug.Assert(state.TryEnsureMinimumStackCapacity(NeededStackSpace), "LUA_MINSTACK should ensure this always succeeds");
 
             // Get sandbox_env and "KEYS" on the stack
-            var sandboxEnvIndex = state.StackTop;
             _ = state.RawGetInteger(LuaType.Table, (int)LuaRegistry.Index, sandboxEnvRegistryIndex);
+            var sandboxEnvIndex = state.StackTop;
             state.PushConstantString(constStrs.KEYS);
 
             // Make new KEYS
@@ -1442,8 +1442,8 @@ namespace Garnet.server
             Debug.Assert(state.TryEnsureMinimumStackCapacity(NeededStackSpace), "LUA_MINSTACK should ensure this always succeeds");
 
             // Get sandbox_env and "KEYS" on the stack
-            var sandboxEnvIndex = state.StackTop;
             _ = state.RawGetInteger(LuaType.Table, (int)LuaRegistry.Index, sandboxEnvRegistryIndex);
+            var sandboxEnvIndex = state.StackTop;
             state.PushConstantString(constStrs.ARGV);
 
             // Make new ARGV

--- a/test/Garnet.test/LuaScriptRunnerTests.cs
+++ b/test/Garnet.test/LuaScriptRunnerTests.cs
@@ -738,6 +738,17 @@ namespace Garnet.test
         }
 
         [Test]
+        public void Issue1165()
+        {
+            // See: https://github.com/microsoft/garnet/issues/1165
+
+            using var runner = new LuaRunner(new(LuaMemoryManagementMode.Native, "10m", Timeout.InfiniteTimeSpan, LuaLoggingMode.Enable, []), "return 1");
+
+            runner.CompileForRunner();
+            _ = runner.RunForRunner([.. Enumerable.Repeat("key", 9)], [.. Enumerable.Repeat("argv", 9)]);
+        }
+
+        [Test]
         public void NeedsDisposeCheck()
         {
             foreach (var mode in Enum.GetValues<LuaMemoryManagementMode>())


### PR DESCRIPTION
These appear to have just slipped through in testing.

Should fix #1165.