### PR TITLE
Fix Garnet.Worker.exe failing on 9.0 in the published win-x64-based-readytorun.zip

### DIFF
--- a/main/GarnetServer/Properties/PublishProfiles/win-x64-based-readytorun.pubxml
+++ b/main/GarnetServer/Properties/PublishProfiles/win-x64-based-readytorun.pubxml
@@ -30,21 +30,20 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 	<DependantDLLFiles Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\*.dll" />
 	<DependantXMLFiles Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\*.xml" />
 	<RuntimeFilesWinx64 Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\runtimes\win-x64\native\*" />
+	<RuntimeFilesWin Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\runtimes\win\lib\$(TargetFramework)\*" />
 	<GWRunTimeConfigFiles Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\Garnet.worker.runtimeconfig.json" />
 	<GWDepsFiles Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\Garnet.worker.deps.json" />
 	<GWEXEFiles Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\Garnet.worker.exe" />
-    <RuntimeFilesWin Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\runtimes\win\lib\$(TargetFramework)\*" />
   </ItemGroup>
-    <Copy SourceFiles="@(GWRunTimeConfigFiles)" DestinationFolder="$(PublishDir)Service" />
+	<Copy SourceFiles="@(GWRunTimeConfigFiles)" DestinationFolder="$(PublishDir)Service" />
 	<Copy SourceFiles="@(DependantDLLFiles)" DestinationFolder="$(PublishDir)Service" />
 	<Copy SourceFiles="@(DependantXMLFiles)" DestinationFolder="$(PublishDir)Service" />
 	<Copy SourceFiles="@(RuntimeFilesWinx64)" DestinationFolder="$(PublishDir)Service\runtimes\win-x64\native" />
+	<Copy SourceFiles="@(RuntimeFilesWin)" DestinationFolder="$(PublishDir)Service\runtimes\win\lib\$(TargetFramework)" />
 	<Copy SourceFiles="@(GWDepsFiles)" DestinationFolder="$(PublishDir)Service" />
 	<Copy SourceFiles="@(GWEXEFiles)" DestinationFolder="$(PublishDir)Service" />
 	<Copy SourceFiles="@(GWRunTimeConfigFiles)" DestinationFolder="$(PublishDir)Service" />
-    <Copy SourceFiles="@(RuntimeFilesWin)" DestinationFolder="$(PublishDir)Service\runtimes\win\lib\$(TargetFramework)" />
   </Target>
-
   <Target Name="DeleteWorkerFiles" AfterTargets="CopyWorkerDll">
 	<Delete Files="$(PublishDir)Garnet.worker.exe" />
 	<Delete Files="$(PublishDir)Garnet.worker.deps.json" />

--- a/main/GarnetServer/Properties/PublishProfiles/win-x64-based-readytorun.pubxml
+++ b/main/GarnetServer/Properties/PublishProfiles/win-x64-based-readytorun.pubxml
@@ -30,20 +30,21 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 	<DependantDLLFiles Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\*.dll" />
 	<DependantXMLFiles Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\*.xml" />
 	<RuntimeFilesWinx64 Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\runtimes\win-x64\native\*" />
-	<RuntimeFilesWin Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\runtimes\win\lib\net8.0\*" />
 	<GWRunTimeConfigFiles Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\Garnet.worker.runtimeconfig.json" />
 	<GWDepsFiles Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\Garnet.worker.deps.json" />
 	<GWEXEFiles Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\Garnet.worker.exe" />
+    <RuntimeFilesWin Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\runtimes\win\lib\$(TargetFramework)\*" />
   </ItemGroup>
-	<Copy SourceFiles="@(GWRunTimeConfigFiles)" DestinationFolder="$(PublishDir)Service" />
+    <Copy SourceFiles="@(GWRunTimeConfigFiles)" DestinationFolder="$(PublishDir)Service" />
 	<Copy SourceFiles="@(DependantDLLFiles)" DestinationFolder="$(PublishDir)Service" />
 	<Copy SourceFiles="@(DependantXMLFiles)" DestinationFolder="$(PublishDir)Service" />
 	<Copy SourceFiles="@(RuntimeFilesWinx64)" DestinationFolder="$(PublishDir)Service\runtimes\win-x64\native" />
-	<Copy SourceFiles="@(RuntimeFilesWin)" DestinationFolder="$(PublishDir)Service\runtimes\win\lib\net8.0" />
 	<Copy SourceFiles="@(GWDepsFiles)" DestinationFolder="$(PublishDir)Service" />
 	<Copy SourceFiles="@(GWEXEFiles)" DestinationFolder="$(PublishDir)Service" />
 	<Copy SourceFiles="@(GWRunTimeConfigFiles)" DestinationFolder="$(PublishDir)Service" />
+    <Copy SourceFiles="@(RuntimeFilesWin)" DestinationFolder="$(PublishDir)Service\runtimes\win\lib\$(TargetFramework)" />
   </Target>
+
   <Target Name="DeleteWorkerFiles" AfterTargets="CopyWorkerDll">
 	<Delete Files="$(PublishDir)Garnet.worker.exe" />
 	<Delete Files="$(PublishDir)Garnet.worker.deps.json" />


### PR DESCRIPTION
The win-x64-based-readytorun.pubxml had hard coded net8.0 files that still worked for net9.0 until Garnet Release 61. Looks like nuget update caused 9.0 to fail. Just changing that hardcode net80 to $(TargetFramework) fixed the issue.

Verified fix by running release pipeline (without push to production) and verified win-x64-based-readytorun.zip