### PR TITLE
Add Lua test for cluster replication

### DIFF
--- a/test/Garnet.test.cluster/ClusterTestContext.cs
+++ b/test/Garnet.test.cluster/ClusterTestContext.cs
@@ -118,6 +118,7 @@ namespace Garnet.test.cluster
         /// <param name="luaMemoryMode"></param>
         /// <param name="luaMemoryLimit"></param>
         /// <param name="useHostname"></param>
+        /// <param name="luaTransactionMode"></param>
         public void CreateInstances(
             int shards,
             bool enableCluster = true,
@@ -152,7 +153,8 @@ namespace Garnet.test.cluster
             string replicaDisklessSyncFullSyncAofThreshold = null,
             LuaMemoryManagementMode luaMemoryMode = LuaMemoryManagementMode.Native,
             string luaMemoryLimit = "",
-            bool useHostname = false)
+            bool useHostname = false,
+            bool luaTransactionMode = false)
         {
             var ipAddress = IPAddress.Loopback;
             TestUtils.EndPoint = new IPEndPoint(ipAddress, 7000);
@@ -195,7 +197,8 @@ namespace Garnet.test.cluster
                 replicaDisklessSyncDelay: replicaDisklessSyncDelay,
                 replicaDisklessSyncFullSyncAofThreshold: replicaDisklessSyncFullSyncAofThreshold,
                 luaMemoryMode: luaMemoryMode,
-                luaMemoryLimit: luaMemoryLimit);
+                luaMemoryLimit: luaMemoryLimit,
+                luaTransactionMode: luaTransactionMode);
 
             foreach (var node in nodes)
                 node.Start();

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -478,7 +478,8 @@ namespace Garnet.test
             string replicaDisklessSyncFullSyncAofThreshold = null,
             LuaMemoryManagementMode luaMemoryMode = LuaMemoryManagementMode.Native,
             string luaMemoryLimit = "",
-            EndPoint clusterAnnounceEndpoint = null)
+            EndPoint clusterAnnounceEndpoint = null,
+            bool luaTransactionMode = false)
         {
             if (UseAzureStorage)
                 IgnoreIfNotRunningAzureTests();
@@ -528,7 +529,8 @@ namespace Garnet.test
                     replicaDisklessSyncFullSyncAofThreshold: replicaDisklessSyncFullSyncAofThreshold,
                     luaMemoryMode: luaMemoryMode,
                     luaMemoryLimit: luaMemoryLimit,
-                    clusterAnnounceEndpoint: clusterAnnounceEndpoint);
+                    clusterAnnounceEndpoint: clusterAnnounceEndpoint,
+                    luaTransactionMode: luaTransactionMode);
 
                 ClassicAssert.IsNotNull(opts);
 
@@ -593,7 +595,8 @@ namespace Garnet.test
             LuaLoggingMode luaLoggingMode = LuaLoggingMode.Enable,
             IEnumerable<string> luaAllowedFunctions = null,
             string unixSocketPath = null,
-            EndPoint clusterAnnounceEndpoint = null)
+            EndPoint clusterAnnounceEndpoint = null,
+            bool luaTransactionMode = false)
         {
             if (useAzureStorage)
                 IgnoreIfNotRunningAzureTests();
@@ -696,6 +699,7 @@ namespace Garnet.test
                 ClusterUsername = authUsername,
                 ClusterPassword = authPassword,
                 EnableLua = enableLua,
+                LuaTransactionMode = luaTransactionMode,
                 ReplicationOffsetMaxLag = asyncReplay ? -1 : 0,
                 LuaOptions = enableLua ? new LuaOptions(luaMemoryMode, luaMemoryLimit, luaTimeout ?? Timeout.InfiniteTimeSpan, luaLoggingMode, luaAllowedFunctions ?? [], logger) : null,
                 UnixSocketPath = unixSocketPath,


### PR DESCRIPTION
Per request by @vazois , adding a Lua test similar to the transactional proc one added as part of #1252 .

Does a simple (parameterized) `SET` against primary, waits for replication, and then does a (likewise, parameterized) `GET` against a replica.

Test both and without Lua transactions enabled.