### PR TITLE
Enforce stricter client name limits also for HELLO command

### DIFF
--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -1314,7 +1314,10 @@ namespace Garnet.server
                             break;
                         }
 
-                        tmpClientName = parseState.GetString(tokenIdx++);
+                        if (!parseState.TryGetClientName(tokenIdx++, out tmpClientName))
+                        {
+                            return AbortWithErrorMessage(CmdStrings.RESP_ERR_INVALID_CLIENT_NAME);
+                        }
                     }
                     else
                     {

--- a/libs/server/Resp/ClientCommands.cs
+++ b/libs/server/Resp/ClientCommands.cs
@@ -522,10 +522,9 @@ namespace Garnet.server
                 return AbortWithWrongNumberOfArguments("CLIENT|SETNAME");
             }
 
-            var name = parseState.GetString(0);
-            if (string.IsNullOrEmpty(name) || name.Contains(' '))   // it is not possible to use spaces in the connection name as this would violate the format of the CLIENT LIST reply
+            if (!parseState.TryGetClientName(0, out var name))
             {
-                return AbortWithErrorMessage(CmdStrings.RESP_SYNTAX_ERROR);
+                return AbortWithErrorMessage(CmdStrings.RESP_ERR_INVALID_CLIENT_NAME);
             }
 
             this.clientName = name;

--- a/libs/server/Resp/CmdStrings.cs
+++ b/libs/server/Resp/CmdStrings.cs
@@ -276,6 +276,7 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> RESP_ERR_UBLOCKING_CLINET => "ERR Unable to unblock client because of error."u8;
         public static ReadOnlySpan<byte> RESP_ERR_NO_SUCH_CLIENT => "ERR No such client"u8;
         public static ReadOnlySpan<byte> RESP_ERR_INVALID_CLIENT_ID => "ERR Invalid client ID"u8;
+        public static ReadOnlySpan<byte> RESP_ERR_INVALID_CLIENT_NAME => "ERR Client names cannot contain spaces, newlines or special characters."u8;
         public static ReadOnlySpan<byte> RESP_ERR_ACL_AUTH_DISABLED => "ERR ACL Authenticator is disabled."u8;
         public static ReadOnlySpan<byte> RESP_ERR_ACL_AUTH_FILE_DISABLED => "ERR This Garnet instance is not configured to use an ACL file. Please restart server with --acl-file option."u8;
         public static ReadOnlySpan<byte> RESP_ERR_XX_NX_NOT_COMPATIBLE => "ERR XX and NX options at the same time are not compatible"u8;

--- a/libs/server/SessionParseStateExtensions.cs
+++ b/libs/server/SessionParseStateExtensions.cs
@@ -104,7 +104,13 @@ namespace Garnet.server
         {
             clientName = parseState.GetString(idx);
 
-            if (string.IsNullOrEmpty(clientName))
+            if (clientName == null)
+            {
+                return false;
+            }
+
+            // Reference allows clearing client name
+            if (clientName == string.Empty)
             {
                 return true;
             }

--- a/libs/server/SessionParseStateExtensions.cs
+++ b/libs/server/SessionParseStateExtensions.cs
@@ -94,6 +94,33 @@ namespace Garnet.server
         }
 
         /// <summary>
+        /// Parse client name from parse state at specified index.
+        /// </summary>
+        /// <param name="parseState">The parse state</param>
+        /// <param name="idx">The argument index</param>
+        /// <param name="clientName">Client name</param>
+        /// <returns>True if value parsed successfully</returns>
+        internal static bool TryGetClientName(this SessionParseState parseState, int idx, out string clientName)
+        {
+            clientName = parseState.GetString(idx);
+
+            if (string.IsNullOrEmpty(clientName))
+            {
+                return true;
+            }
+
+            foreach (var c in clientName)
+            {
+                if (c < 33 || c > 126)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// Parse client type from parse state at specified index
         /// </summary>
         /// <param name="parseState">The parse state</param>
@@ -555,7 +582,6 @@ namespace Garnet.server
 
             return true;
         }
-
 
         /// <summary>
         /// Parse manager type from parse state at specified index

--- a/libs/server/SessionParseStateExtensions.cs
+++ b/libs/server/SessionParseStateExtensions.cs
@@ -109,6 +109,8 @@ namespace Garnet.server
                 return true;
             }
 
+            // Client names cannot contain spaces, newlines or special characters.
+            // We limit names to printable characters excluding space.
             foreach (var c in clientName)
             {
                 if (c < 33 || c > 126)

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -4408,6 +4408,11 @@ namespace Garnet.test
             db.Execute("CLIENT", "SETNAME", "testname");
             var result = (string)db.Execute("CLIENT", "GETNAME");
             ClassicAssert.AreEqual("testname", result);
+
+            // Test clearing client name
+            db.Execute("CLIENT", "SETNAME", "");
+            result = (string)db.Execute("CLIENT", "GETNAME");
+            ClassicAssert.AreEqual(null, result);
         }
 
         [Test]

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -4411,22 +4411,31 @@ namespace Garnet.test
         }
 
         [Test]
-        [TestCase("validname", true, Description = "Set valid name")]
-        [TestCase("", false, Description = "Set empty name")]
-        [TestCase(null, false, Description = "Set null name")]
-        [TestCase("name with spaces", false, Description = "Set name with spaces")]
-        public void ClientSetNameTest(string name, bool shouldSucceed)
+        [TestCase(false, "validname", true, "validname", Description = "Set valid name")]
+        [TestCase(true, "validname", true, "validname", Description = "Set valid name")]
+        [TestCase(false, "", true, Description = "Set empty name")]
+        [TestCase(true, "", true, Description = "Set empty name")]
+        [TestCase(false, "name with spaces", false, Description = "Set name with spaces")]
+        [TestCase(true, "name with spaces", false, Description = "Set name with spaces")]
+        public void ClientSetNameTest(bool hello, string name, bool shouldSucceed, string expectedName = null)
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = redis.GetDatabase(0);
 
             if (shouldSucceed)
             {
-                var result = (string)db.Execute("CLIENT", "SETNAME", name);
-                ClassicAssert.AreEqual("OK", result);
+                if (!hello)
+                {
+                    var result = (string)db.Execute("CLIENT", "SETNAME", name);
+                    ClassicAssert.AreEqual("OK", result);
+                }
+                else
+                {
+                    db.Execute("HELLO", "2", "SETNAME", name);
+                }
 
                 var getName = (string)db.Execute("CLIENT", "GETNAME");
-                ClassicAssert.AreEqual(name, getName);
+                ClassicAssert.AreEqual(expectedName, getName);
             }
             else
             {


### PR DESCRIPTION
Redis/valkey enforce limits on client names. These limits were not enforced on HELLO SETNAME command, and even when enforced, current limits allowed tab characters and so on. This PR enforces stricter limits for both commands setting client name.