### PR TITLE
Fix ARGV not being set if KEYS is grown during Lua script

### DIFF
--- a/libs/server/Lua/LuaRunner.cs
+++ b/libs/server/Lua/LuaRunner.cs
@@ -1426,6 +1426,9 @@ namespace Garnet.server
             var ignored = 0;
             state.RawSet(1, sandboxEnvIndex, ref ignored);
 
+            // Get sandbox_env off the stack
+            state.Pop(1);
+
             keysArrCapacity = length;
 
             return true;
@@ -1455,6 +1458,9 @@ namespace Garnet.server
             // Save it, which should have NO allocation impact because we're updating an existing slot
             var ignored = 0;
             state.RawSet(1, sandboxEnvIndex, ref ignored);
+
+            // Get sandbox_env off the stack
+            state.Pop(1);
 
             argvArrCapacity = length;
 

--- a/test/Garnet.test/LuaScriptTests.cs
+++ b/test/Garnet.test/LuaScriptTests.cs
@@ -2750,6 +2750,11 @@ return cjson.encode(nested)");
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = redis.GetDatabase();
 
+            // Underlying issue is that KEYS/ARGV resizing left the stack misaligned
+            //
+            // In order to trigger the issue, you need enough KEYS to force a re-allocation
+            // but without enough ARGVs to do the same.
+
             var res =
                 (string)db.ScriptEvaluate(
                     "return ARGV[3]",

--- a/test/Garnet.test/LuaScriptTests.cs
+++ b/test/Garnet.test/LuaScriptTests.cs
@@ -2743,6 +2743,23 @@ return cjson.encode(nested)");
         }
 
         [Test]
+        public void Issue1235()
+        {
+            // See: https://github.com/microsoft/garnet/issues/1235
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase();
+
+            var res =
+                (string)db.ScriptEvaluate(
+                    "return ARGV[3]",
+                    ["a", "b", "c", "d", "e", "f",],
+                    ["0", "1", "2", "3", "4", "5",]
+            );
+            ClassicAssert.AreEqual("2", res);
+        }
+
+        [Test]
         [Ignore("Long running, disabled by default")]
         public void StressTimeouts()
         {

--- a/test/Garnet.test/LuaScriptTests.cs
+++ b/test/Garnet.test/LuaScriptTests.cs
@@ -2760,7 +2760,7 @@ return cjson.encode(nested)");
                     "return ARGV[3]",
                     ["a", "b", "c", "d", "e", "f",],
                     ["0", "1", "2", "3", "4", "5",]
-            );
+                );
             ClassicAssert.AreEqual("2", res);
         }
 

--- a/test/Garnet.test/LuaScriptTests.cs
+++ b/test/Garnet.test/LuaScriptTests.cs
@@ -2759,7 +2759,7 @@ return cjson.encode(nested)");
                 (string)db.ScriptEvaluate(
                     "return ARGV[3]",
                     ["a", "b", "c", "d", "e", "f",],
-                    ["0", "1", "2", "3", "4", "5",]
+                    ["0", "1", "2"]
                 );
             ClassicAssert.AreEqual("2", res);
         }


### PR DESCRIPTION
Fixes the `-ERR Lua encountered an error: bad argument to unpack` part of #1235.

The underlying issue was a Lua stack misalignment, if `KEYS` is grown one extra item was left on the stack which prevented values from going into `ARGV`.  If _both_ `KEYS` and `ARGV` were grown the issue was masked, which is probably how this slipped through testing.

There's a small security implication here, as the values that should have gone into `ARGV` in this case would have ended up in the "global" (not truly global, because of the sandbox) environment for the script.  This could allow prior invocations to communicate string values to future invocations, but would not allow a sandbox escape.