### PR TITLE
Cleaned up compliance pipeline 

### DIFF
--- a/.azure/pipelines/azure-pipelines-compliance.yml
+++ b/.azure/pipelines/azure-pipelines-compliance.yml
@@ -2,10 +2,12 @@ trigger:
   branches:
     exclude:
       - continuousbenchmark
+      - continuousbenchmark_net80
 pr:
   branches:
     exclude:
       - continuousbenchmark
+      - continuousbenchmark_net80
 variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
@@ -25,38 +27,6 @@ jobs:
      clean: False
      submodules: recursive
      persistCredentials: True
-   - task: UseDotNet@2
-     displayName: 'Use .NET Core sdk 8.0.x'
-     inputs:
-       version: 8.0.x
-   - task: UseDotNet@2
-     displayName: 'Use .NET Core sdk 9.0.x'
-     inputs:
-       version: 9.0.x
-   - task: NuGetToolInstaller@1
-     displayName: Nuget Tool Installer
-     inputs:
-       versionspec: '*'
-       checkLatest: true
-   - task: NuGetAuthenticate@1
-     displayName: 'NuGet Authenticate'
-   - task: DotNetCoreCLI@2
-     displayName: dotnet build
-     inputs:
-       projects: '**/Garnet.*.csproj'
-       arguments: '-c Release'
-   - task: CopyFiles@2
-     displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
-     inputs:
-       Contents: '**\bin\AnyCPU\$(BuildConfiguration)\**\*'
-       TargetFolder: '$(Build.ArtifactStagingDirectory)'
-   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-     displayName: Component Detection
-     inputs:
-       detectorsToRun: NuGet,Npm
-       scanType: 'Register'
-       verbosity: 'Verbose'
-       alertWarningLevel: 'High'
    - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
      name: CredScan6  
      displayName: Run CredScan


### PR DESCRIPTION
After doing compliance pipeline for another project, I realized that Garnet compliance pipeline needed updating. We don't check any built files anymore so we don't need to do a build. Also, removed component detection task because that is auto injected into the pipeline by the system. 