### PR TITLE
More tiny SortedSet fixes

### DIFF
--- a/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using Garnet.common;
 
-using LimitDef = (int offset, int countLimit);
+using Limit = (int offset, int count);
 
 namespace Garnet.server
 {
@@ -26,7 +26,7 @@ namespace Garnet.server
             public bool Reverse { get; set; }
             public bool WithScores { get; set; }
             public bool ValidLimit { get; set; }
-            public LimitDef Limit { get; set; }
+            public Limit Limit { get; set; }
         };
 
         private enum SpecialRanges : byte
@@ -938,7 +938,7 @@ namespace Garnet.server
             bool validLimit,
             bool rem,
             out int errorCode,
-            LimitDef limit = default)
+            Limit limit = default)
         {
             var elementsInLex = new List<(double, byte[])>();
 
@@ -962,7 +962,7 @@ namespace Garnet.server
 
             if (minValueInfinity == SpecialRanges.InfiniteMax ||
                 maxValueInfinity == SpecialRanges.InfiniteMin ||
-                (validLimit && (limit.offset < 0 || limit.countLimit == 0)))
+                (validLimit && (limit.offset < 0 || limit.count == 0)))
             {
                 errorCode = 0;
                 return elementsInLex;
@@ -1013,7 +1013,7 @@ namespace Garnet.server
                 {
                     elementsInLex = [.. elementsInLex
                                         .Skip(limit.offset > 0 ? limit.offset : 0)
-                                        .Take(limit.countLimit >= 0 ? limit.countLimit : elementsInLex.Count)];
+                                        .Take(limit.count >= 0 ? limit.count : elementsInLex.Count)];
                 }
             }
             catch (ArgumentException)
@@ -1042,7 +1042,7 @@ namespace Garnet.server
         /// <param name="rem"></param>
         /// <param name="limit"></param>
         /// <returns></returns>
-        private List<(double, byte[])> GetElementsInRangeByScore(double minValue, double maxValue, bool minExclusive, bool maxExclusive, bool withScore, bool doReverse, bool validLimit, bool rem, LimitDef limit = default)
+        private List<(double, byte[])> GetElementsInRangeByScore(double minValue, double maxValue, bool minExclusive, bool maxExclusive, bool withScore, bool doReverse, bool validLimit, bool rem, Limit limit = default)
         {
             if (doReverse)
             {
@@ -1051,7 +1051,7 @@ namespace Garnet.server
             }
 
             List<(double, byte[])> scoredElements = new();
-            if ((validLimit && (limit.offset < 0 || limit.countLimit == 0)) ||
+            if ((validLimit && (limit.offset < 0 || limit.count == 0)) ||
                 (sortedSet.Max.Score < minValue))
             {
                 return scoredElements;
@@ -1069,7 +1069,7 @@ namespace Garnet.server
             {
                 scoredElements = [.. scoredElements
                                  .Skip(limit.offset > 0 ? limit.offset : 0)
-                                 .Take(limit.countLimit >= 0 ? limit.countLimit : scoredElements.Count)];
+                                 .Take(limit.count >= 0 ? limit.count : scoredElements.Count)];
             }
 
             if (rem)

--- a/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
@@ -959,7 +959,9 @@ namespace Garnet.server
                 (maxValueExclusive, minValueExclusive) = (minValueExclusive, maxValueExclusive);
             }
 
-            if (minValueInfinity == SpecialRanges.InfiniteMax || maxValueInfinity == SpecialRanges.InfiniteMin)
+            if (minValueInfinity == SpecialRanges.InfiniteMax ||
+                maxValueInfinity == SpecialRanges.InfiniteMin ||
+                (validLimit && (limit.Item1 < 0 || limit.Item2 == 0)))
             {
                 errorCode = 0;
                 return elementsInLex;
@@ -1011,7 +1013,7 @@ namespace Garnet.server
                 {
                     elementsInLex = [.. elementsInLex
                                         .Skip(limit.Item1 > 0 ? limit.Item1 : 0)
-                                        .Take(limit.Item2 > 0 ? limit.Item2 : elementsInLex.Count)];
+                                        .Take(limit.Item2 >= 0 ? limit.Item2 : elementsInLex.Count)];
                 }
             }
             catch (ArgumentException)
@@ -1048,7 +1050,8 @@ namespace Garnet.server
             }
 
             List<(double, byte[])> scoredElements = new();
-            if (sortedSet.Max.Item1 < minValue)
+            if ((validLimit && (limit.Item1 < 0 || limit.Item2 == 0)) ||
+                (sortedSet.Max.Item1 < minValue))
             {
                 return scoredElements;
             }
@@ -1065,7 +1068,7 @@ namespace Garnet.server
             {
                 scoredElements = [.. scoredElements
                                  .Skip(limit.Item1 > 0 ? limit.Item1 : 0)
-                                 .Take(limit.Item2 > 0 ? limit.Item2 : scoredElements.Count)];
+                                 .Take(limit.Item2 >= 0 ? limit.Item2 : scoredElements.Count)];
             }
 
             if (rem)

--- a/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
@@ -1047,6 +1047,7 @@ namespace Garnet.server
             if (doReverse)
             {
                 (minValue, maxValue) = (maxValue, minValue);
+                (minExclusive, maxExclusive) = (maxExclusive, minExclusive);
             }
 
             List<(double, byte[])> scoredElements = new();

--- a/libs/server/Storage/Session/ObjectStore/SetOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/SetOps.cs
@@ -985,7 +985,7 @@ namespace Garnet.server
                 var status = SetIntersect(keys, ref setObjectStoreLockableContext, out var result);
                 if (status == GarnetStatus.OK && result != null)
                 {
-                    count = limit.HasValue ? Math.Min(result.Count, limit.Value) : result.Count;
+                    count = limit > 0 ? Math.Min(result.Count, limit.Value) : result.Count;
                 }
                 return status;
             }

--- a/libs/server/Storage/Session/ObjectStore/SortedSetOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/SortedSetOps.cs
@@ -1335,7 +1335,7 @@ namespace Garnet.server
             var status = SortedSetIntersect(keys, null, SortedSetAggregateType.Sum, out var pairs);
             if (status == GarnetStatus.OK && pairs != null)
             {
-                count = limit.HasValue ? Math.Min(pairs.Count, limit.Value) : pairs.Count;
+                count = limit > 0 ? Math.Min(pairs.Count, limit.Value) : pairs.Count;
             }
 
             return status;

--- a/test/Garnet.test/RespSetTest.cs
+++ b/test/Garnet.test/RespSetTest.cs
@@ -723,15 +723,15 @@ namespace Garnet.test
         }
 
         [Test]
-        [TestCase("1,2,3", "2,3,4", "2", null, Description = "Basic intersection")]
-        [TestCase("1,2,3", "", "0", null, Description = "Intersection with empty set")]
-        [TestCase("1,2,3", "4,5,6", "0", null, Description = "No intersection")]
-        [TestCase("1,1,1", "1,1,1", "1", null, Description = "Sets with duplicate values")]
-        [TestCase("", "", "0", null, Description = "Both sets empty")]
-        [TestCase("1,2,3,4,5", "2,3,4,5,6", "1", "1", Description = "Basic intersection with limit")]
-        [TestCase("1,2,3", "2,3,4", "2", "5", Description = "Limit greater than intersection")]
-        [TestCase("1,2,3,4,5", "2,3,4,5,6", "0", "0", Description = "Zero limit")]
-        public void CanDoSinterCard(string values1, string values2, string expectedCount, string limit)
+        [TestCase("1,2,3", "2,3,4", 2, null, Description = "Basic intersection")]
+        [TestCase("1,2,3", "", 0, null, Description = "Intersection with empty set")]
+        [TestCase("1,2,3", "4,5,6", 0, null, Description = "No intersection")]
+        [TestCase("1,1,1", "1,1,1", 1, null, Description = "Sets with duplicate values")]
+        [TestCase("", "", 0, null, Description = "Both sets empty")]
+        [TestCase("1,2,3,4,5", "2,3,4,5,6", 1, "1", Description = "Basic intersection with limit")]
+        [TestCase("1,2,3", "2,3,4", 2, "5", Description = "Limit greater than intersection")]
+        [TestCase("1,2,3,4,5", "2,3,4,5,6", 4, "0", Description = "Zero limit")]
+        public void CanDoSinterCard(string values1, string values2, long expectedCount, string limit)
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = redis.GetDatabase(0);
@@ -752,7 +752,7 @@ namespace Garnet.test
                 (long)db.Execute("SINTERCARD", 2, "key1", "key2") :
                 (long)db.Execute("SINTERCARD", 2, "key1", "key2", "LIMIT", limit);
 
-            ClassicAssert.AreEqual(long.Parse(expectedCount), result);
+            ClassicAssert.AreEqual(expectedCount, result);
 
             // Test with non-existing keys
             result = (long)db.Execute("SINTERCARD", 2, "nonexistent1", "nonexistent2");

--- a/test/Garnet.test/RespSortedSetTests.cs
+++ b/test/Garnet.test/RespSortedSetTests.cs
@@ -3799,6 +3799,10 @@ namespace Garnet.test
             expectedResponse = "*4\r\n$6\r\nSunsui\r\n$4\r\n2200\r\n$2\r\nLG\r\n$4\r\n2500\r\n";
             response = lightClientRequest.Execute("ZRANGEBYSCORE mysales -inf +inf WITHSCORES LIMIT 4 10", expectedResponse.Length, bytesSent);
             ClassicAssert.AreEqual(expectedResponse, response);
+
+            expectedResponse = "*0\r\n";
+            response = lightClientRequest.Execute("ZRANGEBYSCORE mysales -inf +inf WITHSCORES LIMIT 4 0", expectedResponse.Length, bytesSent);
+            ClassicAssert.AreEqual(expectedResponse, response);
         }
 
         [Test]
@@ -3860,13 +3864,7 @@ namespace Garnet.test
         {
             //ZRANGE key min max BYLEX REV [WITHSCORES]
             using var lightClientRequest = TestUtils.CreateRequest();
-            var response = lightClientRequest.SendCommand("ZADD board 0 a");
-            lightClientRequest.SendCommand("ZADD board 0 b");
-            lightClientRequest.SendCommand("ZADD board 0 c");
-            lightClientRequest.SendCommand("ZADD board 0 d");
-            lightClientRequest.SendCommand("ZADD board 0 e");
-            lightClientRequest.SendCommand("ZADD board 0 f");
-            lightClientRequest.SendCommand("ZADD board 0 g");
+            var response = lightClientRequest.SendCommand("ZADD board 0 a 0 b 0 c 0 d 0 e 0 f 0 g");
 
             // get a range by lex order
             response = lightClientRequest.SendCommand("ZRANGE board (a (d BYLEX REV", 1);
@@ -3916,6 +3914,11 @@ namespace Garnet.test
             response = lightClientRequest.SendCommand("ZRANGEBYLEX mycity - + LIMIT 2 3", 4);
             //expectedResponse = "*3\r\n$7\r\nNewYork\r\n$5\r\nParis\r\n$5\r\nSeoul\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
+            // LIMIT x 0
+            response = lightClientRequest.SendCommand("ZRANGEBYLEX mycity - + LIMIT 2 0");
+            expectedResponse = "*0\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]
@@ -3926,12 +3929,7 @@ namespace Garnet.test
         {
             //ZRANGE key min max REV
             using var lightClientRequest = TestUtils.CreateRequest();
-            var response = lightClientRequest.SendCommand("ZADD board 0 a");
-            lightClientRequest.SendCommand("ZADD board 0 b");
-            lightClientRequest.SendCommand("ZADD board 0 c");
-            lightClientRequest.SendCommand("ZADD board 0 d");
-            lightClientRequest.SendCommand("ZADD board 0 e");
-            lightClientRequest.SendCommand("ZADD board 0 f");
+            var response = lightClientRequest.SendCommand("ZADD board 0 a 0 b 0 c 0 d 0 e 0 f");
 
             // get a range by lex order
             response = lightClientRequest.SendCommandChunks("ZRANGE board 0 -1 REV", bytesSent, 7);
@@ -4231,12 +4229,7 @@ namespace Garnet.test
         {
             //ZREVRANGE key start stop [WITHSCORES]
             using var lightClientRequest = TestUtils.CreateRequest();
-            var response = lightClientRequest.SendCommand("ZADD board 10 a");
-            lightClientRequest.SendCommand("ZADD board 20 b");
-            lightClientRequest.SendCommand("ZADD board 30 c");
-            lightClientRequest.SendCommand("ZADD board 40 d");
-            lightClientRequest.SendCommand("ZADD board 50 e");
-            lightClientRequest.SendCommand("ZADD board 60 f");
+            var response = lightClientRequest.SendCommand("ZADD board 10 a 20 b 30 c 40 d 50 e 60 f");
 
             // get a range by lex order
             response = lightClientRequest.SendCommand("ZREVRANGE board 0 -1", 7);
@@ -4258,12 +4251,7 @@ namespace Garnet.test
         {
             //ZREVRANGESCORE key start stop [WITHSCORES] [LIMIT offset count]
             using var lightClientRequest = TestUtils.CreateRequest();
-            var response = lightClientRequest.SendCommand("ZADD board 10 a");
-            lightClientRequest.SendCommand("ZADD board 20 b");
-            lightClientRequest.SendCommand("ZADD board 30 c");
-            lightClientRequest.SendCommand("ZADD board 40 d");
-            lightClientRequest.SendCommand("ZADD board 50 e");
-            lightClientRequest.SendCommand("ZADD board 60 f");
+            var response = lightClientRequest.SendCommand("ZADD board 10 a 20 b 30 c 40 d 50 e 60 f");
 
             // get a reverse range by score order
             response = lightClientRequest.SendCommand("ZREVRANGEBYSCORE board 70 0", 7);
@@ -4279,8 +4267,13 @@ namespace Garnet.test
             expectedResponse = "*2\r\n$1\r\nf\r\n$1\r\ne\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
+            // Test LIMITs
             response = lightClientRequest.SendCommand("ZREVRANGEBYSCORE board 70 45 LIMIT 0 1", 2);
             expectedResponse = "*1\r\n$1\r\nf\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
+            response = lightClientRequest.SendCommand("ZREVRANGEBYSCORE board 70 45 LIMIT -1 1");
+            expectedResponse = "*0\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 

--- a/test/Garnet.test/RespSortedSetTests.cs
+++ b/test/Garnet.test/RespSortedSetTests.cs
@@ -4275,6 +4275,11 @@ namespace Garnet.test
             response = lightClientRequest.SendCommand("ZREVRANGEBYSCORE board 70 45 LIMIT -1 1");
             expectedResponse = "*0\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
+            // Exclusions should be reversed too
+            response = lightClientRequest.SendCommand("ZREVRANGEBYSCORE board +inf (40", 3);
+            expectedResponse = "*2\r\n$1\r\nf\r\n$1\r\ne\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]

--- a/test/Garnet.test/RespSortedSetTests.cs
+++ b/test/Garnet.test/RespSortedSetTests.cs
@@ -5088,6 +5088,7 @@ namespace Garnet.test
         [TestCase("ZINTERCARD 2 zset1 zset2", 2, Description = "Basic intersection cardinality")]
         [TestCase("ZINTERCARD 3 zset1 zset2 zset3", 1, Description = "Three-way intersection cardinality")]
         [TestCase("ZINTERCARD 2 zset1 zset2 LIMIT 1", 1, Description = "With limit")]
+        [TestCase("ZINTERCARD 2 zset1 zset2 LIMIT 0", 2, Description = "With unlimited limit")]
         public void CanDoZInterCard(string command, int expectedCount)
         {
             using var lightClientRequest = TestUtils.CreateRequest();


### PR DESCRIPTION
1. ZINTERCARD z LIMIT 0 is defined as 'unlimited' in docs, yet code enforced 0 as limit. Same for SINTERCARD.

https://redis.io/docs/latest/commands/zintercard/

>When provided with the optional LIMIT argument (which defaults to 0 and means unlimited)

2. ZREVRANGEBYSCORE didn't reverse exclusions (i.e. open intervals) which can lead to wrong results.

3. ZRANGE BYLEX/BYSCORE LIMIT (something) 0 should return an empty array. 
ZRANGE LIMIT (negative) (count) also acts this way in practice. An extension to make it work from the end makes sense, this PR makes it follows reference behaviour though.

4. Some style changes for SortedSet code - use tuple provided name where possible, use more efficient Dictionary.Remove overload.