### PR TITLE
Fix ExecuteClusterAppendLog

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- VersionPrefix property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>1.0.63</VersionPrefix>
+		<VersionPrefix>1.0.64</VersionPrefix>
 	</PropertyGroup>
 </Project>

--- a/libs/client/ClientSession/GarnetClientSession.cs
+++ b/libs/client/ClientSession/GarnetClientSession.cs
@@ -328,11 +328,12 @@ namespace Garnet.client
         {
             Debug.Assert(nodeId != null);
 
-            byte* curr = offset;
-            int arraySize = 7;
+            var curr = offset;
+            var arraySize = 7;
 
             while (!RespWriteUtils.TryWriteArrayLength(arraySize, ref curr, end))
             {
+                logger?.LogWarning("1. Flushing Log under epoch protection");
                 Flush();
                 curr = offset;
             }
@@ -340,6 +341,7 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteDirect(CLUSTER, ref curr, end))
             {
+                logger?.LogWarning("2. Flushing Log under epoch protection");
                 Flush();
                 curr = offset;
             }
@@ -347,6 +349,7 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteBulkString(appendLog, ref curr, end))
             {
+                logger?.LogWarning("3. Flushing Log under epoch protection");
                 Flush();
                 curr = offset;
             }
@@ -354,6 +357,7 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteAsciiBulkString(nodeId, ref curr, end))
             {
+                logger?.LogWarning("4. Flushing Log under epoch protection");
                 Flush();
                 curr = offset;
             }
@@ -361,6 +365,7 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteArrayItem(previousAddress, ref curr, end))
             {
+                logger?.LogWarning("5. Flushing Log under epoch protection");
                 Flush();
                 curr = offset;
             }
@@ -368,6 +373,7 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteArrayItem(currentAddress, ref curr, end))
             {
+                logger?.LogWarning("6. Flushing Log under epoch protection");
                 Flush();
                 curr = offset;
             }
@@ -375,6 +381,7 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteArrayItem(nextAddress, ref curr, end))
             {
+                logger?.LogWarning("7. Flushing Log under epoch protection");
                 Flush();
                 curr = offset;
             }
@@ -385,11 +392,11 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteBulkString(new Span<byte>((void*)payloadPtr, payloadLength), ref curr, end))
             {
+                logger?.LogWarning("8. Flushing Log under epoch protection");
                 Flush();
                 curr = offset;
             }
             offset = curr;
-            Flush();
         }
 
         /// <summary>

--- a/libs/client/ClientSession/GarnetClientSession.cs
+++ b/libs/client/ClientSession/GarnetClientSession.cs
@@ -330,11 +330,9 @@ namespace Garnet.client
 
             var curr = offset;
             var arraySize = 7;
-            var flushed = false;
 
             while (!RespWriteUtils.TryWriteArrayLength(arraySize, ref curr, end))
             {
-                flushed = true;
                 Flush();
                 curr = offset;
             }
@@ -342,7 +340,6 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteDirect(CLUSTER, ref curr, end))
             {
-                flushed = true;
                 Flush();
                 curr = offset;
             }
@@ -350,7 +347,6 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteBulkString(appendLog, ref curr, end))
             {
-                flushed = true;
                 Flush();
                 curr = offset;
             }
@@ -358,7 +354,6 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteAsciiBulkString(nodeId, ref curr, end))
             {
-                flushed = true;
                 Flush();
                 curr = offset;
             }
@@ -366,7 +361,6 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteArrayItem(previousAddress, ref curr, end))
             {
-                flushed = true;
                 Flush();
                 curr = offset;
             }
@@ -374,7 +368,6 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteArrayItem(currentAddress, ref curr, end))
             {
-                flushed = true;
                 Flush();
                 curr = offset;
             }
@@ -382,7 +375,6 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteArrayItem(nextAddress, ref curr, end))
             {
-                flushed = true;
                 Flush();
                 curr = offset;
             }
@@ -393,14 +385,10 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteBulkString(new Span<byte>((void*)payloadPtr, payloadLength), ref curr, end))
             {
-                flushed = true;
                 Flush();
                 curr = offset;
             }
             offset = curr;
-
-            if (flushed)
-                logger?.LogWarning("Flushed under epoch protection due to payload being too large {payloadLength}", payloadLength);
         }
 
         /// <summary>

--- a/libs/client/ClientSession/GarnetClientSession.cs
+++ b/libs/client/ClientSession/GarnetClientSession.cs
@@ -330,10 +330,11 @@ namespace Garnet.client
 
             var curr = offset;
             var arraySize = 7;
+            var flushed = false;
 
             while (!RespWriteUtils.TryWriteArrayLength(arraySize, ref curr, end))
             {
-                logger?.LogWarning("1. Flushing Log under epoch protection");
+                flushed = true;
                 Flush();
                 curr = offset;
             }
@@ -341,7 +342,7 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteDirect(CLUSTER, ref curr, end))
             {
-                logger?.LogWarning("2. Flushing Log under epoch protection");
+                flushed = true;
                 Flush();
                 curr = offset;
             }
@@ -349,7 +350,7 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteBulkString(appendLog, ref curr, end))
             {
-                logger?.LogWarning("3. Flushing Log under epoch protection");
+                flushed = true;
                 Flush();
                 curr = offset;
             }
@@ -357,7 +358,7 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteAsciiBulkString(nodeId, ref curr, end))
             {
-                logger?.LogWarning("4. Flushing Log under epoch protection");
+                flushed = true;
                 Flush();
                 curr = offset;
             }
@@ -365,7 +366,7 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteArrayItem(previousAddress, ref curr, end))
             {
-                logger?.LogWarning("5. Flushing Log under epoch protection");
+                flushed = true;
                 Flush();
                 curr = offset;
             }
@@ -373,7 +374,7 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteArrayItem(currentAddress, ref curr, end))
             {
-                logger?.LogWarning("6. Flushing Log under epoch protection");
+                flushed = true;
                 Flush();
                 curr = offset;
             }
@@ -381,7 +382,7 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteArrayItem(nextAddress, ref curr, end))
             {
-                logger?.LogWarning("7. Flushing Log under epoch protection");
+                flushed = true;
                 Flush();
                 curr = offset;
             }
@@ -392,11 +393,14 @@ namespace Garnet.client
 
             while (!RespWriteUtils.TryWriteBulkString(new Span<byte>((void*)payloadPtr, payloadLength), ref curr, end))
             {
-                logger?.LogWarning("8. Flushing Log under epoch protection");
+                flushed = true;
                 Flush();
                 curr = offset;
             }
             offset = curr;
+
+            if (flushed)
+                logger?.LogWarning("Flushed under epoch protection due to payload being too large {payloadLength}", payloadLength);
         }
 
         /// <summary>

--- a/libs/cluster/Server/Replication/PrimaryOps/AofSyncTaskInfo.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/AofSyncTaskInfo.cs
@@ -87,6 +87,8 @@ namespace Garnet.cluster
 
         public void Throttle()
         {
+            // Trigger flush while we are out of epoch protection
+            garnetClient.CompletePending(false);
             garnetClient.Throttle();
         }
 

--- a/libs/cluster/Server/Replication/ReplicationManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationManager.cs
@@ -114,6 +114,7 @@ namespace Garnet.cluster
             this.storeWrapper = clusterProvider.storeWrapper;
             this.pageSizeBits = storeWrapper.appendOnlyFile == null ? 0 : storeWrapper.appendOnlyFile.UnsafeGetLogPageSizeBits();
 
+            networkBufferSettings.Log(logger, nameof(ReplicationManager));
             this.networkPool = networkBufferSettings.CreateBufferPool(logger: logger);
             ValidateNetworkBufferSettings();
 

--- a/libs/cluster/Server/Replication/ReplicationNetworkBufferSettings.cs
+++ b/libs/cluster/Server/Replication/ReplicationNetworkBufferSettings.cs
@@ -12,9 +12,7 @@ namespace Garnet.cluster
         /// <summary>
         /// NetworkBufferSettings for the buffer pool maintained by the ReplicationManager
         /// </summary>
-        const int defaultSendBufferSize = 1 << 22;
-        const int defaultInitialReceiveBufferSize = 1 << 12;
-        readonly NetworkBufferSettings networkBufferSettings = new(defaultSendBufferSize, defaultInitialReceiveBufferSize);
+        NetworkBufferSettings networkBufferSettings => NetworkBufferSettings.GetInclusive([GetRSSNetworkBufferSettings, GetIRSNetworkBufferSettings, GetAofSyncNetworkBufferSettings]);
 
         /// <summary>
         /// Network pool maintained by the ReplicationManager
@@ -38,10 +36,11 @@ namespace Garnet.cluster
 
         /// <summary>
         /// NetworkBufferSettings for the AOF sync task clients
+        /// NOTE: double buffer size for send page to ensure payload (command header + page size) always fits into client buffer.
         /// </summary>
-        const int aofSyncSendBufferSize = 1 << 22;
+        int aofSyncSendBufferSize => 1 << clusterProvider.storeWrapper.serverOptions.AofPageSizeBits() << 1;
         const int aofSyncInitialReceiveBufferSize = 1 << 17;
-        public NetworkBufferSettings GetAofSyncNetworkBufferSettings { get; } = new(aofSyncSendBufferSize, aofSyncInitialReceiveBufferSize);
+        public NetworkBufferSettings GetAofSyncNetworkBufferSettings => new(aofSyncSendBufferSize, aofSyncInitialReceiveBufferSize);
 
         void ValidateNetworkBufferSettings()
         {

--- a/libs/cluster/Server/Replication/ReplicationNetworkBufferSettings.cs
+++ b/libs/cluster/Server/Replication/ReplicationNetworkBufferSettings.cs
@@ -38,7 +38,7 @@ namespace Garnet.cluster
         /// NetworkBufferSettings for the AOF sync task clients
         /// NOTE: double buffer size for send page to ensure payload (command header + page size) always fits into client buffer.
         /// </summary>
-        int aofSyncSendBufferSize => 1 << clusterProvider.storeWrapper.serverOptions.AofPageSizeBits() << 1;
+        int aofSyncSendBufferSize => 2 << clusterProvider.storeWrapper.serverOptions.AofPageSizeBits();
         const int aofSyncInitialReceiveBufferSize = 1 << 17;
         public NetworkBufferSettings GetAofSyncNetworkBufferSettings => new(aofSyncSendBufferSize, aofSyncInitialReceiveBufferSize);
 

--- a/libs/common/NetworkBufferSettings.cs
+++ b/libs/common/NetworkBufferSettings.cs
@@ -48,6 +48,25 @@ namespace Garnet.common
         }
 
         /// <summary>
+        /// Return inclusive size for array of settings
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <returns></returns>
+        public static NetworkBufferSettings GetInclusive(NetworkBufferSettings[] settings)
+        {
+            var maxSendBufferSize = 1 << 17;
+            var minInitialReceiveBufferSize = 1 << 17;
+            var maxReceiveBufferSize = 1 << 20;
+            foreach (var setting in settings)
+            {
+                maxSendBufferSize = Math.Max(maxSendBufferSize, setting.sendBufferSize);
+                minInitialReceiveBufferSize = Math.Min(minInitialReceiveBufferSize, setting.initialReceiveBufferSize);
+                maxReceiveBufferSize = Math.Min(maxReceiveBufferSize, setting.maxReceiveBufferSize);
+            }
+            return new NetworkBufferSettings(maxSendBufferSize, minInitialReceiveBufferSize, maxReceiveBufferSize);
+        }
+
+        /// <summary>
         /// Allocate network buffer pool
         /// </summary>
         /// <param name="maxEntriesPerLevel"></param>
@@ -63,5 +82,8 @@ namespace Garnet.common
             levels = Math.Max(4, levels);
             return new LimitedFixedBufferPool(minSize, maxEntriesPerLevel: maxEntriesPerLevel, numLevels: levels, logger: logger);
         }
+
+        public void Log(ILogger logger, string category)
+            => logger?.LogInformation("[{category}] network settings: {sendBufferSize}, {initialReceiveBufferSize}, {maxReceiveBufferSize}", category, sendBufferSize, initialReceiveBufferSize, maxReceiveBufferSize);
     }
 }


### PR DESCRIPTION
Ensure ExecuteClusterAppendLog flush happens outside epoch protection to avoid delaying writers.