### PR TITLE
Null objects on delete, update cache size tracker

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- VersionPrefix property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>1.0.71</VersionPrefix>
+		<VersionPrefix>1.0.72</VersionPrefix>
 	</PropertyGroup>
 </Project>

--- a/libs/server/Storage/Functions/ObjectStore/DeleteMethods.cs
+++ b/libs/server/Storage/Functions/ObjectStore/DeleteMethods.cs
@@ -31,6 +31,7 @@ namespace Garnet.server
             if (functionsState.appendOnlyFile != null)
                 WriteLogDelete(ref key, deleteInfo.Version, deleteInfo.SessionID);
             functionsState.objectStoreSizeTracker?.AddTrackedSize(-value.Size);
+            value = null;
             return true;
         }
     }

--- a/libs/server/Storage/Functions/ObjectStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/ObjectStore/RMWMethods.cs
@@ -110,6 +110,7 @@ namespace Garnet.server
             // Expired data
             if (value.Expiration > 0 && input.header.CheckExpiry(value.Expiration))
             {
+                functionsState.objectStoreSizeTracker?.AddTrackedSize(-value.Size);
                 value = null;
                 rmwInfo.Action = input.header.type == GarnetObjectType.DelIfExpIm ? RMWAction.ExpireAndStop : RMWAction.ExpireAndResume;
                 return false;
@@ -161,6 +162,7 @@ namespace Garnet.server
 
                         if (output.HasRemoveKey)
                         {
+                            functionsState.objectStoreSizeTracker?.AddTrackedSize(-value.Size);
                             value = null;
                             rmwInfo.Action = RMWAction.ExpireAndStop;
                             return false;

--- a/libs/storage/Tsavorite/cs/src/core/Index/Common/LogSizeTracker.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Common/LogSizeTracker.cs
@@ -51,7 +51,6 @@ namespace Tsavorite.core
             while (records.GetNext(out RecordInfo info, out TKey key, out TValue value))
             {
                 Debug.Assert(key != null);
-                Debug.Assert(value != null);
 
                 size += logSizeTracker.LogSizeCalculator.CalculateRecordSize(info, key, value);
             }
@@ -147,7 +146,6 @@ namespace Tsavorite.core
             while (records.GetNext(out RecordInfo info, out TKey key, out TValue value))
             {
                 Debug.Assert(key != null);
-                Debug.Assert(value != null);
 
                 size += LogSizeCalculator.CalculateRecordSize(info, key, value);
             }

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/FindRecord.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/FindRecord.cs
@@ -96,8 +96,8 @@ namespace Tsavorite.core
                 if (!TryTransientSLock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref key, ref stackCtx, out internalStatus))
                     return needIO = false;
             }
-            else
-                stackCtx.SetRecordSourceToHashEntry(hlogBase);
+
+            stackCtx.SetRecordSourceToHashEntry(hlogBase);
 
             try
             {


### PR DESCRIPTION
Also, fix bug with TryFindRecordInMainLogForConditionalOperation that resulted in null objects found during collect scan.

Fixes https://github.com/microsoft/garnet/issues/1224