### PR TITLE
Bug Fix: Corrected checkpoint task used in WaitOrDie for object store snapshot

### DIFF
--- a/libs/cluster/Server/Replication/PrimaryOps/DisklessReplication/ReplicationSyncManager.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/DisklessReplication/ReplicationSyncManager.cs
@@ -289,9 +289,9 @@ namespace Garnet.cluster
                 if (!ClusterProvider.serverOptions.DisableObjects)
                 {
                     // Iterate through object store
-                    var objectStoreCheckpointTask = await ClusterProvider.storeWrapper.objectStore.
+                    var objectStoreCheckpointTask = ClusterProvider.storeWrapper.objectStore.
                         TakeFullCheckpointAsync(CheckpointType.StreamingSnapshot, streamingSnapshotIteratorFunctions: manager.objectStoreSnapshotIterator);
-                    result = await WaitOrDie(checkpointTask: mainStoreCheckpointTask, iteratorManager: manager);
+                    result = await WaitOrDie(checkpointTask: objectStoreCheckpointTask, iteratorManager: manager);
                     if (!result.success)
                         throw new InvalidOperationException("Object store checkpoint stream failed!");
                 }


### PR DESCRIPTION
This PR fixes a bug in the diskless replication checkpoint flow where the wrong task `mainStoreCheckpointTask` was being passed to the `WaitOrDie` method during object store snapshotting.

Bug:
Previously, during object store checkpointing, `WaitOrDie` was incorrectly invoked with `mainStoreCheckpointTask`, which corresponds to the **main store checkpoint**. This could result in:
- Incorrect progress checks: Monitoring main store progress while object store is being snapshotted
- Potential hangs or premature success handling: WaitOrDie would complete based on main store status, not object store
- Misleading exception triggers: "Object store checkpoint stream failed" would trigger based on main store result
- Main store checkpoint task being awaited twice: Once for main store, once incorrectly for object store