### PR TITLE
Optimize ACL Parser Performance by Conditional Application of Recursive Analysis

### DIFF
--- a/test/Garnet.test/Resp/ACL/AclParserTests.cs
+++ b/test/Garnet.test/Resp/ACL/AclParserTests.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Garnet.server.ACL;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace Garnet.test.Resp.ACL
+{
+    /// <summary>
+    /// Tests for the <see cref="ACLParser"/>.
+    /// </summary>
+    [TestFixture]
+    class AclParserTests : AclTest
+    {
+        /// <summary>
+        /// Test cases for scenarios where ACLs reduce.
+        /// </summary>
+        [Test, MaxTime(1000)]
+        [TestCase("user 1-command on +set", "+set")]
+        [TestCase("user 2-command on +set +get", "+set +get")]
+        [TestCase("user 3-command-duplicates-reduce on +set +set", "+set")]
+        [TestCase("user 4-command-duplicates-complicated on +set +set -set +set", "+set")]
+        [TestCase("user 5-command-duplicates-complicated on +get -set +set", "+get +set")]
+        [TestCase("user 6-category on +@keyspace", "+@keyspace")]
+        [TestCase("user 7-category-reduces on +@all", "+@all")]
+        [TestCase("user 7-category-reduces on -@all", "")]
+        [TestCase("user 8-category-reduces on -@all +@keyspace", "+@keyspace")]
+        [TestCase("user 9-category-reduces on +@all +@keyspace", "+@all")]
+        [TestCase("user 10-category-command-reduces on +@keyspace +del", "+@keyspace")]
+        [TestCase("user 11-category-command-reduces on +@keyspace +set", "+@keyspace +set")]
+        [TestCase("user 12-category-command-reduces on +@keyspace +del -del", "+@keyspace -del")]
+        [TestCase("user 13-category-command-reduces on +del -@keyspace", "")]
+        [TestCase("user 14-category-command-reduces on -del +@keyspace", "+@keyspace")]
+        [TestCase("user 15-category-command-reduces on +set +@keyspace", "+set +@keyspace")]
+        [TestCase("user 16-category-command-reduces on +@all +set", "+@all")]
+        [TestCase("user 17-category-command-reduces on +@all +set +get +incr -decr", "+@all -decr")]
+        [TestCase("user 18-category-command-reduces on -@all +set", "+set")]
+        [TestCase("user 19-category-command-reduces on -@all +set +get", "+set +get")]
+        [TestCase("user 20-category-command-reduces on -@all +set +get +incr +decr +incrby +decrby", "+set +get +incr +decr +incrby +decrby")]
+        [TestCase("user 21-category-command-reduces on -@all +ping +auth +set +get +del +incr +decr +incrby +decrby +expire +ttl +keys +scan +hget", "+ping +auth +set +get +del +incr +decr +incrby +decrby +expire +ttl +keys +scan +hget")]
+        [TestCase("user 22-category-command-reduces on -@all +ping +auth +set +get +del +incr +decr +incrby +decrby +expire +ttl +keys +scan +hget +config|get", "+ping +auth +set +get +del +incr +decr +incrby +decrby +expire +ttl +keys +scan +hget +config|get")]
+        [TestCase("user 23-category-command-reduces on -@all +set +get +incr +decr +@keyspace +@hash +incrby +decrby", "+set +get +incr +decr +@keyspace +@hash +incrby +decrby")]
+        [TestCase("user 24-multi-category-reduces on -@all +@keyspace +@hash", "+@keyspace +@hash")]
+        [TestCase("user 25-multi-category-reduces on -@all +@keyspace +@hash -flushdb", "+@keyspace +@hash -flushdb")]
+        [TestCase("user 26-multi-category-reduces on -@all +@keyspace -flushdb +@hash -flushdb", "+@keyspace -flushdb +@hash")]
+        [TestCase("user 27-multi-category-reduces on -@all +set +get +incr +decr +@keyspace +@hash +incrby +decrby +script|exists +@pubsub +expire +ttl", "+set +get +incr +decr +@keyspace +@hash +incrby +decrby +script|exists +@pubsub")]
+        public void ParseACLRuleDescriptionTest(string acl, string expectedDescription)
+        {
+            User user = ACLParser.ParseACLRule(acl);
+            ClassicAssert.IsNotNull(user);
+            ClassicAssert.AreEqual(expectedDescription, user.GetEnabledCommandsDescription());
+        }
+
+        /// <summary>
+        /// Test cases for scenarios where ACLs reduce and timeouts have been encountered in the past.
+        /// </summary>
+        [Test, MaxTime(1000)]
+        [TestCase("user 1-command-notimeout on +auth +ping +get +set +del +exists +incr +decr +mget +mset +expire +ttl +keys +scan +hget +hset +lpush +rpush +sadd +decrby", "+auth +ping +get +set +del +exists +incr +decr +mget +mset +expire +ttl +keys +scan +hget +hset +lpush +rpush +sadd +decrby")]
+        [TestCase("user 2-category-command-notimeout on -@all +ping +auth +set +get +del +incr +decr +incrby +decrby +expire +ttl +keys +scan +hget +mget +mset +eval +evalsha +setex", "+ping +auth +set +get +del +incr +decr +incrby +decrby +expire +ttl +keys +scan +hget +mget +mset +eval +evalsha +setex")]
+        [TestCase("user 3-category-command-notimeout on -@all +client|id +client|info +cluster|nodes +cluster|slots +echo +info +ping +config|get +decr -decr +decrby +del +expire +flushdb +get +incr +incrby +latency +eval +evalsha +script|exists +script|flush +script|load +set +setex +unlink", "+client|id +client|info +cluster|nodes +cluster|slots +echo +info +ping +config|get +decr -decr +decrby +del +expire +flushdb +get +incr +incrby +latency +eval +evalsha +script|exists +script|flush +script|load +set +setex +unlink")]
+        [TestCase("user 4-category-command-notimeout on +@keyspace +client|id +client|info +cluster|nodes +cluster|slots +echo +info +ping +config|get +decr -decr +decrby +del +expire +flushdb +get +incr +incrby +latency +eval +evalsha +script|exists +script|flush +script|load +set +setex +unlink", "+@keyspace +client|id +client|info +cluster|nodes +cluster|slots +echo +info +ping +config|get +decr -decr +decrby +get +incr +incrby +latency +eval +evalsha +script|exists +script|flush +script|load +set +setex")]
+        [TestCase("user 5-category-command-notimeout on -@all +@keyspace +client|id +client|info +cluster|nodes +cluster|slots +echo +info +ping +config|get +decr -decr +decrby +del +expire +flushdb +get +incr +incrby +latency +eval +evalsha +script|exists +script|flush +script|load +set +setex +unlink", "+@keyspace +client|id +client|info +cluster|nodes +cluster|slots +echo +info +ping +config|get +decr -decr +decrby +get +incr +incrby +latency +eval +evalsha +script|exists +script|flush +script|load +set +setex")]
+        public void ParseACLRuleDescriptionTimeoutsTest(string acl, string expectedDescription)
+        {
+            User user = ACLParser.ParseACLRule(acl);
+            ClassicAssert.IsNotNull(user);
+            ClassicAssert.AreEqual(expectedDescription, user.GetEnabledCommandsDescription());
+        }
+
+        /// <summary>
+        /// Test cases for scenarios where ACLs reductions should occur but do not. Fixes required.
+        /// </summary>
+        [Explicit("Fails due to issues with reducing the commands in the ACL.")]
+        [Test, MaxTime(1000)]
+        [TestCase("user 1-category-command-reduces on +@keyspace +del -del +del", "+@keyspace")]
+        [TestCase("user 2-command-duplicates-complicated on +set -get +get +set -set +set", "+set +get")]
+        public void ParseACLRuleDescriptionShouldReduceTest(string acl, string expectedDescription)
+        {
+            User user = ACLParser.ParseACLRule(acl);
+            ClassicAssert.AreEqual(expectedDescription, user.GetEnabledCommandsDescription());
+        }
+    }
+}


### PR DESCRIPTION
# Problem

When the ACL SETUSER command is invoked with a large number of commands in the ACL (15+) the Garnet Server spins for a long time (1-2+ min) and can exceed the default timeout settings of a client in some cases.

The degraded runtime performance can be attributed to the `RationalizeACLDescription` method which unconditionally applies a recursive algorithm to eliminate duplicate commands in the ACL description returned to the user. This method has a high time complexity (n^3 according to copilot) and performance of the method degrades quickly when there are a large number of ACLs. Comments surrounding the method also indicate that it is expensive. In some test cases, execution of the method can take minutes.
---

# Fix

This change applies an optimization that avoids the expensive recursive analysis/rationalization when it is unnecessary, significantly improving the performance of the ACL parser.

The logic works on the following premises:
- When the parser is processing an ACL it is moving from left to right.
- Each time a new command is parsed, the existing `CommandPermissionSet` contains all commands the user has permission to execute.
- If the existing `CommandPermissionSet` does not grant access to execute the current command to be added, there is no redundancy in the command description that needs to be reduced.
- Because there is no redundancy between the new command to add and the existing command set we can forgo the expensive `RationalizeACLDescription` method.

---

# Testing Approach

To validate the change, I took the following steps:
- Wrote unit tests to produce the performance problem and tested it against current/historical branches.
- Create more advanced unit tests to capture the current behavior of the parsers and to avoid introducing any obvious regressions. These are not all encompassing but I think they cover a large amount of scenarios.
- Some test cases I created had issues with rationalization of the command description. I considered these out of scope for the optimization PR. However, I included them to capture the problem (explicit to prevent running in CI).

---
# Performance
I captured before / after results of my test executions in Visual Studio. Here are the results. I believe the first test suffers from a cold start problem, however there are significant improvements on the long running tests.

## ParseACLRuleDescriptionTest

| Name                             | Before | After | Improvement (%) |
|-----------------------------------|--------|-------|----------------|
| 1-command                        | 354ms  | 164ms | 53.67%         |
| 2-command                        | 3ms    | 1ms   | 66.67%         |
| 3-command-duplicates-reduce      | 1ms    | 1ms   | 0.00%          |
| 4-command-duplicates-complicated | 2ms    | 2ms   | 0.00%          |
| 5-command-duplicates-complicated | 1ms    | 1ms   | 0.00%          |
| 6-category                       | 3ms    | 2ms   | 33.33%         |
| 7-category-reduces               | 2ms    | 1ms   | 50.00%         |
| 8-category-reduces               | 1ms    | 1ms   | 0.00%          |
| 9-category-reduces               | 1ms    | 1ms   | 0.00%          |
| 10-category-reduces              | 1ms    | 1ms   | 0.00%          |
| 11-category-command-reduces      | 1ms    | 1ms   | 0.00%          |
| 12-category-command-reduces      | 1ms    | 1ms   | 0.00%          |
| 13-category-command-reduces      | 1ms    | 1ms   | 0.00%          |
| 14-category-command-reduces      | 1ms    | 1ms   | 0.00%          |
| 15-category-command-reduces      | 1ms    | 1ms   | 0.00%          |
| 16-category-command-reduces      | 1ms    | 1ms   | 0.00%          |
| 17-category-command-reduces      | 1ms    | 1ms   | 0.00%          |
| 18-category-command-reduces      | 2ms    | 1ms   | 50.00%         |
| 19-category-command-reduces      | 1ms    | 1ms   | 0.00%          |
| 20-category-command-reduces      | 1ms    | 1ms   | 0.00%          |
| 21-category-command-reduces      | 1ms    | 1ms   | 0.00%          |
| 22-category-command-reduces      | 98ms   | 1ms   | 98.98%         |
| 23-category-command-reduces      | 125ms  | 1ms   | 99.20%         |
| 24-category-command-reduces      | 2ms    | 1ms   | 50.00%         |
| 25-multi-category-reduces        | 1ms    | 1ms   | 0.00%          |
| 26-multi-category-reduces        | 1ms    | 1ms   | 0.00%          |
| 27-multi-category-reduces        | 1ms    | 1ms   | 0.00%          |
| 28-multi-category-reduces        | 6ms    | 1ms   | 83.33%         |
---

## ParseACLRuleDescriptionTimeoutsTest

| Name                              | Before  | After | Improvement (%) |
|------------------------------------|---------|-------|----------------|
| 1-command-notimeout                | 2.4s    | 1ms   | 99.96%         |
| 2-category-command-notimeout       | 1.3s    | 1ms   | 99.92%         |
| 3-category-command-notimeout       | 2.5min  | 1ms   | 99.9993%       |
| 4-category-command-notimeout       | 24s     | 1ms   | 99.996%        |
| 5-category-command-notimeout       | 21.2s   | 1ms   | 99.99%         |
---

# Follow On Work
The approach taken to producing the ACL description should be evaluated to see if a simpler strategy can be used. For example, a strategy could be used that only reduces at the same level, meaning we would not reduce individual commands when their category is specified.
