### PR TITLE
Reduce the BDN Chart Size from max items per chart from 50 to 25.  

### DIFF
--- a/.github/workflows/ci-bdnbenchmark.yml
+++ b/.github/workflows/ci-bdnbenchmark.yml
@@ -89,7 +89,7 @@ jobs:
           summary-always: true
           gh-pages-branch: 'continuousbenchmark'
           benchmark-data-dir-path: 'website/static/charts'
-          max-items-in-chart: 50
+          max-items-in-chart: 25
           alert-threshold: '110%'
           comment-always: true
           fail-on-alert: false


### PR DESCRIPTION
Reduce the BDN Chart Size from max items per chart from 50 to 25.  This will keep net80 and net90 and it reduces the data file by half. This is in hope that we get around the BDN charting scalability problems.