### PR TITLE
Update 'redis' server version to 7.4.3.

### DIFF
--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -34,7 +34,7 @@ namespace Garnet
         /// <summary>
         /// Resp protocol version
         /// </summary>
-        internal const string RedisProtocolVersion = "7.2.5";
+        internal const string RedisProtocolVersion = "7.4.3";
 
         static readonly string version = GetVersion();
         static string GetVersion()


### PR DESCRIPTION
As far as I can tell, every feature between 7.2.5 and 7.4.3 is implemented in Garnet. Hash field expiration? os.clock()? CLIENT KILL MAXAGE? All already there. What's missing for 7.4.3 is missing for 7.2.5 too. It's useful to announce to clients they can use these features by giving an higher version.