### PR TITLE
Fix SCRIPT|LOAD and EVAL performance regression

### DIFF
--- a/libs/server/Lua/LuaCommands.cs
+++ b/libs/server/Lua/LuaCommands.cs
@@ -121,7 +121,7 @@ namespace Garnet.server
             // that this is stack allocated is load bearing - if it moves, things will break
             Span<byte> digest = stackalloc byte[SessionScriptCache.SHA1Len];
             sessionScriptCache.GetScriptDigest(script.ReadOnlySpan, digest);
-            
+
             var scriptKey = new ScriptHashKey(digest);
             if (!storeWrapper.storeScriptCache.TryGetValue(scriptKey, out var globalScriptHandle))
             {
@@ -129,7 +129,7 @@ namespace Garnet.server
             }
 
             var sessionScriptHandle = globalScriptHandle;
-            
+
             if (!sessionScriptCache.TryLoad(this, script.ReadOnlySpan, scriptKey, ref sessionScriptHandle, out var runner, out var digestOnHeap))
             {
                 // TryLoad will have written any errors out

--- a/libs/server/Lua/LuaCommands.cs
+++ b/libs/server/Lua/LuaCommands.cs
@@ -121,39 +121,45 @@ namespace Garnet.server
             // that this is stack allocated is load bearing - if it moves, things will break
             Span<byte> digest = stackalloc byte[SessionScriptCache.SHA1Len];
             sessionScriptCache.GetScriptDigest(script.ReadOnlySpan, digest);
-
-            LuaScriptHandle newScriptHandle = null;
+            
             var scriptKey = new ScriptHashKey(digest);
-            if (!sessionScriptCache.TryLoad(this, script.ReadOnlySpan, scriptKey, ref newScriptHandle, out var runner, out var digestOnHeap))
+            if (!storeWrapper.storeScriptCache.TryGetValue(scriptKey, out var globalScriptHandle))
+            {
+                globalScriptHandle = null;
+            }
+
+            var sessionScriptHandle = globalScriptHandle;
+            
+            if (!sessionScriptCache.TryLoad(this, script.ReadOnlySpan, scriptKey, ref sessionScriptHandle, out var runner, out var digestOnHeap))
             {
                 // TryLoad will have written any errors out
                 return true;
             }
-            else if (newScriptHandle != null)
+            else if (sessionScriptHandle != globalScriptHandle)
             {
-                // Add script to the store dictionary IF we didn't already have it cached for this session
+                // Add script to the store dictionary IF we didn't already have it cached
                 //
                 // This may strike you as odd, but it is how Redis behaves
                 if (digestOnHeap == null)
                 {
                     var newAlloc = GC.AllocateUninitializedArray<byte>(SessionScriptCache.SHA1Len, pinned: true);
                     digest.CopyTo(newAlloc);
-                    if (!storeWrapper.storeScriptCache.TryAdd(new(newAlloc), newScriptHandle))
+                    if (!storeWrapper.storeScriptCache.TryAdd(new(newAlloc), sessionScriptHandle))
                     {
                         // Some other session loaded the script, toss our new handle
                         //
                         // Next time this script is run, it'll be pulled from the global cache
-                        newScriptHandle.Dispose();
+                        sessionScriptHandle.Dispose();
                     }
                 }
                 else
                 {
-                    if (!storeWrapper.storeScriptCache.TryAdd(digestOnHeap.Value, newScriptHandle))
+                    if (!storeWrapper.storeScriptCache.TryAdd(digestOnHeap.Value, sessionScriptHandle))
                     {
                         // Some other session loaded the script, toss our new handle
                         //
                         // Next time this script is run, it'll be pulled from the global cache
-                        newScriptHandle.Dispose();
+                        sessionScriptHandle.Dispose();
                     }
                 }
             }
@@ -288,30 +294,39 @@ namespace Garnet.server
             Span<byte> digest = stackalloc byte[SessionScriptCache.SHA1Len];
             sessionScriptCache.GetScriptDigest(source.Span, digest);
 
-            LuaScriptHandle newScriptHandle = null;
-            if (sessionScriptCache.TryLoad(this, source.ReadOnlySpan, new(digest), ref newScriptHandle, out _, out var digestOnHeap))
+            var onStackScriptHashKey = new ScriptHashKey(digest);
+            if (!storeWrapper.storeScriptCache.TryGetValue(onStackScriptHashKey, out var globalScriptHandle))
+            {
+                globalScriptHandle = null;
+            }
+
+            var sessionScriptHandle = globalScriptHandle;
+            if (sessionScriptCache.TryLoad(this, source.ReadOnlySpan, onStackScriptHashKey, ref sessionScriptHandle, out _, out var digestOnHeap))
             {
                 // TryLoad will write any errors out
 
-                // Add script to the store dictionary
-                if (digestOnHeap == null)
+                // Add script to the global store dictionary if not already in there
+                if (globalScriptHandle != sessionScriptHandle)
                 {
-                    var newAlloc = GC.AllocateUninitializedArray<byte>(SessionScriptCache.SHA1Len, pinned: true);
-                    digest.CopyTo(newAlloc);
-                    if (!storeWrapper.storeScriptCache.TryAdd(new(newAlloc), newScriptHandle))
+                    if (digestOnHeap == null)
                     {
-                        // Some other caller added the script already, our new handle is dead
-                        // but we'll load it from the shared cache on next invocation
-                        newScriptHandle.Dispose();
+                        var newAlloc = GC.AllocateUninitializedArray<byte>(SessionScriptCache.SHA1Len, pinned: true);
+                        digest.CopyTo(newAlloc);
+                        if (!storeWrapper.storeScriptCache.TryAdd(new(newAlloc), sessionScriptHandle))
+                        {
+                            // Some other caller added the script already, our new handle is dead
+                            // but we'll load it from the shared cache on next invocation
+                            sessionScriptHandle.Dispose();
+                        }
                     }
-                }
-                else
-                {
-                    if (!storeWrapper.storeScriptCache.TryAdd(digestOnHeap.Value, newScriptHandle))
+                    else
                     {
-                        // Some other caller added the script already, our new handle is dead
-                        // but we'll load it from the shared cache on next invocation
-                        newScriptHandle.Dispose();
+                        if (!storeWrapper.storeScriptCache.TryAdd(digestOnHeap.Value, sessionScriptHandle))
+                        {
+                            // Some other caller added the script already, our new handle is dead
+                            // but we'll load it from the shared cache on next invocation
+                            sessionScriptHandle.Dispose();
+                        }
                     }
                 }
 

--- a/libs/server/Lua/LuaCommands.cs
+++ b/libs/server/Lua/LuaCommands.cs
@@ -122,15 +122,12 @@ namespace Garnet.server
             Span<byte> digest = stackalloc byte[SessionScriptCache.SHA1Len];
             sessionScriptCache.GetScriptDigest(script.ReadOnlySpan, digest);
 
-            var scriptKey = new ScriptHashKey(digest);
-            if (!storeWrapper.storeScriptCache.TryGetValue(scriptKey, out var globalScriptHandle))
-            {
-                globalScriptHandle = null;
-            }
+            var onStackScriptKey = new ScriptHashKey(digest);
+            _ = storeWrapper.storeScriptCache.TryGetValue(onStackScriptKey, out var globalScriptHandle);
 
             var sessionScriptHandle = globalScriptHandle;
 
-            if (!sessionScriptCache.TryLoad(this, script.ReadOnlySpan, scriptKey, ref sessionScriptHandle, out var runner, out var digestOnHeap))
+            if (!sessionScriptCache.TryLoad(this, script.ReadOnlySpan, onStackScriptKey, ref sessionScriptHandle, out var runner, out var digestOnHeap))
             {
                 // TryLoad will have written any errors out
                 return true;
@@ -178,7 +175,7 @@ namespace Garnet.server
 
                 if (!res)
                 {
-                    sessionScriptCache.Remove(scriptKey);
+                    sessionScriptCache.Remove(onStackScriptKey);
                 }
             }
 
@@ -295,10 +292,7 @@ namespace Garnet.server
             sessionScriptCache.GetScriptDigest(source.Span, digest);
 
             var onStackScriptHashKey = new ScriptHashKey(digest);
-            if (!storeWrapper.storeScriptCache.TryGetValue(onStackScriptHashKey, out var globalScriptHandle))
-            {
-                globalScriptHandle = null;
-            }
+            _ = storeWrapper.storeScriptCache.TryGetValue(onStackScriptHashKey, out var globalScriptHandle);
 
             var sessionScriptHandle = globalScriptHandle;
             if (sessionScriptCache.TryLoad(this, source.ReadOnlySpan, onStackScriptHashKey, ref sessionScriptHandle, out _, out var digestOnHeap))

--- a/test/BDNPerfTests/run_bdnperftest.ps1
+++ b/test/BDNPerfTests/run_bdnperftest.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7
+
 <#$f
 .SYNOPSIS
     This script is designed for to run BDN Benchmarking and use the results as a gate in the GitHub CIs to ensure performance isn't declining. 


### PR DESCRIPTION
In fixing [these bugs](https://github.com/microsoft/garnet/commit/f619caf9d11d19db91836fe09bbe53f79a1d73a5), a regression was introduced if the same script is repeatedly `SCRIPT|LOAD`'d or (more likely) `EVAL`'d.

The root cause is that the 2nd attempt at loading will, correctly, fail to populate the global cache. However this results in removing the newly compiled script from the session cache, so each subsequent call redoes all the compilation and cache construction work.

While strictly speaking repeated `SCRIPT|LOAD`s and `EVAL`s are already sub-par for performance, it's possible for a user to fall into this pattern legitimately due to the ephemeral nature of the script cache.  Thus it's worth fixing, IMO.

The fix is simple, we just consult the global cache for a reusable handle before attempt the load.

This also add `#Requires -Version 7` to `run_bdnperftests.ps1` so you get a nicer error message when (failing) to run it on the default Windows install of Powershell.
