### PR TITLE
FullSync Initiate Check when at least one sync session is still active.

### DIFF
--- a/test/Garnet.test.cluster/ReplicationTests/ClusterReplicationDisklessSyncTests.cs
+++ b/test/Garnet.test.cluster/ReplicationTests/ClusterReplicationDisklessSyncTests.cs
@@ -185,6 +185,9 @@ namespace Garnet.test.cluster
 
             // Validate replica data
             Validate(primaryIndex, replicaIndex, disableObjects);
+
+            // Wait for replica to catch up
+            context.clusterTestUtils.WaitForReplicaAofSync(primaryIndex, replicaIndex, logger: context.logger);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR ensures that streaming snapshot is initiated only one at least one sync session requires fully synchronization.