### PR TITLE
Disable protected mode by patching defaults.conf

### DIFF
--- a/.github/workflows/docker-linux.yml
+++ b/.github/workflows/docker-linux.yml
@@ -76,6 +76,6 @@ jobs:
           file: ${{ matrix.dockerfile }}
           provenance: false
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ (github.ref_name == 'main' || (github.ref_type == 'tag' && startsWith(github.ref_name, 'v'))) && github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-windows.yml
+++ b/.github/workflows/docker-windows.yml
@@ -45,7 +45,7 @@ jobs:
             username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Build
+      - name: Build and Push
         if: ${{ (github.ref_name == 'main' || (github.ref_type == 'tag' && startsWith(github.ref_name, 'v'))) && github.event_name != 'pull_request' }}
         run: |
           docker build -f Dockerfile.nanoserver `
@@ -56,7 +56,7 @@ jobs:
           docker push ${{ fromJSON(steps.meta.outputs.json).tags[1] }}
           docker push ${{ fromJSON(steps.meta.outputs.json).tags[2] }}
 
-      - name: Push
-        if: ${{ (github.ref_name != 'main' && (github.ref_type != 'tag' || !startsWith(github.ref_name, 'v'))) || github.event_name == 'pull_request' }}
+      - name: Build Only
+        if: ${{ !((github.ref_name == 'main' || (github.ref_type == 'tag' && startsWith(github.ref_name, 'v'))) && github.event_name != 'pull_request') }}
         run: |
           docker build -f Dockerfile.nanoserver .

--- a/.github/workflows/docker-windows.yml
+++ b/.github/workflows/docker-windows.yml
@@ -46,7 +46,7 @@ jobs:
             password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Build and push
-        if: github.event_name != 'pull_request'
+        if: ${{ (github.ref_name == 'main' || (github.ref_type == 'tag' && startsWith(github.ref_name, 'v'))) && github.event_name != 'pull_request' }}
         run: |
           docker build -f Dockerfile.nanoserver `
             --tag ${{ fromJSON(steps.meta.outputs.json).tags[0] }} `

--- a/.github/workflows/docker-windows.yml
+++ b/.github/workflows/docker-windows.yml
@@ -46,16 +46,17 @@ jobs:
             password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Build
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ (github.ref_name == 'main' || (github.ref_type == 'tag' && startsWith(github.ref_name, 'v'))) && github.event_name != 'pull_request' }}
         run: |
           docker build -f Dockerfile.nanoserver `
             --tag ${{ fromJSON(steps.meta.outputs.json).tags[0] }} `
             --tag ${{ fromJSON(steps.meta.outputs.json).tags[1] }} `
             --tag ${{ fromJSON(steps.meta.outputs.json).tags[2] }} .
-
-      - name: Push
-        if: ${{ (github.ref_name == 'main' || (github.ref_type == 'tag' && startsWith(github.ref_name, 'v'))) && github.event_name != 'pull_request' }}
-        run: |
           docker push ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           docker push ${{ fromJSON(steps.meta.outputs.json).tags[1] }}
           docker push ${{ fromJSON(steps.meta.outputs.json).tags[2] }}
+
+      - name: Push
+        if: ${{ (github.ref_name != 'main' && (github.ref_type != 'tag' || !startsWith(github.ref_name, 'v'))) || github.event_name == 'pull_request' }}
+        run: |
+          docker build -f Dockerfile.nanoserver .

--- a/.github/workflows/docker-windows.yml
+++ b/.github/workflows/docker-windows.yml
@@ -45,14 +45,17 @@ jobs:
             username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Build and push
-        if: ${{ (github.ref_name == 'main' || (github.ref_type == 'tag' && startsWith(github.ref_name, 'v'))) && github.event_name != 'pull_request' }}
+      - name: Build
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           docker build -f Dockerfile.nanoserver `
             --tag ${{ fromJSON(steps.meta.outputs.json).tags[0] }} `
             --tag ${{ fromJSON(steps.meta.outputs.json).tags[1] }} `
             --tag ${{ fromJSON(steps.meta.outputs.json).tags[2] }} .
 
+      - name: Push
+        if: ${{ (github.ref_name == 'main' || (github.ref_type == 'tag' && startsWith(github.ref_name, 'v'))) && github.event_name != 'pull_request' }}
+        run: |
           docker push ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           docker push ${{ fromJSON(steps.meta.outputs.json).tags[1] }}
           docker push ${{ fromJSON(steps.meta.outputs.json).tags[2] }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ COPY main/ main/
 COPY metrics/ metrics/
 COPY test/testcerts test/testcerts
 
+# Set protected mode to no for Docker images
+RUN sed -i 's/"ProtectedMode": "yes",/"ProtectedMode": "no",/' /src/libs/host/defaults.conf
+
 WORKDIR /src/main/GarnetServer
 RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contained false -f net8.0 -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false
 
@@ -52,4 +55,4 @@ USER $APP_UID
 # For inter-container communication.
 EXPOSE 6379
 
-ENTRYPOINT ["/app/GarnetServer", "--protected-mode", "no"]
+ENTRYPOINT ["/app/GarnetServer"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -27,6 +27,9 @@ COPY main/ main/
 COPY metrics/ metrics/
 COPY test/testcerts test/testcerts
 
+# Set protected mode to no for Docker images
+RUN sed -i 's/"ProtectedMode": "yes",/"ProtectedMode": "no",/' /src/libs/host/defaults.conf
+
 WORKDIR /src/main/GarnetServer
 RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contained false -f net8.0 -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false
 
@@ -50,4 +53,4 @@ USER $APP_UID
 # For inter-container communication.
 EXPOSE 6379
 
-ENTRYPOINT ["/app/GarnetServer", "--protected-mode", "no"]
+ENTRYPOINT ["/app/GarnetServer"]

--- a/Dockerfile.cbl-mariner
+++ b/Dockerfile.cbl-mariner
@@ -27,6 +27,9 @@ COPY main/ main/
 COPY metrics/ metrics/
 COPY test/testcerts test/testcerts
 
+# Set protected mode to no for Docker images
+RUN sed -i 's/"ProtectedMode": "yes",/"ProtectedMode": "no",/' /src/libs/host/defaults.conf
+
 WORKDIR /src/main/GarnetServer
 RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contained false -f net8.0 -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false
 
@@ -50,4 +53,4 @@ USER $APP_UID
 # For inter-container communication.
 EXPOSE 6379
 
-ENTRYPOINT ["/app/GarnetServer", "--protected-mode", "no"]
+ENTRYPOINT ["/app/GarnetServer"]

--- a/Dockerfile.chiseled
+++ b/Dockerfile.chiseled
@@ -31,6 +31,9 @@ COPY main/ main/
 COPY metrics/ metrics/
 COPY test/testcerts test/testcerts
 
+# Set protected mode to no for Docker images
+RUN sed -i 's/"ProtectedMode": "yes",/"ProtectedMode": "no",/' /src/libs/host/defaults.conf
+
 WORKDIR /src/main/GarnetServer
 RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contained false -f net8.0 -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false
 
@@ -46,4 +49,4 @@ VOLUME /data
 # For inter-container communication.
 EXPOSE 6379
 
-ENTRYPOINT ["/app/GarnetServer", "--protected-mode", "no"]
+ENTRYPOINT ["/app/GarnetServer"]

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -9,8 +9,8 @@ WORKDIR /src
 COPY . .
 
 # Set protected mode to no for Docker images
-RUN attrib -r /src/libs/host/defaults.conf
-RUN pwsh -Command "(Get-Content /src/libs/host/defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content /src/libs/host/defaults.conf"
+RUN attrib -r C:\src\libs\host\defaults.conf
+RUN pwsh -Command "(Get-Content C:\src\libs\host\defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content C:\src\libs\host\defaults.conf"
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -9,8 +9,10 @@ WORKDIR /src
 COPY . .
 
 # Set protected mode to no for Docker images
-RUN attrib -r C:\src\libs\host\defaults.conf
-RUN pwsh -Command "(Get-Content C:\src\libs\host\defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content C:\src\libs\host\defaults.conf"
+USER ContainerAdministrator
+RUN attrib -r /src/libs/host/defaults.conf
+RUN pwsh -Command "(Get-Content /src/libs/host/defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content /src/libs/host/defaults.conf"
+USER ContainerUser
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -8,15 +8,17 @@ WORKDIR /src
 # Copy files
 COPY . .
 
+WORKDIR /src/libs/host
+
 # Set protected mode to no for Docker images
-RUN icacls 'libs/host/defaults.conf'
+RUN icacls 'defaults.conf'
 
-RUN if (Test-Path 'libs/host/defaults.conf') { \
-    (Get-Content 'libs/host/defaults.conf' -Raw -Encoding UTF8) -replace '"ProtectedMode": "yes",', '"ProtectedMode": "no",' | \
-    Set-Content 'libs/host/defaults.conf' -Encoding UTF8 \
-} else { Write-Host "File not found: libs/host/defaults.conf" }
+RUN if (Test-Path 'defaults.conf') { \
+    (Get-Content 'defaults.conf' -Raw -Encoding UTF8) -replace '"ProtectedMode": "yes",', '"ProtectedMode": "no",' | \
+    Set-Content 'defaults.conf' -Encoding UTF8 \
+} else { Write-Host "File not found: defaults.conf" }
 
-#RUN pwsh -Command "(Get-Content '' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content '/src/libs/host/defaults.conf' -Encoding UTF8"
+#RUN pwsh -Command "(Get-Content 'defaults.conf' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content 'defaults.conf' -Encoding UTF8"
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -5,13 +5,11 @@ ENV NUGET_PACKAGES=/src/pkg
 
 WORKDIR /src
 
+# Set protected mode to no for Docker images
+RUN pwsh -Command "(Get-Content libs/host/defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content libs/host/defaults.conf"
+
 # Copy files
 COPY . .
-
-RUN pwsh -Command "Write-Host '--- Contents of /src ---'; Get-ChildItem -Path /src -Recurse; Write-Host '--- End contents of /src ---'"
-
-# Set protected mode to no for Docker images
-RUN pwsh -Command "(Get-Content /src/libs/host/defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content /src/libs/host/defaults.conf"
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -9,7 +9,7 @@ WORKDIR /src
 COPY . .
 
 # Set protected mode to no for Docker images
-RUN powershell -Command "(Get-Content '/src/libs/host/defaults.conf' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content '/src/libs/host/defaults.conf' -Encoding UTF8"
+RUN pwsh -Command "(Get-Content '/src/libs/host/defaults.conf' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content '/src/libs/host/defaults.conf' -Encoding UTF8"
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -8,12 +8,8 @@ WORKDIR /src
 # Copy files
 COPY . .
 
-#WORKDIR /src/libs/host
-
 # Set protected mode to no for Docker images
-#RUN icacls 'defaults.conf'
-
-#RUN pwsh -Command "(Get-Content 'defaults.conf' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content 'defaults.conf' -Encoding UTF8"
+RUN pwsh -Command "(Get-Content 'C:\\src\\libs\\host\\defaults.conf' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content 'C:\\src\\libs\\host\\defaults.conf' -Encoding UTF8"
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -9,7 +9,8 @@ WORKDIR /src
 COPY . .
 
 # Set protected mode to no for Docker images
-RUN pwsh -Command "(Get-Content /src/libs/host/defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content /src/libs/host/defaults.conf"
+RUN attrib -r /src/libs/host/defaults.conf; `
+	pwsh -Command "(Get-Content /src/libs/host/defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content /src/libs/host/defaults.conf"
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -8,6 +8,8 @@ WORKDIR /src
 # Copy files
 COPY . .
 
+RUN pwsh -Command "Write-Host '--- Contents of /src ---'; Get-ChildItem -Path /src -Recurse; Write-Host '--- End contents of /src ---'"
+
 # Set protected mode to no for Docker images
 RUN pwsh -Command "(Get-Content /src/libs/host/defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content /src/libs/host/defaults.conf"
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -5,11 +5,11 @@ ENV NUGET_PACKAGES=/src/pkg
 
 WORKDIR /src
 
-# Set protected mode to no for Docker images
-RUN pwsh -Command "(Get-Content libs/host/defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content libs/host/defaults.conf"
-
 # Copy files
 COPY . .
+
+# Set protected mode to no for Docker images
+RUN pwsh -Command "(Get-Content /src/libs/host/defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content /src/libs/host/defaults.conf"
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -7,6 +7,10 @@ WORKDIR /src
 
 # Copy files
 COPY . .
+
+# Set protected mode to no for Docker images
+RUN powershell -Command "(Get-Content 'C:\\src\\libs\\host\\defaults.conf' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content 'C:\\src\\libs\\host\\defaults.conf' -Encoding UTF8"
+
 WORKDIR /src/main/GarnetServer
 
 # Restore, build, and publish
@@ -22,4 +26,4 @@ COPY --from=build /app .
 # For inter-container communication.
 EXPOSE 6379
 
-ENTRYPOINT ["/app/GarnetServer", "--protected-mode", "no"]
+ENTRYPOINT ["/app/GarnetServer"]

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -9,12 +9,12 @@ WORKDIR /src
 COPY . .
 
 # Set protected mode to no for Docker images
-RUN icacls 'C:\src\libs\host\defaults.conf'
+RUN icacls 'libs/host/defaults.conf'
 
-RUN if (Test-Path 'C:\src\libs\host\defaults.conf') { \
-    (Get-Content 'C:\src\libs\host\defaults.conf' -Raw -Encoding UTF8) -replace '"ProtectedMode": "yes",', '"ProtectedMode": "no",' | \
-    Set-Content 'C:\src\libs\host\defaults.conf' -Encoding UTF8 \
-} else { Write-Host "File not found: C:\\src\\libs\\host\\defaults.conf" }
+RUN if (Test-Path 'libs/host/defaults.conf') { \
+    (Get-Content 'libs/host/defaults.conf' -Raw -Encoding UTF8) -replace '"ProtectedMode": "yes",', '"ProtectedMode": "no",' | \
+    Set-Content 'libs/host/defaults.conf' -Encoding UTF8 \
+} else { Write-Host "File not found: libs/host/defaults.conf" }
 
 #RUN pwsh -Command "(Get-Content '' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content '/src/libs/host/defaults.conf' -Encoding UTF8"
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -9,7 +9,7 @@ WORKDIR /src
 COPY . .
 
 # Set protected mode to no for Docker images
-RUN pwsh -Command "(Get-Content 'C:\\src\\libs\\host\\defaults.conf' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content 'C:\\src\\libs\\host\\defaults.conf' -Encoding UTF8"
+RUN pwsh -Command "(Get-Content /src/libs/host/defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content /src/libs/host/defaults.conf"
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -9,7 +9,7 @@ WORKDIR /src
 COPY . .
 
 # Set protected mode to no for Docker images
-RUN pwsh -Command "(Get-Content '/src/libs/host/defaults.conf' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content '/src/libs/host/defaults.conf' -Encoding UTF8"
+RUN pwsh -Command "Set-ItemProperty -Path '/src/libs/host/defaults.conf' -Name IsReadOnly -Value $false -ErrorAction SilentlyContinue; (Get-Content '/src/libs/host/defaults.conf' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content 'C:\\src\\libs\\host\\defaults.conf' -Encoding UTF8"
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -10,7 +10,6 @@ COPY . .
 
 # Set protected mode to no for Docker images
 USER ContainerAdministrator
-RUN attrib -r /src/libs/host/defaults.conf
 RUN pwsh -Command "(Get-Content /src/libs/host/defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content /src/libs/host/defaults.conf"
 USER ContainerUser
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -8,15 +8,10 @@ WORKDIR /src
 # Copy files
 COPY . .
 
-WORKDIR /src/libs/host
+#WORKDIR /src/libs/host
 
 # Set protected mode to no for Docker images
-RUN icacls 'defaults.conf'
-
-RUN if (Test-Path 'defaults.conf') { \
-    (Get-Content 'defaults.conf' -Raw -Encoding UTF8) -replace '"ProtectedMode": "yes",', '"ProtectedMode": "no",' | \
-    Set-Content 'defaults.conf' -Encoding UTF8 \
-} else { Write-Host "File not found: defaults.conf" }
+#RUN icacls 'defaults.conf'
 
 #RUN pwsh -Command "(Get-Content 'defaults.conf' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content 'defaults.conf' -Encoding UTF8"
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -9,8 +9,7 @@ WORKDIR /src
 COPY . .
 
 # Set protected mode to no for Docker images
-RUN attrib -r C:\src\libs\host\defaults.conf
-RUN pwsh -Command "(Get-Content C:\src\libs\host\defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content C:\src\libs\host\defaults.conf"
+RUN pwsh -Command "(Get-Content libs\host\defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content libs\host\defaults.conf"
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -9,6 +9,7 @@ WORKDIR /src
 COPY . .
 
 # Set protected mode to no for Docker images
+RUN attrib -r libs\host\defaults.conf
 RUN pwsh -Command "(Get-Content libs\host\defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content libs\host\defaults.conf"
 
 WORKDIR /src/main/GarnetServer

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -9,7 +9,7 @@ WORKDIR /src
 COPY . .
 
 # Set protected mode to no for Docker images
-RUN powershell -Command "(Get-Content 'C:\\src\\libs\\host\\defaults.conf' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content 'C:\\src\\libs\\host\\defaults.conf' -Encoding UTF8"
+RUN powershell -Command "(Get-Content '/src/libs/host/defaults.conf' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content '/src/libs/host/defaults.conf' -Encoding UTF8"
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -9,7 +9,7 @@ WORKDIR /src
 COPY . .
 
 # Set protected mode to no for Docker images
-RUN pwsh -Command "Set-ItemProperty -Path '/src/libs/host/defaults.conf' -Name IsReadOnly -Value $false -ErrorAction SilentlyContinue; (Get-Content '/src/libs/host/defaults.conf' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content 'C:\\src\\libs\\host\\defaults.conf' -Encoding UTF8"
+RUN pwsh -Command "Set-ItemProperty -Path '/src/libs/host/defaults.conf' -Name IsReadOnly -Value $false -ErrorAction SilentlyContinue; (Get-Content '/src/libs/host/defaults.conf' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content '/src/libs/host/defaults.conf' -Encoding UTF8"
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -9,8 +9,8 @@ WORKDIR /src
 COPY . .
 
 # Set protected mode to no for Docker images
-RUN attrib -r /src/libs/host/defaults.conf; `
-	pwsh -Command "(Get-Content /src/libs/host/defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content /src/libs/host/defaults.conf"
+RUN attrib -r /src/libs/host/defaults.conf
+RUN pwsh -Command "(Get-Content /src/libs/host/defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content /src/libs/host/defaults.conf"
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -9,7 +9,14 @@ WORKDIR /src
 COPY . .
 
 # Set protected mode to no for Docker images
-RUN pwsh -Command "Set-ItemProperty -Path '/src/libs/host/defaults.conf' -Name IsReadOnly -Value $false -ErrorAction SilentlyContinue; (Get-Content '/src/libs/host/defaults.conf' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content '/src/libs/host/defaults.conf' -Encoding UTF8"
+RUN icacls 'C:\src\libs\host\defaults.conf'
+
+RUN if (Test-Path 'C:\src\libs\host\defaults.conf') { \
+    (Get-Content 'C:\src\libs\host\defaults.conf' -Raw -Encoding UTF8) -replace '"ProtectedMode": "yes",', '"ProtectedMode": "no",' | \
+    Set-Content 'C:\src\libs\host\defaults.conf' -Encoding UTF8 \
+} else { Write-Host "File not found: C:\\src\\libs\\host\\defaults.conf" }
+
+#RUN pwsh -Command "(Get-Content '' -Raw -Encoding UTF8) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content '/src/libs/host/defaults.conf' -Encoding UTF8"
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.nanoserver
+++ b/Dockerfile.nanoserver
@@ -9,8 +9,8 @@ WORKDIR /src
 COPY . .
 
 # Set protected mode to no for Docker images
-RUN attrib -r libs\host\defaults.conf
-RUN pwsh -Command "(Get-Content libs\host\defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content libs\host\defaults.conf"
+RUN attrib -r C:\src\libs\host\defaults.conf
+RUN pwsh -Command "(Get-Content C:\src\libs\host\defaults.conf) -replace '\""ProtectedMode\"": \"yes\",', '\""ProtectedMode\"": \"no\",' | Set-Content C:\src\libs\host\defaults.conf"
 
 WORKDIR /src/main/GarnetServer
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -27,6 +27,9 @@ COPY main/ main/
 COPY metrics/ metrics/
 COPY test/testcerts test/testcerts
 
+# Set protected mode to no for Docker images
+RUN sed -i 's/"ProtectedMode": "yes",/"ProtectedMode": "no",/' /src/libs/host/defaults.conf
+
 WORKDIR /src/main/GarnetServer
 RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore --self-contained false -f net8.0 -p:EnableSourceLink=false -p:EnableSourceControlManagerQueries=false
 
@@ -54,4 +57,4 @@ USER $APP_UID
 # For inter-container communication.
 EXPOSE 6379
 
-ENTRYPOINT ["/app/GarnetServer", "--protected-mode", "no"]
+ENTRYPOINT ["/app/GarnetServer"]

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- VersionPrefix property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>1.0.67</VersionPrefix>
+		<VersionPrefix>1.0.68</VersionPrefix>
 	</PropertyGroup>
 </Project>

--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -360,7 +360,7 @@
 	"EnableDebugCommand": "no",
 
 	/* Protected mode */
-	"ProtectedMode": "yes",
+	"ProtectedMode": "no",
 
 	/* List of directories on server from which custom command binaries can be loaded by admin users */
 	"ExtensionBinPaths": null,

--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -360,7 +360,7 @@
 	"EnableDebugCommand": "no",
 
 	/* Protected mode */
-	"ProtectedMode": "no",
+	"ProtectedMode": "yes",
 
 	/* List of directories on server from which custom command binaries can be loaded by admin users */
 	"ExtensionBinPaths": null,


### PR DESCRIPTION
Disable protected mode for Docker usage by patching `defaults.conf` instead of setting `--protected-mode no` via Dockerfile's `ENTRYLINE`. This change allows downstream consumers to override the arguments and still not lose the disabling of protected mode.

Updates version to 1.0.68 for new release

Fixes https://github.com/microsoft/garnet/issues/1220