### PR TITLE
Add DELIFGREATER ETag Command

### DIFF
--- a/libs/resources/RespCommandsDocs.json
+++ b/libs/resources/RespCommandsDocs.json
@@ -1898,7 +1898,7 @@
   {
     "Command": "DELIFGREATER",
     "Name": "DELIFGREATER",
-    "Summary": "Given a key and an Etag only deletes the key if the Etag given in the request is strictly greater than the already existing etag for the key.",
+    "Summary": "Deletes a key only if the provided Etag is strictly greater than the existing Etag for the key.",
     "Group": "Generic",
     "Complexity": "O(1)",
     "Arguments": [

--- a/libs/resources/RespCommandsDocs.json
+++ b/libs/resources/RespCommandsDocs.json
@@ -1896,6 +1896,29 @@
     ]
   },
   {
+    "Command": "DELIFGREATER",
+    "Name": "DELIFGREATER",
+    "Summary": "Given a key and an Etag only deletes the key if the Etag given in the request is strictly greater than the already existing etag for the key.",
+    "Group": "Generic",
+    "Complexity": "O(1)",
+    "Arguments": [
+      {
+        "TypeDiscriminator": "RespCommandKeyArgument",
+        "Name": "KEY",
+        "DisplayText": "key",
+        "Type": "Key",
+        "KeySpecIndex": 0
+      },
+      {
+        "TypeDiscriminator": "RespCommandBasicArgument",
+        "Name": "ETAG",
+        "DisplayText": "etag",
+        "Type": "Integer"
+      }
+    ]
+  },
+
+  {
     "Command": "DISCARD",
     "Name": "DISCARD",
     "Summary": "Discards a transaction.",

--- a/libs/resources/RespCommandsInfo.json
+++ b/libs/resources/RespCommandsInfo.json
@@ -1196,6 +1196,30 @@
     ]
   },
   {
+    "Command": "DELIFGREATER",
+    "Name": "DELIFGREATER",
+    "Arity": 2,
+    "FirstKey": 1,
+    "LastKey": 1,
+    "Step": 1,
+    "AclCategories": "Slow, String, Write",
+    "KeySpecifications": [
+      {
+        "BeginSearch": {
+          "TypeDiscriminator": "BeginSearchIndex",
+          "Index": 1
+        },
+        "FindKeys": {
+          "TypeDiscriminator": "FindKeysRange",
+          "LastKey": 0,
+          "KeyStep": 1,
+          "Limit": 0
+        },
+        "Flags": "RM, Delete"
+      }
+    ]
+  },
+  {
     "Command": "DISCARD",
     "Name": "DISCARD",
     "Arity": 1,

--- a/libs/server/API/GarnetApi.cs
+++ b/libs/server/API/GarnetApi.cs
@@ -131,6 +131,10 @@ namespace Garnet.server
             => storageSession.SET_Conditional(ref key, ref input, ref context);
 
         /// <inheritdoc />
+        public GarnetStatus DEL_Conditional(ref SpanByte key, ref RawStringInput input)
+            => storageSession.DEL_Conditional(ref key, ref input, ref context);
+
+        /// <inheritdoc />
         public GarnetStatus SET_Conditional(ref SpanByte key, ref RawStringInput input, ref SpanByteAndMemory output)
             => storageSession.SET_Conditional(ref key, ref input, ref output, ref context);
 

--- a/libs/server/API/IGarnetApi.cs
+++ b/libs/server/API/IGarnetApi.cs
@@ -39,6 +39,11 @@ namespace Garnet.server
         GarnetStatus SET_Conditional(ref SpanByte key, ref RawStringInput input);
 
         /// <summary>
+        /// DEL Conditional
+        /// </summary>
+        GarnetStatus DEL_Conditional(ref SpanByte key, ref RawStringInput input);
+
+        /// <summary>
         /// SET Conditional
         /// </summary>
         GarnetStatus SET_Conditional(ref SpanByte key, ref RawStringInput input, ref SpanByteAndMemory output);

--- a/libs/server/Resp/BasicEtagCommands.cs
+++ b/libs/server/Resp/BasicEtagCommands.cs
@@ -88,7 +88,7 @@ namespace Garnet.server
         private bool NetworkDELIFGREATER<TGarnetApi>(ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetApi
         {
-           if (parseState.Count != 3)
+           if (parseState.Count != 2)
                 return AbortWithWrongNumberOfArguments(nameof(RespCommand.DELIFGREATER));
 
             SpanByte key = parseState.GetArgSliceByRef(0).SpanByte;
@@ -102,13 +102,13 @@ namespace Garnet.server
             RawStringInput input = new RawStringInput(RespCommand.DELIFGREATER, ref parseState, startIdx: 1);
             input.header.SetWithEtagFlag();
 
-            GarnetStatus status = storageApi.SET_Conditional(ref key, ref input);
+            GarnetStatus status = storageApi.DEL_Conditional(ref key, ref input);
 
-            // HK TODO: this keys deleted is probably not even correct lmao need to test this manuall at some point
             int keysDeleted = status == GarnetStatus.OK ? 1 : 0;
 
             while (!RespWriteUtils.TryWriteInt32(keysDeleted, ref dcurr, dend))
                 SendAndReset();
+
             return true;
         } 
 

--- a/libs/server/Resp/BasicEtagCommands.cs
+++ b/libs/server/Resp/BasicEtagCommands.cs
@@ -77,6 +77,40 @@ namespace Garnet.server
             return true;
         }
 
+        /// <summary>
+        /// DELIFGREATER key etag
+        /// since normal delete tombstoning provides no support for doing a conditional delete on records that are in the stable region
+        /// we will use conditional SET to get RMW access and use that for deletion
+        /// </summary>
+        /// <typeparam name="TGarnetApi"></typeparam>
+        /// <param name="storageApi"></param>
+        /// <returns></returns>
+        private bool NetworkDELIFGREATER<TGarnetApi>(ref TGarnetApi storageApi)
+            where TGarnetApi : IGarnetApi
+        {
+           if (parseState.Count != 3)
+                return AbortWithWrongNumberOfArguments(nameof(RespCommand.DELIFGREATER));
+
+            SpanByte key = parseState.GetArgSliceByRef(0).SpanByte;
+            if (!parseState.TryGetLong(1, out long givenEtag) || givenEtag < 0)
+            {
+                while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_INVALID_ETAG, ref dcurr, dend))
+                    SendAndReset();
+                return true;
+            }
+            
+            RawStringInput input = new RawStringInput(RespCommand.DELIFGREATER, ref parseState, startIdx: 1);
+            input.header.SetWithEtagFlag();
+
+            GarnetStatus status = storageApi.SET_Conditional(ref key, ref input);
+
+            // HK TODO: this keys deleted is probably not even correct lmao need to test this manuall at some point
+            int keysDeleted = status == GarnetStatus.OK ? 1 : 0;
+
+            while (!RespWriteUtils.TryWriteInt32(keysDeleted, ref dcurr, dend))
+                SendAndReset();
+            return true;
+        } 
 
         /// <summary>
         /// SETIFMATCH key val etag [EX|PX] [expiry] [NOGET]
@@ -88,9 +122,7 @@ namespace Garnet.server
         /// <returns></returns>
         private bool NetworkSETIFMATCH<TGarnetApi>(ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetApi
-        {
-            return NetworkSetETagConditional(RespCommand.SETIFMATCH, ref storageApi);
-        }
+            => NetworkSetETagConditional(RespCommand.SETIFMATCH, ref storageApi);
 
 
         /// <summary>
@@ -103,9 +135,7 @@ namespace Garnet.server
         /// <returns></returns>
         private bool NetworkSETIFGREATER<TGarnetApi>(ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetApi
-        {
-            return NetworkSetETagConditional(RespCommand.SETIFGREATER, ref storageApi);
-        }
+            => NetworkSetETagConditional(RespCommand.SETIFGREATER, ref storageApi);
 
         private bool NetworkSetETagConditional<TGarnetApi>(RespCommand cmd, ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetApi
@@ -115,7 +145,7 @@ namespace Garnet.server
 
             if (parseState.Count < 3 || parseState.Count > 6)
             {
-                return AbortWithWrongNumberOfArguments(nameof(cmd));
+                return AbortWithWrongNumberOfArguments(cmd.ToString());
             }
 
             int expiry = 0;

--- a/libs/server/Resp/CmdStrings.cs
+++ b/libs/server/Resp/CmdStrings.cs
@@ -155,6 +155,7 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> GETIFNOTMATCH => "GETIFNOTMATCH"u8;
         public static ReadOnlySpan<byte> SETIFMATCH => "SETIFMATCH"u8;
         public static ReadOnlySpan<byte> SETIFGREATER => "SETIFGREATER"u8;
+        public static ReadOnlySpan<byte> DELIFGREATER => "DELIFGREATER"u8;
         public static ReadOnlySpan<byte> FIELDS => "FIELDS"u8;
         public static ReadOnlySpan<byte> MEMBERS => "MEMBERS"u8;
         public static ReadOnlySpan<byte> TIMEOUT => "TIMEOUT"u8;

--- a/libs/server/Resp/Parser/RespCommand.cs
+++ b/libs/server/Resp/Parser/RespCommand.cs
@@ -117,6 +117,7 @@ namespace Garnet.server
         DECR,
         DECRBY,
         DEL,
+        DELIFGREATER,
         EXPIRE,
         EXPIREAT,
         FLUSHALL,
@@ -2562,6 +2563,10 @@ namespace Garnet.server
             else if (command.SequenceEqual(CmdStrings.GETIFNOTMATCH))
             {
                 return RespCommand.GETIFNOTMATCH;
+            }
+            else if (command.SequenceEqual(CmdStrings.DELIFGREATER))
+            {
+                return RespCommand.DELIFGREATER;
             }
 
             // If this command name was not known to the slow pass, we are out of options and the command is unknown.

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -946,6 +946,7 @@ namespace Garnet.server
                 RespCommand.GETIFNOTMATCH => NetworkGETIFNOTMATCH(ref storageApi),
                 RespCommand.SETIFMATCH => NetworkSETIFMATCH(ref storageApi),
                 RespCommand.SETIFGREATER => NetworkSETIFGREATER(ref storageApi),
+                RespCommand.DELIFGREATER => NetworkDELIFGREATER(ref storageApi),
 
                 _ => Process(command, ref storageApi)
             };

--- a/libs/server/Storage/Functions/MainStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/RMWMethods.cs
@@ -27,6 +27,7 @@ namespace Garnet.server
                 case RespCommand.PEXPIREAT:
                 case RespCommand.GETDEL:
                 case RespCommand.GETEX:
+                case RespCommand.DELIFGREATER:
                     return false;
                 case RespCommand.SETEXXX:
                     // when called withetag all output needs to be placed on the buffer
@@ -355,9 +356,16 @@ namespace Garnet.server
                     EtagState.ResetState(ref functionsState.etagState);
                     // Nothing is set because being in this block means NX was already violated
                     return true;
+                case RespCommand.DELIFGREATER:
+                    long etagFromClient = input.parseState.GetLong(1);
+                    if (etagFromClient > functionsState.etagState.etag)
+                        rmwInfo.Action = RMWAction.ExpireAndStop;
+
+                    EtagState.ResetState(ref functionsState.etagState);
+                    return false;
                 case RespCommand.SETIFGREATER:
                 case RespCommand.SETIFMATCH:
-                    long etagFromClient = input.parseState.GetLong(1);
+                    etagFromClient = input.parseState.GetLong(1);
                     // in IFMATCH we check for equality, in IFGREATER we are checking for sent etag being strictly greater
                     int comparisonResult = etagFromClient.CompareTo(functionsState.etagState.etag);
                     int expectedResult = cmd is RespCommand.SETIFMATCH ? 0 : 1;
@@ -936,7 +944,14 @@ namespace Garnet.server
 
                     EtagState.ResetState(ref functionsState.etagState);
                     return false;
+                case RespCommand.DELIFGREATER:
+                    // at NCU we already know whether to delete or not so we are safe to never go into RCU
+                    etagToCheckWith = input.parseState.GetLong(1);
+                    if (etagToCheckWith > functionsState.etagState.etag)
+                        rmwInfo.Action = RMWAction.ExpireAndStop;
 
+                    EtagState.ResetState(ref functionsState.etagState);
+                    return false;
                 case RespCommand.SETEXNX:
                     // Expired data, return false immediately
                     // ExpireAndResume ensures that we set as new value, since it does not exist

--- a/libs/server/Storage/Functions/MainStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/RMWMethods.cs
@@ -1032,7 +1032,6 @@ namespace Garnet.server
                 return false;
             }
 
-            // threw an exception here
             rmwInfo.ClearExtraValueLength(ref recordInfo, ref newValue, newValue.TotalSize);
 
             RespCommand cmd = input.header.cmd;

--- a/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
@@ -238,7 +238,7 @@ namespace Garnet.server
                     case RespCommand.DELIFGREATER:
                         // Min allocation (only metadata) needed since this is going to be used for tombstoning anyway.
                         return sizeof(int);
-            
+
                     default:
                         if (cmd > RespCommandExtensions.LastValidCommand)
                         {

--- a/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
@@ -224,10 +224,6 @@ namespace Garnet.server
                             return sizeof(int) + newValue.Length + offset + t.MetadataSize + functionsState.etagState.etagOffsetForVarlen;
                         return sizeof(int) + t.Length;
 
-                    case RespCommand.GETDEL:
-                        // No additional allocation needed.
-                        break;
-
                     case RespCommand.GETEX:
                         return sizeof(int) + t.LengthWithoutMetadata + (input.arg1 > 0 ? sizeof(long) : 0);
 
@@ -235,6 +231,7 @@ namespace Garnet.server
                         var valueLength = input.parseState.GetArgSliceByRef(0).Length;
                         return sizeof(int) + t.Length + valueLength;
 
+                    case RespCommand.GETDEL:
                     case RespCommand.DELIFGREATER:
                         // Min allocation (only metadata) needed since this is going to be used for tombstoning anyway.
                         return sizeof(int);

--- a/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
@@ -235,6 +235,10 @@ namespace Garnet.server
                         var valueLength = input.parseState.GetArgSliceByRef(0).Length;
                         return sizeof(int) + t.Length + valueLength;
 
+                    case RespCommand.DELIFGREATER:
+                        // Min allocation (only metadata) needed since this is going to be used for tombstoning anyway.
+                        return sizeof(int);
+            
                     default:
                         if (cmd > RespCommandExtensions.LastValidCommand)
                         {

--- a/libs/server/Storage/Session/MainStore/MainStoreOps.cs
+++ b/libs/server/Storage/Session/MainStore/MainStoreOps.cs
@@ -377,6 +377,37 @@ namespace Garnet.server
             }
         }
 
+
+        public unsafe GarnetStatus DEL_Conditional<TContext>(ref SpanByte key, ref RawStringInput input, ref TContext context)
+            where TContext : ITsavoriteContext<SpanByte, SpanByte, RawStringInput, SpanByteAndMemory, long, MainSessionFunctions, MainStoreFunctions, MainStoreAllocator>
+        {
+            Debug.Assert(input.header.cmd == RespCommand.DELIFGREATER);
+
+            byte* pbOutput = stackalloc byte[8];
+            var o = new SpanByteAndMemory(pbOutput, 8);
+            var status = context.RMW(ref key, ref input, ref o);
+
+            if (status.IsPending)
+            {
+                StartPendingMetrics();
+                CompletePendingForSession(ref status, ref o, ref context);
+                StopPendingMetrics();
+            }
+
+            if (status.Expired)
+            {
+                incr_session_found(); 
+                return GarnetStatus.OK;
+            }
+            else
+            {
+                if (status.NotFound)
+                    incr_session_notfound();
+
+                return GarnetStatus.NOTFOUND;
+            }
+        }
+
         public unsafe GarnetStatus SET_Conditional<TContext>(ref SpanByte key, ref RawStringInput input, ref SpanByteAndMemory output, ref TContext context)
             where TContext : ITsavoriteContext<SpanByte, SpanByte, RawStringInput, SpanByteAndMemory, long, MainSessionFunctions, MainStoreFunctions, MainStoreAllocator>
         {

--- a/libs/server/Storage/Session/MainStore/MainStoreOps.cs
+++ b/libs/server/Storage/Session/MainStore/MainStoreOps.cs
@@ -394,9 +394,10 @@ namespace Garnet.server
                 StopPendingMetrics();
             }
 
+            // Deletions in RMW are done by expiring the record, hence we use expiration as the indicator of success.
             if (status.Expired)
             {
-                incr_session_found(); 
+                incr_session_found();
                 return GarnetStatus.OK;
             }
             else

--- a/libs/server/Transaction/TxnKeyManager.cs
+++ b/libs/server/Transaction/TxnKeyManager.cs
@@ -160,6 +160,7 @@ namespace Garnet.server
                 RespCommand.SETEXNX => SingleKey(1, false, LockType.Exclusive),
                 RespCommand.SETEXXX => SingleKey(1, false, LockType.Exclusive),
                 RespCommand.DEL => ListKeys(inputCount, false, LockType.Exclusive),
+                RespCommand.DELIFGREATER => ListKeys(1, false, LockType.Exclusive),
                 RespCommand.EXISTS => SingleKey(1, false, LockType.Shared),
                 RespCommand.RENAME => SingleKey(1, false, LockType.Exclusive),
                 RespCommand.INCR => SingleKey(1, false, LockType.Exclusive),

--- a/libs/server/Transaction/TxnKeyManager.cs
+++ b/libs/server/Transaction/TxnKeyManager.cs
@@ -160,7 +160,7 @@ namespace Garnet.server
                 RespCommand.SETEXNX => SingleKey(1, false, LockType.Exclusive),
                 RespCommand.SETEXXX => SingleKey(1, false, LockType.Exclusive),
                 RespCommand.DEL => ListKeys(inputCount, false, LockType.Exclusive),
-                RespCommand.DELIFGREATER => ListKeys(1, false, LockType.Exclusive),
+                RespCommand.DELIFGREATER => SingleKey(1, false, LockType.Exclusive),
                 RespCommand.EXISTS => SingleKey(1, false, LockType.Shared),
                 RespCommand.RENAME => SingleKey(1, false, LockType.Exclusive),
                 RespCommand.INCR => SingleKey(1, false, LockType.Exclusive),

--- a/playground/CommandInfoUpdater/GarnetCommandsDocs.json
+++ b/playground/CommandInfoUpdater/GarnetCommandsDocs.json
@@ -216,6 +216,28 @@
     ]
   },
   {
+    "Command": "DELIFGREATER",
+    "Name": "DELIFGREATER",
+    "Summary": "Given a key and an Etag only deletes the key if the Etag given in the request is strictly greater than the already existing etag for the key.",
+    "Group": "Generic",
+    "Complexity": "O(1)",
+    "Arguments": [
+      {
+        "TypeDiscriminator": "RespCommandKeyArgument",
+        "Name": "KEY",
+        "DisplayText": "key",
+        "Type": "Key",
+        "KeySpecIndex": 0
+      },
+      {
+        "TypeDiscriminator": "RespCommandBasicArgument",
+        "Name": "ETAG",
+        "DisplayText": "etag",
+        "Type": "Integer"
+      }
+    ]
+  },
+  {
     "Command": "FORCEGC",
     "Name": "FORCEGC",
     "Summary": "Forces garbage collection.",

--- a/playground/CommandInfoUpdater/GarnetCommandsDocs.json
+++ b/playground/CommandInfoUpdater/GarnetCommandsDocs.json
@@ -218,7 +218,7 @@
   {
     "Command": "DELIFGREATER",
     "Name": "DELIFGREATER",
-    "Summary": "Given a key and an Etag only deletes the key if the Etag given in the request is strictly greater than the already existing etag for the key.",
+    "Summary": "Deletes a key only if the provided Etag is strictly greater than the existing Etag for the key.",
     "Group": "Generic",
     "Complexity": "O(1)",
     "Arguments": [

--- a/playground/CommandInfoUpdater/GarnetCommandsInfo.json
+++ b/playground/CommandInfoUpdater/GarnetCommandsInfo.json
@@ -394,6 +394,30 @@
     "SubCommands": null
   },
   {
+    "Command": "DELIFGREATER",
+    "Name": "DELIFGREATER",
+    "Arity": 2,
+    "FirstKey": 1,
+    "LastKey": 1,
+    "Step": 1,
+    "AclCategories": "Slow, String, Write",
+    "KeySpecifications": [
+      {
+        "BeginSearch": {
+          "TypeDiscriminator": "BeginSearchIndex",
+          "Index": 1
+        },
+        "FindKeys": {
+          "TypeDiscriminator": "FindKeysRange",
+          "LastKey": 0,
+          "KeyStep": 1,
+          "Limit": 0
+        },
+        "Flags": "RM, Delete"
+      }
+    ]
+  },
+  {
     "Command": "FORCEGC",
     "Name": "FORCEGC",
     "Arity": -1,

--- a/playground/CommandInfoUpdater/SupportedCommand.cs
+++ b/playground/CommandInfoUpdater/SupportedCommand.cs
@@ -126,6 +126,7 @@ namespace CommandInfoUpdater
             new("DECR", RespCommand.DECR),
             new("DECRBY", RespCommand.DECRBY),
             new("DEL", RespCommand.DEL),
+            new("DELIFGREATER", RespCommand.DELIFGREATER),
             new("DISCARD", RespCommand.DISCARD),
             new("DUMP", RespCommand.DUMP),
             new("ECHO", RespCommand.ECHO),

--- a/test/Garnet.test/Resp/ACL/RespCommandTests.cs
+++ b/test/Garnet.test/Resp/ACL/RespCommandTests.cs
@@ -5603,6 +5603,21 @@ namespace Garnet.test.Resp.ACL
         }
 
         [Test]
+        public async Task DelIfGreaterACLsAsync()
+        {
+            await CheckCommandsAsync(
+               "DELIFGREATER",
+               [DoDelIfGreaterAsync]
+           );
+
+            static async Task DoDelIfGreaterAsync(GarnetClient client)
+            {
+                var res = await client.ExecuteForStringArrayResultAsync("DELIFGREATER", ["foo", "1"]);
+                ClassicAssert.IsNotNull(res);
+            }
+        }
+
+        [Test]
         public async Task GetIfNotMatchACLsAsync()
         {
             await CheckCommandsAsync(

--- a/test/Garnet.test/RespEtagTests.cs
+++ b/test/Garnet.test/RespEtagTests.cs
@@ -585,7 +585,6 @@ namespace Garnet.test
             ClassicAssert.AreEqual(1, etag);
         }
 
-
         [Test]
         public void SetIfMatchOnNonEtagDataReturnsNewEtagAndNoValue()
         {

--- a/test/Garnet.test/RespEtagTests.cs
+++ b/test/Garnet.test/RespEtagTests.cs
@@ -549,7 +549,7 @@ namespace Garnet.test
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             IDatabase db = redis.GetDatabase(0);
-            
+
             RedisResult res = db.Execute("DELIFGREATER", "nonexistingkey", 10);
             ClassicAssert.AreEqual(0, (long)res);
         }

--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -7,5 +7,4 @@ badrishc:
 hkhalid:
   name: Hamdaan Khalid
   title: Software Engineer, Azure Resource Graph
-  url: https://hamdaan-rails-personal.herokuapp.com/
-  image_url: https://media.licdn.com/dms/image/v2/D5603AQEB5k6B-_kYcg/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1713142460509?e=1743033600&v=beta&t=efEhRJq1SLgi09uCSUQJN3ssq-_cwljG0ysUc54GcSc
+  url: https://hamdaan-rails-personal.herokuapp.com/assets/me-f1fa367c094eedf1c151b0b0dfbc057c2b047dec4e10f3974167ec3f803d81f0.jpg 

--- a/website/docs/commands/garnet-specific.md
+++ b/website/docs/commands/garnet-specific.md
@@ -275,6 +275,22 @@ One of the following:
 
 ---
 
+### **DELIFGREATER**
+
+#### **Syntax**
+
+```bash
+DELIFGREATER key etag
+```
+
+Given a key and an Etag only deletes the key if the Etag given in the request is strictly greater than the already existing etag for the key.
+
+#### **Response**
+
+- **Integer reply**: 1 if key was deleted else 0.
+
+---
+
 ### Compatibility and Behavior with Non-ETag Commands
 
 ETags are currently not supported for servers running in Cluster mode. This will be supported soon.

--- a/website/docs/commands/garnet-specific.md
+++ b/website/docs/commands/garnet-specific.md
@@ -283,11 +283,11 @@ One of the following:
 DELIFGREATER key etag
 ```
 
-Given a key and an Etag only deletes the key if the Etag given in the request is strictly greater than the already existing etag for the key.
+Deletes a key only if the provided Etag is strictly greater than the existing Etag for the key.
 
 #### **Response**
 
-- **Integer reply**: 1 if key was deleted else 0.
+- **Integer reply**: Returns 1 if the key was successfully deleted; otherwise, returns 0.
 
 ---
 


### PR DESCRIPTION
Adds DELIFGREATER RMW Operation to Garnet.
This can be used to synchronize deletes without relying on transactions.

Also minor bugfix of GETDEL overallocating in RCU route