### PR TITLE
Fix RCU Bug in metadata and value overlap of SETIFGREATER and SETIFMATCH

### DIFF
--- a/libs/server/Storage/Functions/MainStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/RMWMethods.cs
@@ -1058,7 +1058,6 @@ namespace Garnet.server
                     // By now the comparison for etag against existing etag has already been done in NeedCopyUpdate
                     shouldUpdateEtag = true;
                     // Copy input to value
-                    Span<byte> dest = newValue.AsSpan(EtagConstants.EtagSize);
                     ReadOnlySpan<byte> src = input.parseState.GetArgSliceByRef(0).ReadOnlySpan;
 
                     // retain metadata unless metadata sent
@@ -1066,13 +1065,14 @@ namespace Garnet.server
 
                     Debug.Assert(src.Length + EtagConstants.EtagSize + metadataSize == newValue.Length);
 
-                    src.CopyTo(dest);
-
                     newValue.ExtraMetadata = oldValue.ExtraMetadata;
                     if (input.arg1 != 0)
                     {
                         newValue.ExtraMetadata = input.arg1;
                     }
+
+                    Span<byte> dest = newValue.AsSpan(EtagConstants.EtagSize);
+                    src.CopyTo(dest);
 
                     etagFromClient = input.parseState.GetLong(1);
 

--- a/test/Garnet.test/RespEtagTests.cs
+++ b/test/Garnet.test/RespEtagTests.cs
@@ -591,7 +591,7 @@ namespace Garnet.test
         #endregion
 
         #region Edgecases
- 
+
         [Test]
         [TestCase("m", "mo", null)] // RCU with no existing exp on noetag key
         [TestCase("mexicanmochawithdoubleespresso", "c", null)] // IPU with no existing exp on noetag key

--- a/test/Garnet.test/RespEtagTests.cs
+++ b/test/Garnet.test/RespEtagTests.cs
@@ -591,8 +591,7 @@ namespace Garnet.test
         #endregion
 
         #region Edgecases
-
-
+ 
         [Test]
         [TestCase("m", "mo", null)] // RCU with no existing exp on noetag key
         [TestCase("mexicanmochawithdoubleespresso", "c", null)] // IPU with no existing exp on noetag key

--- a/test/Garnet.test/RespEtagTests.cs
+++ b/test/Garnet.test/RespEtagTests.cs
@@ -396,6 +396,7 @@ namespace Garnet.test
         #endregion
 
         #region ETAG DEL Happy Paths
+
         [Test]
         public void DelIfGreaterOnAnAlreadyExistingKeyWithEtagWorks()
         {
@@ -590,6 +591,61 @@ namespace Garnet.test
         #endregion
 
         #region Edgecases
+
+
+        [Test]
+        [TestCase("m", "mo", null)] // RCU with no existing exp on noetag key
+        [TestCase("mexicanmochawithdoubleespresso", "c", null)] // IPU with no existing exp on noetag key
+        [TestCase("m", "mo", 30)] // RCU with existing exp on noetag key
+        [TestCase("mexicanmochawithdoubleespresso", "c", 30)] // IPU with existing exp on noetag key
+        public void SetIfGreaterWhenExpIsSentForExistingNonEtagKey(string initialValue, string newValue, double? exp)
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            IDatabase db = redis.GetDatabase(0);
+            var key = "meow-key";
+
+            if (exp != null)
+                db.StringSet(key, initialValue, TimeSpan.FromSeconds(exp.Value));
+            else
+                db.StringSet(key, initialValue);
+
+            RedisResult[] arrRes = (RedisResult[])db.Execute("SETIFGREATER", key, newValue, 5, "EX", 90);
+
+            ClassicAssert.AreEqual(5, (long)arrRes[0]);
+            ClassicAssert.IsTrue(arrRes[1].IsNull);
+
+            var res = db.StringGetWithExpiry(key);
+            ClassicAssert.AreEqual(newValue, res.Value.ToString());
+            ClassicAssert.IsTrue(res.Expiry.HasValue);
+        }
+
+        [Test]
+        [TestCase("m", "mo", null)] // RCU with no existing exp on noetag key
+        [TestCase("mexicanmochawithdoubleespresso", "c", null)] // IPU with no existing exp on noetag key
+        [TestCase("m", "mo", 30)] // RCU with existing exp on noetag key
+        [TestCase("mexicanmochawithdoubleespresso", "c", 30)] // IPU with existing exp on noetag key
+        public void SetIfMatchWhenExpIsSentForExistingNonEtagKey(string initialValue, string newValue, int? exp)
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            IDatabase db = redis.GetDatabase(0);
+            var key = "meow-key";
+
+            if (exp != null)
+                db.StringSet(key, initialValue, TimeSpan.FromSeconds(exp.Value));
+            else
+                db.StringSet(key, initialValue);
+
+            RedisResult[] arrRes = (RedisResult[])db.Execute("SETIFMATCH", key, newValue, 0, "EX", 90);
+
+            ClassicAssert.AreEqual(1, (long)arrRes[0]);
+            ClassicAssert.IsTrue(arrRes[1].IsNull);
+
+            var res = db.StringGetWithExpiry(key);
+            ClassicAssert.AreEqual(newValue, res.Value.ToString());
+            ClassicAssert.IsTrue(res.Expiry.HasValue);
+        }
+
+
         [Test]
         public void SetIfMatchSetsKeyValueOnNonExistingKey()
         {


### PR DESCRIPTION
When we add an expiration on a keyw ith no etag, SETIFGREATER and SETIFMATCH both go via RCU.
Incorrect order of value memcpy and metadata setting would lead to metadata overriding the value partially.

This PR adds test cases and fixes this bug.