### PR TITLE
Fix BDN scaling issue so that each framework is saved to different branch

### DIFF
--- a/.github/workflows/ci-bdnbenchmark.yml
+++ b/.github/workflows/ci-bdnbenchmark.yml
@@ -87,7 +87,7 @@ jobs:
           auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           save-data-file: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           summary-always: true
-          gh-pages-branch: 'continuousbenchmark'
+          gh-pages-branch: ${{ matrix.framework == 'net8.0' && 'continuousbenchmark_net80' || 'continuousbenchmark' }}
           benchmark-data-dir-path: 'website/static/charts'
           max-items-in-chart: 50
           alert-threshold: '110%'

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -32,10 +32,17 @@ jobs:
           sparse-checkout: |
             website/static/charts
           path: continuousbenchmark
+      - uses: actions/checkout@v4
+        with:
+          ref: continuousbenchmark_net80
+          sparse-checkout: |
+            website/static/charts
+          path: continuousbenchmark_net80
       - name: Copy charts
         run: |
           mkdir -p static/charts
           cp ../continuousbenchmark/website/static/charts/* static/charts
+          cp ../continuousbenchmark_net80/website/static/charts/data.js static/charts/data_net80.js
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
Due to scalability issues with the BDN (run into contention when pushing so much chart data to the same branch \ file), we will break the data location to separate branch for 8.0 (continuousbenchmark_net80) and continue to use existing continuousbenchmark branch as the "latest".  

Also includes changes to deploy-website.yml where it copies over as data.js (from 80 branch) to data_net8.0.js

We will NOT push this PR until the chart html file on continuousbenchmark branch is updated .

