### PR TITLE
Detect AOF History Divergence with No Checkpoint

### DIFF
--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -607,56 +607,15 @@ namespace Garnet.cluster
             return replicaWorkerIds;
         }
 
-        private string CreateFormattedNodeInfo(int workerId)
-        {
-            var nodeInfo = "*12\r\n";
-            nodeInfo += "$2\r\nid\r\n";
-            nodeInfo += $"$40\r\n{workers[workerId].Nodeid}\r\n";
-            nodeInfo += "$4\r\nport\r\n";
-            nodeInfo += $":{workers[workerId].Port}\r\n";
-            nodeInfo += "$7\r\naddress\r\n";
-            nodeInfo += $"${workers[workerId].Address.Length}\r\n{workers[workerId].Address}\r\n";
-            nodeInfo += "$4\r\nrole\r\n";
-            nodeInfo += $"${workers[workerId].Role.ToString().Length}\r\n{workers[workerId].Role}\r\n";
-            nodeInfo += "$18\r\nreplication-offset\r\n";
-            nodeInfo += $":{workers[workerId].ReplicationOffset}\r\n";
-            nodeInfo += "$6\r\nhealth\r\n";
-            nodeInfo += $"$6\r\nonline\r\n";
-            return nodeInfo;
-        }
-
-        private string CreateFormattedShardInfo(int primaryWorkerId, List<(ushort, ushort)> shardRanges, List<int> replicaWorkerIds)
-        {
-            var shardInfo = $"*4\r\n";
-
-            shardInfo += $"$5\r\nslots\r\n";//1
-
-            shardInfo += $"*{shardRanges.Count * 2}\r\n";//2
-            for (int i = 0; i < shardRanges.Count; i++)
-            {
-                var range = shardRanges[i];
-                shardInfo += $":{range.Item1}\r\n";
-                shardInfo += $":{range.Item2}\r\n";
-            }
-
-            shardInfo += $"$5\r\nnodes\r\n";//3
-
-            shardInfo += $"*{1 + replicaWorkerIds.Count}\r\n";//4
-            shardInfo += CreateFormattedNodeInfo(primaryWorkerId);
-            foreach (var id in replicaWorkerIds)
-                shardInfo += CreateFormattedNodeInfo(id);
-
-            return shardInfo;
-        }
-
         /// <summary>
         /// Get formatted (using CLUSTER SHARDS format) cluster config information.
         /// </summary>
+        /// <param name="clusterConnection"></param>
         /// <returns>RESP formatted string</returns>
-        public string GetShardsInfo()
+        public string GetShardsInfo(GarnetClusterConnectionStore clusterConnection)
         {
-            string shardsInfo = "";
-            int shardCount = 0;
+            var shardsInfo = "";
+            var shardCount = 0;
             for (ushort i = 1; i <= NumWorkers; i++)
             {
                 if (workers[i].Role == NodeRole.PRIMARY)
@@ -669,6 +628,54 @@ namespace Garnet.cluster
             }
             shardsInfo = $"*{shardCount}\r\n" + shardsInfo;
             return shardsInfo;
+
+            string CreateFormattedShardInfo(int primaryWorkerId, List<(ushort, ushort)> shardRanges, List<int> replicaWorkerIds)
+            {
+                var shardInfo = $"*4\r\n";
+                shardInfo += $"$5\r\nslots\r\n";
+                shardInfo += $"*{shardRanges.Count * 2}\r\n";
+                for (var i = 0; i < shardRanges.Count; i++)
+                {
+                    var range = shardRanges[i];
+                    shardInfo += $":{range.Item1}\r\n";
+                    shardInfo += $":{range.Item2}\r\n";
+                }
+
+                shardInfo += $"$5\r\nnodes\r\n";
+                shardInfo += $"*{1 + replicaWorkerIds.Count}\r\n";
+                if (primaryWorkerId == 1)
+                    shardInfo += CreateFormattedNodeInfo(primaryWorkerId, true);
+                else
+                {
+                    _ = clusterConnection.GetConnectionInfo(workers[primaryWorkerId].Nodeid, out var info);
+                    shardInfo += CreateFormattedNodeInfo(primaryWorkerId, info.connected);
+                }
+                foreach (var id in replicaWorkerIds)
+                {
+                    _ = clusterConnection.GetConnectionInfo(workers[id].Nodeid, out var info);
+                    shardInfo += CreateFormattedNodeInfo(id, info.connected);
+                }
+
+                return shardInfo;
+
+                string CreateFormattedNodeInfo(int workerId, bool connected)
+                {
+                    var nodeInfo = "*12\r\n";
+                    nodeInfo += "$2\r\nid\r\n";
+                    nodeInfo += $"$40\r\n{workers[workerId].Nodeid}\r\n";
+                    nodeInfo += "$4\r\nport\r\n";
+                    nodeInfo += $":{workers[workerId].Port}\r\n";
+                    nodeInfo += "$7\r\naddress\r\n";
+                    nodeInfo += $"${workers[workerId].Address.Length}\r\n{workers[workerId].Address}\r\n";
+                    nodeInfo += "$4\r\nrole\r\n";
+                    nodeInfo += $"${workers[workerId].Role.ToString().Length}\r\n{workers[workerId].Role}\r\n";
+                    nodeInfo += "$18\r\nreplication-offset\r\n";
+                    nodeInfo += $":{workers[workerId].ReplicationOffset}\r\n";
+                    nodeInfo += "$6\r\nhealth\r\n";
+                    nodeInfo += connected ? "$6\r\nonline\r\n" : "$7\r\noffline\r\n";
+                    return nodeInfo;
+                }
+            }
         }
 
         private string CreateFormattedSlotInfo(int slotStart, int slotEnd, string address, int port, string nodeid, string hostname, List<string> replicaIds)

--- a/libs/cluster/Server/Replication/PrimaryOps/ReplicaSyncSession.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/ReplicaSyncSession.cs
@@ -257,6 +257,16 @@ namespace Garnet.cluster
                                 replayUntilAddress = clusterProvider.replicationManager.ReplicationOffset2;
                             checkpointAofBeginAddress = replayUntilAddress;
                         }
+
+                        var sameMainStoreCheckpointHistory = !string.IsNullOrEmpty(replicaCheckpointEntry.metadata.storePrimaryReplId) && replicaCheckpointEntry.metadata.storePrimaryReplId.Equals(localEntry.metadata.storePrimaryReplId);
+                        var sameObjectStoreCheckpointHistory = !string.IsNullOrEmpty(replicaCheckpointEntry.metadata.objectStorePrimaryReplId) && replicaCheckpointEntry.metadata.objectStorePrimaryReplId.Equals(localEntry.metadata.objectStorePrimaryReplId);
+                        if (!sameMainStoreCheckpointHistory || !sameObjectStoreCheckpointHistory)
+                        {
+                            // If we are not in the same checkpoint history, we need to stream the AOF from the primary's beginning address
+                            checkpointAofBeginAddress = beginAddress;
+                            replayAOF = false;
+                            logger?.LogInformation("ReplicaSyncSession: not in same checkpoint history, will replay from beginning address {checkpointAofBeginAddress}", checkpointAofBeginAddress);
+                        }
                     }
                 }
 

--- a/libs/cluster/Server/Replication/ReplicationManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationManager.cs
@@ -333,7 +333,7 @@ namespace Garnet.cluster
                     PrimaryRecover();
                     break;
                 case NodeRole.REPLICA:
-                    // We will instead recover as part of TryConnectToPrimary instead
+                    // We will instead recover as part of TryReplicate instead
                     // ReplicaRecover();
                     break;
                 default:

--- a/libs/cluster/Session/RespClusterBasicCommands.cs
+++ b/libs/cluster/Session/RespClusterBasicCommands.cs
@@ -331,7 +331,7 @@ namespace Garnet.cluster
                 return true;
             }
 
-            var shardsInfo = clusterProvider.clusterManager.CurrentConfig.GetShardsInfo();
+            var shardsInfo = clusterProvider.clusterManager.CurrentConfig.GetShardsInfo(clusterProvider.clusterManager.clusterConnectionStore);
             while (!RespWriteUtils.TryWriteAsciiDirect(shardsInfo, ref dcurr, dend))
                 SendAndReset();
 

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -2887,6 +2887,16 @@ namespace Garnet.test.cluster
             }
         }
 
+        public void WaitForPrimaryRole(int nodeIndex, ILogger logger = null)
+        {
+            while (true)
+            {
+                var role = RoleCommand(nodeIndex, logger);
+                if (role.Value.Equals("master")) break;
+                BackOff(cancellationToken: context.cts.Token);
+            }
+        }
+
         public void Checkpoint(int nodeIndex, ILogger logger = null)
             => Checkpoint((IPEndPoint)endpoints[nodeIndex], logger: logger);
 

--- a/test/Garnet.test.cluster/ReplicationTests/ClusterReplicationBaseTests.cs
+++ b/test/Garnet.test.cluster/ReplicationTests/ClusterReplicationBaseTests.cs
@@ -1178,7 +1178,7 @@ namespace Garnet.test.cluster
             }
         }
 
-        [Test, Order(24)]
+        [Test, Order(23)]
         [Category("REPLICATION")]
         public void ClusterReplicationLua([Values] bool luaTransactionMode)
         {
@@ -1188,6 +1188,7 @@ namespace Garnet.test.cluster
             var primaryNodeIndex = 0;
             var replicaNodeIndex = 1;
             ClassicAssert.IsTrue(primary_count > 0);
+
             context.CreateInstances(nodes_count, disableObjects: false, enableAOF: true, useTLS: useTLS, asyncReplay: asyncReplay, enableLua: true, luaTransactionMode: luaTransactionMode);
             context.CreateConnection(useTLS: useTLS);
             _ = context.clusterTestUtils.SimpleSetupCluster(primary_count, replica_count, logger: context.logger);
@@ -1204,6 +1205,77 @@ namespace Garnet.test.cluster
 
             ClassicAssert.AreEqual("bar", res1);
             ClassicAssert.AreEqual("buzz", res2);
+        }
+
+        [Test, Order(24)]
+        [Category("REPLICATION")]
+        public async Task ClusterReplicationMultiRestartRecover()
+        {
+            var replica_count = 1;// Per primary
+            var primary_count = 1;
+            var nodes_count = primary_count + (primary_count * replica_count);
+            var primaryNodeIndex = 0;
+            var replicaNodeIndex = 1;
+            ClassicAssert.IsTrue(primary_count > 0);
+
+            context.CreateInstances(nodes_count, disableObjects: false, enableAOF: true, useTLS: useTLS, asyncReplay: asyncReplay, cleanClusterConfig: false);
+            context.CreateConnection(useTLS: useTLS);
+            _ = context.clusterTestUtils.SimpleSetupCluster(primary_count, replica_count, logger: context.logger);
+
+            var primaryServer = context.clusterTestUtils.GetServer(primaryNodeIndex);
+            var replicaServer = context.clusterTestUtils.GetServer(replicaNodeIndex);
+            var keyCount = 1000;
+
+            var taskCount = 4;
+            var tasks = new List<Task>();
+            for (var i = 0; i < taskCount; i++)
+                tasks.Add(Task.Run(() => RunWorkload(i * keyCount, (i + 1) * keyCount)));
+            var restartRecover = 10;
+            tasks.Add(Task.Run(() => RestartRecover(restartRecover)));
+
+            await Task.WhenAll(tasks);
+            context.clusterTestUtils.WaitForReplicaAofSync(primaryNodeIndex, replicaNodeIndex, context.logger);
+
+            // Validate that replica has the same keys as primary
+            var resp = primaryServer.Execute("KEYS", ["*"]);
+            var resp2 = replicaServer.Execute("KEYS", ["*"]);
+            ClassicAssert.AreEqual(resp.Length, resp2.Length);
+            for (var i = 0; i < resp.Length; i++)
+                ClassicAssert.AreEqual((string)resp[i], (string)resp2[i]);
+
+            // Run write workload at primary
+            void RunWorkload(int start, int count)
+            {
+                var primaryServer = context.clusterTestUtils.GetServer(primaryNodeIndex);
+                var end = start + count;
+                while (start++ < end)
+                {
+                    var key = keyCount.ToString();
+                    var resp = primaryServer.Execute("SET", [key, key]);
+                    ClassicAssert.AreEqual("OK", (string)resp);
+                    resp = primaryServer.Execute("GET", key);
+                    ClassicAssert.AreEqual(key, (string)resp);
+                }
+            }
+
+            // Restart and recover replica multiple times
+            void RestartRecover(int iteration)
+            {
+                //if (iteration > 0) return;
+                while (iteration-- > 0)
+                {
+                    context.nodes[replicaNodeIndex].Dispose(false);
+                    context.nodes[replicaNodeIndex] = context.CreateInstance(
+                        context.clusterTestUtils.GetEndPoint(replicaNodeIndex),
+                        disableObjects: false,
+                        enableAOF: true,
+                        useTLS: useTLS,
+                        asyncReplay: asyncReplay,
+                        tryRecover: true,
+                        cleanClusterConfig: false);
+                    context.nodes[replicaNodeIndex].Start();
+                }
+            }
         }
     }
 }

--- a/test/Garnet.test.cluster/ReplicationTests/ClusterReplicationBaseTests.cs
+++ b/test/Garnet.test.cluster/ReplicationTests/ClusterReplicationBaseTests.cs
@@ -89,6 +89,7 @@ namespace Garnet.test.cluster
         public Dictionary<string, LogLevel> monitorTests = new()
         {
             {"ClusterReplicationSimpleFailover", LogLevel.Warning},
+            {"ClusterReplicationMultiRestartRecover", LogLevel.Trace}
         };
 
         [SetUp]
@@ -1250,7 +1251,7 @@ namespace Garnet.test.cluster
                 var end = start + count;
                 while (start++ < end)
                 {
-                    var key = keyCount.ToString();
+                    var key = start.ToString();
                     var resp = primaryServer.Execute("SET", [key, key]);
                     ClassicAssert.AreEqual("OK", (string)resp);
                     resp = primaryServer.Execute("GET", key);
@@ -1261,7 +1262,6 @@ namespace Garnet.test.cluster
             // Restart and recover replica multiple times
             void RestartRecover(int iteration)
             {
-                //if (iteration > 0) return;
                 while (iteration-- > 0)
                 {
                     context.nodes[replicaNodeIndex].Dispose(false);
@@ -1274,6 +1274,88 @@ namespace Garnet.test.cluster
                         tryRecover: true,
                         cleanClusterConfig: false);
                     context.nodes[replicaNodeIndex].Start();
+                }
+            }
+        }
+
+        [Test, Order(25)]
+        [Category("REPLICATION")]
+        public void ClusterReplicationDivergentHistoryWithoutCheckpoint()
+        {
+            var replica_count = 1;// Per primary
+            var primary_count = 1;
+            var nodes_count = primary_count + (primary_count * replica_count);
+            var primaryNodeIndex = 0;
+            var replicaNodeIndex = 1;
+            ClassicAssert.IsTrue(primary_count > 0);
+
+            context.CreateInstances(nodes_count, disableObjects: false, enableAOF: true, useTLS: useTLS, asyncReplay: asyncReplay, cleanClusterConfig: false);
+            context.CreateConnection(useTLS: useTLS);
+            _ = context.clusterTestUtils.SimpleSetupCluster(primary_count, replica_count, logger: context.logger);
+
+            var primaryServer = context.clusterTestUtils.GetServer(primaryNodeIndex);
+            var replicaServer = context.clusterTestUtils.GetServer(replicaNodeIndex);
+            var offset = 0;
+            var keyCount = 100;
+
+            RunWorkload(primaryServer, offset, keyCount);
+            context.clusterTestUtils.WaitForReplicaAofSync(primaryNodeIndex, replicaNodeIndex, context.logger);
+            // Validate that replica has the same keys as primary
+            var resp = primaryServer.Execute("KEYS", ["*"]);
+            var resp2 = replicaServer.Execute("KEYS", ["*"]);
+            ClassicAssert.AreEqual(resp.Length, resp2.Length);
+            for (var i = 0; i < resp.Length; i++)
+                ClassicAssert.AreEqual((string)resp[i], (string)resp2[i]);
+
+            // Kill primary
+            context.nodes[primaryNodeIndex].Dispose(false);
+            // Kill replica
+            context.nodes[replicaNodeIndex].Dispose(false);
+
+            // Restart primary and do not recover
+            context.nodes[primaryNodeIndex] = context.CreateInstance(
+                context.clusterTestUtils.GetEndPoint(primaryNodeIndex),
+                disableObjects: false,
+                enableAOF: true,
+                useTLS: useTLS,
+                asyncReplay: asyncReplay,
+                tryRecover: false,
+                cleanClusterConfig: false);
+            context.nodes[primaryNodeIndex].Start();
+
+            offset += keyCount;
+            // Populate primary with different history
+            RunWorkload(primaryServer, offset, keyCount / 2);
+
+            // Restart replica with recover to be ahead of primary but without checkpoint
+            context.nodes[replicaNodeIndex] = context.CreateInstance(
+                context.clusterTestUtils.GetEndPoint(replicaNodeIndex),
+                disableObjects: false,
+                enableAOF: true,
+                useTLS: useTLS,
+                asyncReplay: asyncReplay,
+                tryRecover: true,
+                cleanClusterConfig: false);
+            context.nodes[replicaNodeIndex].Start();
+
+            // Validate that replica has the same keys as primary
+            resp = primaryServer.Execute("KEYS", ["*"]);
+            resp2 = replicaServer.Execute("KEYS", ["*"]);
+            ClassicAssert.AreEqual(resp.Length, resp2.Length);
+            for (var i = 0; i < resp.Length; i++)
+                ClassicAssert.AreEqual((string)resp[i], (string)resp2[i]);
+
+            // Run write workload at primary
+            void RunWorkload(IServer server, int start, int count)
+            {
+                var end = start + count;
+                while (start++ < end)
+                {
+                    var key = start.ToString();
+                    var resp = server.Execute("SET", [key, key]);
+                    ClassicAssert.AreEqual("OK", (string)resp);
+                    resp = server.Execute("GET", key);
+                    ClassicAssert.AreEqual(key, (string)resp);
                 }
             }
         }


### PR DESCRIPTION
Added check for history divergence when no checkpoint is taken. 
In that case, we need to replay AOF from BeginAddress to ensure replica does not diverge