### PR TITLE
Revivification In-Chain Stats fix

### DIFF
--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalRMW.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalRMW.cs
@@ -288,6 +288,7 @@ namespace Tsavorite.core
                                 ref srcRecordInfo, ref key, ref recordValue, requiredSize, recordLengths);
                     }
 
+                    ref RevivificationStats stats = ref sessionFunctions.Ctx.RevivificationStats;
                     if (ok && sessionFunctions.InitialUpdater(ref key, ref input, ref recordValue, ref output, ref rmwInfo, ref srcRecordInfo))
                     {
                         // Success
@@ -295,11 +296,13 @@ namespace Tsavorite.core
                         pendingContext.recordInfo = srcRecordInfo;
                         pendingContext.logicalAddress = stackCtx.recSrc.LogicalAddress;
                         status = OperationStatusUtils.AdvancedOpCode(OperationStatus.SUCCESS, StatusCode.InPlaceUpdatedRecord);
+                        stats.inChainSuccesses++;
                         return true;
                     }
 
                     // Did not revivify; restore the tombstone and leave the deleted record there.
                     srcRecordInfo.SetTombstone();
+                    stats.inChainFailures++;
                 }
             }
             finally

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalUpsert.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalUpsert.cs
@@ -236,6 +236,8 @@ namespace Tsavorite.core
                                 ref srcRecordInfo, ref key, ref recordValue, requiredSize, recordLengths);
                     }
 
+                    ref RevivificationStats stats = ref sessionFunctions.Ctx.RevivificationStats;
+
                     if (ok && sessionFunctions.SingleWriter(ref key, ref input, ref value, ref recordValue, ref output, ref upsertInfo, WriteReason.Upsert, ref srcRecordInfo))
                     {
                         // Success
@@ -243,11 +245,13 @@ namespace Tsavorite.core
                         pendingContext.recordInfo = srcRecordInfo;
                         pendingContext.logicalAddress = stackCtx.recSrc.LogicalAddress;
                         status = OperationStatusUtils.AdvancedOpCode(OperationStatus.SUCCESS, StatusCode.InPlaceUpdatedRecord);
+                        stats.inChainSuccesses++;
                         return true;
                     }
 
                     // Did not revivify; restore the tombstone and leave the deleted record there.
                     srcRecordInfo.SetTombstone();
+                    stats.inChainFailures++;
                 }
             }
             finally


### PR DESCRIPTION
Realized in-chain stats are never filled in, minor PR change do just that in InternalRMW and InternalUpsert