### PR TITLE
CollectionItemBroker Cleanup + Fixes

### DIFF
--- a/libs/server/Objects/ItemBroker/CollectionItemBrokerEvent.cs
+++ b/libs/server/Objects/ItemBroker/CollectionItemBrokerEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System.Collections.Concurrent;
-
 namespace Garnet.server
 {
     /// <summary>
@@ -22,15 +20,9 @@ namespace Garnet.server
         /// </summary>
         internal readonly byte[] Key;
 
-        /// <summary>
-        /// Observers
-        /// </summary>
-        internal readonly ConcurrentQueue<CollectionItemObserver> Observers;
-
-        public CollectionUpdatedEvent(byte[] key, ConcurrentQueue<CollectionItemObserver> observers)
+        public CollectionUpdatedEvent(byte[] key)
         {
             Key = key;
-            Observers = observers;
         }
     }
 

--- a/libs/server/Objects/ItemBroker/CollectionItemResult.cs
+++ b/libs/server/Objects/ItemBroker/CollectionItemResult.cs
@@ -34,9 +34,10 @@ namespace Garnet.server
             Items = items;
         }
 
-        private CollectionItemResult(bool isForceUnblocked)
+        private CollectionItemResult(bool isForceUnblocked, bool isTypeMismatch)
         {
             IsForceUnblocked = isForceUnblocked;
+            IsTypeMismatch = isTypeMismatch;
         }
 
         /// <summary>
@@ -72,7 +73,12 @@ namespace Garnet.server
         /// <summary>
         /// Gets a value indicating whether the item retrieval was force unblocked.
         /// </summary>
-        internal readonly bool IsForceUnblocked { get; }
+        internal bool IsForceUnblocked { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the item retrieval returned a type mismatch.
+        /// </summary>
+        internal bool IsTypeMismatch { get; }
 
         /// <summary>
         /// Instance of empty result
@@ -80,8 +86,13 @@ namespace Garnet.server
         internal static readonly CollectionItemResult Empty = new(null, item: null);
 
         /// <summary>
-        /// Instance representing an Force Unblocked result.
+        /// Instance representing a Force Unblocked result.
         /// </summary>
-        internal static readonly CollectionItemResult ForceUnblocked = new(true);
+        internal static readonly CollectionItemResult ForceUnblocked = new(isForceUnblocked: true, isTypeMismatch: false);
+
+        /// <summary>
+        /// Instance representing a Type Mismatch result.
+        /// </summary>
+        internal static readonly CollectionItemResult TypeMismatch = new(isForceUnblocked: false, isTypeMismatch: true);
     }
 }

--- a/libs/server/Resp/Objects/ListCommands.cs
+++ b/libs/server/Resp/Objects/ListCommands.cs
@@ -325,6 +325,13 @@ namespace Garnet.server
                 return true;
             }
 
+            if (result.IsTypeMismatch)
+            {
+                while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_WRONG_TYPE, ref dcurr, dend))
+                    SendAndReset();
+                return true;
+            }
+
             if (!result.Found)
             {
                 while (!RespWriteUtils.TryWriteNullArray(ref dcurr, dend))
@@ -418,6 +425,20 @@ namespace Garnet.server
 
             var result = storeWrapper.itemBroker.MoveCollectionItemAsync(RespCommand.BLMOVE, srcKey.ToArray(), this, timeout,
                 cmdArgs).Result;
+
+            if (result.IsForceUnblocked)
+            {
+                while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_UNBLOCKED_CLIENT_VIA_CLIENT_UNBLOCK, ref dcurr, dend))
+                    SendAndReset();
+                return true;
+            }
+
+            if (result.IsTypeMismatch)
+            {
+                while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_WRONG_TYPE, ref dcurr, dend))
+                    SendAndReset();
+                return true;
+            }
 
             if (!result.Found)
             {
@@ -993,6 +1014,13 @@ namespace Garnet.server
             {
                 while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_UNBLOCKED_CLIENT_VIA_CLIENT_UNBLOCK, ref dcurr, dend))
                     SendAndReset();
+            }
+
+            if (result.IsTypeMismatch)
+            {
+                while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_WRONG_TYPE, ref dcurr, dend))
+                    SendAndReset();
+                return true;
             }
 
             if (!result.Found)

--- a/libs/server/Resp/Objects/SortedSetCommands.cs
+++ b/libs/server/Resp/Objects/SortedSetCommands.cs
@@ -1565,6 +1565,20 @@ namespace Garnet.server
 
             var result = storeWrapper.itemBroker.GetCollectionItemAsync(command, keysBytes, this, timeout).Result;
 
+            if (result.IsForceUnblocked)
+            {
+                while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_UNBLOCKED_CLIENT_VIA_CLIENT_UNBLOCK, ref dcurr, dend))
+                    SendAndReset();
+                return true;
+            }
+
+            if (result.IsTypeMismatch)
+            {
+                while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_WRONG_TYPE, ref dcurr, dend))
+                    SendAndReset();
+                return true;
+            }
+
             if (!result.Found)
             {
                 WriteNull();
@@ -1667,6 +1681,20 @@ namespace Garnet.server
             cmdArgs[1] = new ArgSlice((byte*)&popCount, sizeof(int));
 
             var result = storeWrapper.itemBroker.GetCollectionItemAsync(RespCommand.BZMPOP, keysBytes, this, timeout, cmdArgs).Result;
+
+            if (result.IsForceUnblocked)
+            {
+                while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_UNBLOCKED_CLIENT_VIA_CLIENT_UNBLOCK, ref dcurr, dend))
+                    SendAndReset();
+                return true;
+            }
+
+            if (result.IsTypeMismatch)
+            {
+                while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_WRONG_TYPE, ref dcurr, dend))
+                    SendAndReset();
+                return true;
+            }
 
             if (!result.Found)
             {


### PR DESCRIPTION
Addressing some comments / issues with the existing CollectionItemBroker implementation:
- When are keys removed from keysToObservers?
  - [x] Added logic for removing keys from keysToObservers when the observer queue is empty
  - [ ] Will add an additional event that triggers key removal in the main loop (in case the observers died and we never checked that key's queue again)
- HandleBrokerEvent is sync; if there are a large number of blocking sessions, can this be a scalaibility bottleneck?
  - This is by design, as the blocking commands are operating in a first-come-first-serve manner. We can change the logic here but that might be confusing as this behavior might not be expected by the user.
- Use named (e.g. NotStarted, Started, Disposed) constants for mainLoopTaskStatus. Badrish's checkin added a "2" value for Dispose() so this will improve readability.
  - [x] Done.
- Dispose() loops on Interlocked.CompareExchange but is not testing anything about the value before doing the CompareExchange, so a single Interlocked.Exchange should work
  - [x] Done. 

Also addressed in this PR - 
- [x] Handling WRONGTYPE errors in blocking commands as expected by the protocol (this is in place of PR #1130 which first mentioned the issue)
- [x] Adding tests to check proper WRONGTYPE handling in blocking commands
- [x] Handling "special" CollectionItemResult instances in previously missed commands
- [ ] Need to have all blocking commands covered in "forced unblock" tests (ClientUnblockBasicTest, MultipleClientsUnblockAndAddTest in RespTests) 