### PR TITLE
Implementing Multi-DB support in StoreWrapper's ObjectCollectTask

### DIFF
--- a/libs/server/Databases/DatabaseManagerBase.cs
+++ b/libs/server/Databases/DatabaseManagerBase.cs
@@ -77,7 +77,7 @@ namespace Garnet.server
         public abstract bool GrowIndexesIfNeeded(CancellationToken token = default);
 
         /// <inheritdoc/>
-        public abstract void ExecuteObjectCollection(CancellationToken token = default);
+        public abstract void ExecuteObjectCollection();
 
         /// <inheritdoc/>
         public abstract void StartObjectSizeTrackers(CancellationToken token = default);

--- a/libs/server/Databases/DatabaseManagerBase.cs
+++ b/libs/server/Databases/DatabaseManagerBase.cs
@@ -77,6 +77,9 @@ namespace Garnet.server
         public abstract bool GrowIndexesIfNeeded(CancellationToken token = default);
 
         /// <inheritdoc/>
+        public abstract void ExecuteObjectCollection(CancellationToken token = default);
+
+        /// <inheritdoc/>
         public abstract void StartObjectSizeTrackers(CancellationToken token = default);
 
         /// <inheritdoc/>

--- a/libs/server/Databases/DatabaseManagerBase.cs
+++ b/libs/server/Databases/DatabaseManagerBase.cs
@@ -410,7 +410,7 @@ namespace Garnet.server
             {
                 var scratchBufferManager = new ScratchBufferManager();
                 db.DatabaseStorageSession =
-                    new StorageSession(StoreWrapper, scratchBufferManager, null, null, Logger);
+                    new StorageSession(StoreWrapper, scratchBufferManager, null, null, db.Id, Logger);
             }
 
             ExecuteHashCollect(db.DatabaseStorageSession);

--- a/libs/server/Databases/IDatabaseManager.cs
+++ b/libs/server/Databases/IDatabaseManager.cs
@@ -180,6 +180,11 @@ namespace Garnet.server
         public bool GrowIndexesIfNeeded(CancellationToken token = default);
 
         /// <summary>
+        /// Executes a store-wide object collect operation
+        /// </summary>
+        public void ExecuteObjectCollection(CancellationToken token = default);
+
+        /// <summary>
         /// Start object size trackers for all active databases
         /// </summary>
         public void StartObjectSizeTrackers(CancellationToken token = default);

--- a/libs/server/Databases/IDatabaseManager.cs
+++ b/libs/server/Databases/IDatabaseManager.cs
@@ -182,7 +182,7 @@ namespace Garnet.server
         /// <summary>
         /// Executes a store-wide object collect operation
         /// </summary>
-        public void ExecuteObjectCollection(CancellationToken token = default);
+        public void ExecuteObjectCollection();
 
         /// <summary>
         /// Start object size trackers for all active databases

--- a/libs/server/Databases/MultiDatabaseManager.cs
+++ b/libs/server/Databases/MultiDatabaseManager.cs
@@ -506,7 +506,19 @@ namespace Garnet.server
         }
 
         /// <inheritdoc/>
-        public override void ExecuteObjectCollection(CancellationToken token = default) => throw new NotImplementedException();
+        public override void ExecuteObjectCollection(CancellationToken token = default)
+        {
+            var databasesMapSnapshot = databases.Map;
+
+            var activeDbIdsMapSize = activeDbIds.ActualSize;
+            var activeDbIdsMapSnapshot = activeDbIds.Map;
+
+            for (var i = 0; i < activeDbIdsMapSize; i++)
+            {
+                var dbId = activeDbIdsMapSnapshot[i];
+                ExecuteObjectCollection(databasesMapSnapshot[dbId], Logger);
+            }
+        }
 
         /// <inheritdoc/>
         public override void StartObjectSizeTrackers(CancellationToken token = default)

--- a/libs/server/Databases/MultiDatabaseManager.cs
+++ b/libs/server/Databases/MultiDatabaseManager.cs
@@ -506,7 +506,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc/>
-        public override void ExecuteObjectCollection(CancellationToken token = default)
+        public override void ExecuteObjectCollection()
         {
             var databasesMapSnapshot = databases.Map;
 

--- a/libs/server/Databases/MultiDatabaseManager.cs
+++ b/libs/server/Databases/MultiDatabaseManager.cs
@@ -506,6 +506,9 @@ namespace Garnet.server
         }
 
         /// <inheritdoc/>
+        public override void ExecuteObjectCollection(CancellationToken token = default) => throw new NotImplementedException();
+
+        /// <inheritdoc/>
         public override void StartObjectSizeTrackers(CancellationToken token = default)
         {
             sizeTrackersStarted = true;

--- a/libs/server/Databases/SingleDatabaseManager.cs
+++ b/libs/server/Databases/SingleDatabaseManager.cs
@@ -296,7 +296,7 @@ namespace Garnet.server
             GrowIndexesIfNeeded(defaultDatabase);
 
         /// <inheritdoc/>
-        public override void ExecuteObjectCollection(CancellationToken token = default) =>
+        public override void ExecuteObjectCollection() =>
             ExecuteObjectCollection(defaultDatabase, Logger);
 
         /// <inheritdoc/>

--- a/libs/server/Databases/SingleDatabaseManager.cs
+++ b/libs/server/Databases/SingleDatabaseManager.cs
@@ -296,7 +296,8 @@ namespace Garnet.server
             GrowIndexesIfNeeded(defaultDatabase);
 
         /// <inheritdoc/>
-        public override void ExecuteObjectCollection(CancellationToken token = default) => throw new NotImplementedException();
+        public override void ExecuteObjectCollection(CancellationToken token = default) =>
+            ExecuteObjectCollection(defaultDatabase, Logger);
 
         /// <inheritdoc/>
         public override void StartObjectSizeTrackers(CancellationToken token = default) =>

--- a/libs/server/Databases/SingleDatabaseManager.cs
+++ b/libs/server/Databases/SingleDatabaseManager.cs
@@ -291,8 +291,12 @@ namespace Garnet.server
         /// <inheritdoc/>
         public override void DoCompaction(CancellationToken token = default, ILogger logger = null) => DoCompaction(defaultDatabase);
 
+        /// <inheritdoc/>
         public override bool GrowIndexesIfNeeded(CancellationToken token = default) =>
             GrowIndexesIfNeeded(defaultDatabase);
+
+        /// <inheritdoc/>
+        public override void ExecuteObjectCollection(CancellationToken token = default) => throw new NotImplementedException();
 
         /// <inheritdoc/>
         public override void StartObjectSizeTrackers(CancellationToken token = default) =>

--- a/libs/server/GarnetDatabase.cs
+++ b/libs/server/GarnetDatabase.cs
@@ -97,6 +97,11 @@ namespace Garnet.server
         /// </summary>
         public SingleWriterMultiReaderLock CheckpointingLock;
 
+        /// <summary>
+        /// Storage session intended for store-wide object collection operations
+        /// </summary>
+        internal StorageSession DatabaseStorageSession;
+
         bool disposed = false;
 
         public GarnetDatabase(int id, TsavoriteKV<SpanByte, SpanByte, MainStoreFunctions, MainStoreAllocator> mainStore,
@@ -160,6 +165,7 @@ namespace Garnet.server
             ObjectStore?.Dispose();
             AofDevice?.Dispose();
             AppendOnlyFile?.Dispose();
+            DatabaseStorageSession?.Dispose();
 
             if (ObjectStoreSizeTracker != null)
             {

--- a/libs/server/Resp/LocalServerSession.cs
+++ b/libs/server/Resp/LocalServerSession.cs
@@ -48,7 +48,7 @@ namespace Garnet.server
             this.scratchBufferManager = new ScratchBufferManager();
 
             // Create storage session and API
-            this.storageSession = new StorageSession(storeWrapper, scratchBufferManager, sessionMetrics, LatencyMetrics, logger);
+            this.storageSession = new StorageSession(storeWrapper, scratchBufferManager, sessionMetrics, LatencyMetrics, dbId: 0, logger);
 
             this.BasicGarnetApi = new BasicGarnetApi(storageSession, storageSession.basicContext, storageSession.objectStoreBasicContext);
         }

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -1595,7 +1595,7 @@ namespace Garnet.server
         /// <returns>New database session</returns>
         private GarnetDatabaseSession CreateDatabaseSession(int dbId)
         {
-            var dbStorageSession = new StorageSession(storeWrapper, scratchBufferManager, sessionMetrics, LatencyMetrics, logger, dbId, respProtocolVersion);
+            var dbStorageSession = new StorageSession(storeWrapper, scratchBufferManager, sessionMetrics, LatencyMetrics, dbId, logger, respProtocolVersion);
             var dbGarnetApi = new BasicGarnetApi(dbStorageSession, dbStorageSession.basicContext, dbStorageSession.objectStoreBasicContext);
             var dbLockableGarnetApi = new LockableGarnetApi(dbStorageSession, dbStorageSession.lockableContext, dbStorageSession.objectStoreLockableContext);
 

--- a/libs/server/Storage/Session/StorageSession.cs
+++ b/libs/server/Storage/Session/StorageSession.cs
@@ -59,8 +59,8 @@ namespace Garnet.server
             ScratchBufferManager scratchBufferManager,
             GarnetSessionMetrics sessionMetrics,
             GarnetLatencyMetricsSession LatencyMetrics,
+            int dbId,
             ILogger logger = null,
-            int dbId = 0,
             byte respProtocolVersion = ServerOptions.DEFAULT_RESP_VERSION)
         {
             this.sessionMetrics = sessionMetrics;

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -681,7 +681,7 @@ namespace Garnet.server
                 {
                     if (token.IsCancellationRequested) return;
 
-                    databaseManager.ExecuteObjectCollection(token);
+                    databaseManager.ExecuteObjectCollection();
 
                     await Task.Delay(TimeSpan.FromSeconds(objectCollectFrequencySecs), token);
                 }

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -673,7 +673,7 @@ namespace Garnet.server
             {
                 var scratchBufferManager = new ScratchBufferManager();
                 using var storageSession = new StorageSession(this, scratchBufferManager, null, null, logger);
-
+                
                 if (serverOptions.DisableObjects)
                 {
                     logger?.LogWarning("ExpiredObjectCollectionFrequencySecs option is configured but Object store is disabled. Stopping the background hash collect task.");

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -671,9 +671,6 @@ namespace Garnet.server
             Debug.Assert(objectCollectFrequencySecs > 0);
             try
             {
-                var scratchBufferManager = new ScratchBufferManager();
-                using var storageSession = new StorageSession(this, scratchBufferManager, null, null, logger);
-                
                 if (serverOptions.DisableObjects)
                 {
                     logger?.LogWarning("ExpiredObjectCollectionFrequencySecs option is configured but Object store is disabled. Stopping the background hash collect task.");
@@ -684,8 +681,7 @@ namespace Garnet.server
                 {
                     if (token.IsCancellationRequested) return;
 
-                    ExecuteHashCollect(scratchBufferManager, storageSession);
-                    ExecuteSortedSetCollect(scratchBufferManager, storageSession);
+                    databaseManager.ExecuteObjectCollection(token);
 
                     await Task.Delay(TimeSpan.FromSeconds(objectCollectFrequencySecs), token);
                 }
@@ -697,22 +693,6 @@ namespace Garnet.server
             catch (Exception ex)
             {
                 logger?.LogCritical(ex, "Unknown exception received for background hash collect task. Object collect task won't be resumed.");
-            }
-
-            static void ExecuteHashCollect(ScratchBufferManager scratchBufferManager, StorageSession storageSession)
-            {
-                var header = new RespInputHeader(GarnetObjectType.Hash) { HashOp = HashOperation.HCOLLECT };
-                var input = new ObjectInput(header);
-
-                ReadOnlySpan<ArgSlice> key = [ArgSlice.FromPinnedSpan("*"u8)];
-                storageSession.HashCollect(key, ref input, ref storageSession.objectStoreBasicContext);
-                scratchBufferManager.Reset();
-            }
-
-            static void ExecuteSortedSetCollect(ScratchBufferManager scratchBufferManager, StorageSession storageSession)
-            {
-                storageSession.SortedSetCollect(ref storageSession.objectStoreBasicContext);
-                scratchBufferManager.Reset();
             }
         }
 


### PR DESCRIPTION
This was an oversight in #1005, `StoreWrapper`'s `ObjectCollectTask` was only running collection on the default database. 
Thanks @hamdaankhalid for finding this 🥇 