### PR TITLE
Standardize timeout parsing with correct errors for too small or too large

### DIFF
--- a/libs/server/Resp/CmdStrings.cs
+++ b/libs/server/Resp/CmdStrings.cs
@@ -254,6 +254,7 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> RESP_ERR_RADIUS_IS_NEGATIVE => "ERR radius cannot be negative"u8;
         public static ReadOnlySpan<byte> RESP_ERR_TIMEOUT_IS_NEGATIVE => "ERR timeout is negative"u8;
         public static ReadOnlySpan<byte> RESP_ERR_TIMEOUT_NOT_VALID_FLOAT => "ERR timeout is not a float or out of range"u8;
+        public static ReadOnlySpan<byte> RESP_ERR_TIMEOUT_IS_OUT_OF_RANGE => "ERR timeout is out of range"u8;
         public static ReadOnlySpan<byte> RESP_WRONGPASS_INVALID_PASSWORD => "WRONGPASS Invalid password"u8;
         public static ReadOnlySpan<byte> RESP_WRONGPASS_INVALID_USERNAME_PASSWORD => "WRONGPASS Invalid username/password combination"u8;
         public static ReadOnlySpan<byte> RESP_SYNTAX_ERROR => "ERR syntax error"u8;

--- a/libs/server/Resp/Objects/ListCommands.cs
+++ b/libs/server/Resp/Objects/ListCommands.cs
@@ -303,11 +303,9 @@ namespace Garnet.server
                 keysBytes[i] = parseState.GetArgSliceByRef(i).SpanByte.ToByteArray();
             }
 
-            if (!parseState.TryGetDouble(parseState.Count - 1, out var timeout))
+            if (!parseState.TryGetTimeout(parseState.Count - 1, out var timeout, out var error))
             {
-                while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_TIMEOUT_NOT_VALID_FLOAT, ref dcurr, dend))
-                    SendAndReset();
-                return true;
+                return AbortWithErrorMessage(error);
             }
 
             if (storeWrapper.objectStore == null)
@@ -360,11 +358,9 @@ namespace Garnet.server
             var srcDir = parseState.GetArgSliceByRef(2);
             var dstDir = parseState.GetArgSliceByRef(3);
 
-            if (!parseState.TryGetDouble(4, out var timeout))
+            if (!parseState.TryGetTimeout(4, out var timeout, out var error))
             {
-                while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_TIMEOUT_NOT_VALID_FLOAT, ref dcurr, dend))
-                    SendAndReset();
-                return true;
+                return AbortWithErrorMessage(error);
             }
 
             return ListBlockingMove(srcKey, dstKey, srcDir, dstDir, timeout);
@@ -386,11 +382,9 @@ namespace Garnet.server
             var rightOption = ArgSlice.FromPinnedSpan(CmdStrings.RIGHT);
             var leftOption = ArgSlice.FromPinnedSpan(CmdStrings.LEFT);
 
-            if (!parseState.TryGetDouble(2, out var timeout))
+            if (!parseState.TryGetTimeout(2, out var timeout, out var error))
             {
-                while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_TIMEOUT_NOT_VALID_FLOAT, ref dcurr, dend))
-                    SendAndReset();
-                return true;
+                return AbortWithErrorMessage(error);
             }
 
             return ListBlockingMove(srcKey, dstKey, rightOption, leftOption, timeout);
@@ -943,9 +937,9 @@ namespace Garnet.server
             var currTokenId = 0;
 
             // Read timeout
-            if (!parseState.TryGetDouble(currTokenId++, out var timeout))
+            if (!parseState.TryGetTimeout(currTokenId++, out var timeout, out var error))
             {
-                return AbortWithErrorMessage(CmdStrings.RESP_ERR_TIMEOUT_NOT_VALID_FLOAT);
+                return AbortWithErrorMessage(error);
             }
 
             // Read count of keys

--- a/libs/server/Resp/Objects/SortedSetCommands.cs
+++ b/libs/server/Resp/Objects/SortedSetCommands.cs
@@ -1573,9 +1573,9 @@ namespace Garnet.server
                 return AbortWithWrongNumberOfArguments(command.ToString());
             }
 
-            if (!parseState.TryGetDouble(parseState.Count - 1, out var timeout) || (timeout < 0))
+            if (!parseState.TryGetTimeout(parseState.Count - 1, out var timeout, out var error))
             {
-                return AbortWithErrorMessage(CmdStrings.RESP_ERR_TIMEOUT_NOT_VALID_FLOAT);
+                return AbortWithErrorMessage(error);
             }
 
             var keysBytes = new byte[parseState.Count - 1][];
@@ -1638,14 +1638,9 @@ namespace Garnet.server
             var currTokenId = 0;
 
             // Read timeout
-            if (!parseState.TryGetDouble(currTokenId++, out var timeout))
+            if (!parseState.TryGetTimeout(currTokenId++, out var timeout, out var error))
             {
-                return AbortWithErrorMessage(CmdStrings.RESP_ERR_TIMEOUT_NOT_VALID_FLOAT);
-            }
-
-            if (timeout < 0)
-            {
-                return AbortWithErrorMessage(CmdStrings.RESP_ERR_TIMEOUT_IS_NEGATIVE);
+                return AbortWithErrorMessage(error);
             }
 
             // Read count of keys

--- a/libs/server/SessionParseStateExtensions.cs
+++ b/libs/server/SessionParseStateExtensions.cs
@@ -757,6 +757,43 @@ namespace Garnet.server
         }
 
         /// <summary>
+        /// Parse timeout (in seconds) from parse state at specified index.
+        /// </summary>
+        /// <param name="parseState">The parse state</param>
+        /// <param name="idx">The argument index</param>
+        /// <param name="timeout">Timeout</param>
+        /// <param name="error">Error if failed</param>
+        /// <returns>True if value parsed successfully</returns>
+        internal static bool TryGetTimeout(this SessionParseState parseState, int idx, out double timeout, out ReadOnlySpan<byte> error)
+        {
+            // .NET APIs do not support an higher value than int.MaxValue milliseconds.
+            const double MAXTIMEOUT = int.MaxValue / 1000D;
+
+            error = default;
+
+            if (!parseState.TryGetDouble(idx, out timeout))
+            {
+                error = CmdStrings.RESP_ERR_TIMEOUT_NOT_VALID_FLOAT;
+                return false;
+            }
+
+            if (timeout < 0)
+            {
+                error = CmdStrings.RESP_ERR_TIMEOUT_IS_NEGATIVE;
+                return false;
+            }
+
+            if (timeout > MAXTIMEOUT)
+            {
+                error = CmdStrings.RESP_ERR_TIMEOUT_IS_OUT_OF_RANGE;
+                return false;
+            }
+
+            return true;
+        }
+
+
+        /// <summary>
         /// Tries to extract keys from the key specifications in the given RespCommandsInfo.
         /// </summary>
         /// <param name="state">The SessionParseState instance.</param>


### PR DESCRIPTION
There are a number of places where Garnet parses timeouts for blocking commands. These did not consistently error on negative values, and none of them errored on too large values (where .NET will raise an ArgumentOutOfRangeException and then Garnet closes the connection). Using a central SessionParseStateExtension for timeouts fixes all these issues neatly.

Note the .NET maximum timeout (int.MaxValue milliseconds) is far lower than the Valkey maximum timeout (63-bit integer seconds). I don't think the complexity justifies supporting this much? However, the .NET runtime maximum can be easily raised to uint32.MaxValue - 1 milliseconds, I'll be opening an issue on their tracker for this.