### PR TITLE
Allow Lua scripts to modify `KEYS` and `ARGV`

### DIFF
--- a/libs/server/Lua/LuaRunner.Loader.cs
+++ b/libs/server/Lua/LuaRunner.Loader.cs
@@ -290,7 +290,7 @@ function recursively_readonly_table(table)
     table.__readonly = true
 
     for key, value in pairs(table) do
-        if type(value) == 'table' then
+        if type(value) == 'table' and key ~= 'KEYS' and key ~= 'ARGV' then
             recursively_readonly_table(value)
         end
     end

--- a/test/Garnet.test/LuaScriptTests.cs
+++ b/test/Garnet.test/LuaScriptTests.cs
@@ -225,13 +225,13 @@ namespace Garnet.test
             List<string> illegalToModify = ["_G", "bit", "cjson", "cmsgpack", "math", "os", "redis", "string", "struct", "table"];
             List<string> legalToModify = ["KEYS", "ARGV"];
 
-            foreach(var illegal in illegalToModify)
+            foreach (var illegal in illegalToModify)
             {
                 var exc = ClassicAssert.Throws<RedisServerException>(() => db.ScriptEvaluate($"table.insert({illegal}, 'foo')"));
                 ClassicAssert.IsTrue(exc.Message.Contains("Attempt to modify a readonly table"));
             }
 
-            foreach(var legal in legalToModify)
+            foreach (var legal in legalToModify)
             {
                 var res = (string[])db.ScriptEvaluate($"table.insert({legal}, 'fizz'); return {legal};");
                 ClassicAssert.IsTrue(res.Contains("fizz"));

--- a/test/Garnet.test/LuaScriptTests.cs
+++ b/test/Garnet.test/LuaScriptTests.cs
@@ -214,6 +214,31 @@ namespace Garnet.test
         }
 
         [Test]
+        public void ReadOnlyGlobalTables()
+        {
+            // This is a bit tricky, but basically Redis forbids modifying any global tables (things like cmsgpack.*) EXCEPT
+            // for KEYS and ARGV
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            List<string> illegalToModify = ["_G", "bit", "cjson", "cmsgpack", "math", "os", "redis", "string", "struct", "table"];
+            List<string> legalToModify = ["KEYS", "ARGV"];
+
+            foreach(var illegal in illegalToModify)
+            {
+                var exc = ClassicAssert.Throws<RedisServerException>(() => db.ScriptEvaluate($"table.insert({illegal}, 'foo')"));
+                ClassicAssert.IsTrue(exc.Message.Contains("Attempt to modify a readonly table"));
+            }
+
+            foreach(var legal in legalToModify)
+            {
+                var res = (string[])db.ScriptEvaluate($"table.insert({legal}, 'fizz'); return {legal};");
+                ClassicAssert.IsTrue(res.Contains("fizz"));
+            }
+        }
+
+        [Test]
         public void CanDoEvalUsingGarnetCallSE()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());


### PR DESCRIPTION
Redis allows `KEYS` and `ARGV` to be modified in scripts, despite being "global" tables.

This adds tests and a fix for that.

Test was also run against Redis to confirm behaviors match.