### PR TITLE
Implement the inline command format

### DIFF
--- a/libs/client/ClientSession/GarnetClientSession.cs
+++ b/libs/client/ClientSession/GarnetClientSession.cs
@@ -69,7 +69,7 @@ namespace Garnet.client
         public bool RawResult = false;
 
         /// <summary>
-        /// Send raw string to server
+        /// Send raw string + crlf to server
         /// </summary>
         public bool RawSend = false;
 
@@ -109,7 +109,7 @@ namespace Garnet.client
         /// <param name="networkPool">Buffer pool to use for allocating send and receive buffers</param>
         /// <param name="networkSendThrottleMax">Max outstanding network sends allowed</param>
         /// <param name="rawResult">Recieve result as raw string</param>
-        /// <param name="rawSend">Send command as raw string</param>
+        /// <param name="rawSend">Send command as raw string + crlf</param>
         /// <param name="logger">Logger</param>
         public GarnetClientSession(
             EndPoint endpoint,
@@ -465,6 +465,13 @@ namespace Garnet.client
                 foreach (var cmd in command)
                 {
                     while (!RespWriteUtils.TryWriteDirect(Encoding.ASCII.GetBytes(cmd), ref curr, end))
+                    {
+                        Flush();
+                        curr = offset;
+                    }
+                    offset = curr;
+
+                    while (!RespWriteUtils.TryWriteNewLine(ref curr, end))
                     {
                         Flush();
                         curr = offset;

--- a/libs/common/AsciiUtils.cs
+++ b/libs/common/AsciiUtils.cs
@@ -30,6 +30,14 @@ public static class AsciiUtils
         return (uint)(c - minInclusive) <= (uint)(maxInclusive - minInclusive);
     }
 
+    /// <summary>Indicates whether character is ASCII quote character.</summary>
+    /// <param name="c">The character to evaluate.</param>
+    /// <returns>true if <paramref name="c"/> is an ASCII quote character; otherwise, false.</returns>
+    public static bool IsQuoteChar(byte c)
+    {
+        return (c == '"') || (c == '\'');
+    }
+
     /// <summary>Indicates whether character is ASCII whitespace.</summary>
     /// <param name="c">The character to evaluate.</param>
     /// <returns>true if <paramref name="c"/> is an ASCII whitespace character; otherwise, false.</returns>

--- a/libs/common/AsciiUtils.cs
+++ b/libs/common/AsciiUtils.cs
@@ -30,6 +30,14 @@ public static class AsciiUtils
         return (uint)(c - minInclusive) <= (uint)(maxInclusive - minInclusive);
     }
 
+    /// <summary>Indicates whether character is ASCII whitespace.</summary>
+    /// <param name="c">The character to evaluate.</param>
+    /// <returns>true if <paramref name="c"/> is an ASCII whitespace character; otherwise, false.</returns>
+    public static bool IsWhiteSpace(byte c)
+    {
+        return (c == ' ') || (c == '\t') || (c == '\xA0');
+    }
+
     public static byte ToLower(byte c)
     {
         if (IsBetween(c, 'A', 'Z'))

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -1747,8 +1747,8 @@ namespace Garnet.server
         bool ParseGETAndKey(ref SpanByte key)
         {
             var oldEndReadHead = readHead = endReadHead;
-            var cmd = ParseCommand(writeErrorOnFailure: true, out var success);
-            if (!success || cmd != RespCommand.GET)
+            var cmd = ParseCommand(writeErrorOnFailure: true, out var commandReceived);
+            if (!commandReceived || cmd != RespCommand.GET)
             {
                 // If we either find no command or a different command, we back off
                 endReadHead = readHead = oldEndReadHead;

--- a/libs/server/Resp/CmdStrings.cs
+++ b/libs/server/Resp/CmdStrings.cs
@@ -197,6 +197,7 @@ namespace Garnet.server
         /// </summary>
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_UNK_CMD => "ERR unknown command"u8;
         public static ReadOnlySpan<byte> RESP_ERR_NOT_SUPPORTED_RESP2 => "ERR command not supported in RESP2"u8;
+        public static ReadOnlySpan<byte> RESP_ERR_UNBALANCED_QUOTES => "ERR Protocol error: unbalanced quotes in request"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_CLUSTER_DISABLED => "ERR This instance has cluster support disabled"u8;
         public static ReadOnlySpan<byte> RESP_ERR_LUA_DISABLED => "ERR This instance has Lua scripting support disabled"u8;
         public static ReadOnlySpan<byte> RESP_ERR_GENERIC_WRONG_ARGUMENTS => "ERR wrong number of arguments for 'config|set' command"u8;
@@ -410,7 +411,7 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> NO => "NO"u8;
 
         // Cluster subcommands which are internal and thus undocumented
-        // 
+        //
         // Because these are internal, they have lower case property names
         public static ReadOnlySpan<byte> gossip => "GOSSIP"u8;
         public static ReadOnlySpan<byte> myparentid => "MYPARENTID"u8;

--- a/libs/server/Resp/Parser/RespCommand.cs
+++ b/libs/server/Resp/Parser/RespCommand.cs
@@ -643,55 +643,6 @@ namespace Garnet.server
         private static readonly ushort crlf = MemoryMarshal.Read<ushort>("\r\n"u8);
 
         /// <summary>
-        /// Fast-parses command type for inline RESP commands, starting at the current read head in the receive buffer
-        /// and advances read head.
-        /// </summary>
-        /// <returns>RespCommand that was parsed or RespCommand.NONE, if no command was matched in this pass.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private RespCommand FastParseInlineCommand()
-        {
-            bool PeekAhead(int length)
-            {
-                // Optimistically advance read head to the end of the command name
-                readHead += length;
-
-                if (bytesRead - readHead >= 2)
-                {
-                    var ptr = recvBufferPtr + readHead;
-
-                    // Can be enabled if the fast path is taught to read command arguments.
-                    //if (AsciiUtils.IsWhiteSpace(*ptr))
-                        //return true;
-
-                    if (*(ushort*)ptr == crlf)
-                        return true;
-                }
-
-                // Reset optimistically changed state, if no matching command was found
-                readHead -= length;
-                return false;
-            }
-
-            if (bytesRead - readHead < 6)
-                return RespCommand.NONE;
-
-            var ptr = recvBufferPtr + readHead;
-            
-            if ((*(uint*)ptr) == MemoryMarshal.Read<uint>("PING"u8))
-            {
-                if (PeekAhead(4))
-                    return RespCommand.PING;
-            }
-            else if ((*(uint*)ptr) == MemoryMarshal.Read<uint>("QUIT"u8))
-            {
-                if (PeekAhead(4))
-                    return RespCommand.QUIT;
-            }
-
-            return RespCommand.NONE;
-        }
-
-        /// <summary>
         /// Fast-parses for command type, starting at the current read head in the receive buffer
         /// and advances the read head to the position after the parsed command.
         /// </summary>
@@ -800,15 +751,6 @@ namespace Garnet.server
 
                         return RespCommand.NONE;
                     }
-                }
-            }
-            else
-            {
-                var cmd = FastParseInlineCommand();
-                if (cmd != RespCommand.NONE)
-                {
-                    count = 0;
-                    return cmd;
                 }
             }
 
@@ -2616,29 +2558,6 @@ namespace Garnet.server
         }
 
         /// <summary>
-        /// Attempts to skip to the end of the line ("\r\n") under the current read head.
-        /// </summary>
-        /// <returns>True if string terminator was found and readHead and endReadHead was changed, otherwise false. </returns>
-        private bool AttemptSkipLine()
-        {
-            // We might have received an inline command package.Try to find the end of the line.
-            logger?.LogWarning("Received malformed input message. Trying to skip line.");
-
-            for (int stringEnd = readHead; stringEnd < bytesRead - 1; stringEnd++)
-            {
-                if (recvBufferPtr[stringEnd] == '\r' && recvBufferPtr[stringEnd + 1] == '\n')
-                {
-                    // Skip to the end of the string
-                    readHead = endReadHead = stringEnd + 2;
-                    return true;
-                }
-            }
-
-            // We received an incomplete string and require more input.
-            return false;
-        }
-
-        /// <summary>
         /// Try to parse a command out of a provided buffer.
         ///
         /// Useful for when we have a command to validate somewhere, but aren't actually running it.
@@ -2738,28 +2657,40 @@ namespace Garnet.server
         private RespCommand ParseCommand(bool writeErrorOnFailure, out bool commandReceived)
         {
             var cmd = RespCommand.INVALID;
-            bool inline = false;
 
             // Initialize count as -1 (i.e., read head has not been advanced)
             var count = -1;
             commandReceived = true;
             endReadHead = readHead;
 
-            // Attempt parsing using fast parse pass for most common operations
-            cmd = FastParseCommand(out count, recvBufferPtr + readHead, bytesRead - readHead);
-
-            // If we have not found a command, continue parsing on slow path
-            if (cmd == RespCommand.NONE)
-            {
-                cmd = ArrayParseCommand(writeErrorOnFailure, ref count, ref commandReceived, out inline);
-                if (!commandReceived) return cmd;
-            }
-
             var ptr = recvBufferPtr + readHead;
             var end = recvBufferPtr + bytesRead;
 
-            if (!inline)
+            // Attempt parsing using fast parse pass for most common operations
+            cmd = FastParseCommand(out count, ptr, bytesRead - readHead);
+
+            // See if input command is all upper-case. If not, convert and try fast parse pass again.
+            if ((cmd == RespCommand.NONE) && MakeUpperCase(ptr))
             {
+                cmd = FastParseCommand(out count, ptr, bytesRead - readHead);
+            }
+
+            // If we have not found a command, continue parsing on slow path
+            if ((cmd == RespCommand.NONE) &&
+                // Ensure we are attempting to read a RESP array header
+                (*ptr == '*'))
+            {
+                cmd = ArrayParseCommand(writeErrorOnFailure, ptr, end, out count, out commandReceived);
+                if (!commandReceived) return cmd;
+            }
+
+            if (cmd != RespCommand.NONE)
+            {
+                // Eureka!
+
+                // Set up read pointer past the command.
+                ptr = recvBufferPtr + readHead;
+
                 // Set up parse state
                 parseState.Initialize(count);
                 for (var i = 0; i < count; i++)
@@ -2770,11 +2701,48 @@ namespace Garnet.server
                         return RespCommand.INVALID;
                     }
                 }
-            }
-            endReadHead = (int)(ptr - recvBufferPtr);
-            if (readHead < endReadHead)
-                readHead = endReadHead;
 
+                readHead = (int)(ptr - recvBufferPtr);
+            }
+            else
+            {
+                // This may be an inline command string. We'll parse it and convert a part to a RESP command string,
+                // which is then parsed to get the command.
+                SpanByteAndMemory spam = new(null);
+                if (!ParseInlineCommandline(ref spam, writeErrorOnFailure, ref ptr, out commandReceived, out var nbytes, out var result))
+                {
+                    if (commandReceived)
+                        endReadHead = readHead;
+                    return RespCommand.INVALID;
+                }
+
+                // If we're here, commandReceived is true, and we've reached end-of-line.
+                endReadHead = readHead;
+
+                fixed (byte* nptr = spam.Memory.Memory.Span)
+                {
+                    var nend = nptr + nbytes;
+
+                    cmd = FastParseCommand(out count, nptr, nbytes);
+
+                    // Since we're operating on a temporary buffer and not the actual receive buffer,
+                    // we don't care for its commandReceived, and we reset readHead afterwards.
+                    if (cmd == RespCommand.NONE)
+                    {
+                        cmd = ArrayParseCommand(writeErrorOnFailure, nptr, nend, out count, out _,
+                                                result[0].ReadOnlySpan, result.Length > 1 ? result[1] : default);
+                    }
+                    readHead = endReadHead;
+
+                    if (cmd == RespCommand.INVALID)
+                        logger?.LogWarning("Received malformed input message. Line is skipped.");
+                }
+
+                // Note that arguments are initialized from the actual command string, and not our made-up RESP string.
+                parseState.InitializeWithArguments(result[(result.Length - count)..]);
+            }
+
+            endReadHead = readHead;
             if (storeWrapper.serverOptions.EnableAOF && storeWrapper.serverOptions.WaitForCommit)
                 HandleAofCommitMode(cmd);
 
@@ -2782,13 +2750,13 @@ namespace Garnet.server
         }
 
         private bool ParseInlineCommandline(ref SpanByteAndMemory spam,
-                                            bool writeErrorOnFailure, byte* ptr, out bool commandReceived,
-                                            out int nbytes, out int postArrayPosition, out ArgSlice[] result)
+                                            bool writeErrorOnFailure, ref byte* ptr, out bool commandReceived,
+                                            out int nbytes, out ArgSlice[] result)
         {
             using var writer = new RespMemoryWriter(respProtocolVersion, ref spam);
 
             nbytes = 0;
-            postArrayPosition = 0;
+            result = default;
 
             // Minimum processing length is 4. But a user can send shorter lines (e.g. in telnet),
             // and these get appended to next lines.
@@ -2800,6 +2768,18 @@ namespace Garnet.server
                 if (*(ushort*)tptr++ == crlf)
                 {
                     ptr = tptr + 1;
+
+                    if (bytesRead - i < MINIMUMPROCESSLENGTH)
+                    {
+                        commandReceived = true;
+                        readHead = i + 2;
+                        if (writeErrorOnFailure)
+                        {
+                            while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_GENERIC_UNK_CMD, ref dcurr, dend))
+                                SendAndReset();
+                        }
+                        return false;
+                    }
                     break;
                 }
             }
@@ -2833,13 +2813,12 @@ namespace Garnet.server
 
             // We'll parse the result by creating a RESP string to parse and then calling the regular code.
 
-            // Minumum estinate is both lengths + minimum header sizes + crlf.
-            nbytes = command.Length + subCommand.Length + 4 + 4 + 4 + 2;
+            // Minumum estimate is array header + length + command + crlf + length + subcommand + crlf
+            nbytes = 4 + 4 + command.Length + 2 + 4 + subCommand.Length + 2;
 
             writer.Realloc(nbytes);
             // We use the actual length because it may be read back later.
             writer.WriteArrayLength(result.Length);
-            postArrayPosition = writer.GetPosition();
 
             // The resp string is technically invalid since the length doesn't match the actual items.
             writer.WriteBulkString(command.ReadOnlySpan);
@@ -2953,103 +2932,33 @@ namespace Garnet.server
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private RespCommand ArrayParseCommand(bool writeErrorOnFailure, ref int count, ref bool commandReceived, out bool inline)
+        private RespCommand ArrayParseCommand(bool writeErrorOnFailure, byte* ptr, byte* end,
+                                              out int count, out bool commandReceived,
+                                              ReadOnlySpan<byte> command = default,
+                                              ArgSlice subCommand = default)
         {
             RespCommand cmd = RespCommand.INVALID;
             ReadOnlySpan<byte> specificErrorMessage = default;
-
-            inline = false;
+            commandReceived = true;
             endReadHead = readHead;
-            var ptr = recvBufferPtr + readHead;
 
-            // See if input command is all upper-case. If not, convert and try fast parse pass again.
-            if (MakeUpperCase(ptr))
+            var optr = ptr;
+            // Read the array length
+            if (!RespReadUtils.TryReadUnsignedArrayLength(out count, ref ptr, end))
             {
-                cmd = FastParseCommand(out count, ptr, bytesRead - readHead);
-                if (cmd != RespCommand.NONE)
-                {
-                    return cmd;
-                }
-            }
-
-            // Ensure we are attempting to read a RESP array header
-            if (*ptr == '*')
-            {
-                // Read the array length
-                if (!RespReadUtils.TryReadUnsignedArrayLength(out count, ref ptr, recvBufferPtr + bytesRead))
-                {
-                    commandReceived = false;
-                    return RespCommand.INVALID;
-                }
-
-                // Move readHead to start of command payload
-                readHead = (int)(ptr - recvBufferPtr);
-
-                // Try parsing the most important variable-length commands
-                cmd = FastParseArrayCommand(ref count, recvBufferPtr + readHead,
-                                            bytesRead - readHead, ref specificErrorMessage);
-
-                if (cmd == RespCommand.NONE)
-                {
-                    cmd = SlowParseCommand(ref count, ref specificErrorMessage, out commandReceived);
-                }
-            }
-            // Very likely an attempt to send a RESP command in parts. Or junk.
-            // Try to skip it.
-            else if (*ptr == '$')
-            {
-                commandReceived = AttemptSkipLine();
+                commandReceived = false;
                 return RespCommand.INVALID;
             }
-            else
+
+            // Move readHead to start of command payload
+            readHead += (int)(ptr - optr);
+
+            // Try parsing the most important variable-length commands
+            cmd = FastParseArrayCommand(ref count, ptr, (int)(end - ptr), ref specificErrorMessage);
+
+            if (cmd == RespCommand.NONE)
             {
-                inline = true;
-
-                SpanByteAndMemory spam = new(null);
-                if (!ParseInlineCommandline(ref spam, writeErrorOnFailure, ptr, out commandReceived, out var nbytes, out var postArrayPosition, out var result))
-                {
-                    return RespCommand.INVALID;
-                }
-
-                fixed (byte* nptr = spam.Memory.Memory.Span)
-                {
-                    var oldReadHead = readHead;
-
-                    // These functions are usually called in a different path with commandReceived == false.
-                    // To emulate how they're called, we typically need to reset count beforehand, and we need to
-                    // reset readHead afterwards because we're not operating on the 'real' buffer this time.
-                    cmd = FastParseCommand(out count, nptr, nbytes);
-                    readHead = oldReadHead;
-
-                    if (cmd == RespCommand.NONE)
-                    {
-                        // We can avoid the read array length step since we already know the length and position.
-                        count = result.Length;
-                        cmd = FastParseArrayCommand(ref count, nptr + postArrayPosition, nbytes, ref specificErrorMessage);
-                        readHead = oldReadHead;
-
-                        if (cmd == RespCommand.NONE)
-                        {
-                            var command = result[0].ReadOnlySpan;
-                            var subCommand = result.Length > 1 ? result[1] : default;
-
-                            // We use a slightly different method here where we just give the functions
-                            // the data they need instead of using the RESP string.
-                            count = result.Length;
-                            cmd = SlowParseCommand(ref count, ref specificErrorMessage, out commandReceived, command, subCommand);
-                        }
-                    }
-
-                    if ((cmd != RespCommand.NONE) && (cmd != RespCommand.INVALID))
-                    {
-                        // result[result.Length..] works and creates an empty parseState.
-                        parseState.InitializeWithArguments(result[(result.Length - count)..]);
-                    }
-                    else
-                    {
-                        logger?.LogWarning("Received malformed input message. Line is skipped.");
-                    }
-                }
+                cmd = SlowParseCommand(ref count, ref specificErrorMessage, out commandReceived, command, subCommand);
             }
 
             // Parsing for command name was successful, but the command is unknown

--- a/libs/server/Resp/Parser/RespCommand.cs
+++ b/libs/server/Resp/Parser/RespCommand.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Garnet.common;
 using Microsoft.Extensions.Logging;
+using Tsavorite.core;
 
 namespace Garnet.server
 {
@@ -695,13 +696,12 @@ namespace Garnet.server
         /// and advances the read head to the position after the parsed command.
         /// </summary>
         /// <param name="count">Outputs the number of arguments stored with the command</param>
+        /// <param name="ptr">The current read head to continue reading from</param>
+        /// <param name="remainingBytes">Bytes remaining in the read buffer</param>
         /// <returns>RespCommand that was parsed or RespCommand.NONE, if no command was matched in this pass.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private RespCommand FastParseCommand(out int count)
+        private RespCommand FastParseCommand(out int count, byte* ptr, int remainingBytes)
         {
-            var ptr = recvBufferPtr + readHead;
-            var remainingBytes = bytesRead - readHead;
-
             // Check if the package starts with "*_\r\n$_\r\n" (_ = masked out),
             // i.e. an array with a single-digit length and single-digit first string length.
             if ((remainingBytes >= 8) && (*(ulong*)ptr & 0xFFFF00FFFFFF00FF) == MemoryMarshal.Read<ulong>("*\0\r\n$\0\r\n"u8))
@@ -823,15 +823,13 @@ namespace Garnet.server
         /// the parsed command/subcommand name.
         /// </summary>
         /// <param name="count">Reference to the number of remaining tokens in the packet. Will be reduced to number of command arguments.</param>
+        /// <param name="ptr">The current read head to continue reading from</param>
+        /// <param name="remainingBytes">Bytes remaining in the read buffer</param>
+        /// <param name="specificErrorMessage"></param>
         /// <returns>The parsed command name.</returns>
-        private RespCommand FastParseArrayCommand(ref int count, ref ReadOnlySpan<byte> specificErrorMessage)
+        private RespCommand FastParseArrayCommand(ref int count, byte* ptr, int remainingBytes,
+                                                  ref ReadOnlySpan<byte> specificErrorMessage)
         {
-            // Bytes remaining in the read buffer
-            int remainingBytes = bytesRead - readHead;
-
-            // The current read head to continue reading from
-            byte* ptr = recvBufferPtr + readHead;
-
             //
             // Fast-path parsing by (1) command string length, (2) First character of command name (optional) and (3) priority (manual order)
             //
@@ -1793,14 +1791,22 @@ namespace Garnet.server
         /// <param name="specificErrorMsg">If the command could not be parsed, will be non-empty if a specific error message should be returned.</param>
         /// <param name="commandReceived">True if the input RESP string was completely included in the buffer, false if we couldn't read the full command name.</param>
         /// <returns>The parsed command name.</returns>
-        private RespCommand SlowParseCommand(ref int count, ref ReadOnlySpan<byte> specificErrorMsg, out bool commandReceived)
+        private RespCommand SlowParseCommand(ref int count, ref ReadOnlySpan<byte> specificErrorMsg, out bool commandReceived,
+                                             ReadOnlySpan<byte> command = default, ArgSlice subCommand = default)
         {
-            // Try to extract the current string from the front of the read head
-            var command = GetCommand(out commandReceived);
-
-            if (!commandReceived)
+            if (command.IsEmpty)
             {
-                return RespCommand.INVALID;
+                // Try to extract the current string from the front of the read head
+                command = GetCommand(out commandReceived);
+
+                if (!commandReceived)
+                {
+                    return RespCommand.INVALID;
+                }
+            }
+            else
+            {
+                commandReceived = true;
             }
 
             // Account for the command name being taken off the read head
@@ -1812,7 +1818,7 @@ namespace Garnet.server
             }
             else
             {
-                return SlowParseCommand(command, ref count, ref specificErrorMsg, out commandReceived);
+                return SlowParseCommand(command, ref count, ref specificErrorMsg, out commandReceived, subCommand);
             }
         }
 
@@ -1854,7 +1860,7 @@ namespace Garnet.server
                     return RespCommand.INVALID;
                 }
 
-                var subCommand = GetUpperCaseCommand(out var gotSubCommand);
+                var subCommand = GetSubCommand(out var gotSubCommand);
                 if (!gotSubCommand)
                 {
                     commandReceived = false;
@@ -2610,6 +2616,29 @@ namespace Garnet.server
         }
 
         /// <summary>
+        /// Attempts to skip to the end of the line ("\r\n") under the current read head.
+        /// </summary>
+        /// <returns>True if string terminator was found and readHead and endReadHead was changed, otherwise false. </returns>
+        private bool AttemptSkipLine()
+        {
+            // We might have received an inline command package.Try to find the end of the line.
+            logger?.LogWarning("Received malformed input message. Trying to skip line.");
+
+            for (int stringEnd = readHead; stringEnd < bytesRead - 1; stringEnd++)
+            {
+                if (recvBufferPtr[stringEnd] == '\r' && recvBufferPtr[stringEnd + 1] == '\n')
+                {
+                    // Skip to the end of the string
+                    readHead = endReadHead = stringEnd + 2;
+                    return true;
+                }
+            }
+
+            // We received an incomplete string and require more input.
+            return false;
+        }
+
+        /// <summary>
         /// Try to parse a command out of a provided buffer.
         ///
         /// Useful for when we have a command to validate somewhere, but aren't actually running it.
@@ -2717,7 +2746,7 @@ namespace Garnet.server
             endReadHead = readHead;
 
             // Attempt parsing using fast parse pass for most common operations
-            cmd = FastParseCommand(out count);
+            cmd = FastParseCommand(out count, recvBufferPtr + readHead, bytesRead - readHead);
 
             // If we have not found a command, continue parsing on slow path
             if (cmd == RespCommand.NONE)
@@ -2743,11 +2772,82 @@ namespace Garnet.server
                 }
             }
             endReadHead = (int)(ptr - recvBufferPtr);
+            if (readHead < endReadHead)
+                readHead = endReadHead;
 
             if (storeWrapper.serverOptions.EnableAOF && storeWrapper.serverOptions.WaitForCommit)
                 HandleAofCommitMode(cmd);
 
             return cmd;
+        }
+
+        private bool ParseInlineCommandline(ref SpanByteAndMemory spam,
+                                            bool writeErrorOnFailure, byte* ptr, out bool commandReceived,
+                                            out int nbytes, out int postArrayPosition, out ArgSlice[] result)
+        {
+            using var writer = new RespMemoryWriter(respProtocolVersion, ref spam);
+
+            nbytes = 0;
+            postArrayPosition = 0;
+
+            // Minimum processing length is 4. But a user can send shorter lines (e.g. in telnet),
+            // and these get appended to next lines.
+            // We priorize the normal processing, it's better to let inline parsing hack around it.
+            // We can exploit the fact that any such short command would be invalid to skip it.
+            var tptr = ptr;
+            for (var i = 0; i < MINIMUMPROCESSLENGTH - 1; ++i)
+            {
+                if (*(ushort*)tptr++ == crlf)
+                {
+                    ptr = tptr + 1;
+                    break;
+                }
+            }
+
+            // We might have received an inline command package. Try parsing it.
+            if (!TryParseInlineCommandArguments(writeErrorOnFailure, out commandReceived, out result,
+                                                ref ptr, recvBufferPtr + bytesRead) || (result.Length == 0))
+            {
+                // Move readHead to end of line in input package if we can
+                if (commandReceived)
+                {
+                    logger?.LogWarning("Received malformed input message. Line is skipped.");
+                    readHead = (int)(ptr - recvBufferPtr);
+                }
+                else
+                {
+                    logger?.LogWarning("Received malformed input message.");
+                }
+
+                // The second condition indicates line is CRLF.
+                return false;
+            }
+
+            // Move readHead to end of line in input package
+            // Note there's no situation where we're here and commandReceived is false.
+            readHead = (int)(ptr - recvBufferPtr);
+
+            // command matching only needs the first two elements.
+            var command = result[0];
+            var subCommand = result.Length > 1 ? result[1] : default;
+
+            // We'll parse the result by creating a RESP string to parse and then calling the regular code.
+
+            // Minumum estinate is both lengths + minimum header sizes + crlf.
+            nbytes = command.Length + subCommand.Length + 4 + 4 + 4 + 2;
+
+            writer.Realloc(nbytes);
+            // We use the actual length because it may be read back later.
+            writer.WriteArrayLength(result.Length);
+            postArrayPosition = writer.GetPosition();
+
+            // The resp string is technically invalid since the length doesn't match the actual items.
+            writer.WriteBulkString(command.ReadOnlySpan);
+            if (result.Length > 1)
+                writer.WriteBulkString(subCommand.ReadOnlySpan);
+
+            nbytes = writer.GetPosition();
+            return true;
         }
 
         private bool TryParseInlineCommandArguments(bool writeErrorOnFailure, out bool commandReceived,
@@ -2774,13 +2874,9 @@ namespace Garnet.server
 
                     // Advance past newline
                     ptr += 2;
-                    // Move readHead to end of line in input package
-                    readHead = (int)(ptr - recvBufferPtr);
 
                     if ((quoteChar != 0) || errorAtEnd)
                     {
-                        logger?.LogWarning("Received malformed input message. Line is skipped.");
-
                         if (writeErrorOnFailure)
                         {
                             while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_UNBALANCED_QUOTES, ref dcurr, dend))
@@ -2793,7 +2889,7 @@ namespace Garnet.server
                     return true;
                 }
 
-                if (*ptr == '"' || *ptr == '\'')
+                if (AsciiUtils.IsQuoteChar(*ptr))
                 {
                     if (quoteChar == 0)
                     {
@@ -2869,7 +2965,7 @@ namespace Garnet.server
             // See if input command is all upper-case. If not, convert and try fast parse pass again.
             if (MakeUpperCase(ptr))
             {
-                cmd = FastParseCommand(out count);
+                cmd = FastParseCommand(out count, ptr, bytesRead - readHead);
                 if (cmd != RespCommand.NONE)
                 {
                     return cmd;
@@ -2877,7 +2973,7 @@ namespace Garnet.server
             }
 
             // Ensure we are attempting to read a RESP array header
-            if (recvBufferPtr[readHead] == '*')
+            if (*ptr == '*')
             {
                 // Read the array length
                 if (!RespReadUtils.TryReadUnsignedArrayLength(out count, ref ptr, recvBufferPtr + bytesRead))
@@ -2890,62 +2986,69 @@ namespace Garnet.server
                 readHead = (int)(ptr - recvBufferPtr);
 
                 // Try parsing the most important variable-length commands
-                cmd = FastParseArrayCommand(ref count, ref specificErrorMessage);
+                cmd = FastParseArrayCommand(ref count, recvBufferPtr + readHead,
+                                            bytesRead - readHead, ref specificErrorMessage);
 
                 if (cmd == RespCommand.NONE)
                 {
                     cmd = SlowParseCommand(ref count, ref specificErrorMessage, out commandReceived);
                 }
             }
+            // Very likely an attempt to send a RESP command in parts. Or junk.
+            // Try to skip it.
+            else if (*ptr == '$')
+            {
+                commandReceived = AttemptSkipLine();
+                return RespCommand.INVALID;
+            }
             else
             {
                 inline = true;
 
-                // Minimum processing length is 4. But a user can send shorter lines (e.g. in telnet),
-                // and these get appended to next lines.
-                // We priorize the normal processing, it's better to let inline parsing hack around it.
-                // We can exploit the fact that any such short command would be invalid to skip it.
-                var tptr = ptr;
-                for (var i = 0; i < MINIMUMPROCESSLENGTH - 1; ++i)
+                SpanByteAndMemory spam = new(null);
+                if (!ParseInlineCommandline(ref spam, writeErrorOnFailure, ptr, out commandReceived, out var nbytes, out var postArrayPosition, out var result))
                 {
-                    if (*(ushort *)tptr++ == crlf)
-                    {
-                        ptr = tptr + 1;
-                        break;
-                    }
-                }
-
-                // We might have received an inline command package. Try parsing it.
-                if (!TryParseInlineCommandArguments(writeErrorOnFailure, out commandReceived, out var result,
-                                                    ref ptr, recvBufferPtr + bytesRead) || (result.Length == 0))
-                {
-                    // The second condition indicates line is CRLF.
                     return RespCommand.INVALID;
                 }
 
-                count = result.Length - 1;
-                var origCount = count;
-                var command = result[0].ReadOnlySpan;
-                
-                ArgSlice subCommand = default;
-                if (result.Length > 1)
+                fixed (byte* nptr = spam.Memory.Memory.Span)
                 {
-                    subCommand = result[1];
-                }
+                    var oldReadHead = readHead;
 
-                if (!TryParseCustomCommand(command, out cmd))
-                {
-                    cmd = SlowParseCommand(command, ref count, ref specificErrorMessage, out commandReceived, subCommand);
-                }
+                    // These functions are usually called in a different path with commandReceived == false.
+                    // To emulate how they're called, we typically need to reset count beforehand, and we need to
+                    // reset readHead afterwards because we're not operating on the 'real' buffer this time.
+                    cmd = FastParseCommand(out count, nptr, nbytes);
+                    readHead = oldReadHead;
 
-                if (cmd != RespCommand.INVALID)
-                {
-                    // result[result.Length..] works and creates an empty parseState.
-                    parseState.InitializeWithArguments(result[(origCount - count + 1)..]);
-                }
-                else
-                {
-                    logger?.LogWarning("Received malformed input message. Line is skipped.");
+                    if (cmd == RespCommand.NONE)
+                    {
+                        // We can avoid the read array length step since we already know the length and position.
+                        count = result.Length;
+                        cmd = FastParseArrayCommand(ref count, nptr + postArrayPosition, nbytes, ref specificErrorMessage);
+                        readHead = oldReadHead;
+
+                        if (cmd == RespCommand.NONE)
+                        {
+                            var command = result[0].ReadOnlySpan;
+                            var subCommand = result.Length > 1 ? result[1] : default;
+
+                            // We use a slightly different method here where we just give the functions
+                            // the data they need instead of using the RESP string.
+                            count = result.Length;
+                            cmd = SlowParseCommand(ref count, ref specificErrorMessage, out commandReceived, command, subCommand);
+                        }
+                    }
+
+                    if ((cmd != RespCommand.NONE) && (cmd != RespCommand.INVALID))
+                    {
+                        // result[result.Length..] works and creates an empty parseState.
+                        parseState.InitializeWithArguments(result[(result.Length - count)..]);
+                    }
+                    else
+                    {
+                        logger?.LogWarning("Received malformed input message. Line is skipped.");
+                    }
                 }
             }
 

--- a/libs/server/Resp/Parser/RespCommand.cs
+++ b/libs/server/Resp/Parser/RespCommand.cs
@@ -2832,13 +2832,117 @@ namespace Garnet.server
         private bool TryParseInlineCommandArguments(bool writeErrorOnFailure, out bool commandReceived,
                                                     out ArgSlice[] result, ref byte* ptr, byte* end)
         {
+            // The inline format is defined beyond
+            // "space-separated arguments in a telnet session" and
+            // "no command starts with * (the identifying byte of RESP Arrays)".
+            // This implementation tries to match what go on in practice.
+
+            // Takes a string verified to be 'balanced' and removes unnecessary quotes.
+            static ArgSlice[] Unquote(System.Collections.Generic.List<ArgSlice> input)
+            {
+                var output = new ArgSlice[input.Count];
+
+                var i = 0;
+                foreach (var slice in input)
+                {
+                    // How this works:
+                    // Every quote reduces endpos.
+                    // When we're in a quoting zone, we place the first non-quote character and set in its position a sentinel.
+                    // Eventually, all the sentinels are shunted to the end, and the string is 0-endpos.
+                    //
+                    // start, startPos is an additional optimization to allow skipping over starting quotes.
+                    byte quoteChar = 0;
+                    var start = true;
+                    var startPos = 0;
+                    var endPos = slice.Span.Length;
+
+                    for (var j = 0; j < slice.Span.Length; ++j)
+                    {
+                        var c = slice.Span[j];
+
+                        if (quoteChar == 0)
+                        {
+                            if (!AsciiUtils.IsQuoteChar(c))
+                            {
+                                start = false;
+                                continue;
+                            }
+
+                            // The string is known to be balanced, we know there's another quote to match.
+                            endPos -= 2;
+                            quoteChar = c;
+                            if (start)
+                            {
+                                startPos++;
+                                continue;
+                            }
+                        }
+                        else if (quoteChar == c)
+                        {
+                            quoteChar = 0;
+
+                            if (start)
+                            {
+                                if (startPos == j)
+                                {
+                                    // Without this condition we would accept strings like
+                                    // """"""""PING.
+                                    if (j < slice.Span.Length - 1)
+                                        return default;
+
+                                    startPos++;
+                                    continue;
+                                }
+
+                                start = false;
+                            }
+                        }
+
+                        if (start)
+                            continue;
+
+                        int k;
+                        for (k = j + 1; k < slice.Span.Length; ++k)
+                        {
+                            var d = slice.Span[k];
+
+                            if (d == 0)
+                                // Enabling this would enable strings like PI""""""NG to be accepted.
+                                //continue;
+                                return default;
+
+                            if (((quoteChar != 0) && (d != quoteChar)) ||
+                                ((quoteChar == 0) && !AsciiUtils.IsQuoteChar(d)))
+                            {
+                                slice.Span[j] = d;
+                                slice.Span[k] = 0;
+                                break;
+                            }
+                        }
+
+                        // If we got here the entire string was shuffeled to the start.
+                        // We would only need to adjust endpos, which could be done by simply
+                        // letting the loop run to the end.
+                        // Commenting this block out would allow accepting PING"""".
+                        if ((k == slice.Span.Length) && (endPos + startPos > j))
+                        {
+                            return default;
+                        }
+                    }
+
+                    output[i++] = new ArgSlice(slice.ptr + startPos, endPos);
+                }
+
+                return output;
+            }
+
             result = default;
             commandReceived = false;
 
             var slices = new System.Collections.Generic.List<ArgSlice>();
             var slicePtr = ptr;
             var anyContents = false;
-            var errorAtEnd = false;
+            var anyQuote = false;
             byte quoteChar = 0;
 
             while (ptr + 1 <= end)
@@ -2854,7 +2958,7 @@ namespace Garnet.server
                     // Advance past newline
                     ptr += 2;
 
-                    if ((quoteChar != 0) || errorAtEnd)
+                    if (quoteChar != 0)
                     {
                         if (writeErrorOnFailure)
                         {
@@ -2864,31 +2968,33 @@ namespace Garnet.server
                         return false;
                     }
 
-                    result = [.. slices];
+                    if (anyQuote)
+                        result = Unquote(slices);
+                    else
+                        result = [.. slices];
+                    if (result == default)
+                    {
+                        if (writeErrorOnFailure)
+                        {
+                            while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_UNBALANCED_QUOTES, ref dcurr, dend))
+                                SendAndReset();
+                        }
+                        return false;
+                    }
                     return true;
                 }
 
                 if (AsciiUtils.IsQuoteChar(*ptr))
                 {
+                    anyQuote = true;
                     if (quoteChar == 0)
                     {
                         quoteChar = *ptr;
-
-                        if (anyContents)
-                            // If we didn't use pointers but instead copied the output,
-                            // we could ignore the quote character like the references (mostly) do in this case.
-                            // Since we don't do that currently, we'll output an error later as to not confuse the user.
-                            errorAtEnd = true;
-                        else
-                            slicePtr = ptr + 1;
-                        // We do not ignore consecutive quotes.
                         anyContents = true;
                     }
                     else if (quoteChar == *ptr)
                     {
                         quoteChar = 0;
-                        slices.Add(new ArgSlice(slicePtr, (int)(ptr - slicePtr)));
-                        anyContents = false;
                     }
                 }
                 else if ((quoteChar == 0) && AsciiUtils.IsWhiteSpace(*ptr))

--- a/libs/server/Resp/Parser/RespCommand.cs
+++ b/libs/server/Resp/Parser/RespCommand.cs
@@ -2753,8 +2753,6 @@ namespace Garnet.server
                                             bool writeErrorOnFailure, ref byte* ptr, out bool commandReceived,
                                             out int nbytes, out ArgSlice[] result)
         {
-            using var writer = new RespMemoryWriter(respProtocolVersion, ref spam);
-
             nbytes = 0;
             result = default;
 
@@ -2786,17 +2784,19 @@ namespace Garnet.server
 
             // We might have received an inline command package. Try parsing it.
             if (!TryParseInlineCommandArguments(writeErrorOnFailure, out commandReceived, out result,
-                                                ref ptr, recvBufferPtr + bytesRead) || (result.Length == 0))
+                                                ref ptr, recvBufferPtr + bytesRead, out var error) || (result.Length == 0))
             {
+                if (!error.IsEmpty)
+                {
+                    while (!RespWriteUtils.TryWriteError(error, ref dcurr, dend))
+                        SendAndReset();
+                }
+
                 // Move readHead to end of line in input package if we can
                 if (commandReceived)
                 {
                     logger?.LogWarning("Received malformed input message. Line is skipped.");
                     readHead = (int)(ptr - recvBufferPtr);
-                }
-                else
-                {
-                    logger?.LogWarning("Received malformed input message.");
                 }
 
                 // The second condition indicates line is CRLF.
@@ -2816,6 +2816,8 @@ namespace Garnet.server
             // Minumum estimate is array header + length + command + crlf + length + subcommand + crlf
             nbytes = 4 + 4 + command.Length + 2 + 4 + subCommand.Length + 2;
 
+            using var writer = new RespMemoryWriter(respProtocolVersion, ref spam);
+
             writer.Realloc(nbytes);
             // We use the actual length because it may be read back later.
             writer.WriteArrayLength(result.Length);
@@ -2829,113 +2831,46 @@ namespace Garnet.server
             return true;
         }
 
-        private bool TryParseInlineCommandArguments(bool writeErrorOnFailure, out bool commandReceived,
-                                                    out ArgSlice[] result, ref byte* ptr, byte* end)
+        private static bool TryParseInlineCommandArguments(bool writeErrorOnFailure, out bool commandReceived,
+                                                           out ArgSlice[] result, ref byte* ptr, byte* end,
+                                                           out ReadOnlySpan<byte> error)
         {
-            // The inline format is defined beyond
+            // The inline format is not defined beyond:
             // "space-separated arguments in a telnet session" and
             // "no command starts with * (the identifying byte of RESP Arrays)".
-            // This implementation tries to match what go on in practice.
+            //
+            // Different reference versions do it differently, newer ones use quoting but without defining it anywhere.
+            // The behaviour implemented here is a slight superset of observed reference behaviour.
+            //
+            // We'll use consistent rules:
+            // A character or group of characters under the same rules is a sequence.
+            // There are four types of sequences: quoting, separators, escapes, or normal.
+            // There are two types of contexts: a quote context or a normal context.
+            // Quote contexts allow escaping depending on their starting character.
+            //
+            // Separators separate different arguments.
+            // Separators are start of line (implied), the crlf at end of line, and the characters: space, tab and no-break space,
+            // all when they are in a normal context.
+            // In a quote context the same seqeunces are considered normal.
+            //
+            // Quote characters are ' or ".
+            //
+            // A quoting context starts with a quote character.
+            // A quoting context ends with the same quote character that followed by a separator,
+            // unless the quote character is escaped (see below).
+            // [References seem to not have the 'followed by a separator' rule, but just error out]
+            // 
+            // A quote character not starting or ending a quote context is considered a normal character.
+            //
+            // The character \ inside a quote context starts an escape sequence.
+            // In quote contexts starting with " character, the escape sequence is the typical C escapes.
+            // Other characters are escaped to themselves. All resulting escaped characters are considered normal characters.
+            // In quote contexts starting with ' character, the only allowed escape is \' -> '.
+            //
+            // Normal sequences (or sequences considered such) are echoed to the output, everything else is not echoed.
+            // 
 
-            // Takes a string verified to be 'balanced' and removes unnecessary quotes.
-            static ArgSlice[] Unquote(System.Collections.Generic.List<ArgSlice> input)
-            {
-                var output = new ArgSlice[input.Count];
-
-                var i = 0;
-                foreach (var slice in input)
-                {
-                    // How this works:
-                    // Every quote reduces endpos.
-                    // When we're in a quoting zone, we place the first non-quote character and set in its position a sentinel.
-                    // Eventually, all the sentinels are shunted to the end, and the string is 0-endpos.
-                    //
-                    // start, startPos is an additional optimization to allow skipping over starting quotes.
-                    byte quoteChar = 0;
-                    var start = true;
-                    var startPos = 0;
-                    var endPos = slice.Span.Length;
-
-                    for (var j = 0; j < slice.Span.Length; ++j)
-                    {
-                        var c = slice.Span[j];
-
-                        if (quoteChar == 0)
-                        {
-                            if (!AsciiUtils.IsQuoteChar(c))
-                            {
-                                start = false;
-                                continue;
-                            }
-
-                            // The string is known to be balanced, we know there's another quote to match.
-                            endPos -= 2;
-                            quoteChar = c;
-                            if (start)
-                            {
-                                startPos++;
-                                continue;
-                            }
-                        }
-                        else if (quoteChar == c)
-                        {
-                            quoteChar = 0;
-
-                            if (start)
-                            {
-                                if (startPos == j)
-                                {
-                                    // Without this condition we would accept strings like
-                                    // """"""""PING.
-                                    if (j < slice.Span.Length - 1)
-                                        return default;
-
-                                    startPos++;
-                                    continue;
-                                }
-
-                                start = false;
-                            }
-                        }
-
-                        if (start)
-                            continue;
-
-                        int k;
-                        for (k = j + 1; k < slice.Span.Length; ++k)
-                        {
-                            var d = slice.Span[k];
-
-                            if (d == 0)
-                                // Enabling this would enable strings like PI""""""NG to be accepted.
-                                //continue;
-                                return default;
-
-                            if (((quoteChar != 0) && (d != quoteChar)) ||
-                                ((quoteChar == 0) && !AsciiUtils.IsQuoteChar(d)))
-                            {
-                                slice.Span[j] = d;
-                                slice.Span[k] = 0;
-                                break;
-                            }
-                        }
-
-                        // If we got here the entire string was shuffeled to the start.
-                        // We would only need to adjust endpos, which could be done by simply
-                        // letting the loop run to the end.
-                        // Commenting this block out would allow accepting PING"""".
-                        if ((k == slice.Span.Length) && (endPos + startPos > j))
-                        {
-                            return default;
-                        }
-                    }
-
-                    output[i++] = new ArgSlice(slice.ptr + startPos, endPos);
-                }
-
-                return output;
-            }
-
+            error = default;
             result = default;
             commandReceived = false;
 
@@ -2962,39 +2897,62 @@ namespace Garnet.server
                     {
                         if (writeErrorOnFailure)
                         {
-                            while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_UNBALANCED_QUOTES, ref dcurr, dend))
-                                SendAndReset();
+                            error = CmdStrings.RESP_ERR_UNBALANCED_QUOTES;
                         }
                         return false;
                     }
 
                     if (anyQuote)
-                        result = Unquote(slices);
-                    else
-                        result = [.. slices];
-                    if (result == default)
                     {
-                        if (writeErrorOnFailure)
+                        result = new ArgSlice[slices.Count];
+
+                        var i = 0;
+                        foreach (var slice in slices)
                         {
-                            while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_UNBALANCED_QUOTES, ref dcurr, dend))
-                                SendAndReset();
+                            result[i++] = ArgSliceUtils.Unescape(slice);
                         }
-                        return false;
                     }
+                    // If there are no quotes, we can be faster
+                    else
+                    {
+                        result = [.. slices];
+                    }
+
                     return true;
                 }
 
                 if (AsciiUtils.IsQuoteChar(*ptr))
                 {
-                    anyQuote = true;
                     if (quoteChar == 0)
                     {
                         quoteChar = *ptr;
                         anyContents = true;
+                        anyQuote = true;
                     }
                     else if (quoteChar == *ptr)
                     {
-                        quoteChar = 0;
+                        var next = ptr + 1;
+                        if (AsciiUtils.IsWhiteSpace(*next) || ((next < end) && (*(ushort*)next == crlf)))
+                        {
+                            bool unQuote;
+
+                            if (quoteChar == '"')
+                            {
+                                unQuote = true;
+
+                                for (var index = ptr - 1; *index == '\\' && index >= slicePtr; --index)
+                                {
+                                    unQuote = !unQuote;
+                                }
+                            }
+                            else
+                            {
+                                unQuote = *(ptr - 1) != '\\';
+                            }
+
+                            if (unQuote)
+                                quoteChar = 0;
+                        }
                     }
                 }
                 else if ((quoteChar == 0) && AsciiUtils.IsWhiteSpace(*ptr))

--- a/libs/server/Resp/Parser/RespCommand.cs
+++ b/libs/server/Resp/Parser/RespCommand.cs
@@ -639,38 +639,52 @@ namespace Garnet.server
     /// </summary>
     internal sealed unsafe partial class RespServerSession : ServerSessionBase
     {
+        private static readonly ushort crlf = MemoryMarshal.Read<ushort>("\r\n"u8);
+
         /// <summary>
         /// Fast-parses command type for inline RESP commands, starting at the current read head in the receive buffer
         /// and advances read head.
         /// </summary>
-        /// <param name="count">Outputs the number of arguments stored with the command.</param>
         /// <returns>RespCommand that was parsed or RespCommand.NONE, if no command was matched in this pass.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private RespCommand FastParseInlineCommand(out int count)
+        private RespCommand FastParseInlineCommand()
         {
-            byte* ptr = recvBufferPtr + readHead;
-            count = 0;
-
-            if (bytesRead - readHead >= 6)
+            bool PeekAhead(int length)
             {
-                if ((*(ushort*)(ptr + 4) == MemoryMarshal.Read<ushort>("\r\n"u8)))
+                // Optimistically advance read head to the end of the command name
+                readHead += length;
+
+                if (bytesRead - readHead >= 2)
                 {
-                    // Optimistically increase read head
-                    readHead += 6;
+                    var ptr = recvBufferPtr + readHead;
 
-                    if ((*(uint*)ptr) == MemoryMarshal.Read<uint>("PING"u8))
-                    {
-                        return RespCommand.PING;
-                    }
+                    // Can be enabled if the fast path is taught to read command arguments.
+                    //if (AsciiUtils.IsWhiteSpace(*ptr))
+                        //return true;
 
-                    if ((*(uint*)ptr) == MemoryMarshal.Read<uint>("QUIT"u8))
-                    {
-                        return RespCommand.QUIT;
-                    }
-
-                    // Decrease read head, if no match was found
-                    readHead -= 6;
+                    if (*(ushort*)ptr == crlf)
+                        return true;
                 }
+
+                // Reset optimistically changed state, if no matching command was found
+                readHead -= length;
+                return false;
+            }
+
+            if (bytesRead - readHead < 6)
+                return RespCommand.NONE;
+
+            var ptr = recvBufferPtr + readHead;
+            
+            if ((*(uint*)ptr) == MemoryMarshal.Read<uint>("PING"u8))
+            {
+                if (PeekAhead(4))
+                    return RespCommand.PING;
+            }
+            else if ((*(uint*)ptr) == MemoryMarshal.Read<uint>("QUIT"u8))
+            {
+                if (PeekAhead(4))
+                    return RespCommand.QUIT;
             }
 
             return RespCommand.NONE;
@@ -790,7 +804,12 @@ namespace Garnet.server
             }
             else
             {
-                return FastParseInlineCommand(out count);
+                var cmd = FastParseInlineCommand();
+                if (cmd != RespCommand.NONE)
+                {
+                    count = 0;
+                    return cmd;
+                }
             }
 
             // Couldn't find a matching command in this pass
@@ -1443,47 +1462,47 @@ namespace Garnet.server
                                 }
                                 break;
                             case 8:
-                                if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("ZREVRANK"u8) && *(ushort*)(ptr + 12) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("ZREVRANK"u8) && *(ushort*)(ptr + 12) == crlf)
                                 {
                                     return RespCommand.ZREVRANK;
                                 }
-                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("SMEMBERS"u8) && *(ushort*)(ptr + 12) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("SMEMBERS"u8) && *(ushort*)(ptr + 12) == crlf)
                                 {
                                     return RespCommand.SMEMBERS;
                                 }
-                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("BITFIELD"u8) && *(ushort*)(ptr + 12) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("BITFIELD"u8) && *(ushort*)(ptr + 12) == crlf)
                                 {
                                     return RespCommand.BITFIELD;
                                 }
-                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("EXPIREAT"u8) && *(ushort*)(ptr + 12) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("EXPIREAT"u8) && *(ushort*)(ptr + 12) == crlf)
                                 {
                                     return RespCommand.EXPIREAT;
                                 }
-                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("HPEXPIRE"u8) && *(ushort*)(ptr + 12) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("HPEXPIRE"u8) && *(ushort*)(ptr + 12) == crlf)
                                 {
                                     return RespCommand.HPEXPIRE;
                                 }
-                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("HPERSIST"u8) && *(ushort*)(ptr + 12) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("HPERSIST"u8) && *(ushort*)(ptr + 12) == crlf)
                                 {
                                     return RespCommand.HPERSIST;
                                 }
-                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("ZPEXPIRE"u8) && *(ushort*)(ptr + 12) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("ZPEXPIRE"u8) && *(ushort*)(ptr + 12) == crlf)
                                 {
                                     return RespCommand.ZPEXPIRE;
                                 }
-                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("ZPERSIST"u8) && *(ushort*)(ptr + 12) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("ZPERSIST"u8) && *(ushort*)(ptr + 12) == crlf)
                                 {
                                     return RespCommand.ZPERSIST;
                                 }
-                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("BZPOPMAX"u8) && *(ushort*)(ptr + 12) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("BZPOPMAX"u8) && *(ushort*)(ptr + 12) == crlf)
                                 {
                                     return RespCommand.BZPOPMAX;
                                 }
-                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("BZPOPMIN"u8) && *(ushort*)(ptr + 12) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("BZPOPMIN"u8) && *(ushort*)(ptr + 12) == crlf)
                                 {
                                     return RespCommand.BZPOPMIN;
                                 }
-                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("SPUBLISH"u8) && *(ushort*)(ptr + 12) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("SPUBLISH"u8) && *(ushort*)(ptr + 12) == crlf)
                                 {
                                     return RespCommand.SPUBLISH;
                                 }
@@ -1690,22 +1709,22 @@ namespace Garnet.server
                                 break;
 
                             case 14:
-                                if (*(ulong*)(ptr + 3) == MemoryMarshal.Read<ulong>("\r\nZREMRA"u8) && *(ulong*)(ptr + 11) == MemoryMarshal.Read<ulong>("NGEBYLEX"u8) && *(ushort*)(ptr + 19) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                if (*(ulong*)(ptr + 3) == MemoryMarshal.Read<ulong>("\r\nZREMRA"u8) && *(ulong*)(ptr + 11) == MemoryMarshal.Read<ulong>("NGEBYLEX"u8) && *(ushort*)(ptr + 19) == crlf)
                                 {
                                     return RespCommand.ZREMRANGEBYLEX;
                                 }
-                                else if (*(ulong*)(ptr + 3) == MemoryMarshal.Read<ulong>("\r\nGEOSEA"u8) && *(ulong*)(ptr + 11) == MemoryMarshal.Read<ulong>("RCHSTORE"u8) && *(ushort*)(ptr + 19) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                else if (*(ulong*)(ptr + 3) == MemoryMarshal.Read<ulong>("\r\nGEOSEA"u8) && *(ulong*)(ptr + 11) == MemoryMarshal.Read<ulong>("RCHSTORE"u8) && *(ushort*)(ptr + 19) == crlf)
                                 {
                                     return RespCommand.GEOSEARCHSTORE;
                                 }
-                                else if (*(ulong*)(ptr + 3) == MemoryMarshal.Read<ulong>("\r\nZREVRA"u8) && *(ulong*)(ptr + 11) == MemoryMarshal.Read<ulong>("NGEBYLEX"u8) && *(ushort*)(ptr + 19) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                else if (*(ulong*)(ptr + 3) == MemoryMarshal.Read<ulong>("\r\nZREVRA"u8) && *(ulong*)(ptr + 11) == MemoryMarshal.Read<ulong>("NGEBYLEX"u8) && *(ushort*)(ptr + 19) == crlf)
                                 {
                                     return RespCommand.ZREVRANGEBYLEX;
                                 }
                                 break;
 
                             case 15:
-                                if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("\nZREMRAN"u8) && *(ulong*)(ptr + 12) == MemoryMarshal.Read<ulong>("GEBYRANK"u8) && *(ushort*)(ptr + 20) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("\nZREMRAN"u8) && *(ulong*)(ptr + 12) == MemoryMarshal.Read<ulong>("GEBYRANK"u8) && *(ushort*)(ptr + 20) == crlf)
                                 {
                                     return RespCommand.ZREMRANGEBYRANK;
                                 }
@@ -1767,19 +1786,19 @@ namespace Garnet.server
         /// <summary>
         /// Parses the receive buffer, starting from the current read head, for all command names that are
         /// not covered by FastParseArrayCommand() and advances the read head to the end of the command name.
-        /// 
+        ///
         /// NOTE: Assumes the input command names have already been converted to upper-case.
         /// </summary>
         /// <param name="count">Reference to the number of remaining tokens in the packet. Will be reduced to number of command arguments.</param>
         /// <param name="specificErrorMsg">If the command could not be parsed, will be non-empty if a specific error message should be returned.</param>
-        /// <param name="success">True if the input RESP string was completely included in the buffer, false if we couldn't read the full command name.</param>
+        /// <param name="commandReceived">True if the input RESP string was completely included in the buffer, false if we couldn't read the full command name.</param>
         /// <returns>The parsed command name.</returns>
-        private RespCommand SlowParseCommand(ref int count, ref ReadOnlySpan<byte> specificErrorMsg, out bool success)
+        private RespCommand SlowParseCommand(ref int count, ref ReadOnlySpan<byte> specificErrorMsg, out bool commandReceived)
         {
             // Try to extract the current string from the front of the read head
-            var command = GetCommand(out success);
+            var command = GetCommand(out commandReceived);
 
-            if (!success)
+            if (!commandReceived)
             {
                 return RespCommand.INVALID;
             }
@@ -1793,13 +1812,27 @@ namespace Garnet.server
             }
             else
             {
-                return SlowParseCommand(command, ref count, ref specificErrorMsg, out success);
+                return SlowParseCommand(command, ref count, ref specificErrorMsg, out commandReceived);
             }
         }
 
-        private RespCommand SlowParseCommand(ReadOnlySpan<byte> command, ref int count, ref ReadOnlySpan<byte> specificErrorMsg, out bool success)
+        private RespCommand SlowParseCommand(ReadOnlySpan<byte> command, ref int count, 
+                                             ref ReadOnlySpan<byte> specificErrorMsg, out bool commandReceived,
+                                             ArgSlice inlineSubCommand = default)
         {
-            success = true;
+            ReadOnlySpan<byte> GetSubCommand(out bool gotSubCommand)
+            {
+                if (inlineSubCommand.length == 0)
+                {
+                    return GetUpperCaseCommand(out gotSubCommand);
+                }
+
+                gotSubCommand = true;
+                AsciiUtils.ToUpperInPlace(inlineSubCommand.Span);
+                return inlineSubCommand.ReadOnlySpan;
+            }
+
+            commandReceived = true;
             if (command.SequenceEqual(CmdStrings.SUBSCRIBE))
             {
                 return RespCommand.SUBSCRIBE;
@@ -1824,7 +1857,7 @@ namespace Garnet.server
                 var subCommand = GetUpperCaseCommand(out var gotSubCommand);
                 if (!gotSubCommand)
                 {
-                    success = false;
+                    commandReceived = false;
                     return RespCommand.NONE;
                 }
 
@@ -1888,10 +1921,10 @@ namespace Garnet.server
                     return RespCommand.INVALID;
                 }
 
-                var subCommand = GetUpperCaseCommand(out var gotSubCommand);
+                var subCommand = GetSubCommand(out var gotSubCommand);
                 if (!gotSubCommand)
                 {
-                    success = false;
+                    commandReceived = false;
                     return RespCommand.NONE;
                 }
 
@@ -1925,10 +1958,10 @@ namespace Garnet.server
                     return RespCommand.INVALID;
                 }
 
-                var subCommand = GetUpperCaseCommand(out var gotSubCommand);
+                var subCommand = GetSubCommand(out var gotSubCommand);
                 if (!gotSubCommand)
                 {
-                    success = false;
+                    commandReceived = false;
                     return RespCommand.NONE;
                 }
 
@@ -1992,10 +2025,10 @@ namespace Garnet.server
                     return RespCommand.COMMAND;
                 }
 
-                var subCommand = GetUpperCaseCommand(out var gotSubCommand);
+                var subCommand = GetSubCommand(out var gotSubCommand);
                 if (!gotSubCommand)
                 {
-                    success = false;
+                    commandReceived = false;
                     return RespCommand.NONE;
                 }
 
@@ -2049,10 +2082,10 @@ namespace Garnet.server
                     return RespCommand.INVALID;
                 }
 
-                var subCommand = GetUpperCaseCommand(out var gotSubCommand);
+                var subCommand = GetSubCommand(out var gotSubCommand);
                 if (!gotSubCommand)
                 {
-                    success = false;
+                    commandReceived = false;
                     return RespCommand.NONE;
                 }
 
@@ -2254,10 +2287,10 @@ namespace Garnet.server
                     return RespCommand.INVALID;
                 }
 
-                var subCommand = GetUpperCaseCommand(out var gotSubCommand);
+                var subCommand = GetSubCommand(out var gotSubCommand);
                 if (!gotSubCommand)
                 {
-                    success = false;
+                    commandReceived = false;
                     return RespCommand.NONE;
                 }
 
@@ -2291,10 +2324,10 @@ namespace Garnet.server
                 }
                 else if (count >= 1)
                 {
-                    var subCommand = GetUpperCaseCommand(out var gotSubCommand);
+                    var subCommand = GetSubCommand(out var gotSubCommand);
                     if (!gotSubCommand)
                     {
-                        success = false;
+                        commandReceived = false;
                         return RespCommand.NONE;
                     }
 
@@ -2379,10 +2412,10 @@ namespace Garnet.server
                     return RespCommand.INVALID;
                 }
 
-                var subCommand = GetUpperCaseCommand(out var gotSubCommand);
+                var subCommand = GetSubCommand(out var gotSubCommand);
                 if (!gotSubCommand)
                 {
-                    success = false;
+                    commandReceived = false;
                     return RespCommand.NONE;
                 }
 
@@ -2412,10 +2445,10 @@ namespace Garnet.server
                     return RespCommand.INVALID;
                 }
 
-                var subCommand = GetUpperCaseCommand(out var gotSubCommand);
+                var subCommand = GetSubCommand(out var gotSubCommand);
                 if (!gotSubCommand)
                 {
-                    success = false;
+                    commandReceived = false;
                     return RespCommand.NONE;
                 }
 
@@ -2481,10 +2514,10 @@ namespace Garnet.server
                     return RespCommand.INVALID;
                 }
 
-                var subCommand = GetUpperCaseCommand(out var gotSubCommand);
+                var subCommand = GetSubCommand(out var gotSubCommand);
                 if (!gotSubCommand)
                 {
-                    success = false;
+                    commandReceived = false;
                     return RespCommand.NONE;
                 }
 
@@ -2510,10 +2543,10 @@ namespace Garnet.server
                     return RespCommand.INVALID;
                 }
 
-                var subCommand = GetUpperCaseCommand(out var gotSubCommand);
+                var subCommand = GetSubCommand(out var gotSubCommand);
                 if (!gotSubCommand)
                 {
-                    success = false;
+                    commandReceived = false;
                     return RespCommand.NONE;
                 }
 
@@ -2577,31 +2610,8 @@ namespace Garnet.server
         }
 
         /// <summary>
-        /// Attempts to skip to the end of the line ("\r\n") under the current read head.
-        /// </summary>
-        /// <returns>True if string terminator was found and readHead and endReadHead was changed, otherwise false. </returns>
-        private bool AttemptSkipLine()
-        {
-            // We might have received an inline command package.Try to find the end of the line.
-            logger?.LogWarning("Received malformed input message. Trying to skip line.");
-
-            for (int stringEnd = readHead; stringEnd < bytesRead - 1; stringEnd++)
-            {
-                if (recvBufferPtr[stringEnd] == '\r' && recvBufferPtr[stringEnd + 1] == '\n')
-                {
-                    // Skip to the end of the string
-                    readHead = endReadHead = stringEnd + 2;
-                    return true;
-                }
-            }
-
-            // We received an incomplete string and require more input.
-            return false;
-        }
-
-        /// <summary>
         /// Try to parse a command out of a provided buffer.
-        /// 
+        ///
         /// Useful for when we have a command to validate somewhere, but aren't actually running it.
         /// </summary>
         internal RespCommand ParseRespCommandBuffer(ReadOnlySpan<byte> buffer)
@@ -2631,9 +2641,9 @@ namespace Garnet.server
 
         /// <summary>
         /// Version of <see cref="ParseRespCommandBuffer(ReadOnlySpan{byte})"/> for fuzzing.
-        /// 
+        ///
         /// Expects (and allows) partial commands.
-        /// 
+        ///
         /// Returns true if a command was succesfully parsed
         /// </summary>
         internal bool FuzzParseCommandBuffer(ReadOnlySpan<byte> buffer, out RespCommand cmd)
@@ -2693,16 +2703,17 @@ namespace Garnet.server
         /// Parses the command from the given input buffer.
         /// </summary>
         /// <param name="writeErrorOnFailure">If true, when a parsing error occurs an error response will written.</param>
-        /// <param name="success">Whether processing should continue or a parsing error occurred (e.g. out of tokens).</param>
+        /// <param name="commandReceived">Whether processing should continue or a parsing error occurred (e.g. out of tokens).</param>
         /// <returns>Command parsed from the input buffer.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private RespCommand ParseCommand(bool writeErrorOnFailure, out bool success)
+        private RespCommand ParseCommand(bool writeErrorOnFailure, out bool commandReceived)
         {
-            RespCommand cmd = RespCommand.INVALID;
+            var cmd = RespCommand.INVALID;
+            bool inline = false;
 
             // Initialize count as -1 (i.e., read head has not been advanced)
-            int count = -1;
-            success = true;
+            var count = -1;
+            commandReceived = true;
             endReadHead = readHead;
 
             // Attempt parsing using fast parse pass for most common operations
@@ -2711,19 +2722,24 @@ namespace Garnet.server
             // If we have not found a command, continue parsing on slow path
             if (cmd == RespCommand.NONE)
             {
-                cmd = ArrayParseCommand(writeErrorOnFailure, ref count, ref success);
-                if (!success) return cmd;
+                cmd = ArrayParseCommand(writeErrorOnFailure, ref count, ref commandReceived, out inline);
+                if (!commandReceived) return cmd;
             }
 
-            // Set up parse state
-            parseState.Initialize(count);
             var ptr = recvBufferPtr + readHead;
-            for (int i = 0; i < count; i++)
+            var end = recvBufferPtr + bytesRead;
+
+            if (!inline)
             {
-                if (!parseState.Read(i, ref ptr, recvBufferPtr + bytesRead))
+                // Set up parse state
+                parseState.Initialize(count);
+                for (var i = 0; i < count; i++)
                 {
-                    success = false;
-                    return RespCommand.INVALID;
+                    if (!parseState.Read(i, ref ptr, end))
+                    {
+                        commandReceived = false;
+                        return RespCommand.INVALID;
+                    }
                 }
             }
             endReadHead = (int)(ptr - recvBufferPtr);
@@ -2732,6 +2748,93 @@ namespace Garnet.server
                 HandleAofCommitMode(cmd);
 
             return cmd;
+        }
+
+        private bool TryParseInlineCommandArguments(bool writeErrorOnFailure, out bool commandReceived,
+                                                    out ArgSlice[] result, ref byte* ptr, byte* end)
+        {
+            result = default;
+            commandReceived = false;
+
+            var slices = new System.Collections.Generic.List<ArgSlice>();
+            var slicePtr = ptr;
+            var anyContents = false;
+            var errorAtEnd = false;
+            byte quoteChar = 0;
+
+            while (ptr + 1 <= end)
+            {
+                if (*(ushort*)ptr == crlf)
+                {
+                    commandReceived = true;
+                    if (anyContents)
+                    {
+                        slices.Add(new ArgSlice(slicePtr, (int)(ptr - slicePtr)));
+                    }
+
+                    // Advance past newline
+                    ptr += 2;
+                    // Move readHead to end of line in input package
+                    readHead = (int)(ptr - recvBufferPtr);
+
+                    if ((quoteChar != 0) || errorAtEnd)
+                    {
+                        logger?.LogWarning("Received malformed input message. Line is skipped.");
+
+                        if (writeErrorOnFailure)
+                        {
+                            while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_UNBALANCED_QUOTES, ref dcurr, dend))
+                                SendAndReset();
+                        }
+                        return false;
+                    }
+
+                    result = [.. slices];
+                    return true;
+                }
+
+                if (*ptr == '"' || *ptr == '\'')
+                {
+                    if (quoteChar == 0)
+                    {
+                        quoteChar = *ptr;
+
+                        if (anyContents)
+                            // If we didn't use pointers but instead copied the output,
+                            // we could ignore the quote character like the references (mostly) do in this case.
+                            // Since we don't do that currently, we'll output an error later as to not confuse the user.
+                            errorAtEnd = true;
+                        else
+                            slicePtr = ptr + 1;
+                        // We do not ignore consecutive quotes.
+                        anyContents = true;
+                    }
+                    else if (quoteChar == *ptr)
+                    {
+                        quoteChar = 0;
+                        slices.Add(new ArgSlice(slicePtr, (int)(ptr - slicePtr)));
+                        anyContents = false;
+                    }
+                }
+                else if ((quoteChar == 0) && AsciiUtils.IsWhiteSpace(*ptr))
+                {
+                    if (anyContents)
+                    {
+                        slices.Add(new ArgSlice(slicePtr, (int)(ptr - slicePtr)));
+                        anyContents = false;
+                    }
+
+                    slicePtr = ptr + 1;
+                }
+                else
+                {
+                    anyContents = true;
+                }
+
+                ++ptr;
+            }
+
+            return false;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -2745,7 +2848,7 @@ namespace Garnet.server
             if (txnManager.state == TxnState.Started)
                 return;
 
-            /* 
+            /*
                 If a previous command marked AOF for blocking we should not change AOF blocking flag.
                 If no previous command marked AOF for blocking, then we only change AOF flag to block
                 if the current command is AOF dependent.
@@ -2754,10 +2857,12 @@ namespace Garnet.server
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private RespCommand ArrayParseCommand(bool writeErrorOnFailure, ref int count, ref bool success)
+        private RespCommand ArrayParseCommand(bool writeErrorOnFailure, ref int count, ref bool commandReceived, out bool inline)
         {
             RespCommand cmd = RespCommand.INVALID;
             ReadOnlySpan<byte> specificErrorMessage = default;
+
+            inline = false;
             endReadHead = readHead;
             var ptr = recvBufferPtr + readHead;
 
@@ -2772,33 +2877,80 @@ namespace Garnet.server
             }
 
             // Ensure we are attempting to read a RESP array header
-            if (recvBufferPtr[readHead] != '*')
+            if (recvBufferPtr[readHead] == '*')
             {
-                // We might have received an inline command package. Skip until the end of the line in the input package.
-                success = AttemptSkipLine();
-                return RespCommand.INVALID;
+                // Read the array length
+                if (!RespReadUtils.TryReadUnsignedArrayLength(out count, ref ptr, recvBufferPtr + bytesRead))
+                {
+                    commandReceived = false;
+                    return RespCommand.INVALID;
+                }
+
+                // Move readHead to start of command payload
+                readHead = (int)(ptr - recvBufferPtr);
+
+                // Try parsing the most important variable-length commands
+                cmd = FastParseArrayCommand(ref count, ref specificErrorMessage);
+
+                if (cmd == RespCommand.NONE)
+                {
+                    cmd = SlowParseCommand(ref count, ref specificErrorMessage, out commandReceived);
+                }
             }
-
-            // Read the array length
-            if (!RespReadUtils.TryReadUnsignedArrayLength(out count, ref ptr, recvBufferPtr + bytesRead))
+            else
             {
-                success = false;
-                return RespCommand.INVALID;
-            }
+                inline = true;
 
-            // Move readHead to start of command payload
-            readHead = (int)(ptr - recvBufferPtr);
+                // Minimum processing length is 4. But a user can send shorter lines (e.g. in telnet),
+                // and these get appended to next lines.
+                // We priorize the normal processing, it's better to let inline parsing hack around it.
+                // We can exploit the fact that any such short command would be invalid to skip it.
+                var tptr = ptr;
+                for (var i = 0; i < MINIMUMPROCESSLENGTH - 1; ++i)
+                {
+                    if (*(ushort *)tptr++ == crlf)
+                    {
+                        ptr = tptr + 1;
+                        break;
+                    }
+                }
 
-            // Try parsing the most important variable-length commands
-            cmd = FastParseArrayCommand(ref count, ref specificErrorMessage);
+                // We might have received an inline command package. Try parsing it.
+                if (!TryParseInlineCommandArguments(writeErrorOnFailure, out commandReceived, out var result,
+                                                    ref ptr, recvBufferPtr + bytesRead) || (result.Length == 0))
+                {
+                    // The second condition indicates line is CRLF.
+                    return RespCommand.INVALID;
+                }
 
-            if (cmd == RespCommand.NONE)
-            {
-                cmd = SlowParseCommand(ref count, ref specificErrorMessage, out success);
+                count = result.Length - 1;
+                var origCount = count;
+                var command = result[0].ReadOnlySpan;
+                
+                ArgSlice subCommand = default;
+                if (result.Length > 1)
+                {
+                    subCommand = result[1];
+                }
+
+                if (!TryParseCustomCommand(command, out cmd))
+                {
+                    cmd = SlowParseCommand(command, ref count, ref specificErrorMessage, out commandReceived, subCommand);
+                }
+
+                if (cmd != RespCommand.INVALID)
+                {
+                    // result[result.Length..] works and creates an empty parseState.
+                    parseState.InitializeWithArguments(result[(origCount - count + 1)..]);
+                }
+                else
+                {
+                    logger?.LogWarning("Received malformed input message. Line is skipped.");
+                }
             }
 
             // Parsing for command name was successful, but the command is unknown
-            if (writeErrorOnFailure && success && cmd == RespCommand.INVALID)
+            if (writeErrorOnFailure && commandReceived && cmd == RespCommand.INVALID)
             {
                 if (!specificErrorMessage.IsEmpty)
                 {

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -88,6 +88,11 @@ namespace Garnet.server
         /// </summary>
         int endReadHead;
 
+        /// <summary>
+        /// No redis command (including the terminator) is smaller than this length.
+        /// </summary>
+        private const int MINIMUMPROCESSLENGTH = 4;
+
         internal byte* dcurr, dend;
         bool toDispose;
 
@@ -554,7 +559,7 @@ namespace Garnet.server
 
             var _origReadHead = readHead;
 
-            while (bytesRead - readHead >= 4)
+            while (bytesRead - readHead >= MINIMUMPROCESSLENGTH)
             {
                 // First, parse the command, making sure we have the entire command available
                 // We use endReadHead to track the end of the current command

--- a/test/Garnet.test/RespHashTests.cs
+++ b/test/Garnet.test/RespHashTests.cs
@@ -1299,7 +1299,7 @@ namespace Garnet.test
             }
         }
 
-        #endregion 
+        #endregion
 
         #region LightClientTests
 
@@ -1619,7 +1619,7 @@ namespace Garnet.test
         [TestCase(3, Description = "RESP3 output")]
         public async Task HRespOutput(byte respVersion)
         {
-            using var c = TestUtils.GetGarnetClientSession(raw: true);
+            using var c = TestUtils.GetGarnetClientSession(rawResult: true);
             c.Connect();
 
             var response = await c.ExecuteAsync("HELLO", respVersion.ToString());

--- a/test/Garnet.test/RespSortedSetTests.cs
+++ b/test/Garnet.test/RespSortedSetTests.cs
@@ -3032,7 +3032,7 @@ namespace Garnet.test
         [TestCase(3, Description = "RESP3 output")]
         public async Task ZRespOutput(byte respVersion)
         {
-            using var c = TestUtils.GetGarnetClientSession(raw: true);
+            using var c = TestUtils.GetGarnetClientSession(rawResult: true);
             c.Connect();
 
             var response = await c.ExecuteAsync("HELLO", respVersion.ToString());
@@ -4957,7 +4957,7 @@ namespace Garnet.test
             lightClientRequest.SendCommand("ZADD zset2 4 e 4 f");
 
             var response = lightClientRequest.SendCommand("ZINTER 2 zset2 zset1 WITHSCORES");
-            // ZINTER result should obey sortedset order invariant, 
+            // ZINTER result should obey sortedset order invariant,
             var expectedResponse = "*4\r\n$1\r\nf\r\n$1\r\n8\r\n$1\r\ne\r\n$1\r\n9";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -289,7 +289,7 @@ namespace Garnet.test
 
             var expectedValue = new byte[]
             {
-                 0x00, // value type 
+                 0x00, // value type
                  0x03, // length of payload
                  0x76, 0x61, 0x6C,       // 'v', 'a', 'l'
                  0x0B, 0x00, // RDB version
@@ -2349,7 +2349,7 @@ namespace Garnet.test
             response = lightClientRequest.Execute("GET mykey", expectedResponse.Length, bytesSent);
             ClassicAssert.AreEqual(expectedResponse, response);
 
-            // DECR            
+            // DECR
             expectedResponse = "+OK\r\n";
             response = lightClientRequest.Execute("SET mykeydecr 1", expectedResponse.Length, bytesSent);
             ClassicAssert.AreEqual(expectedResponse, response);
@@ -3846,11 +3846,64 @@ namespace Garnet.test
         }
 
         [Test]
+        public async Task InlineCommandTest()
+        {
+            var clientName = "name1 name2";
+
+            using var c = TestUtils.GetGarnetClientSession(rawResult: true, rawSend: true);
+            c.Connect();
+
+            // Test inline command without arguments
+            var response = await c.ExecuteAsync("HELLO\r\n");
+            ClassicAssert.AreEqual('*', response[0]);
+            // Test lowercase
+            response = await c.ExecuteAsync("hello 3\r\n");
+            ClassicAssert.AreEqual('%', response[0]);
+            // Test extranous whitespace
+            response = await c.ExecuteAsync("HELLO  2\t \r\n");
+            ClassicAssert.AreEqual('*', response[0]);
+            // References accept this too
+            response = await c.ExecuteAsync("HElLO 3 SETNAME a SETNAME b\r\n");
+            ClassicAssert.AreEqual('%', response[0]);
+            // Test setting client name inline, alongside quoting
+            response = await c.ExecuteAsync($"HELLO 2 SETNAME '{clientName}'\r\n");
+            ClassicAssert.AreEqual('*', response[0]);
+
+            c.RawResult = false;
+            // Test client name was actually set
+            response = await c.ExecuteAsync("CLIENT GETNAME\r\n");
+            ClassicAssert.AreEqual(clientName, response);
+            c.RawResult = true;
+
+            // Test inline ping
+            response = await c.ExecuteAsync("PING\r\n");
+            ClassicAssert.AreEqual("+PONG\r\n", response);
+
+            // Test quoting failure
+            response = await c.ExecuteAsync("PING 'unfinished quote\r\n");
+            ClassicAssert.AreEqual('-', response[0]);
+
+            // Test quoted argument
+            response = await c.ExecuteAsync("ping \"hello world\"\r\n");
+            ClassicAssert.AreEqual("$11\r\nhello world\r\n", response);
+
+            // References can even accept commands formed like this
+            response = await c.ExecuteAsync("\"PING\"\tword \r\n");
+            ClassicAssert.AreEqual("$4\r\nword\r\n", response);
+            response = await c.ExecuteAsync("'pING'\t'word '\r\n");
+            ClassicAssert.AreEqual("$5\r\nword \r\n", response);
+
+            // Test quit
+            response = await c.ExecuteAsync("QUIT\r\n");
+            ClassicAssert.AreEqual("+OK\r\n", response);
+        }
+
+        [Test]
         [TestCase([2, "$-1\r\n", "$1\r\n", "*4", '*'], Description = "RESP2 output")]
         [TestCase([3, "_\r\n", ",", "%2", '~'], Description = "RESP3 output")]
         public async Task RespOutputTests(byte respVersion, string expectedResponse, string doublePrefix, string mapPrefix, char setPrefix)
         {
-            using var c = TestUtils.GetGarnetClientSession(raw: true);
+            using var c = TestUtils.GetGarnetClientSession(rawResult: true);
             c.Connect();
 
             var response = await c.ExecuteAsync("HELLO", respVersion.ToString());

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -3850,6 +3850,7 @@ namespace Garnet.test
         {
             var clientName = "name1 name2";
             var key = "key";
+            var value = "1";
 
             using var c = TestUtils.GetGarnetClientSession(rawResult: true, rawSend: true);
             c.Connect();
@@ -3885,6 +3886,8 @@ namespace Garnet.test
             ClassicAssert.AreEqual("+PONG\r\n", response);
 
             // Test quoting failure
+            // We need to test failures too to be sure readHead is reset right,
+            // and that there are no leftovers that would interfere with future commands.
             response = await c.ExecuteAsync("PING 'unfinished quote\r\n");
             ClassicAssert.AreEqual('-', response[0]);
 
@@ -3895,23 +3898,28 @@ namespace Garnet.test
             // Test command failure
             response = await c.ExecuteAsync("PIN\r\n");
             ClassicAssert.AreEqual('-', response[0]);
-            // Test command failure in normal RESP
-            response = await c.ExecuteAsync("*1\r\n$3\r\nPIN\r\n");
-            ClassicAssert.AreEqual('-', response[0]);
 
             // References can even accept commands formed like this
             response = await c.ExecuteAsync("\"PING\"\tword \r\n");
             ClassicAssert.AreEqual("$4\r\nword\r\n", response);
-            response = await c.ExecuteAsync("'pING'\t'word '\r\n");
+            response = await c.ExecuteAsync("pIN'G'\t'word '\r\n");
             ClassicAssert.AreEqual("$5\r\nword \r\n", response);
+            response = await c.ExecuteAsync("PING'' \"hello 'world'!\"\r\n");
+            ClassicAssert.AreEqual("$14\r\nhello 'world'!\r\n", response);
 
             // Test ordinary commands
-            response = await c.ExecuteAsync($"SET {key} 1\r\n");
+            response = await c.ExecuteAsync($"SET {key} {value}\r\n");
             ClassicAssert.AreEqual("+OK\r\n", response);
             response = await c.ExecuteAsync($"GET {key}\r\n");
-            ClassicAssert.AreEqual("$1\r\n1\r\n", response);
+            ClassicAssert.AreEqual($"${value.Length}\r\n{value}\r\n", response);
             response = await c.ExecuteAsync($"EXISTS {key}\r\n");
             ClassicAssert.AreEqual(":1\r\n", response);
+            response = await c.ExecuteAsync($"DEL {key}\r\n");
+            ClassicAssert.AreEqual(":1\r\n", response);
+
+            // Test command failure in normal RESP
+            response = await c.ExecuteAsync("*1\r\n$3\r\nPIN\r\n");
+            ClassicAssert.AreEqual('-', response[0]);
 
             // Test quit
             response = await c.ExecuteAsync("QUIT\r\n");

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -3846,9 +3846,9 @@ namespace Garnet.test
         }
 
         [Test]
-        public async Task InlineCommandTest()
+        public async Task InlineCommandParseTest()
         {
-            var clientName = "name1 name2";
+            var clientName = "name";
             var key = "key";
             var value = "1";
 
@@ -3856,74 +3856,130 @@ namespace Garnet.test
             c.Connect();
 
             // Test inline command without arguments
-            var response = await c.ExecuteAsync("HELLO\r\n");
+            var response = await c.ExecuteAsync("HELLO");
             ClassicAssert.AreEqual('*', response[0]);
             // Test lowercase
-            response = await c.ExecuteAsync("hello 3\r\n");
+            response = await c.ExecuteAsync("hello 3");
             ClassicAssert.AreEqual('%', response[0]);
             // Test extranous whitespace
-            response = await c.ExecuteAsync("HELLO  2\t \r\n");
+            response = await c.ExecuteAsync("HELLO  2\t ");
             ClassicAssert.AreEqual('*', response[0]);
             // References accept this too
-            response = await c.ExecuteAsync("HElLO 3 SETNAME a SETNAME b\r\n");
+            response = await c.ExecuteAsync("HElLO 3 SETNAME a SETNAME b");
             ClassicAssert.AreEqual('%', response[0]);
-            // Test setting client name inline, alongside quoting
-            response = await c.ExecuteAsync($"HELLO 2 SETNAME '{clientName}'\r\n");
+            // Test setting client name inline
+            response = await c.ExecuteAsync($"HELLO 2 SETNAME {clientName}");
             ClassicAssert.AreEqual('*', response[0]);
 
             // Should fail due to missing argument. We test such failures to ensure
             // readhead is not messed up and commands can be placed afterwards.
-            response = await c.ExecuteAsync("CLIENT\r\n");
+            response = await c.ExecuteAsync("CLIENT");
             ClassicAssert.AreEqual('-', response[0]);
             c.RawResult = false;
             // Test client name was actually set
-            response = await c.ExecuteAsync("CLIENT GETNAME\r\n");
+            response = await c.ExecuteAsync("CLIENT GETNAME");
             ClassicAssert.AreEqual(clientName, response);
             c.RawResult = true;
 
             // Test inline ping
-            response = await c.ExecuteAsync("PING\r\n");
+            response = await c.ExecuteAsync("PING");
             ClassicAssert.AreEqual("+PONG\r\n", response);
+
+            // Test command failure
+            response = await c.ExecuteAsync("PIN");
+            ClassicAssert.AreEqual('-', response[0]);
+
+            // Test ordinary commands
+            response = await c.ExecuteAsync($"SET {key} {value}");
+            ClassicAssert.AreEqual("+OK\r\n", response);
+            response = await c.ExecuteAsync($"GET {key}");
+            ClassicAssert.AreEqual($"${value.Length}\r\n{value}\r\n", response);
+            response = await c.ExecuteAsync($"EXISTS {key}");
+            ClassicAssert.AreEqual(":1\r\n", response);
+            response = await c.ExecuteAsync($"DEL {key}");
+            ClassicAssert.AreEqual(":1\r\n", response);
+
+            // Test command failure in normal RESP doesn't interfere
+            response = await c.ExecuteAsync("*1\r\n$3\r\nPIN");
+            ClassicAssert.AreEqual('-', response[0]);
+
+            // Test quit
+            response = await c.ExecuteAsync("QUIT");
+            ClassicAssert.AreEqual("+OK\r\n", response);
+        }
+
+        [Test]
+        public async Task InlineCommandEscapeTest()
+        {
+            using var c = TestUtils.GetGarnetClientSession(rawResult: true, rawSend: true);
+            c.Connect();
+
+            var response = await c.ExecuteAsync("PING \\t");
+            ClassicAssert.AreEqual("$2\r\n\\t\r\n", response);
+            // With ' quoting most escapes aren't recognized
+            response = await c.ExecuteAsync("PING '\\t'");
+            ClassicAssert.AreEqual("$2\r\n\\t\r\n", response);
+            // Except this one form of escaping
+            response = await c.ExecuteAsync("PING '\'\\t\''");
+            ClassicAssert.AreEqual("$4\r\n'\\t'\r\n", response);
+
+            // Test escape
+            response = await c.ExecuteAsync("PING \"\\t\"");
+            ClassicAssert.AreEqual("$1\r\n\t\r\n", response);
+
+            // This should lead to quoting failure
+            response = await c.ExecuteAsync("PING \"\\\\\\\"");
+            ClassicAssert.AreEqual('-', response[0]);
+            // This should work
+            response = await c.ExecuteAsync("PING \"\\\\\\\\\"");
+            ClassicAssert.AreEqual("$2\r\n\\\\\r\n", response);
+
+            // Incomplete hex escape 1
+            response = await c.ExecuteAsync("PING \"\\x\"");
+            ClassicAssert.AreEqual("$1\r\nx\r\n", response);
+            // Incomplete hex escape 2
+            response = await c.ExecuteAsync("PING \"\\x0\"");
+            ClassicAssert.AreEqual("$2\r\nx0\r\n", response);
+            // Invalid hex escape
+            response = await c.ExecuteAsync("PING \"\\xGG\"");
+            ClassicAssert.AreEqual("$3\r\nxGG\r\n", response);
+            // Complete hex escape
+            response = await c.ExecuteAsync("PING \"\\x0A\"");
+            ClassicAssert.AreEqual("$1\r\n\n\r\n", response);
+        }
+
+        [Test]
+        public async Task InlineCommandQuoteTest()
+        {
+            using var c = TestUtils.GetGarnetClientSession(rawResult: true, rawSend: true);
+            c.Connect();
+
+            // Test quoted argument
+            var response = await c.ExecuteAsync("ping \"hello world\"");
+            ClassicAssert.AreEqual("$11\r\nhello world\r\n", response);
 
             // Test quoting failure
             // We need to test failures too to be sure readHead is reset right,
             // and that there are no leftovers that would interfere with future commands.
-            response = await c.ExecuteAsync("PING 'unfinished quote\r\n");
+            response = await c.ExecuteAsync("PING 'unfinished quote");
             ClassicAssert.AreEqual('-', response[0]);
 
-            // Test quoted argument
-            response = await c.ExecuteAsync("ping \"hello world\"\r\n");
-            ClassicAssert.AreEqual("$11\r\nhello world\r\n", response);
+            // Test empty and short strings
+            response = await c.ExecuteAsync("ECHO ''");
+            ClassicAssert.AreEqual("$0\r\n\r\n", response);
 
-            // Test command failure
-            response = await c.ExecuteAsync("PIN\r\n");
-            ClassicAssert.AreEqual('-', response[0]);
+            response = await c.ExecuteAsync("ECHO 'a'");
+            ClassicAssert.AreEqual("$1\r\na\r\n", response);
 
-            // References can even accept commands formed like this
-            response = await c.ExecuteAsync("\"PING\"\tword \r\n");
+            // We can even accept commands formed like this
+            response = await c.ExecuteAsync("\"PING\"\tword ");
             ClassicAssert.AreEqual("$4\r\nword\r\n", response);
-            response = await c.ExecuteAsync("pIN'G'\t'word '\r\n");
-            ClassicAssert.AreEqual("$5\r\nword \r\n", response);
-            response = await c.ExecuteAsync("PING'' \"hello 'world'!\"\r\n");
+            response = await c.ExecuteAsync("PINg \"hello 'world'!\"");
             ClassicAssert.AreEqual("$14\r\nhello 'world'!\r\n", response);
-
-            // Test ordinary commands
-            response = await c.ExecuteAsync($"SET {key} {value}\r\n");
-            ClassicAssert.AreEqual("+OK\r\n", response);
-            response = await c.ExecuteAsync($"GET {key}\r\n");
-            ClassicAssert.AreEqual($"${value.Length}\r\n{value}\r\n", response);
-            response = await c.ExecuteAsync($"EXISTS {key}\r\n");
-            ClassicAssert.AreEqual(":1\r\n", response);
-            response = await c.ExecuteAsync($"DEL {key}\r\n");
-            ClassicAssert.AreEqual(":1\r\n", response);
-
-            // Test command failure in normal RESP
-            response = await c.ExecuteAsync("*1\r\n$3\r\nPIN\r\n");
-            ClassicAssert.AreEqual('-', response[0]);
-
-            // Test quit
-            response = await c.ExecuteAsync("QUIT\r\n");
-            ClassicAssert.AreEqual("+OK\r\n", response);
+            response = await c.ExecuteAsync("PING '\"'\"''");
+            ClassicAssert.AreEqual("$4\r\n\"'\"'\r\n", response);
+            response = await c.ExecuteAsync("P'ING' ab");
+            ClassicAssert.AreEqual("$2\r\nab\r\n", response);
         }
 
         [Test]

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -3849,6 +3849,7 @@ namespace Garnet.test
         public async Task InlineCommandTest()
         {
             var clientName = "name1 name2";
+            var key = "key";
 
             using var c = TestUtils.GetGarnetClientSession(rawResult: true, rawSend: true);
             c.Connect();
@@ -3869,6 +3870,10 @@ namespace Garnet.test
             response = await c.ExecuteAsync($"HELLO 2 SETNAME '{clientName}'\r\n");
             ClassicAssert.AreEqual('*', response[0]);
 
+            // Should fail due to missing argument. We test such failures to ensure
+            // readhead is not messed up and commands can be placed afterwards.
+            response = await c.ExecuteAsync("CLIENT\r\n");
+            ClassicAssert.AreEqual('-', response[0]);
             c.RawResult = false;
             // Test client name was actually set
             response = await c.ExecuteAsync("CLIENT GETNAME\r\n");
@@ -3887,11 +3892,26 @@ namespace Garnet.test
             response = await c.ExecuteAsync("ping \"hello world\"\r\n");
             ClassicAssert.AreEqual("$11\r\nhello world\r\n", response);
 
+            // Test command failure
+            response = await c.ExecuteAsync("PIN\r\n");
+            ClassicAssert.AreEqual('-', response[0]);
+            // Test command failure in normal RESP
+            response = await c.ExecuteAsync("*1\r\n$3\r\nPIN\r\n");
+            ClassicAssert.AreEqual('-', response[0]);
+
             // References can even accept commands formed like this
             response = await c.ExecuteAsync("\"PING\"\tword \r\n");
             ClassicAssert.AreEqual("$4\r\nword\r\n", response);
             response = await c.ExecuteAsync("'pING'\t'word '\r\n");
             ClassicAssert.AreEqual("$5\r\nword \r\n", response);
+
+            // Test ordinary commands
+            response = await c.ExecuteAsync($"SET {key} 1\r\n");
+            ClassicAssert.AreEqual("+OK\r\n", response);
+            response = await c.ExecuteAsync($"GET {key}\r\n");
+            ClassicAssert.AreEqual("$1\r\n1\r\n", response);
+            response = await c.ExecuteAsync($"EXISTS {key}\r\n");
+            ClassicAssert.AreEqual(":1\r\n", response);
 
             // Test quit
             response = await c.ExecuteAsync("QUIT\r\n");

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -822,7 +822,8 @@ namespace Garnet.test
             return new GarnetClient(endpoint ?? EndPoint, sslOptions, recordLatency: recordLatency);
         }
 
-        public static GarnetClientSession GetGarnetClientSession(bool useTLS = false, bool raw = false, EndPoint endPoint = null)
+        public static GarnetClientSession GetGarnetClientSession(bool useTLS = false, bool rawResult = false, bool rawSend = false,
+                                                                 EndPoint endPoint = null)
         {
             SslClientAuthenticationOptions sslOptions = null;
             if (useTLS)
@@ -835,7 +836,7 @@ namespace Garnet.test
                     RemoteCertificateValidationCallback = ValidateServerCertificate,
                 };
             }
-            return new GarnetClientSession(endPoint ?? EndPoint, new(), tlsOptions: sslOptions, rawResult: raw);
+            return new GarnetClientSession(endPoint ?? EndPoint, new(), tlsOptions: sslOptions, rawResult: rawResult, rawSend: rawSend);
         }
 
         public static LightClientRequest CreateRequest(LightClient.OnResponseDelegateUnsafe onReceive = null, bool useTLS = false, CountResponseType countResponseType = CountResponseType.Tokens)


### PR DESCRIPTION
This PR implements parsing command line supplied using Redis's inline command format.

https://redis.io/docs/latest/develop/reference/protocol-spec/#inline-commands

The inline command format allows people to connect with telnet and just write commands, without requiring other command line tools. It can be useful to avoid *-cli quoting and to see raw responses. Also a very few poorly written clients may send the inline format, so it can be useful there too.

The basic implementation strategy was to take the current code, spread it out a bit, and in the same point after seeing the buffer does not contain a RESP string, try to parse as inline command: We separate the buffer to an array of ArgSlice pointing to the original buffer. Each ArgSlice pointing to a 'word' of the original command line. The first two 'words' are printed to a temporary RESP formatted string, and then we run the regular parsing on it. If a command was matched, we initialize the parseState from the ArgSlice array. The intention is to keep the main path fast and (almost) untouched, while the inline path does the necessary work to match itself to the rest of the code. It was also preferred to not implement another command matching for this.

---

### Examples:

> telnet localhost 6379

>ECHO 'hello world!'
> >$12
> >hello world!

>SET key "a\x0Ab"
> >+OK

>GET key
> >$3
> >a
> >x

The PR implements reading the format fully (as far as I can tell, given it's not very specified), with quoting and escaping, matching even rather odd reference behaviour.

>PI"NG"
> >+PONG

>PING \\"a b"
> >$4
> >\\a b

>"ping"
> >+PONG

Another thing to note is that Garnet doesn't close the connection on protocol errors (unlike redis/valkey), so it's much nicer to type there compared to references which will close the connection whenever quotes are mismatched.