### PR TITLE
Add Dependabot configuration for NuGet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This should prevent issues like #1344

[Dependabot is _a lot_ better at NuGet recently 😉][1]

[1]: https://devblogs.microsoft.com/dotnet/the-new-dependabot-nuget-updater/