### PR TITLE
Update publishing to use normal publish and SingleFile for Windows service

### DIFF
--- a/.azure/pipelines/createbinaries.ps1
+++ b/.azure/pipelines/createbinaries.ps1
@@ -1,12 +1,12 @@
-<#$f
+<#
 .SYNOPSIS
-    This script is designed to publish GarnetServer into various platforms. 
+	This script is designed to publish GarnetServer into various platforms.
 
 .DESCRIPTION
 
-    Script to publish the GarnetServer executable from various Profiles. It will clean up all the files not needed and by default it will zip them all up in the output directory. 
+	Script to publish the GarnetServer executable from various Profiles. It will clean up all the files not needed and by default it will zip them all up in the output directory.
 	
-    Parameter: mode
+.PARAMETER mode
 		0 (default) = do both publish and zip
 		1 = publish only
 		2 = zip only
@@ -14,55 +14,80 @@
 		The mode allows for special case when running from a pipeline that it only does one of the two parts (publish  or zip) at a time. 
 			Doing this allows actions (code signing etc) on the files before it is zipped. Running the script after that can zip up everything (using mode 2).
    
+.PARAMETER destDir
+		defaults to main\GarnetServer from base of solution
+.
+		This parameter allows choosing the destination directory for the build.
+.
+.PARAMETER buildDir
+		defaults to none, solution settings will be used
+.
+		This parameter allows choosing the artifacts directory for the build.
+.
 .EXAMPLE
-    ./createbinaries.ps1 
- 	./createbinaries.ps1 0
+	./createbinaries.ps1
+	./createbinaries.ps1 0
 	./createbinaries.ps1 -mode 1
 #>
 
 # Send the config file for the benchmark. Defaults to a simple one
 param (
-  [string]$mode = 0
+  [int]$mode = 0,
+  [string]$destDir = "",
+  [string]$buildDir = ""
 )
-
 
 
 # ******** FUNCTION DEFINITIONS  *********
 
-################## CleanUpFiles ##################### 
+################## BuildAndCleanUpFiles #####################
 #  
-#  After build is published, this cleans it up so only the necessary files will be ready to be zipped
+#  Publishes build and afterwards cleans it up so only the necessary files will be ready to be zipped
 #  
 ######################################################
-function CleanUpFiles {
-    param ($publishFolder, $platform, $framework, $deleteRunTimes = $true)
+function BuildAndCleanUpFiles {
+	param ($publishFolder, $platform, $framework)
 
-	$publishPath = "$basePath/main/GarnetServer/bin/Release/$framework/publish/$publishFolder"
+	$publishPath = "$destDir/bin/Release/$framework/publish/$publishFolder"
 	$excludeGarnetServerPDB = 'GarnetServer.pdb'
 
 	# Native binary is different based on OS by default
-	$nativeFile = "libnative_device.so"
+	$nativeRuntimePathFile = "$publishPath/runtimes/$platform/native/libnative_device.so"
 
-	if ($platform -match "win-x64") {
-		$nativeFile = "native_device.dll"
+	$GarnetServer = "$basePath/main/GarnetServer/GarnetServer.csproj"
+	$GarnetWorker = "$basePath/hosting/Windows/Garnet.worker/Garnet.worker.csproj"
+
+	if ($publishFolder -eq "portable") {
+		dotnet publish $GarnetServer -p:PublishProfile="portable" -f:$framework @artifactArg -o "$publishPath"
+		# don't clean up all files for portable ... leave as is
+		return;
+	} elseif ($platform -eq "win-x64") {
+		$nativeRuntimePathFile = "$publishPath/runtimes/$platform/native/native_device.dll"
+		dotnet publish $GarnetServer -p:PublishProfile="$publishFolder-based-readytorun" -f:$framework @artifactArg -o "$publishPath"
+		dotnet publish $GarnetWorker -r $publishFolder -p:SelfContained=false -p:PublishSingleFile=true -f:$framework @artifactArg -o "$publishPath/Service"
+	} else {
+		dotnet publish $GarnetServer -p:PublishProfile="$publishFolder-based" -f:$framework @artifactArg -o "$publishPath"
 	}
 
-	$nativeRuntimePathFile = "$publishPath/runtimes/$platform/native/$nativeFile"
-
 	if (Test-Path -Path $publishPath) {
-		Get-ChildItem -Path $publishPath -Filter '*.pfx' | Remove-Item -Force
-		Get-ChildItem -Path $publishPath -Filter '*.xml' | Remove-Item -Force
-		Get-ChildItem -Path $publishPath -Filter '*.pdb' | Where-Object { $_.Name -ne $excludeGarnetServerPDB } | Remove-Item
+		Get-ChildItem -Path $publishPath -Filter '*.pfx' -Recurse | Remove-Item -Force
+		Get-ChildItem -Path $publishPath -Filter '*.xml' -Recurse | Remove-Item -Force
+		Get-ChildItem -Path $publishPath -Filter '*.pdb' -Recurse | Where-Object { $_.Name -ne $excludeGarnetServerPDB } | Remove-Item -Force
 
 		# Copy proper native run time to publish directory
 		Copy-Item -Path $nativeRuntimePathFile -Destination $publishPath
+
+		if (Test-Path -Path $publishPath/Service) {
+			# Copy proper native run time to Service publish directory
+			Copy-Item -Path $nativeRuntimePathFile -Destination "$publishPath/Service"
+		} elseif ($platform -eq "win-x64") {
+			Write-Host "Publish Path not found: $publishPath/Service"
+		}
+
+		# Delete the runtimes folder
+		Get-ChildItem -Path $publishPath -Filter 'runtimes' -Recurse | Remove-Item -Recurse -Force
 	} else {
 		Write-Host "Publish Path not found: $publishPath"
-	}
-
-	# Delete the runtimes folder
-	if ($deleteRunTimes -eq $true) {
-		Remove-Item -Path "$publishPath/runtimes" -Recurse -Force
 	}
 }
 
@@ -72,51 +97,45 @@ $lastPwd = $pwd
 $string = $pwd.Path
 $position = $string.IndexOf(".azure")
 $basePath = $string.Substring(0,$position-1)  # take off slash off end as well
-Set-Location $basePath/main/GarnetServer
+
+if ($buildDir -ne "") {
+	New-Item -Type Directory -Force $buildDir | Out-Null
+	$artifactArg = "--artifacts-path",(Resolve-Path $buildDir).Path
+}
+if ($destDir -ne "") {
+	New-Item -Type Directory -Force $destDir | Out-Null
+	$destDir = (Resolve-Path $destDir).Path
+} else {
+	$destDir = "$basePath/main/GarnetServer"
+}
+Set-Location $destDir
 
 if ($mode -eq 0 -or $mode -eq 1) {
 	Write-Host "** Publish ... **"
-	dotnet publish GarnetServer.csproj -p:PublishProfile=linux-arm64-based -f:net8.0
-	dotnet publish GarnetServer.csproj -p:PublishProfile=linux-x64-based -f:net8.0 
-	dotnet publish GarnetServer.csproj -p:PublishProfile=osx-arm64-based -f:net8.0 
-	dotnet publish GarnetServer.csproj -p:PublishProfile=osx-x64-based -f:net8.0 
-	dotnet publish GarnetServer.csproj -p:PublishProfile=portable -f:net8.0 
-	dotnet publish GarnetServer.csproj -p:PublishProfile=win-arm64-based-readytorun -f:net8.0 
-	dotnet publish GarnetServer.csproj -p:PublishProfile=win-x64-based-readytorun -f:net8.0 
 
-	dotnet publish GarnetServer.csproj -p:PublishProfile=linux-arm64-based -f:net9.0
-	dotnet publish GarnetServer.csproj -p:PublishProfile=linux-x64-based -f:net9.0 
-	dotnet publish GarnetServer.csproj -p:PublishProfile=osx-arm64-based -f:net9.0 
-	dotnet publish GarnetServer.csproj -p:PublishProfile=osx-x64-based -f:net9.0 
-	dotnet publish GarnetServer.csproj -p:PublishProfile=portable -f:net9.0 
-	dotnet publish GarnetServer.csproj -p:PublishProfile=win-arm64-based-readytorun -f:net9.0 
-	dotnet publish GarnetServer.csproj -p:PublishProfile=win-x64-based-readytorun -f:net9.0 
+	# Build, then clean up extra files not needed for publishing
+	BuildAndCleanUpFiles "linux-arm64" "linux-x64" "net8.0"
+	BuildAndCleanUpFiles "linux-x64" "linux-x64" "net8.0"
+	BuildAndCleanUpFiles "osx-arm64" "linux-x64" "net8.0"
+	BuildAndCleanUpFiles "osx-x64" "linux-x64" "net8.0"
+	BuildAndCleanUpFiles "portable" "win-x64" "net8.0"
+	BuildAndCleanUpFiles "win-arm64" "win-x64" "net8.0"
+	BuildAndCleanUpFiles "win-x64" "win-x64" "net8.0"
 
-	# Clean up all the extra files
-	CleanUpFiles "linux-arm64" "linux-x64" "net8.0"
-	CleanUpFiles "linux-x64" "linux-x64" "net8.0"
-	CleanUpFiles "osx-arm64" "linux-x64" "net8.0"
-	CleanUpFiles "osx-x64" "linux-x64" "net8.0"
-	#CleanUpFiles "portable" "win-x64" "net8.0" # don't clean up all files for portable ... leave as is
-	CleanUpFiles "win-x64\Service" "win-x64" "net8.0" $false
-	CleanUpFiles "win-x64" "win-x64" "net8.0"
-	CleanUpFiles "win-arm64" "win-x64" "net8.0"
-
-	CleanUpFiles "linux-arm64" "linux-x64" "net9.0"
-	CleanUpFiles "linux-x64" "linux-x64" "net9.0"
-	CleanUpFiles "osx-arm64" "linux-x64" "net9.0"
-	CleanUpFiles "osx-x64" "linux-x64" "net9.0"
-	#CleanUpFiles "portable" "win-x64" "net9.0" # don't clean up all files for portable ... leave as is
-	CleanUpFiles "win-x64\Service" "win-x64" "net9.0" $false
-	CleanUpFiles "win-x64" "win-x64" "net9.0"
-	CleanUpFiles "win-arm64" "win-x64" "net9.0"
+	BuildAndCleanUpFiles "linux-arm64" "linux-x64" "net9.0"
+	BuildAndCleanUpFiles "linux-x64" "linux-x64" "net9.0"
+	BuildAndCleanUpFiles "osx-arm64" "linux-x64" "net9.0"
+	BuildAndCleanUpFiles "osx-x64" "linux-x64" "net9.0"
+	BuildAndCleanUpFiles "portable" "win-x64" "net9.0"
+	BuildAndCleanUpFiles "win-arm64" "win-x64" "net9.0"
+	BuildAndCleanUpFiles "win-x64" "win-x64" "net9.0"
 }
 
 if ($mode -eq 0 -or $mode -eq 2) {
 
 	# Make sure at publish folders are there as basic check files are actually published before trying to zip
-	$publishedFilesFolderNet8 = "$basePath/main/GarnetServer/bin/Release/net8.0/publish"
-	$publishedFilesFolderNet9 = "$basePath/main/GarnetServer/bin/Release/net9.0/publish"
+	$publishedFilesFolderNet8 = "$destDir/bin/Release/net8.0/publish"
+	$publishedFilesFolderNet9 = "$destDir/bin/Release/net9.0/publish"
 	
 	if (!(Test-Path $publishedFilesFolderNet8) -or !(Test-Path $publishedFilesFolderNet9)) {
 		Write-Error "$publishedFilesFolderNet8 or $publishedFilesFolderNet9 does not exist. Run .\CreateBinaries 1 to publish the binaries first."
@@ -127,43 +146,34 @@ if ($mode -eq 0 -or $mode -eq 2) {
 	# Create the directories - both net80 and net90 will be in the same zip file.
 	$directories = @("linux-arm64", "linux-x64", "osx-arm64", "osx-x64", "portable", "win-arm64", "win-x64")
 	$sourceFramework = @("net8.0", "net9.0")
-	$baseSourcePath = "$basePath/main/GarnetServer/bin/Release"
-	$destinationPath = "$basePath/main/GarnetServer/bin/Release/publish"
+	$baseSourcePath = "$destDir/bin/Release"
+	$destinationPath = "$destDir/bin/Release/publish"
 	$zipfiledestinationPath = "$destinationPath/output"
 
 	# Make the destination path where the compressed files will be
-	if (!(Test-Path $destinationPath)) {
-		mkdir $destinationPath
-	}
-	if (!(Test-Path $zipfiledestinationPath)) {
-		mkdir $zipfiledestinationPath
-	}
+	New-Item -Type Directory -Force $destinationPath | Out-Null
+	New-Item -Type Directory -Force $zipfiledestinationPath | Out-Null
 	Set-Location $zipfiledestinationPath
 
 	foreach ($dir in $directories) {
-		if (!(Test-Path (Join-Path -Path $destinationPath -ChildPath $dir))) {
-			mkdir (Join-Path -Path $destinationPath -ChildPath $dir)
-		}
+		New-Item -Type Directory -Force (Join-Path -Path $destinationPath -ChildPath $dir) | Out-Null
 	}
 
 	foreach ($dir in $directories) {
 		foreach ($version in $sourceFramework) {
-			$sourcePath = Join-Path -Path $baseSourcePath -ChildPath "$version\publish\$dir"
+			$sourcePath = Join-Path -Path $baseSourcePath -ChildPath "$version/publish/$dir"
 			$destDirPath = Join-Path -Path $destinationPath -ChildPath $dir
 			$destVersionPath = Join-Path -Path $destDirPath -ChildPath $version
 			
-			if (!(Test-Path $destVersionPath)) {
-				mkdir $destVersionPath
-			}
-			
-			Copy-Item -Path "$sourcePath\*" -Destination $destVersionPath -Recurse -Force
+			New-Item -Type Directory -Force $destVersionPath | Out-Null
+			Copy-Item -Path "$sourcePath/*" -Destination $destVersionPath -Recurse -Force
 		}
 	}
  
 	# Compress the files - both net80 and net90 in the same zip file
 	Write-Host "** Compressing the files ... **"
-	7z a -mmt20 -mx5 -scsWIN -r win-x64-based-readytorun.zip ../win-x64/*
-	7z a -mmt20 -mx5 -scsWIN -r win-arm64-based-readytorun.zip ../win-arm64/*
+	7z a -mmt20 -mx5 -mm=Deflate64 -scsWIN -r win-x64-based-readytorun.zip ../win-x64/*
+	7z a -mmt20 -mx5 -mm=Deflate64 -scsWIN -r win-arm64-based-readytorun.zip ../win-arm64/*
 	7z a -scsUTF-8 -r linux-x64-based.tar ../linux-x64/*
 	7z a -scsUTF-8 -r linux-arm64-based.tar ../linux-arm64/*
 	7z a -scsUTF-8 -r osx-x64-based.tar ../osx-x64/*

--- a/main/GarnetServer/Properties/PublishProfiles/win-x64-based-readytorun.pubxml
+++ b/main/GarnetServer/Properties/PublishProfiles/win-x64-based-readytorun.pubxml
@@ -8,7 +8,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <Platform>Any CPU</Platform>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-	<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>
@@ -16,37 +16,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
-	<PublishDir>bin\Release\net8.0\publish\win-x64\</PublishDir>
+    <PublishDir>bin\Release\net8.0\publish\win-x64\</PublishDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0'">
-	<PublishDir>bin\Release\net9.0\publish\win-x64\</PublishDir>
+    <PublishDir>bin\Release\net9.0\publish\win-x64\</PublishDir>
   </PropertyGroup>
-
-  <ItemGroup>
-	<ProjectReference Include="..\..\hosting\Windows\Garnet.worker\Garnet.worker.csproj" />
-  </ItemGroup>
-  <Target Name="CopyWorkerDll" AfterTargets="Publish">
-  <ItemGroup>
-	<DependantDLLFiles Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\*.dll" />
-	<DependantXMLFiles Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\*.xml" />
-	<RuntimeFilesWinx64 Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\runtimes\win-x64\native\*" />
-	<RuntimeFilesWin Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\runtimes\win\lib\$(TargetFramework)\*" />
-	<GWRunTimeConfigFiles Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\Garnet.worker.runtimeconfig.json" />
-	<GWDepsFiles Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\Garnet.worker.deps.json" />
-	<GWEXEFiles Include="..\..\hosting\Windows\Garnet.worker\bin\$(Configuration)\$(TargetFramework)\Garnet.worker.exe" />
-  </ItemGroup>
-	<Copy SourceFiles="@(GWRunTimeConfigFiles)" DestinationFolder="$(PublishDir)Service" />
-	<Copy SourceFiles="@(DependantDLLFiles)" DestinationFolder="$(PublishDir)Service" />
-	<Copy SourceFiles="@(DependantXMLFiles)" DestinationFolder="$(PublishDir)Service" />
-	<Copy SourceFiles="@(RuntimeFilesWinx64)" DestinationFolder="$(PublishDir)Service\runtimes\win-x64\native" />
-	<Copy SourceFiles="@(RuntimeFilesWin)" DestinationFolder="$(PublishDir)Service\runtimes\win\lib\$(TargetFramework)" />
-	<Copy SourceFiles="@(GWDepsFiles)" DestinationFolder="$(PublishDir)Service" />
-	<Copy SourceFiles="@(GWEXEFiles)" DestinationFolder="$(PublishDir)Service" />
-	<Copy SourceFiles="@(GWRunTimeConfigFiles)" DestinationFolder="$(PublishDir)Service" />
-  </Target>
-  <Target Name="DeleteWorkerFiles" AfterTargets="CopyWorkerDll">
-	<Delete Files="$(PublishDir)Garnet.worker.exe" />
-	<Delete Files="$(PublishDir)Garnet.worker.deps.json" />
-	<Delete Files="$(PublishDir)Garnet.worker.runtimeconfig.json" />
-</Target>  
 </Project>


### PR DESCRIPTION
As of v1.0.78, a handrolled publish target is used to publish the Windows service for win x64 platform. So it can't use settings like SingleFile or ReadyRun (at least I couldn't manage to). The target is also incompatible with an artifact layout.
This PR changes createbinaries script and win=x64 publish target so:

* Normal publishing** is used for Windows service, making publish options available.
* Since a normal target is used, we can enable publishing Windows service as singlefile.
* The handrolled publish target is removed.

In addition the following changes are done too:

* Publish Windows service for win-arm64 too (the same reasoning for publishing with x64 applies I believe).
* Added parameters for script to allow setting up destination and build paths (default is identical to current script).
* Change Zipfile compression to use Deflate64. Windows 7+ supports it, so all supported Windows platforms can decompress. Compresses better with only a small change to running time (less than a second extra, result is very close to what -mx=9 with normal Deflate would achieve).

** It runs dotnet publish separately for the service. If that's a problem we could use a traversal project or msbuildproj files to only run one dotnet publish, but I doubt that's a problem - maybe it costs a little in runtime that's all.