### PR TITLE
Correct GetDistanceWhenInRectangle distance computation.

### DIFF
--- a/libs/server/Objects/SortedSetGeo/GeoHash.cs
+++ b/libs/server/Objects/SortedSetGeo/GeoHash.cs
@@ -303,8 +303,8 @@ namespace Garnet.server
         /// </summary>
         public static bool GetDistanceWhenInRectangle(double widthMts, double heightMts, double latCenterPoint, double lonCenterPoint, double lat2, double lon2, ref double distance)
         {
-            var lonDistance = Distance(lat2, lon2, latCenterPoint, lon2);
-            var latDistance = Distance(lat2, lon2, lat2, lonCenterPoint);
+            var lonDistance = Distance(lat2, lon2, lat2, lonCenterPoint);
+            var latDistance = Distance(lat2, lon2, latCenterPoint, lon2);
             if (lonDistance > widthMts / 2 || latDistance > heightMts / 2)
             {
                 return false;

--- a/test/Garnet.test/RespSortedSetGeoTests.cs
+++ b/test/Garnet.test/RespSortedSetGeoTests.cs
@@ -369,7 +369,7 @@ namespace Garnet.test
             ClassicAssert.AreEqual(4, res.Length);
 
             // Test infinity value
-            res = db.GeoSearch(key, new RedisValue("Columbus"), new GeoSearchBox(double.PositiveInfinity, 2, GeoUnit.Kilometers),
+            res = db.GeoSearch(key, new RedisValue("Columbus"), new GeoSearchBox(2, double.PositiveInfinity, GeoUnit.Kilometers),
                                order: Order.Descending,
                                options: GeoRadiusOptions.WithDistance | GeoRadiusOptions.WithCoordinates);
             ClassicAssert.AreEqual(2, res.Length);


### PR DESCRIPTION
The BYBOX distance check flipped longitude and latitude distances, and apparently we haven't noticed it since May 2024. Fix.

The infinity test is good to test this too, it's just GeoSearchBox's argument order is height,width (unlike the typical width,height), and I didn't notice that at the time.