### PR TITLE
Add `global.json`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "dotnet-sdk"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci-bdnbenchmark.yml
+++ b/.github/workflows/ci-bdnbenchmark.yml
@@ -53,10 +53,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: | 
-            8.0.x
-            9.0.x
       - name: Install dependencies
         run: dotnet restore
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Setup .NET 8.0
+      - name: Setup .NET
         uses: actions/setup-dotnet@v4
       - name: Install dependencies
         run: dotnet restore
@@ -128,7 +128,7 @@ jobs:
       - name: Set environment variable for Windows
         run: echo ("RunAzureTests=yes") >> $env:GITHUB_ENV
         if: ${{ matrix.os == 'windows-latest' }}
-      - name: Setup .NET 8.0
+      - name: Setup .NET
         uses: actions/setup-dotnet@v4
       - name: Setup Node.js for Azurite
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Setup .NET 8.0
+      - name: Setup .NET
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-      - name: Setup .NET 9.0
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 9.0.x
       - name: Install dependencies
         run: dotnet restore Garnet.sln
       - name: Check style format
@@ -70,14 +64,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Setup .NET 8.0
+      - name: Setup .NET
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-      - name: Setup .NET 9.0
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 9.0.x
       - name: Install dependencies
         run: dotnet restore libs/storage/Tsavorite/cs/Tsavorite.sln
       - name: Check style format
@@ -101,12 +89,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-      - name: Setup .NET 9.0
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 9.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build Garnet
@@ -148,12 +130,6 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
       - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-      - name: Setup .NET 9.0
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 9.0.x
       - name: Setup Node.js for Azurite
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,17 +75,9 @@ jobs:
     # to build your code.
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Setup .NET 8.0
+    - name: Setup .NET
       if: ${{ matrix.build-mode == 'manual' }}
       uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0.x
-
-    - name: Setup .NET 9.0
-      if: ${{ matrix.build-mode == 'manual' }}
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 9.0.x
 
     - name: Install dependencies
       if: ${{ matrix.build-mode == 'manual' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,14 +25,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Setup .NET 8.0
+      - name: Setup .NET
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-      - name: Setup .NET 9.0
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 9.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Check style format
@@ -72,14 +66,8 @@ jobs:
       - name: Set environment variable for Windows
         run: echo ("RunAzureTests=yes") >> $env:GITHUB_ENV
         if: ${{ matrix.os == 'windows-latest' }}
-      - name: Setup .NET 8.0
+      - name: Setup .NET
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-      - name: Setup .NET 9.0
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 9.0.x
       - name: Setup Node.js for Azurite
         uses: actions/setup-node@v4
         with:

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.304",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
This adds a `global.json` file to enforce a minimum version of the .NET SDK.

This project contains a mix of .NET 8 and 9 projects, but newer versions of the SDK are backwards compatible, and can build projects targeting older versions of .NET.

I also simplified the GitHub Actions workflows, as `actions/setup-dotnet` looks at `global.json` by default. So there is no need to explicitly specify `dotnet-version` or `global-json-file`.

Finally, I added a Dependabot configuration which will keep `global.json` up-to-date as new security patches are released for .NET.