### PR TITLE
INCRBYFLOAT: fix double's char counting and new API

### DIFF
--- a/libs/common/NumUtils.cs
+++ b/libs/common/NumUtils.cs
@@ -466,7 +466,7 @@ namespace Garnet.common
 
             signSize = (byte)(value < 0 ? 1 : 0); // Add sign if the number is negative
             value = Math.Abs(value);
-            integerDigits = (int)Math.Log10(value) + 1;
+            integerDigits = (value < 10) ? 1 : (int)Math.Log10(value) + 1;
 
             fractionalDigits = 0; // Max of 15 significant digits
             while (fractionalDigits <= 14 && Math.Abs(value - Math.Round(value, fractionalDigits)) > 2 * Double.Epsilon) // 2 * Double.Epsilon is used to handle floating point errors

--- a/libs/server/API/IGarnetApi.cs
+++ b/libs/server/API/IGarnetApi.cs
@@ -280,10 +280,10 @@ namespace Garnet.server
         /// Increment by float (INCRBYFLOAT)
         /// </summary>
         /// <param name="key"></param>
-        /// <param name="outputDbl"></param>
+        /// <param name="output"></param>
         /// <param name="val"></param>
         /// <returns></returns>
-        GarnetStatus IncrementByFloat(ArgSlice key, out double outputDbl, double val);
+        GarnetStatus IncrementByFloat(ArgSlice key, out double output, double val);
         #endregion
 
         #region DELETE

--- a/libs/server/API/IGarnetApi.cs
+++ b/libs/server/API/IGarnetApi.cs
@@ -272,8 +272,9 @@ namespace Garnet.server
         /// <param name="key"></param>
         /// <param name="val"></param>
         /// <param name="output"></param>
+        /// <param name="pinnedOutputBuffer"></param>
         /// <returns></returns>
-        GarnetStatus IncrementByFloat(ArgSlice key, out ArgSlice output, double val);
+        GarnetStatus IncrementByFloat(ArgSlice key, out ArgSlice output, double val, Span<byte> pinnedOutputBuffer);
 
         /// <summary>
         /// Increment by float (INCRBYFLOAT)

--- a/libs/server/API/IGarnetApi.cs
+++ b/libs/server/API/IGarnetApi.cs
@@ -272,9 +272,8 @@ namespace Garnet.server
         /// <param name="key"></param>
         /// <param name="val"></param>
         /// <param name="output"></param>
-        /// <param name="pinnedOutputBuffer"></param>
         /// <returns></returns>
-        GarnetStatus IncrementByFloat(ArgSlice key, out ArgSlice output, double val, Span<byte> pinnedOutputBuffer);
+        GarnetStatus IncrementByFloat(ArgSlice key, ref ArgSlice output, double val);
 
         /// <summary>
         /// Increment by float (INCRBYFLOAT)

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -772,7 +772,8 @@ namespace Garnet.server
             }
 
             Span<byte> outputBuffer = stackalloc byte[NumUtils.MaximumFormatDoubleLength + 1];
-            var status = storageApi.IncrementByFloat(key, out var output, dbl, outputBuffer);
+            var output = ArgSlice.FromPinnedSpan(outputBuffer);
+            var status = storageApi.IncrementByFloat(key, ref output, dbl);
 
             switch (status)
             {

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -771,7 +771,8 @@ namespace Garnet.server
                 return AbortWithErrorMessage(CmdStrings.RESP_ERR_GENERIC_NAN_INFINITY_INCR);
             }
 
-            var status = storageApi.IncrementByFloat(key, out ArgSlice output, dbl);
+            Span<byte> outputBuffer = stackalloc byte[NumUtils.MaximumFormatDoubleLength + 1];
+            var status = storageApi.IncrementByFloat(key, out var output, dbl, outputBuffer);
 
             switch (status)
             {

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -1367,7 +1367,8 @@ namespace Garnet.test
         }
 
         [Test]
-        [TestCase(0, 12.6)]
+        [TestCase(0, 0.1)]
+        [TestCase(0.1, 12.5)]
         [TestCase(12.6, 0)]
         [TestCase(10, 10)]
         [TestCase(910151, 0.23659)]


### PR DESCRIPTION
This PR fixes two problems:

1.
> INCRBYFLOAT key 0.1
> > Error: Server closed the connection
> > (Backend) System.ArgumentException: Destination is too short. (Parameter 'destination') 

Problem is NumUtils.CountCharsInDouble() uses Log10(value) and 0.1 counts as -1 digit.

2. Memory allocation/pinning for the new API was wrong: It should be done by caller, otherwise the runtime may mess with the memory once the API call was done but before the result being printed to the user (this was masked by the runtime usually using similar address and not messing with it, and by NUnit using same global context between tests - so once it was initialized the runtime kept the address).