### PR TITLE
Update default object store page size to 4k

### DIFF
--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -49,7 +49,7 @@
 	"ObjectStoreLogMemorySize" : "32m",
 
 	/* Size of each object store page in bytes (rounds down to power of 2) */
-	"ObjectStorePageSize" : "1m",
+	"ObjectStorePageSize" : "4k",
 
 	/* Size of each object store log segment in bytes on disk (rounds down to power of 2) */
 	"ObjectStoreSegmentSize" : "32m",

--- a/libs/server/Servers/GarnetServerOptions.cs
+++ b/libs/server/Servers/GarnetServerOptions.cs
@@ -34,7 +34,7 @@ namespace Garnet.server
         /// <summary>
         /// Size of each object store page in bytes (rounds down to power of 2).
         /// </summary>
-        public string ObjectStorePageSize = "1m";
+        public string ObjectStorePageSize = "4k";
 
         /// <summary>
         /// Size of each object store log segment in bytes on disk (rounds down to power of 2).


### PR DESCRIPTION
Update default object store page size to 4k. See discussion here: https://github.com/microsoft/garnet/issues/1097#issuecomment-2733821578 and the documentation here: https://microsoft.github.io/garnet/docs/getting-started/memory#log-size-object-store

Default object store page size of 1m is way too large, as memory is reclaimed in chunks of page-worth of objects. This PR will allow the `ObjectStoreHeapMemorySize` setting to reclaim heap space in reasonable granularity (around 170 objects at a time).

```
10::50::31 info: Options[0] [Object Store] Using page size of 4k
10::50::31 info: Options[0] [Object Store] Each page can hold ~170 key-value pairs of objects
10::50::31 info: Options[0] [Object Store] Using log memory size of 32m
10::50::31 info: Options[0] [Object Store] This can hold ~1398101 key-value pairs of objects in memory total
10::50::31 info: Options[0] [Object Store] There are 8k log pages in memory
```