### PR TITLE
Docs: use plus signs for commands with links.

### DIFF
--- a/test/Garnet.test/DocsTests.cs
+++ b/test/Garnet.test/DocsTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace Garnet.test
+{
+    [TestFixture]
+    public partial class DocsTests
+    {
+        [GeneratedRegex(@"^\s*\|\s*\|\s*\[(?<cmd>[^\]]+)\]\(.+?\)\s*\|\s*(?<sig>[➖])")]
+        private static partial Regex CommandLinkAndMinusRegex();
+
+        [Test]
+        public void CommandsWithLinksShouldNotHaveMinusSign()
+        {
+            var markdownPath = Path.GetFullPath(Path.Join(TestUtils.RootTestsProjectPath, "../website/docs/commands/api-compatibility.md"));
+            Assert.That(File.Exists(markdownPath));
+
+            var lines = File.ReadAllLines(markdownPath);
+            var issues = new List<string>();
+            foreach (var line in lines)
+            {
+                var match = CommandLinkAndMinusRegex().Match(line);
+                if (match.Success)
+                    issues.Add($"Command {match.Groups["cmd"].Value}: remove the docs link or use the '➕' sign.");
+            }
+
+            if (issues.Count > 0)
+                Assert.Fail(string.Join('\n', issues));
+        }
+    }
+}

--- a/website/docs/commands/api-compatibility.md
+++ b/website/docs/commands/api-compatibility.md
@@ -76,7 +76,7 @@ Note that this list is subject to change as we continue to expand our API comman
 |  | [SETNAME](client.md#client-setname) | ➕ |  |
 |  | TRACKING | ➖ |  |
 |  | TRACKINGINFO | ➖ |  |
-|  | [UNBLOCK](client.md#client-unblock) | ➖ |  |
+|  | [UNBLOCK](client.md#client-unblock) | ➕ |  |
 |  | UNPAUSE | ➖ |  |
 | <span id="cluster">**CLUSTER**</span> | [ADDSLOTS](cluster.md#cluster-addslots) | ➕ |  |
 |  | [ADDSLOTSRANGE](cluster.md#cluster-addslotsrange) | ➕ |  |
@@ -111,8 +111,8 @@ Note that this list is subject to change as we continue to expand our API comman
 | <span id="command">**COMMAND**</span> | [COMMAND](server.md#command) | ➕ |  |
 |  | [COUNT](server.md#command-count) | ➕ |  |
 |  | [DOCS](server.md#command-docs) | ➕ |  |
-|  | [GETKEYS](server.md#command-getkeys) | ➖ |  |
-|  | [GETKEYSANDFLAGS](server.md#command-getkeysandflags) | ➖ |  | 
+|  | [GETKEYS](server.md#command-getkeys) | ➕ |  |
+|  | [GETKEYSANDFLAGS](server.md#command-getkeysandflags) | ➕ |  |
 |  | HELP | ➖ |  | 
 |  | [INFO](server.md#command-info) | ➕ |  | 
 |  | LIST | ➖ |  | 


### PR DESCRIPTION
This PR fixes new inconsistencies at the command compatibility page. Namely, commands `UNBLOCK`, `GETKEYS`, `GETKEYSANDFLAGS` are implemented and correctly have links to documentation details but they are not marked with the "➕" sign. They look "not implemented", in other words.

As far as this issue is recurring (e.g. https://github.com/microsoft/garnet/pull/785 and https://github.com/microsoft/garnet/pull/757) I have added the docs test that catches such issues. Namely, without the above fix, the test would fail with this message:

```
Command UNBLOCK: remove the docs link or use the '➕' sign.
Command GETKEYS: remove the docs link or use the '➕' sign.
Command GETKEYSANDFLAGS: remove the docs link or use the '➕' sign.
```
