### PR TITLE
HELLO command: Abort protocol change if there's an authentication failure or any other validation failure

### DIFF
--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -1287,6 +1287,11 @@ namespace Garnet.server
                     return AbortWithErrorMessage(CmdStrings.RESP_ERR_PROTOCOL_VALUE_IS_NOT_INTEGER);
                 }
 
+                if (localRespProtocolVersion is < 2 or > 3)
+                {
+                    return AbortWithErrorMessage(CmdStrings.RESP_ERR_UNSUPPORTED_PROTOCOL_VERSION);
+                }
+
                 tmpRespProtocolVersion = (byte)localRespProtocolVersion;
 
                 while (tokenIdx < count)
@@ -1521,23 +1526,20 @@ namespace Garnet.server
         /// </summary>
         void ProcessHelloCommand(byte? respProtocolVersion, ReadOnlySpan<byte> username, ReadOnlySpan<byte> password, string clientName)
         {
-            if (respProtocolVersion != null)
+            // Per RESP3 specifications and observed reference behaviour,
+            // every failure in validation or authentication should prevent
+            // the entire command from being run. For example,
+            // "HELLO 3 AUTH user password SETNAME name" should not change protocol or name if
+            // the user authentication fails for any reason.
+            //
+            // So we must do things in a particular order:
+            // First, validations, if passes then user authentication, and only then if it's fine,
+            // protocol and name changes.
+            if (respProtocolVersion.HasValue && (respProtocolVersion.Value != this.respProtocolVersion) &&
+                (asyncCompleted < asyncStarted))
             {
-                if (respProtocolVersion.Value is < 2 or > 3)
-                {
-                    while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_UNSUPPORTED_PROTOCOL_VERSION, ref dcurr, dend))
-                        SendAndReset();
-                    return;
-                }
-
-                if (respProtocolVersion.Value != this.respProtocolVersion && asyncCompleted < asyncStarted)
-                {
-                    while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_ASYNC_PROTOCOL_CHANGE, ref dcurr, dend))
-                        SendAndReset();
-                    return;
-                }
-
-                this.UpdateRespProtocolVersion(respProtocolVersion.Value);
+                WriteError(CmdStrings.RESP_ERR_ASYNC_PROTOCOL_CHANGE);
+                return;
             }
 
             if (!username.IsEmpty)
@@ -1546,16 +1548,19 @@ namespace Garnet.server
                 {
                     if (username.IsEmpty)
                     {
-                        while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_WRONGPASS_INVALID_PASSWORD, ref dcurr, dend))
-                            SendAndReset();
+                        WriteError(CmdStrings.RESP_WRONGPASS_INVALID_PASSWORD);
                     }
                     else
                     {
-                        while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_WRONGPASS_INVALID_USERNAME_PASSWORD, ref dcurr, dend))
-                            SendAndReset();
+                        WriteError(CmdStrings.RESP_WRONGPASS_INVALID_USERNAME_PASSWORD);
                     }
                     return;
                 }
+            }
+
+            if (respProtocolVersion.HasValue && (respProtocolVersion.Value != this.respProtocolVersion))
+            {
+                UpdateRespProtocolVersion(respProtocolVersion.Value);
             }
 
             if (clientName != null)

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -3849,21 +3849,14 @@ namespace Garnet.test
         }
 
         [Test]
-        public void HelloTest2()
+        public void HelloAuthErrorTest()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: RedisProtocol.Resp2));
             var db = redis.GetDatabase(0);
 
             // Failed HELLO should not change current protocol
-            try
-            {
-                db.Execute("HELLO", "3", "AUTH", "NX", "NX");
-                ClassicAssert.Fail("Should never reach this line, user does not exist");
-            }
-            catch
-            {
-                // Passthrough
-            }
+            Assert.Throws<RedisServerException>(() => db.Execute("HELLO", "3", "AUTH", "NX", "NX"),
+                           Encoding.ASCII.GetString(CmdStrings.RESP_WRONGPASS_INVALID_USERNAME_PASSWORD));
             var result = db.Execute("HELLO");
 
             ClassicAssert.IsNotNull(result);

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -3849,6 +3849,34 @@ namespace Garnet.test
         }
 
         [Test]
+        public void HelloTest2()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: RedisProtocol.Resp2));
+            var db = redis.GetDatabase(0);
+
+            // Failed HELLO should not change current protocol
+            try
+            {
+                db.Execute("HELLO", "3", "AUTH", "NX", "NX");
+                ClassicAssert.Fail("Should never reach this line, user does not exist");
+            }
+            catch
+            {
+                // Passthrough
+            }
+            var result = db.Execute("HELLO");
+
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual(ResultType.Array, result.Resp2Type);
+            ClassicAssert.AreEqual(ResultType.Array, result.Resp3Type);
+            var resultDict = result.ToDictionary();
+            ClassicAssert.IsNotNull(resultDict);
+
+            // Should remain 2 since protocol change failed
+            ClassicAssert.AreEqual(2, (int)resultDict["proto"]);
+        }
+
+        [Test]
         [TestCase([2, "$-1\r\n", "$1\r\n", "*4", '*'], Description = "RESP2 output")]
         [TestCase([3, "_\r\n", ",", "%2", '~'], Description = "RESP3 output")]
         public async Task RespOutputTests(byte respVersion, string expectedResponse, string doublePrefix, string mapPrefix, char setPrefix)


### PR DESCRIPTION
RESP3 spec suggests that a failed auth may prevent protocol version change.

https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md

>Note that even if the protocol is supported, the HELLO command may return an error and perform no action (so the connection will remain in RESP2 mode) in case the authentication credentials are wrong:

Observed reference behaviour is that every validation or authentication failure prevents protocol change (or client name change).
To match this, reorder code in NetworkHELLO() and ProcessHelloMessage() so that verification and then authentication precede every action, so no protocol change is done if user authentication fails.