### PR TITLE
Update `BenchmarkDotNet` from `0.14.0` to `0.15.2`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
   <ItemGroup>
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageVersion Include="Azure.Identity" Version="1.14.1" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.12" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.2" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="JsonPath.Net" Version="1.1.6" />
     <PackageVersion Include="KeraLua" Version="1.4.6" />


### PR DESCRIPTION
The benchmarks were failing after #1340. Updating BenchmarkDotNet from `0.14.0` to `0.15.2` seems to fix the issue. I can't see a relevant issue in [the changelogs][1], and unfortunately, I don't have time to `git bisect` it to find out.

EDIT: I am 99% sure it is this change: https://github.com/dotnet/BenchmarkDotNet/pull/2645

[1]: https://benchmarkdotnet.org/changelog/index.html