### PR TITLE
Save System.Linq.Async dependency by implementing FirstAsync

### DIFF
--- a/libs/storage/Tsavorite/cs/src/devices/AzureStorageDevice/AzureStorageDevice.cs
+++ b/libs/storage/Tsavorite/cs/src/devices/AzureStorageDevice/AzureStorageDevice.cs
@@ -180,11 +180,18 @@ namespace Tsavorite.devices
                         {
                             var client = pageBlobDirectory.Client.WithRetries;
 
-                            var page = await client.GetBlobsAsync(
+                            await using var asEnum = client.GetBlobsAsync(
                                 prefix: prefix,
                                 cancellationToken: StorageErrorHandler.Token)
                                 .AsPages(continuationToken, 100)
-                                .FirstAsync();
+                                .GetAsyncEnumerator();
+
+                            if (!await asEnum.MoveNextAsync())
+                            {
+                                throw new InvalidOperationException("Sequence contains no elements");
+                            }
+
+                            var page = asEnum.Current;
 
                             pageResults = page.Values;
                             continuationToken = page.ContinuationToken;

--- a/libs/storage/Tsavorite/cs/src/devices/AzureStorageDevice/Tsavorite.devices.AzureStorageDevice.csproj
+++ b/libs/storage/Tsavorite/cs/src/devices/AzureStorageDevice/Tsavorite.devices.AzureStorageDevice.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" />
-    <PackageReference Include="System.Interactive.Async" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\Tsavorite.core.csproj" />


### PR DESCRIPTION
One of the largest files in a build is the System.Linq.Async.dll (1.1Mb). It's used only for a single FirstAsync call in Tsavorite.devices.AzureStorageDevice. By inlining an implementation, we can remove the dependency. The natural implementation turns out to be exactly what the sources do under the hood:

https://github.com/dotnet/reactive/blob/de5749f47220b27d9cb1254495246df92de5b8dd/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/First.cs#L31
https://github.com/dotnet/reactive/blob/de5749f47220b27d9cb1254495246df92de5b8dd/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/FirstOrDefault.cs#L128

https://github.com/dotnet/dotnet/blob/d8cf50d2f761738c927508532643cfc9fa69dce7/src/runtime/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/FirstAsync.cs#L20