### PR TITLE
Sketch out VectorAPI support

### DIFF
--- a/libs/cluster/Server/ClusterManagerSlotState.cs
+++ b/libs/cluster/Server/ClusterManagerSlotState.cs
@@ -17,7 +17,10 @@ namespace Garnet.cluster
             SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>,
         BasicContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions,
             /* ObjectStoreFunctions */ StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>,
-            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>>;
+            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>,
+        BasicContext<SpanByte, SpanByte, VectorInput, SpanByte, long, VectorSessionFunctions,
+            /* VectorStoreFunctions */ StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>,
+            SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>>;
 
     /// <summary>
     /// Cluster manager

--- a/libs/cluster/Server/ClusterProvider.cs
+++ b/libs/cluster/Server/ClusterProvider.cs
@@ -20,7 +20,10 @@ namespace Garnet.cluster
             SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>,
         BasicContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions,
             /* ObjectStoreFunctions */ StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>,
-            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>>;
+            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>,
+        BasicContext<SpanByte, SpanByte, VectorInput, SpanByte, long, VectorSessionFunctions,
+            /* VectorStoreFunctions */ StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>,
+            SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>>;
 
     /// <summary>
     /// Cluster provider

--- a/libs/cluster/Session/ClusterSession.cs
+++ b/libs/cluster/Session/ClusterSession.cs
@@ -17,7 +17,10 @@ namespace Garnet.cluster
             SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>,
         BasicContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions,
             /* ObjectStoreFunctions */ StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>,
-            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>>;
+            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>,
+        BasicContext<SpanByte, SpanByte, VectorInput, SpanByte, long, VectorSessionFunctions,
+            /* VectorStoreFunctions */ StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>,
+            SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>>;
 
     internal sealed unsafe partial class ClusterSession : IClusterSession
     {

--- a/libs/cluster/Session/RespClusterMigrateCommands.cs
+++ b/libs/cluster/Session/RespClusterMigrateCommands.cs
@@ -17,7 +17,10 @@ namespace Garnet.cluster
         SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>,
     BasicContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions,
         /* ObjectStoreFunctions */ StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>,
-        GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>>;
+        GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>,
+        BasicContext<SpanByte, SpanByte, VectorInput, SpanByte, long, VectorSessionFunctions,
+            /* VectorStoreFunctions */ StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>,
+            SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>>;
 
     internal sealed unsafe partial class ClusterSession : IClusterSession
     {

--- a/libs/common/RespReadUtils.cs
+++ b/libs/common/RespReadUtils.cs
@@ -1341,5 +1341,40 @@ namespace Garnet.common
             number = default;
             return false;
         }
+
+        /// <summary>
+        /// Parses "[+/-]inf" string and returns float.PositiveInfinity/float.NegativeInfinity respectively.
+        /// If string is not an infinity, parsing fails.
+        /// </summary>
+        /// <param name="value">input data</param>
+        /// <param name="number">If parsing was successful,contains positive or negative infinity</param>
+        /// <returns>True is infinity was read, false otherwise</returns>
+        public static bool TryReadInfinity(ReadOnlySpan<byte> value, out float number)
+        {
+            if (value.Length == 3)
+            {
+                if (value.EqualsUpperCaseSpanIgnoringCase(RespStrings.INFINITY))
+                {
+                    number = float.PositiveInfinity;
+                    return true;
+                }
+            }
+            else if (value.Length == 4)
+            {
+                if (value.EqualsUpperCaseSpanIgnoringCase(RespStrings.POS_INFINITY, true))
+                {
+                    number = float.PositiveInfinity;
+                    return true;
+                }
+                else if (value.EqualsUpperCaseSpanIgnoringCase(RespStrings.NEG_INFINITY, true))
+                {
+                    number = float.NegativeInfinity;
+                    return true;
+                }
+            }
+
+            number = default;
+            return false;
+        }
     }
 }

--- a/libs/resources/RespCommandsDocs.json
+++ b/libs/resources/RespCommandsDocs.json
@@ -7643,6 +7643,182 @@
     "Complexity": "O(1)"
   },
   {
+    "Command": "VADD",
+    "Name": "VADD",
+    "Summary": "Add a new element into the vector set.",
+    "Group": "Vector",
+    "Complexity": "O(log(N))",
+    "Arguments": [
+      {
+        "TypeDiscriminator": "RespCommandKeyArgument",
+        "Name": "KEY",
+        "DisplayText": "key",
+        "Type": "Key",
+        "KeySpecIndex": 0
+      }
+    ]
+  },
+  {
+    "Command": "VCARD",
+    "Name": "VCARD",
+    "Summary": "Return the number of elements in a vector set.",
+    "Group": "Vector",
+    "Complexity": "O(1)",
+    "Arguments": [
+      {
+        "TypeDiscriminator": "RespCommandKeyArgument",
+        "Name": "KEY",
+        "DisplayText": "key",
+        "Type": "Key",
+        "KeySpecIndex": 0
+      }
+    ]
+  },
+  {
+    "Command": "VDIM",
+    "Name": "VDIM",
+    "Summary": "Return the number of dimensions in a vector set.",
+    "Group": "Vector",
+    "Complexity": "O(1)",
+    "Arguments": [
+      {
+        "TypeDiscriminator": "RespCommandKeyArgument",
+        "Name": "KEY",
+        "DisplayText": "key",
+        "Type": "Key",
+        "KeySpecIndex": 0
+      }
+    ]
+  },
+  {
+    "Command": "VEMB",
+    "Name": "VEMB",
+    "Summary": "Return the approximate vector associated with an element in a vector set.",
+    "Group": "Vector",
+    "Complexity": "O(1)",
+    "Arguments": [
+      {
+        "TypeDiscriminator": "RespCommandKeyArgument",
+        "Name": "KEY",
+        "DisplayText": "key",
+        "Type": "Key",
+        "KeySpecIndex": 0
+      }
+    ]
+  },
+  {
+    "Command": "VGETATTR",
+    "Name": "VGETATTR",
+    "Summary": "Return the JSON attributes associated with the element in the vector set.",
+    "Group": "Vector",
+    "Complexity": "O(1)",
+    "Arguments": [
+      {
+        "TypeDiscriminator": "RespCommandKeyArgument",
+        "Name": "KEY",
+        "DisplayText": "key",
+        "Type": "Key",
+        "KeySpecIndex": 0
+      }
+    ]
+  },
+  {
+    "Command": "VINFO",
+    "Name": "VINFO",
+    "Summary": "Return details about a vector set, including dimensions, quantization, and structure.",
+    "Group": "Vector",
+    "Complexity": "O(1)",
+    "Arguments": [
+      {
+        "TypeDiscriminator": "RespCommandKeyArgument",
+        "Name": "KEY",
+        "DisplayText": "key",
+        "Type": "Key",
+        "KeySpecIndex": 0
+      }
+    ]
+  },
+  {
+    "Command": "VLINKS",
+    "Name": "VLINKS",
+    "Summary": "Return the neighbors of an element in a vector set.",
+    "Group": "Vector",
+    "Complexity": "O(1)",
+    "Arguments": [
+      {
+        "TypeDiscriminator": "RespCommandKeyArgument",
+        "Name": "KEY",
+        "DisplayText": "key",
+        "Type": "Key",
+        "KeySpecIndex": 0
+      }
+    ]
+  },
+  {
+    "Command": "VRANDMEMBER",
+    "Name": "VRANDMEMBER",
+    "Summary": "Return some number of random elements from a vector set.",
+    "Group": "Vector",
+    "Complexity": "O(1)",
+    "Arguments": [
+      {
+        "TypeDiscriminator": "RespCommandKeyArgument",
+        "Name": "KEY",
+        "DisplayText": "key",
+        "Type": "Key",
+        "KeySpecIndex": 0
+      }
+    ]
+  },
+  {
+    "Command": "VREM",
+    "Name": "VREM",
+    "Summary": "Remove an element from a vector set.",
+    "Group": "Vector",
+    "Complexity": "O(log(N))",
+    "Arguments": [
+      {
+        "TypeDiscriminator": "RespCommandKeyArgument",
+        "Name": "KEY",
+        "DisplayText": "key",
+        "Type": "Key",
+        "KeySpecIndex": 0
+      }
+    ]
+  },
+  {
+    "Command": "VSETATTR",
+    "Name": "VSETATTR",
+    "Summary": "Store attributes alongside a member of a vector set.",
+    "Group": "Vector",
+    "Complexity": "O(1)",
+    "Arguments": [
+      {
+        "TypeDiscriminator": "RespCommandKeyArgument",
+        "Name": "KEY",
+        "DisplayText": "key",
+        "Type": "Key",
+        "KeySpecIndex": 0
+      }
+    ]
+  },
+  {
+    "Command": "VSIM",
+    "Name": "VSIM",
+    "Summary": "Return elements similar to a given vector or existing element of a vector set.",
+    "Group": "Vector",
+    "Complexity": "O(log(N))",
+    "Arguments": [
+      {
+        "TypeDiscriminator": "RespCommandKeyArgument",
+        "Name": "KEY",
+        "DisplayText": "key",
+        "Type": "Key",
+        "KeySpecIndex": 0
+      }
+    ]
+  },
+  {
     "Command": "WATCH",
     "Name": "WATCH",
     "Summary": "Monitors changes to keys to determine the execution of a transaction.",

--- a/libs/resources/RespCommandsInfo.json
+++ b/libs/resources/RespCommandsInfo.json
@@ -4951,6 +4951,281 @@
     "AclCategories": "Fast, Transaction"
   },
   {
+    "Command": "VADD",
+    "Name": "VADD",
+    "Arity": -1,
+    "Flags": "DenyOom, Write, Module",
+    "FirstKey": 1,
+    "LastKey": 1,
+    "Step": 1,
+    "AclCategories": "Fast, Vector, Write",
+    "KeySpecifications": [
+      {
+        "BeginSearch": {
+          "TypeDiscriminator": "BeginSearchIndex",
+          "Index": 1
+        },
+        "FindKeys": {
+          "TypeDiscriminator": "FindKeysRange",
+          "LastKey": 0,
+          "KeyStep": 1,
+          "Limit": 0
+        },
+        "Flags": "RW, Insert"
+      }
+    ]
+  },
+  {
+    "Command": "VCARD",
+    "Name": "VCARD",
+    "Arity": -1,
+    "Flags": "Fast, ReadOnly, Module",
+    "FirstKey": 1,
+    "LastKey": 1,
+    "Step": 1,
+    "AclCategories": "Fast, Read, Vector",
+    "KeySpecifications": [
+      {
+        "BeginSearch": {
+          "TypeDiscriminator": "BeginSearchIndex",
+          "Index": 1
+        },
+        "FindKeys": {
+          "TypeDiscriminator": "FindKeysRange",
+          "LastKey": 0,
+          "KeyStep": 1,
+          "Limit": 0
+        },
+        "Flags": "RO"
+      }
+    ]
+  },
+  {
+    "Command": "VDIM",
+    "Name": "VDIM",
+    "Arity": -1,
+    "Flags": "Fast, ReadOnly, Module",
+    "FirstKey": 1,
+    "LastKey": 1,
+    "Step": 1,
+    "AclCategories": "Fast, Read, Vector",
+    "KeySpecifications": [
+      {
+        "BeginSearch": {
+          "TypeDiscriminator": "BeginSearchIndex",
+          "Index": 1
+        },
+        "FindKeys": {
+          "TypeDiscriminator": "FindKeysRange",
+          "LastKey": 0,
+          "KeyStep": 1,
+          "Limit": 0
+        },
+        "Flags": "RO"
+      }
+    ]
+  },
+  {
+    "Command": "VEMB",
+    "Name": "VEMB",
+    "Arity": -1,
+    "Flags": "Fast, ReadOnly, Module",
+    "FirstKey": 1,
+    "LastKey": 1,
+    "Step": 1,
+    "AclCategories": "Fast, Read, Vector",
+    "KeySpecifications": [
+      {
+        "BeginSearch": {
+          "TypeDiscriminator": "BeginSearchIndex",
+          "Index": 1
+        },
+        "FindKeys": {
+          "TypeDiscriminator": "FindKeysRange",
+          "LastKey": 0,
+          "KeyStep": 1,
+          "Limit": 0
+        },
+        "Flags": "RO"
+      }
+    ]
+  },
+  {
+    "Command": "VGETATTR",
+    "Name": "VGETATTR",
+    "Arity": -1,
+    "Flags": "Fast, ReadOnly, Module",
+    "FirstKey": 1,
+    "LastKey": 1,
+    "Step": 1,
+    "AclCategories": "Fast, Read, Vector",
+    "KeySpecifications": [
+      {
+        "BeginSearch": {
+          "TypeDiscriminator": "BeginSearchIndex",
+          "Index": 1
+        },
+        "FindKeys": {
+          "TypeDiscriminator": "FindKeysRange",
+          "LastKey": 0,
+          "KeyStep": 1,
+          "Limit": 0
+        },
+        "Flags": "RO"
+      }
+    ]
+  },
+  {
+    "Command": "VINFO",
+    "Name": "VINFO",
+    "Arity": -1,
+    "Flags": "Fast, ReadOnly, Module",
+    "FirstKey": 1,
+    "LastKey": 1,
+    "Step": 1,
+    "AclCategories": "Fast, Read, Vector",
+    "KeySpecifications": [
+      {
+        "BeginSearch": {
+          "TypeDiscriminator": "BeginSearchIndex",
+          "Index": 1
+        },
+        "FindKeys": {
+          "TypeDiscriminator": "FindKeysRange",
+          "LastKey": 0,
+          "KeyStep": 1,
+          "Limit": 0
+        },
+        "Flags": "RO"
+      }
+    ]
+  },
+  {
+    "Command": "VLINKS",
+    "Name": "VLINKS",
+    "Arity": -1,
+    "Flags": "Fast, ReadOnly, Module",
+    "FirstKey": 1,
+    "LastKey": 1,
+    "Step": 1,
+    "AclCategories": "Fast, Read, Vector",
+    "KeySpecifications": [
+      {
+        "BeginSearch": {
+          "TypeDiscriminator": "BeginSearchIndex",
+          "Index": 1
+        },
+        "FindKeys": {
+          "TypeDiscriminator": "FindKeysRange",
+          "LastKey": 0,
+          "KeyStep": 1,
+          "Limit": 0
+        },
+        "Flags": "RO"
+      }
+    ]
+  },
+  {
+    "Command": "VRANDMEMBER",
+    "Name": "VRANDMEMBER",
+    "Arity": -1,
+    "Flags": "ReadOnly, Module",
+    "FirstKey": 1,
+    "LastKey": 1,
+    "Step": 1,
+    "AclCategories": "Slow, Read, Vector",
+    "KeySpecifications": [
+      {
+        "BeginSearch": {
+          "TypeDiscriminator": "BeginSearchIndex",
+          "Index": 1
+        },
+        "FindKeys": {
+          "TypeDiscriminator": "FindKeysRange",
+          "LastKey": 0,
+          "KeyStep": 1,
+          "Limit": 0
+        },
+        "Flags": "RO"
+      }
+    ]
+  },
+  {
+    "Command": "VREM",
+    "Name": "VREM",
+    "Arity": -1,
+    "Flags": "Write, Module",
+    "FirstKey": 1,
+    "LastKey": 1,
+    "Step": 1,
+    "AclCategories": "Slow, Write, Vector",
+    "KeySpecifications": [
+      {
+        "BeginSearch": {
+          "TypeDiscriminator": "BeginSearchIndex",
+          "Index": 1
+        },
+        "FindKeys": {
+          "TypeDiscriminator": "FindKeysRange",
+          "LastKey": 0,
+          "KeyStep": 1,
+          "Limit": 0
+        },
+        "Flags": "RW, Delete"
+      }
+    ]
+  },
+  {
+    "Command": "VSETATTR",
+    "Name": "VSETATTR",
+    "Arity": -1,
+    "Flags": "Fast, Write, Module",
+    "FirstKey": 1,
+    "LastKey": 1,
+    "Step": 1,
+    "AclCategories": "Fast, Write, Vector",
+    "KeySpecifications": [
+      {
+        "BeginSearch": {
+          "TypeDiscriminator": "BeginSearchIndex",
+          "Index": 1
+        },
+        "FindKeys": {
+          "TypeDiscriminator": "FindKeysRange",
+          "LastKey": 0,
+          "KeyStep": 1,
+          "Limit": 0
+        },
+        "Flags": "RW, Insert"
+      }
+    ]
+  },
+  {
+    "Command": "VSIM",
+    "Name": "VSIM",
+    "Arity": -1,
+    "Flags": "ReadOnly, Module",
+    "FirstKey": 1,
+    "LastKey": 1,
+    "Step": 1,
+    "AclCategories": "Slow, Read, Vector",
+    "KeySpecifications": [
+      {
+        "BeginSearch": {
+          "TypeDiscriminator": "BeginSearchIndex",
+          "Index": 1
+        },
+        "FindKeys": {
+          "TypeDiscriminator": "FindKeysRange",
+          "LastKey": 0,
+          "KeyStep": 1,
+          "Limit": 0
+        },
+        "Flags": "RO"
+      }
+    ]
+  },
+  {
     "Command": "WATCH",
     "Name": "WATCH",
     "Arity": -2,

--- a/libs/server/ACL/ACLParser.cs
+++ b/libs/server/ACL/ACLParser.cs
@@ -33,6 +33,7 @@ namespace Garnet.server.ACL
             ["stream"] = RespAclCategories.Stream,
             ["string"] = RespAclCategories.String,
             ["transaction"] = RespAclCategories.Transaction,
+            ["vector"] = RespAclCategories.Vector,
             ["write"] = RespAclCategories.Write,
             ["garnet"] = RespAclCategories.Garnet,
             ["custom"] = RespAclCategories.Custom,

--- a/libs/server/API/GarnetApiObjectCommands.cs
+++ b/libs/server/API/GarnetApiObjectCommands.cs
@@ -16,9 +16,10 @@ namespace Garnet.server
     /// <summary>
     /// Garnet API implementation
     /// </summary>
-    public partial struct GarnetApi<TContext, TObjectContext> : IGarnetApi, IGarnetWatchApi
+    public partial struct GarnetApi<TContext, TObjectContext, TVectorContext> : IGarnetApi, IGarnetWatchApi
         where TContext : ITsavoriteContext<SpanByte, SpanByte, RawStringInput, SpanByteAndMemory, long, MainSessionFunctions, MainStoreFunctions, MainStoreAllocator>
         where TObjectContext : ITsavoriteContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions, ObjectStoreFunctions, ObjectStoreAllocator>
+        where TVectorContext : ITsavoriteContext<SpanByte, SpanByte, VectorInput, SpanByte, long, VectorSessionFunctions, MainStoreFunctions, MainStoreAllocator>
     {
         #region SortedSet Methods
 

--- a/libs/server/API/IGarnetApi.cs
+++ b/libs/server/API/IGarnetApi.cs
@@ -1206,6 +1206,36 @@ namespace Garnet.server
         GarnetStatus HyperLogLogMerge(ref RawStringInput input, out bool error);
 
         #endregion
+
+        #region VectorSet Methods
+
+        // TODO: Span-ish types are very inconsistent here, think about them maybe?
+
+        /// <summary>
+        /// Adds to (and may create) a vector set with the given parameters.
+        /// </summary>
+        GarnetStatus VectorSetAdd(SpanByte key, int reduceDims, ReadOnlySpan<float> values, ArgSlice element, VectorQuantType quantizer, int buildExplorationFactor, ArgSlice attributes, int numLinks, out VectorManagerResult result);
+
+        /// <summary>
+        /// Perform a similarity search given a vector and these parameters.
+        /// 
+        /// Ids are encoded in <paramref name="outputIds"/> as length prefixed blobs of bytes.
+        /// </summary>
+        GarnetStatus VectorSetValueSimilarity(SpanByte key, ReadOnlySpan<float> values, int count, float delta, int searchExplorationFactor, ReadOnlySpan<byte> filter, int maxFilteringEffort, ref SpanByteAndMemory outputIds, ref SpanByteAndMemory outputDistances, out VectorManagerResult result);
+
+        /// <summary>
+        /// Perform a similarity search given an element already in the vector set and these parameters.
+        /// 
+        /// Ids are encoded in <paramref name="outputIds"/> as length prefixed blobs of bytes.
+        /// </summary>
+        GarnetStatus VectorSetElementSimilarity(SpanByte key, ReadOnlySpan<byte> element, int count, float delta, int searchExplorationFactor, ReadOnlySpan<byte> filter, int maxFilteringEffort, ref SpanByteAndMemory outputIds, ref SpanByteAndMemory outputDistances, out VectorManagerResult result);
+
+        /// <summary>
+        /// Fetch the embedding of a given element in a Vector set.
+        /// </summary>
+        GarnetStatus VectorEmbedding(SpanByte key, ReadOnlySpan<byte> element, ref SpanByteAndMemory outputDistances);
+
+        #endregion
     }
 
     /// <summary>

--- a/libs/server/Cluster/IClusterProvider.cs
+++ b/libs/server/Cluster/IClusterProvider.cs
@@ -17,7 +17,10 @@ namespace Garnet.server
             SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>,
         BasicContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions,
             /* ObjectStoreFunctions */ StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>,
-            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>>;
+            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>,
+        BasicContext<SpanByte, SpanByte, VectorInput, SpanByte, long, VectorSessionFunctions,
+            /* VectorStoreFunctions */ StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>,
+            SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>>;
 
     /// <summary>
     /// Cluster provider

--- a/libs/server/InputHeader.cs
+++ b/libs/server/InputHeader.cs
@@ -529,4 +529,15 @@ namespace Garnet.server
         [FieldOffset(0)]
         public int result1;
     }
+
+    /// <summary>
+    /// Header for Garnet Main Store inputs but for Vector element r/w/d ops
+    /// </summary>
+    public struct VectorInput : IStoreInput
+    {
+        public int SerializedLength => throw new NotImplementedException();
+
+        public unsafe int CopyTo(byte* dest, int length) => throw new NotImplementedException();
+        public unsafe int DeserializeFrom(byte* src) => throw new NotImplementedException();
+    }
 }

--- a/libs/server/Resp/GarnetDatabaseSession.cs
+++ b/libs/server/Resp/GarnetDatabaseSession.cs
@@ -8,13 +8,19 @@ namespace Garnet.server
             SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>,
         BasicContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions,
             /* ObjectStoreFunctions */ StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>,
-            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>>;
+            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>,
+        BasicContext<SpanByte, SpanByte, VectorInput, SpanByte, long, VectorSessionFunctions,
+            /* VectorStoreFunctions */ StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>,
+            SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>>;
     using LockableGarnetApi = GarnetApi<LockableContext<SpanByte, SpanByte, RawStringInput, SpanByteAndMemory, long, MainSessionFunctions,
             /* MainStoreFunctions */ StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>,
             SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>,
         LockableContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions,
             /* ObjectStoreFunctions */ StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>,
-            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>>;
+            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>,
+        LockableContext<SpanByte, SpanByte, VectorInput, SpanByte, long, VectorSessionFunctions,
+            /* VectorStoreFunctions */ StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>,
+            SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>>;
 
     /// <summary>
     /// Represents a logical database session in Garnet

--- a/libs/server/Resp/LocalServerSession.cs
+++ b/libs/server/Resp/LocalServerSession.cs
@@ -12,7 +12,10 @@ namespace Garnet.server
             SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>,
         BasicContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions,
             /* ObjectStoreFunctions */ StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>,
-            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>>;
+            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>,
+        BasicContext<SpanByte, SpanByte, VectorInput, SpanByte, long, VectorSessionFunctions,
+            /* VectorStoreFunctions */ StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>,
+            SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>>;
 
     /// <summary>
     /// Local server session
@@ -50,7 +53,7 @@ namespace Garnet.server
             // Create storage session and API
             this.storageSession = new StorageSession(storeWrapper, scratchBufferBuilder, sessionMetrics, LatencyMetrics, dbId: 0, logger);
 
-            this.BasicGarnetApi = new BasicGarnetApi(storageSession, storageSession.basicContext, storageSession.objectStoreBasicContext);
+            this.BasicGarnetApi = new BasicGarnetApi(storageSession, storageSession.basicContext, storageSession.objectStoreBasicContext, storageSession.vectorContext);
         }
 
         /// <inheritdoc />

--- a/libs/server/Resp/Parser/ParseUtils.cs
+++ b/libs/server/Resp/Parser/ParseUtils.cs
@@ -131,6 +131,26 @@ namespace Garnet.server
         }
 
         /// <summary>
+        /// Try to read a signed 64-bit float from a given ArgSlice.
+        /// </summary>
+        /// <param name="slice">Source</param>
+        /// <param name="number">Result</param>
+        /// <param name="canBeInfinite">Allow reading an infinity</param>
+        /// <returns>
+        /// True if float parsed successfully
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadFloat(ref ArgSlice slice, out float number, bool canBeInfinite)
+        {
+            var sbNumber = slice.ReadOnlySpan;
+            if (Utf8Parser.TryParse(sbNumber, out number, out var bytesConsumed) &&
+                            bytesConsumed == sbNumber.Length)
+                return true;
+
+            return canBeInfinite && RespReadUtils.TryReadInfinity(sbNumber, out number);
+        }
+
+        /// <summary>
         /// Read an ASCII string from a given ArgSlice.
         /// </summary>
         /// <returns>

--- a/libs/server/Resp/Parser/RespCommand.cs
+++ b/libs/server/Resp/Parser/RespCommand.cs
@@ -81,6 +81,14 @@ namespace Garnet.server
         SUNION,
         TTL,
         TYPE,
+        VCARD,
+        VDIM,
+        VEMB,
+        VGETATTR,
+        VINFO,
+        VLINKS,
+        VRANDMEMBER,
+        VSIM,
         WATCH,
         WATCHMS,
         WATCHOS,
@@ -195,6 +203,9 @@ namespace Garnet.server
         SUNIONSTORE,
         SWAPDB,
         UNLINK,
+        VADD,
+        VREM,
+        VSETATTR,
         ZADD,
         ZCOLLECT,
         ZDIFFSTORE,
@@ -958,6 +969,29 @@ namespace Garnet.server
                                         }
                                         break;
 
+                                    case 'V':
+                                        if (*(ulong*)(ptr + 2) == MemoryMarshal.Read<ulong>("\r\nVADD\r\n"u8))
+                                        {
+                                            return RespCommand.VADD;
+                                        }
+                                        else if (*(ulong*)(ptr + 2) == MemoryMarshal.Read<ulong>("\r\nVDIM\r\n"u8))
+                                        {
+                                            return RespCommand.VDIM;
+                                        }
+                                        else if (*(ulong*)(ptr + 2) == MemoryMarshal.Read<ulong>("\r\nVEMB\r\n"u8))
+                                        {
+                                            return RespCommand.VEMB;
+                                        }
+                                        else if (*(ulong*)(ptr + 2) == MemoryMarshal.Read<ulong>("\r\nVREM\r\n"u8))
+                                        {
+                                            return RespCommand.VREM;
+                                        }
+                                        else if (*(ulong*)(ptr + 2) == MemoryMarshal.Read<ulong>("\r\nVSIM\r\n"u8))
+                                        {
+                                            return RespCommand.VSIM;
+                                        }
+                                        break;
+
                                     case 'Z':
                                         if (*(ulong*)(ptr + 2) == MemoryMarshal.Read<ulong>("\r\nZADD\r\n"u8))
                                         {
@@ -1115,6 +1149,17 @@ namespace Garnet.server
                                         else if (*(ulong*)(ptr + 3) == MemoryMarshal.Read<ulong>("\nSDIFF\r\n"u8))
                                         {
                                             return RespCommand.SDIFF;
+                                        }
+                                        break;
+
+                                    case 'V':
+                                        if (*(ulong*)(ptr + 3) == MemoryMarshal.Read<ulong>("\nVCARD\r\n"u8))
+                                        {
+                                            return RespCommand.VCARD;
+                                        }
+                                        else if (*(ulong*)(ptr + 3) == MemoryMarshal.Read<ulong>("\nVINFO\r\n"u8))
+                                        {
+                                            return RespCommand.VINFO;
                                         }
                                         break;
 
@@ -1312,6 +1357,13 @@ namespace Garnet.server
                                         }
                                         break;
 
+                                    case 'V':
+                                        if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("VLINKS\r\n"u8))
+                                        {
+                                            return RespCommand.VLINKS;
+                                        }
+                                        break;
+
                                     case 'Z':
                                         if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("ZCOUNT\r\n"u8))
                                         {
@@ -1487,6 +1539,14 @@ namespace Garnet.server
                                 {
                                     return RespCommand.SPUBLISH;
                                 }
+                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("VGETATTR"u8) && *(ushort*)(ptr + 12) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                {
+                                    return RespCommand.VGETATTR;
+                                }
+                                else if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("VSETATTR"u8) && *(ushort*)(ptr + 12) == MemoryMarshal.Read<ushort>("\r\n"u8))
+                                {
+                                    return RespCommand.VSETATTR;
+                                }
                                 break;
                             case 9:
                                 if (*(ulong*)(ptr + 4) == MemoryMarshal.Read<ulong>("SUBSCRIB"u8) && *(uint*)(ptr + 11) == MemoryMarshal.Read<uint>("BE\r\n"u8))
@@ -1660,6 +1720,10 @@ namespace Garnet.server
                                 else if (*(ulong*)(ptr + 2) == MemoryMarshal.Read<ulong>("1\r\nZEXPI"u8) && *(ulong*)(ptr + 10) == MemoryMarshal.Read<ulong>("RETIME\r\n"u8))
                                 {
                                     return RespCommand.ZEXPIRETIME;
+                                }
+                                else if (*(ulong*)(ptr + 2) == MemoryMarshal.Read<ulong>("1\r\nVRAND"u8) && *(ulong*)(ptr + 10) == MemoryMarshal.Read<ulong>("MEMBER\r\n"u8))
+                                {
+                                    return RespCommand.VRANDMEMBER;
                                 }
                                 break;
 

--- a/libs/server/Resp/Parser/SessionParseState.cs
+++ b/libs/server/Resp/Parser/SessionParseState.cs
@@ -163,21 +163,6 @@ namespace Garnet.server
         }
 
         /// <summary>
-        /// Initialize the parse state with a given set of arguments
-        /// </summary>
-        /// <param name="args">Set of arguments to initialize buffer with</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void InitializeWithArguments(ArgSlice[] args)
-        {
-            Initialize(args.Length);
-
-            for (var i = 0; i < args.Length; i++)
-            {
-                *(bufferPtr + i) = args[i];
-            }
-        }
-
-        /// <summary>
         /// Limit access to the argument buffer to start at a specified index.
         /// </summary>
         /// <param name="idxOffset">Offset value to the underlying buffer</param>
@@ -430,6 +415,17 @@ namespace Garnet.server
         {
             Debug.Assert(i < Count);
             return ParseUtils.TryReadDouble(ref Unsafe.AsRef<ArgSlice>(bufferPtr + i), out value, canBeInfinite);
+        }
+
+        /// <summary>
+        /// Try to get double argument at the given index
+        /// </summary>
+        /// <returns>True if double parsed successfully</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryGetFloat(int i, out float value, bool canBeInfinite = true)
+        {
+            Debug.Assert(i < Count);
+            return ParseUtils.TryReadFloat(ref Unsafe.AsRef<ArgSlice>(bufferPtr + i), out value, canBeInfinite);
         }
 
         /// <summary>

--- a/libs/server/Resp/RespCommandDocs.cs
+++ b/libs/server/Resp/RespCommandDocs.cs
@@ -330,6 +330,8 @@ namespace Garnet.server
         String,
         [Description("transactions")]
         Transactions,
+        [Description("vector")]
+        Vector
     }
 
     /// <summary>

--- a/libs/server/Resp/RespCommandInfoFlags.cs
+++ b/libs/server/Resp/RespCommandInfoFlags.cs
@@ -55,6 +55,8 @@ namespace Garnet.server
         Write = 1 << 19,
         [Description("allow_busy")]
         AllowBusy = 1 << 20,
+        [Description("module")]
+        Module = 1 << 21,
     }
 
     /// <summary>
@@ -110,6 +112,8 @@ namespace Garnet.server
         Garnet = 1 << 21,
         [Description("custom")]
         Custom = 1 << 22,
+        [Description("vector")]
+        Vector = 1 << 23,
         [Description("all")]
         All = (Custom << 1) - 1,
     }

--- a/libs/server/Resp/Vector/IVectorService.cs
+++ b/libs/server/Resp/Vector/IVectorService.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+
+namespace Garnet.server
+{
+    public delegate int VectorReadDelegate(ulong context, ReadOnlySpan<byte> key, Span<byte> value);
+    public delegate bool VectorWriteDelegate(ulong context, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value);
+    public delegate bool VectorDeleteDelegate(ulong context, ReadOnlySpan<byte> key);
+
+    /// <summary>
+    /// For Mocking/Plugging purposes, represents the actual implementation of a bunch of Vector Set operations.
+    /// </summary>
+    public unsafe interface IVectorService
+    {
+        /// <summary>
+        /// When creating an index, indicates which method to use.
+        /// </summary>
+        bool UseUnmanagedCallbacks { get; }
+
+        /// <summary>
+        /// Construct a new index to back a Vector Set.
+        /// </summary>
+        /// <param name="context">Unique value for construction, will be passed for all for operations alongside the returned index.  Always a multiple of 4.</param>
+        /// <param name="dimensions">Dimensions of vectors will be passed to future operations. Always > 0</param>
+        /// <param name="reduceDims">If non-0, the requested dimension of the random projection to apply before indexing vectors.</param>
+        /// <param name="quantType">Type of quantization requested.</param>
+        /// <param name="buildExplorationFactor">Exploration factor requested.</param>
+        /// <param name="numLinks">Number of links between adjacent vectors requested.</param>
+        /// <param name="readCallback">Callback used to read values out of Garnet store.</param>
+        /// <param name="writeCallback">Callback used to write values to Garnet store.</param>
+        /// <param name="deleteCallback">Callback used to delete values from Garnet store.</param>
+        /// <returns>Reference to constructed index.</returns>
+        nint CreateIndexUnmanaged(ulong context, uint dimensions, uint reduceDims, VectorQuantType quantType, uint buildExplorationFactor, uint numLinks, delegate* unmanaged[Cdecl]<ulong, byte*, nuint, byte*, nuint, int> readCallback, delegate* unmanaged[Cdecl]<ulong, byte*, nuint, byte*, nuint, bool> writeCallback, delegate* unmanaged[Cdecl]<ulong, byte*, nuint, bool> deleteCallback);
+
+        /// <summary>
+        /// Equivalent of <see cref="CreateIndexUnmanaged"/>, but with managed callbacks.
+        /// </summary>
+        nint CreateIndexManaged(ulong context, uint dimensions, uint reduceDims, VectorQuantType quantType, uint buildExplorationFactor, uint numLinks, VectorReadDelegate readCallback, VectorWriteDelegate writeCallback, VectorDeleteDelegate deleteCallback);
+
+        /// <summary>
+        /// Delete a previously created index.
+        /// </summary>
+        void DropIndex(ulong context, nint index);
+
+        /// <summary>
+        /// Insert a vector into an index.
+        /// </summary>
+        /// <returns>True if the vector was added, false otherwise.</returns>
+        bool Insert(ulong context, nint index, ReadOnlySpan<byte> id, ReadOnlySpan<float> vector, ReadOnlySpan<byte> attributes);
+
+        /// <summary>
+        /// Search for similar vectors, given a vector.
+        /// 
+        /// <paramref name="outputIds"/> are length prefixed with little endian ints.
+        /// <paramref name="continuation"/> is non-zero if there are more results to fetch than could be fit in <paramref name="outputIds"/>.
+        /// 
+        /// Returns number of results placed in outputXXX parameters.
+        /// </summary>
+        int SearchVector(ulong context, nint index, ReadOnlySpan<float> vector, float delta, int searchExplorationFactor, ReadOnlySpan<byte> filter, int maxFilteringEffort, Span<byte> outputIds, Span<float> outputDistances, out nint continuation);
+
+        /// <summary>
+        /// Search for similar vectors, given a vector.
+        /// 
+        /// <paramref name="outputIds"/> are length prefixed with little endian ints.
+        /// <paramref name="continuation"/> is non-zero if there are more results to fetch than could be fit in <paramref name="outputIds"/>.
+        /// 
+        /// Returns number of results placed in outputXXX parameters.
+        /// </summary>
+        int SearchElement(ulong context, nint index, ReadOnlySpan<byte> id, float delta, int searchExplorationFactor, ReadOnlySpan<byte> filter, int maxFilteringEffort, Span<byte> outputIds, Span<float> outputDistances, out nint continuation);
+
+        /// <summary>
+        /// Continue fetching results when a call to <see cref="SearchVector"/> or <see cref="SearchElement"/> had a non-zero continuation result.
+        /// 
+        /// Will be called exactly once per continuation provided, and will always be called if a search operation produced a continuation.
+        /// </summary>
+        int ContinueSearch(ulong context, nint index, nint continuation, Span<byte> outputIds, Span<float> outputDistances, out nint newContinuation);
+
+        /// <summary>
+        /// Fetch the embedding of a vector in the vector set, if it exists.
+        /// 
+        /// This undoes any dimensionality reduction, so values may be approximate.
+        /// 
+        /// <paramref name="dimensions"/> is always the size of dimesions passed to <see cref="CreateIndexManaged"/> or <see cref="CreateIndexUnmanaged"/>.
+        /// </summary>
+        bool TryGetEmbedding(ulong context, nint index, ReadOnlySpan<byte> id, Span<float> dimensions);
+    }
+}

--- a/libs/server/Resp/Vector/RespServerSessionVectors.cs
+++ b/libs/server/Resp/Vector/RespServerSessionVectors.cs
@@ -1,0 +1,762 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+using Garnet.common;
+using Tsavorite.core;
+
+namespace Garnet.server
+{
+    internal sealed unsafe partial class RespServerSession : ServerSessionBase
+    {
+        private bool NetworkVADD<TGarnetApi>(ref TGarnetApi storageApi)
+            where TGarnetApi : IGarnetApi
+        {
+            // VADD key [REDUCE dim] (FP32 | VALUES num) vector element [CAS] [NOQUANT | Q8 | BIN] [EF build-exploration-factor] [SETATTR attributes] [M numlinks]
+
+            // key FP32|VALUES vector element
+            if (parseState.Count < 4)
+            {
+                return AbortWithWrongNumberOfArguments("VADD");
+            }
+
+            var key = parseState.GetArgSliceByRef(0).SpanByte;
+
+            var curIx = 1;
+
+            var reduceDim = 0;
+            if (parseState.GetArgSliceByRef(curIx).Span.EqualsUpperCaseSpanIgnoringCase("REDUCE"u8))
+            {
+                curIx++;
+                if (!parseState.TryGetInt(curIx, out var reduceDimValue) || reduceDimValue <= 0)
+                {
+                    return AbortWithErrorMessage("REDUCE dimension must be > 0"u8);
+                }
+
+                reduceDim = reduceDimValue;
+                curIx++;
+            }
+
+            float[] rentedValues = null;
+            Span<float> values = stackalloc float[64];
+
+            try
+            {
+                if (parseState.GetArgSliceByRef(curIx).Span.EqualsUpperCaseSpanIgnoringCase("FP32"u8))
+                {
+                    curIx++;
+                    if (curIx >= parseState.Count)
+                    {
+                        return AbortWithWrongNumberOfArguments("VADD");
+                    }
+
+                    var asBytes = parseState.GetArgSliceByRef(curIx).Span;
+                    if ((asBytes.Length % sizeof(float)) != 0)
+                    {
+                        return AbortWithErrorMessage("FP32 values must be multiple of 4-bytes in size");
+                    }
+
+                    values = MemoryMarshal.Cast<byte, float>(asBytes);
+                }
+                else if (parseState.GetArgSliceByRef(curIx).Span.EqualsUpperCaseSpanIgnoringCase("VALUES"u8))
+                {
+                    curIx++;
+                    if (curIx >= parseState.Count)
+                    {
+                        return AbortWithWrongNumberOfArguments("VADD");
+                    }
+
+                    if (!parseState.TryGetInt(curIx, out var valueCount) || valueCount <= 0)
+                    {
+                        return AbortWithErrorMessage("VALUES count must > 0");
+                    }
+                    curIx++;
+
+                    if (valueCount > values.Length)
+                    {
+                        values = rentedValues = ArrayPool<float>.Shared.Rent(valueCount);
+                    }
+                    values = values[..valueCount];
+
+                    if (curIx + valueCount > parseState.Count)
+                    {
+                        return AbortWithWrongNumberOfArguments("VADD");
+                    }
+
+                    for (var valueIx = 0; valueIx < valueCount; valueIx++)
+                    {
+                        if (!parseState.TryGetFloat(curIx, out values[valueIx]))
+                        {
+                            return AbortWithErrorMessage("VALUES value must be valid float");
+                        }
+
+                        curIx++;
+                    }
+                }
+
+                if (curIx >= parseState.Count)
+                {
+                    return AbortWithWrongNumberOfArguments("VADD");
+                }
+
+                var element = parseState.GetArgSliceByRef(curIx);
+                curIx++;
+
+                if (curIx < parseState.Count)
+                {
+                    if (parseState.GetArgSliceByRef(curIx).Span.EqualsUpperCaseSpanIgnoringCase("CAS"u8))
+                    {
+                        // We ignore CAS
+                        curIx++;
+                    }
+                }
+
+                VectorQuantType quantType;
+                if (curIx < parseState.Count)
+                {
+                    if (parseState.GetArgSliceByRef(curIx).Span.EqualsUpperCaseSpanIgnoringCase("NOQUANT"u8))
+                    {
+                        quantType = VectorQuantType.NoQuant;
+                        curIx++;
+                    }
+                    else if (parseState.GetArgSliceByRef(curIx).Span.EqualsUpperCaseSpanIgnoringCase("Q8"u8))
+                    {
+                        quantType = VectorQuantType.Q8;
+                        curIx++;
+                    }
+                    else if (parseState.GetArgSliceByRef(curIx).Span.EqualsUpperCaseSpanIgnoringCase("BIN"u8))
+                    {
+                        quantType = VectorQuantType.Bin;
+                        curIx++;
+                    }
+                    else
+                    {
+                        return AbortWithErrorMessage("Unrecogized quantization"u8);
+                    }
+                }
+                else
+                {
+                    quantType = VectorQuantType.Invalid;
+                }
+
+                var buildExplorationFactor = 0;
+                if (curIx < parseState.Count)
+                {
+                    if (parseState.GetArgSliceByRef(curIx).Span.EqualsUpperCaseSpanIgnoringCase("EF"u8))
+                    {
+                        curIx++;
+
+                        if (curIx >= parseState.Count)
+                        {
+                            return AbortWithWrongNumberOfArguments("VADD");
+                        }
+
+                        if (!parseState.TryGetInt(curIx, out buildExplorationFactor) || buildExplorationFactor <= 0)
+                        {
+                            return AbortWithErrorMessage("EF must be > 0");
+                        }
+
+                        curIx++;
+                    }
+                }
+
+                ArgSlice attributes = default;
+                if (curIx < parseState.Count)
+                {
+                    if (parseState.GetArgSliceByRef(curIx).Span.EqualsUpperCaseSpanIgnoringCase("SETATTR"u8))
+                    {
+                        curIx++;
+                        if (curIx >= parseState.Count)
+                        {
+                            return AbortWithWrongNumberOfArguments("VADD");
+                        }
+
+                        attributes = parseState.GetArgSliceByRef(curIx);
+                        curIx++;
+
+                        // TODO: Validate attributes
+                    }
+                }
+
+                var numLinks = 0;
+                if (curIx < parseState.Count)
+                {
+                    if (parseState.GetArgSliceByRef(curIx).Span.EqualsUpperCaseSpanIgnoringCase("M"u8))
+                    {
+                        curIx++;
+                        if (curIx >= parseState.Count)
+                        {
+                            return AbortWithWrongNumberOfArguments("VADD");
+                        }
+
+                        if (!parseState.TryGetInt(curIx, out numLinks) || numLinks <= 0)
+                        {
+                            return AbortWithErrorMessage("M must be > 0");
+                        }
+
+                        curIx++;
+                    }
+                }
+
+                if (parseState.Count != curIx)
+                {
+                    return AbortWithWrongNumberOfArguments("VADD");
+                }
+
+                var res = storageApi.VectorSetAdd(key, reduceDim, values, element, quantType, buildExplorationFactor, attributes, numLinks, out var result);
+
+                if (res == GarnetStatus.OK)
+                {
+                    if (result == VectorManagerResult.OK)
+                    {
+                        if (respProtocolVersion == 3)
+                        {
+                            while (!RespWriteUtils.TryWriteTrue(ref dcurr, dend))
+                                SendAndReset();
+                        }
+                        else
+                        {
+                            while (!RespWriteUtils.TryWriteInt32(1, ref dcurr, dend))
+                                SendAndReset();
+                        }
+                    }
+                    else if (result == VectorManagerResult.Duplicate)
+                    {
+                        if (respProtocolVersion == 3)
+                        {
+                            while (!RespWriteUtils.TryWriteFalse(ref dcurr, dend))
+                                SendAndReset();
+                        }
+                        else
+                        {
+                            while (!RespWriteUtils.TryWriteInt32(0, ref dcurr, dend))
+                                SendAndReset();
+                        }
+                    }
+                    else if (result == VectorManagerResult.BadParams)
+                    {
+                        while (!RespWriteUtils.TryWriteError("VADD parameters did not match Vector Set construction parameters"u8, ref dcurr, dend))
+                            SendAndReset();
+                    }
+                }
+                else
+                {
+                    while (!RespWriteUtils.TryWriteError($"Unexpected GarnetStatus: {res}", ref dcurr, dend))
+                        SendAndReset();
+                }
+
+                return true;
+            }
+            finally
+            {
+                if (rentedValues != null)
+                {
+                    ArrayPool<float>.Shared.Return(rentedValues);
+                }
+            }
+        }
+
+        private bool NetworkVSIM<TGarnetApi>(ref TGarnetApi storageApi)
+            where TGarnetApi : IGarnetApi
+        {
+            const int DefaultResultSetSize = 64;
+            const int DefaultIdSize = sizeof(ulong);
+
+            // VSIM key (ELE | FP32 | VALUES num) (vector | element) [WITHSCORES] [WITHATTRIBS] [COUNT num] [EPSILON delta] [EF search-exploration - factor] [FILTER expression][FILTER-EF max - filtering - effort] [TRUTH][NOTHREAD]
+
+            if (parseState.Count < 3)
+            {
+                return AbortWithWrongNumberOfArguments("VSIM");
+            }
+
+            var key = parseState.GetArgSliceByRef(0).SpanByte;
+            var kind = parseState.GetArgSliceByRef(1);
+
+            var curIx = 2;
+
+            ReadOnlySpan<byte> element;
+
+            float[] rentedValues = null;
+            try
+            {
+                Span<float> values = stackalloc float[64];
+                if (kind.Span.EqualsUpperCaseSpanIgnoringCase("ELE"u8))
+                {
+                    element = parseState.GetArgSliceByRef(curIx).ReadOnlySpan;
+                    values = default;
+                    curIx++;
+                }
+                else
+                {
+                    element = default;
+                    if (kind.Span.EqualsUpperCaseSpanIgnoringCase("FP32"u8))
+                    {
+                        if (curIx >= parseState.Count)
+                        {
+                            return AbortWithWrongNumberOfArguments("VSIM");
+                        }
+
+                        var asBytes = parseState.GetArgSliceByRef(curIx).Span;
+                        if ((asBytes.Length % sizeof(float)) != 0)
+                        {
+                            return AbortWithErrorMessage("FP32 values must be multiple of 4-bytes in size");
+                        }
+
+                        values = MemoryMarshal.Cast<byte, float>(asBytes);
+                        curIx++;
+                    }
+                    else if (kind.Span.EqualsUpperCaseSpanIgnoringCase("VALUES"u8))
+                    {
+                        if (curIx >= parseState.Count)
+                        {
+                            return AbortWithWrongNumberOfArguments("VSIM");
+                        }
+
+                        if (!parseState.TryGetInt(curIx, out var valueCount) || valueCount <= 0)
+                        {
+                            return AbortWithErrorMessage("VALUES count must > 0");
+                        }
+                        curIx++;
+
+                        if (valueCount > values.Length)
+                        {
+                            values = rentedValues = ArrayPool<float>.Shared.Rent(valueCount);
+                        }
+                        values = values[..valueCount];
+
+                        if (curIx + valueCount > parseState.Count)
+                        {
+                            return AbortWithWrongNumberOfArguments("VSIM");
+                        }
+
+                        for (var valueIx = 0; valueIx < valueCount; valueIx++)
+                        {
+                            if (!parseState.TryGetFloat(curIx, out values[valueIx]))
+                            {
+                                return AbortWithErrorMessage("VALUES value must be valid float");
+                            }
+
+                            curIx++;
+                        }
+                    }
+                    else
+                    {
+                        return AbortWithErrorMessage("VSIM expected ELE, FP32, or VALUES");
+                    }
+                }
+
+                var withScores = false;
+                if (curIx < parseState.Count)
+                {
+                    if (parseState.GetArgSliceByRef(curIx).ReadOnlySpan.EqualsUpperCaseSpanIgnoringCase("WITHSCORES"u8))
+                    {
+                        withScores = true;
+                        curIx++;
+                    }
+                }
+
+                var withAttributes = false;
+                if (curIx < parseState.Count)
+                {
+                    if (parseState.GetArgSliceByRef(curIx).ReadOnlySpan.EqualsUpperCaseSpanIgnoringCase("WITHATTRIBS"u8))
+                    {
+                        withAttributes = true;
+                        curIx++;
+                    }
+                }
+
+                var count = 0;
+                if (curIx < parseState.Count)
+                {
+                    if (parseState.GetArgSliceByRef(curIx).ReadOnlySpan.EqualsUpperCaseSpanIgnoringCase("COUNT"u8))
+                    {
+                        curIx++;
+                        if (curIx >= parseState.Count)
+                        {
+                            return AbortWithWrongNumberOfArguments("VSIM");
+                        }
+
+                        if (!parseState.TryGetInt(curIx, out count) || count < 0)
+                        {
+                            return AbortWithErrorMessage("COUNT must be integer >= 0");
+                        }
+                        curIx++;
+                    }
+                }
+
+                var delta = 0f;
+                if (curIx < parseState.Count)
+                {
+                    if (parseState.GetArgSliceByRef(curIx).ReadOnlySpan.EqualsUpperCaseSpanIgnoringCase("EPSILON"u8))
+                    {
+                        curIx++;
+                        if (curIx >= parseState.Count)
+                        {
+                            return AbortWithWrongNumberOfArguments("VSIM");
+                        }
+
+                        if (!parseState.TryGetFloat(curIx, out delta) || delta <= 0)
+                        {
+                            return AbortWithErrorMessage("EPSILON must be float > 0");
+                        }
+                        curIx++;
+                    }
+                }
+
+                var searchExplorationFactor = 0;
+                if (curIx < parseState.Count)
+                {
+                    if (parseState.GetArgSliceByRef(curIx).ReadOnlySpan.EqualsUpperCaseSpanIgnoringCase("EF"u8))
+                    {
+                        curIx++;
+                        if (curIx >= parseState.Count)
+                        {
+                            return AbortWithWrongNumberOfArguments("VSIM");
+                        }
+
+                        if (!parseState.TryGetInt(curIx, out searchExplorationFactor) || searchExplorationFactor < 0)
+                        {
+                            return AbortWithErrorMessage("EF must be >= 0");
+                        }
+                        curIx++;
+                    }
+                }
+
+                ReadOnlySpan<byte> filter = default;
+                if (curIx < parseState.Count)
+                {
+                    if (parseState.GetArgSliceByRef(curIx).ReadOnlySpan.EqualsUpperCaseSpanIgnoringCase("FILTER"u8))
+                    {
+                        curIx++;
+                        if (curIx >= parseState.Count)
+                        {
+                            return AbortWithWrongNumberOfArguments("VSIM");
+                        }
+
+                        filter = parseState.GetArgSliceByRef(curIx).ReadOnlySpan;
+                        curIx++;
+
+                        // TODO: validate filter
+                    }
+                }
+
+                var maxFilteringEffort = 0;
+                if (curIx < parseState.Count)
+                {
+                    if (parseState.GetArgSliceByRef(curIx).ReadOnlySpan.EqualsUpperCaseSpanIgnoringCase("FILTER-EF"u8))
+                    {
+                        curIx++;
+                        if (curIx >= parseState.Count)
+                        {
+                            return AbortWithWrongNumberOfArguments("VSIM");
+                        }
+
+                        if (!parseState.TryGetInt(curIx, out maxFilteringEffort) || maxFilteringEffort < 0)
+                        {
+                            return AbortWithErrorMessage("FILTER-EF must be >= 0");
+                        }
+                        curIx++;
+                    }
+                }
+
+                if (curIx < parseState.Count)
+                {
+                    if (parseState.GetArgSliceByRef(curIx).ReadOnlySpan.EqualsUpperCaseSpanIgnoringCase("TRUTH"u8))
+                    {
+                        // TODO: should we implement TRUTH?
+                        curIx++;
+                    }
+                }
+
+                if (curIx < parseState.Count)
+                {
+                    if (parseState.GetArgSliceByRef(curIx).ReadOnlySpan.EqualsUpperCaseSpanIgnoringCase("NOTHREAD"u8))
+                    {
+                        // We ignore NOTHREAD
+                        curIx++;
+                    }
+                }
+
+                if (curIx != parseState.Count)
+                {
+                    return AbortWithWrongNumberOfArguments("VSIM");
+                }
+
+                Span<byte> idSpace = stackalloc byte[(DefaultResultSetSize * DefaultIdSize) + (DefaultResultSetSize * sizeof(int))];
+                Span<float> distanceSpace = stackalloc float[DefaultResultSetSize];
+
+                SpanByteAndMemory idResult = SpanByteAndMemory.FromPinnedSpan(idSpace);
+                SpanByteAndMemory distanceResult = SpanByteAndMemory.FromPinnedSpan(MemoryMarshal.Cast<float, byte>(distanceSpace));
+                try
+                {
+
+                    GarnetStatus res;
+                    VectorManagerResult vectorRes;
+                    if (element.IsEmpty)
+                    {
+                        res = storageApi.VectorSetValueSimilarity(key, values, count, delta, searchExplorationFactor, filter, maxFilteringEffort, ref idResult, ref distanceResult, out vectorRes);
+                    }
+                    else
+                    {
+                        res = storageApi.VectorSetElementSimilarity(key, element, count, delta, searchExplorationFactor, filter, maxFilteringEffort, ref idResult, ref distanceResult, out vectorRes);
+                    }
+
+                    if (res == GarnetStatus.NOTFOUND)
+                    {
+                        // Vector Set does not exist
+
+                        while (!RespWriteUtils.TryWriteEmptyArray(ref dcurr, dend))
+                            SendAndReset();
+                    }
+                    else if (res == GarnetStatus.OK)
+                    {
+                        if (vectorRes == VectorManagerResult.MissingElement)
+                        {
+                            while (!RespWriteUtils.TryWriteError("Element not in Vector Set"u8, ref dcurr, dend))
+                                SendAndReset();
+                        }
+                        else if (vectorRes == VectorManagerResult.OK)
+                        {
+                            if (respProtocolVersion == 3)
+                            {
+                                // TODO: this is rather complicated, so punt for now
+                                throw new NotImplementedException();
+                            }
+                            else
+                            {
+
+                                var remainingIds = idResult.AsReadOnlySpan();
+                                var distancesSpan = MemoryMarshal.Cast<byte, float>(distanceResult.AsReadOnlySpan());
+
+                                var arrayItemCount = distancesSpan.Length;
+                                if (withScores)
+                                {
+                                    arrayItemCount += distancesSpan.Length;
+                                }
+                                if (withAttributes)
+                                {
+                                    throw new NotImplementedException();
+                                }
+
+                                while (!RespWriteUtils.TryWriteArrayLength(arrayItemCount, ref dcurr, dend))
+                                    SendAndReset();
+
+                                for (var resultIndex = 0; resultIndex < distancesSpan.Length; resultIndex++)
+                                {
+                                    var elementLen = BinaryPrimitives.ReadInt32LittleEndian(remainingIds);
+                                    var elementData = remainingIds.Slice(sizeof(int), elementLen);
+                                    remainingIds = remainingIds[(sizeof(int) + elementLen)..];
+
+                                    while (!RespWriteUtils.TryWriteBulkString(elementData, ref dcurr, dend))
+                                        SendAndReset();
+
+                                    if (withScores)
+                                    {
+                                        var distance = distancesSpan[resultIndex];
+
+                                        while (!RespWriteUtils.TryWriteDoubleBulkString(distance, ref dcurr, dend))
+                                            SendAndReset();
+                                    }
+
+                                    if (withAttributes)
+                                    {
+                                        throw new NotImplementedException();
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            throw new GarnetException($"Unexpected {nameof(VectorManagerResult)}: {vectorRes}");
+                        }
+                    }
+                    else
+                    {
+                        throw new GarnetException($"Unexpected {nameof(GarnetStatus)}: {res}");
+                    }
+
+                    return true;
+                }
+                finally
+                {
+                    if (!idResult.IsSpanByte)
+                    {
+                        idResult.Memory.Dispose();
+                    }
+
+                    if (!distanceResult.IsSpanByte)
+                    {
+                        distanceResult.Memory.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (rentedValues != null)
+                {
+                    ArrayPool<float>.Shared.Return(rentedValues);
+                }
+            }
+        }
+
+        private bool NetworkVEMB<TGarnetApi>(ref TGarnetApi storageApi)
+            where TGarnetApi : IGarnetApi
+        {
+            const int DefaultResultSetSize = 64;
+
+            // VEMB key element [RAW]
+
+            if (parseState.Count < 2 || parseState.Count > 3)
+            {
+                return AbortWithWrongNumberOfArguments("VEMB");
+            }
+
+            var key = parseState.GetArgSliceByRef(0).SpanByte;
+            var elem = parseState.GetArgSliceByRef(1).ReadOnlySpan;
+
+            var raw = false;
+            if (parseState.Count == 3)
+            {
+                if (!parseState.GetArgSliceByRef(2).Span.EqualsUpperCaseSpanIgnoringCase("RAW"u8))
+                {
+                    return AbortWithErrorMessage("Unexpected option to VSIM");
+                }
+
+                raw = true;
+            }
+
+            // TODO: what do we do here?
+            if (raw)
+            {
+                throw new NotImplementedException();
+            }
+
+            Span<float> distanceSpace = stackalloc float[DefaultResultSetSize];
+
+            var distanceResult = SpanByteAndMemory.FromPinnedSpan(MemoryMarshal.Cast<float, byte>(distanceSpace));
+
+            try
+            {
+                var res = storageApi.VectorEmbedding(key, elem, ref distanceResult);
+
+                if (res == GarnetStatus.OK)
+                {
+                    var distanceSpan = MemoryMarshal.Cast<byte, float>(distanceResult.AsReadOnlySpan());
+
+                    while (!RespWriteUtils.TryWriteArrayLength(distanceSpan.Length, ref dcurr, dend))
+                        SendAndReset();
+
+                    for (var i = 0; i < distanceSpan.Length; i++)
+                    {
+                        while (!RespWriteUtils.TryWriteDoubleBulkString(distanceSpan[i], ref dcurr, dend))
+                            SendAndReset();
+                    }
+                }
+                else
+                {
+                    while (!RespWriteUtils.TryWriteEmptyArray(ref dcurr, dend))
+                        SendAndReset();
+                }
+
+                return true;
+            }
+            finally
+            {
+                if (!distanceResult.IsSpanByte)
+                {
+                    distanceResult.Memory.Dispose();
+                }
+            }
+        }
+
+        private bool NetworkVCARD<TGarnetApi>(ref TGarnetApi storageApi)
+            where TGarnetApi : IGarnetApi
+        {
+            // TODO: implement!
+
+            while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
+                SendAndReset();
+
+            return true;
+        }
+
+        private bool NetworkVDIM<TGarnetApi>(ref TGarnetApi storageApi)
+            where TGarnetApi : IGarnetApi
+        {
+            // TODO: implement!
+
+            while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
+                SendAndReset();
+
+            return true;
+        }
+
+        private bool NetworkVGETATTR<TGarnetApi>(ref TGarnetApi storageApi)
+            where TGarnetApi : IGarnetApi
+        {
+            // TODO: implement!
+
+            while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
+                SendAndReset();
+
+            return true;
+        }
+
+        private bool NetworkVINFO<TGarnetApi>(ref TGarnetApi storageApi)
+            where TGarnetApi : IGarnetApi
+        {
+            // TODO: implement!
+
+            while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
+                SendAndReset();
+
+            return true;
+        }
+
+        private bool NetworkVLINKS<TGarnetApi>(ref TGarnetApi storageApi)
+            where TGarnetApi : IGarnetApi
+        {
+            // TODO: implement!
+
+            while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
+                SendAndReset();
+
+            return true;
+        }
+
+        private bool NetworkVRANDMEMBER<TGarnetApi>(ref TGarnetApi storageApi)
+            where TGarnetApi : IGarnetApi
+        {
+            // TODO: implement!
+
+            while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
+                SendAndReset();
+
+            return true;
+        }
+
+        private bool NetworkVREM<TGarnetApi>(ref TGarnetApi storageApi)
+            where TGarnetApi : IGarnetApi
+        {
+            // TODO: implement!
+
+            while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
+                SendAndReset();
+
+            return true;
+        }
+
+        private bool NetworkVSETATTR<TGarnetApi>(ref TGarnetApi storageApi)
+            where TGarnetApi : IGarnetApi
+        {
+            // TODO: implement!
+
+            while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
+                SendAndReset();
+
+            return true;
+        }
+    }
+}

--- a/libs/server/Resp/Vector/VectorManager.cs
+++ b/libs/server/Resp/Vector/VectorManager.cs
@@ -1,0 +1,608 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Tsavorite.core;
+
+namespace Garnet.server
+{
+    using MainStoreAllocator = SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>;
+    using MainStoreFunctions = StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>;
+
+    internal sealed unsafe class DummyService : IVectorService
+    {
+        private const byte FullVector = 0;
+        private const byte NeighborList = 1;
+        private const byte QuantizedVector = 2;
+        private const byte Attributes = 3;
+
+        private sealed class ByteArrayEqualityComparer : IEqualityComparer<byte[]>
+        {
+            public static readonly ByteArrayEqualityComparer Instance = new();
+
+            private ByteArrayEqualityComparer() { }
+
+            public bool Equals(byte[] x, byte[] y)
+            => x.AsSpan().SequenceEqual(y);
+
+            public int GetHashCode([DisallowNull] byte[] obj)
+            {
+                var hash = new HashCode();
+                hash.AddBytes(obj);
+
+                return hash.ToHashCode();
+            }
+        }
+
+        private readonly ConcurrentDictionary<nint, (VectorReadDelegate Read, VectorWriteDelegate Write, VectorDeleteDelegate Delete, ConcurrentDictionary<byte[], byte> Members)> data = new();
+
+        /// <inheritdoc/>
+        public bool UseUnmanagedCallbacks { get; } = false;
+
+        /// <inheritdoc/>
+        public nint CreateIndexUnmanaged(ulong context, uint dimensions, uint reduceDims, VectorQuantType quantType, uint buildExplorationFactor, uint numLinks, delegate* unmanaged[Cdecl]<ulong, byte*, nuint, byte*, nuint, int> readCallback, delegate* unmanaged[Cdecl]<ulong, byte*, nuint, byte*, nuint, bool> writeCallback, delegate* unmanaged[Cdecl]<ulong, byte*, nuint, bool> deleteCallback)
+        => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        public nint CreateIndexManaged(ulong context, uint dimensions, uint reduceDims, VectorQuantType quantType, uint buildExplorationFactor, uint numLinks, VectorReadDelegate readCallback, VectorWriteDelegate writeCallback, VectorDeleteDelegate deleteCallback)
+        {
+            var ptr = (nint)(context + 17); // some arbitrary non-multiple of 4 to mess with things
+
+            if (!data.TryAdd(ptr, new(readCallback, writeCallback, deleteCallback, new(ByteArrayEqualityComparer.Instance))))
+            {
+                throw new InvalidOperationException("Shouldn't be possible");
+            }
+
+            return ptr;
+        }
+
+        /// <inheritdoc/>
+        public void DropIndex(ulong context, nint index)
+        {
+            if (!data.TryRemove(index, out _))
+            {
+                throw new InvalidOperationException("Attempted to drop index that was already dropped");
+            }
+        }
+
+        /// <inheritdoc/>
+        public bool Insert(ulong context, nint index, ReadOnlySpan<byte> id, ReadOnlySpan<float> vector, ReadOnlySpan<byte> attributes)
+        {
+            var (_, write, _, members) = data[index];
+
+            // save vector data
+            _ = members.AddOrUpdate(id.ToArray(), static (_) => 0, static (key, old) => (byte)(old + 1));
+            _ = write(context + FullVector, id, MemoryMarshal.Cast<float, byte>(vector));
+
+            if (!attributes.IsEmpty)
+            {
+                _ = write(context + Attributes, id, attributes);
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public int SearchVector(ulong context, nint index, ReadOnlySpan<float> vector, float delta, int searchExplorationFactor, ReadOnlySpan<byte> filter, int maxFilteringEffort, Span<byte> outputIds, Span<float> outputDistances, out nint continuation)
+        {
+            var (read, _, _, members) = data[index];
+
+            // Hack, just use a fixed sized buffer for now
+            Span<byte> memberData = stackalloc byte[128];
+
+            var matches = 0;
+            var remainingOutputIds = outputIds;
+            var remainingDistances = outputDistances;
+
+            // We don't actually do the distance calc, this is just for testing
+            foreach (var member in members.Keys)
+            {
+                var len = read(context + FullVector, member, memberData);
+                if (len == 0)
+                {
+                    continue;
+                }
+
+                var asFloats = MemoryMarshal.Cast<byte, float>(memberData[..len]);
+                if (member.Length > remainingOutputIds.Length + sizeof(int))
+                {
+                    // This is where a continuation would be set
+                    throw new NotImplementedException();
+                }
+
+                BinaryPrimitives.WriteInt32LittleEndian(remainingOutputIds, member.Length);
+                remainingOutputIds = remainingOutputIds[sizeof(int)..];
+                member.AsSpan().CopyTo(remainingOutputIds);
+                remainingOutputIds = remainingOutputIds[member.Length..];
+
+                remainingDistances[0] = (float)Random.Shared.NextDouble();
+                remainingDistances = remainingDistances[1..];
+                matches++;
+
+                if (remainingDistances.IsEmpty)
+                {
+                    break;
+                }
+            }
+
+            continuation = 0;
+            return matches;
+        }
+
+        /// <inheritdoc/>
+        public int SearchElement(ulong context, nint index, ReadOnlySpan<byte> id, float delta, int searchExplorationFactor, ReadOnlySpan<byte> filter, int maxFilteringEffort, Span<byte> outputIds, Span<float> outputDistances, out nint continuation)
+        {
+            var (read, _, _, members) = data[index];
+
+            // Hack, just use a fixed sized buffer for now
+            Span<byte> memberData = stackalloc byte[128];
+            var len = read(context + FullVector, id, memberData);
+            if (len == 0)
+            {
+                continuation = 0;
+                return 0;
+            }
+
+            var vector = MemoryMarshal.Cast<byte, float>(memberData[..len]);
+            return SearchVector(context, index, vector, delta, searchExplorationFactor, filter, maxFilteringEffort, outputIds, outputDistances, out continuation);
+        }
+
+        /// <inheritdoc/>
+        public int ContinueSearch(ulong context, nint index, nint continuation, Span<byte> outputIds, Span<float> outputDistances, out nint newContinuation)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetEmbedding(ulong context, nint index, ReadOnlySpan<byte> id, Span<float> dimensions)
+        {
+            var (read, _, _, _) = data[index];
+
+            return read(context + FullVector, id, MemoryMarshal.Cast<float, byte>(dimensions)) != 0;
+        }
+    }
+
+    public enum VectorManagerResult
+    {
+        Invalid = 0,
+
+        OK,
+        BadParams,
+        Duplicate,
+        MissingElement,
+    }
+
+    /// <summary>
+    /// Methods for managing an implementation of various vector operations.
+    /// </summary>
+    internal static class VectorManager
+    {
+        internal const int IndexSizeBytes = Index.Size;
+
+        [StructLayout(LayoutKind.Explicit, Size = Size)]
+        private struct Index
+        {
+            internal const int Size = 33;
+
+            [FieldOffset(0)]
+            public ulong Context;
+            [FieldOffset(8)]
+            public ulong IndexPtr;
+            [FieldOffset(16)]
+            public uint Dimensions;
+            [FieldOffset(20)]
+            public uint ReduceDims;
+            [FieldOffset(24)]
+            public uint NumLinks;
+            [FieldOffset(28)]
+            public uint BuildExplorationFactor;
+            [FieldOffset(32)]
+            public VectorQuantType QuantType;
+        }
+
+        private static readonly unsafe delegate* unmanaged[Cdecl]<ulong, byte*, nuint, byte*, nuint, int> ReadCallbackPtr = &ReadCallbackUnmanaged;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<ulong, byte*, nuint, byte*, nuint, bool> WriteCallbackPtr = &WriteCallbackUnmanaged;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<ulong, byte*, nuint, bool> DeleteCallbackPtr = &DeleteCallbackUnmanaged;
+
+        private static readonly VectorReadDelegate ReadCallbackDel = ReadCallbackManaged;
+        private static readonly VectorWriteDelegate WriteCallbackDel = WriteCallbackManaged;
+        private static readonly VectorDeleteDelegate DeleteCallbackDel = DeleteCallbackManaged;
+
+        private static readonly IVectorService Service = new DummyService();
+
+        private static ulong NextContextValue;
+
+        [ThreadStatic]
+        private static StorageSession ActiveThreadSession;
+
+        /// <summary>
+        /// Get a new unique context for a vector set.
+        /// 
+        /// This value is guaranteed to not be shared by any other vector set in the store.
+        /// </summary>
+        /// <returns></returns>
+        private static ulong NextContext()
+        => Interlocked.Add(ref NextContextValue, 4);
+
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+        private static unsafe int ReadCallbackUnmanaged(ulong context, byte* keyData, nuint keyLength, byte* writeData, nuint writeLength)
+        => ReadCallbackManaged(context, MemoryMarshal.CreateReadOnlySpan(ref *keyData, (int)keyLength), MemoryMarshal.CreateSpan(ref *writeData, (int)writeLength));
+
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+        private static unsafe bool WriteCallbackUnmanaged(ulong context, byte* keyData, nuint keyLength, byte* writeData, nuint writeLength)
+        => WriteCallbackManaged(context, MemoryMarshal.CreateReadOnlySpan(ref *keyData, (int)keyLength), MemoryMarshal.CreateReadOnlySpan(ref *writeData, (int)writeLength));
+
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+        private static unsafe bool DeleteCallbackUnmanaged(ulong context, byte* keyData, nuint keyLength)
+        => DeleteCallbackManaged(context, MemoryMarshal.CreateReadOnlySpan(ref *keyData, (int)keyLength));
+
+        private static int ReadCallbackManaged(ulong context, ReadOnlySpan<byte> key, Span<byte> value)
+        {
+            ref var ctx = ref ActiveThreadSession.vectorContext;
+            var keySpan = SpanByte.FromPinnedSpan(key);
+            VectorInput input = new();
+            var outputSpan = SpanByte.FromPinnedSpan(value);
+
+            var status = ctx.Read(ref keySpan, ref input, ref outputSpan);
+            if (status.IsPending)
+            {
+                CompletePending(ref status, ref outputSpan, ref ctx);
+            }
+
+            if (status.Found)
+            {
+                return outputSpan.Length;
+            }
+
+            return 0;
+        }
+
+        private static bool WriteCallbackManaged(ulong context, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+        {
+            ref var ctx = ref ActiveThreadSession.vectorContext;
+            var keySpan = SpanByte.FromPinnedSpan(key);
+            VectorInput input = new();
+            var valueSpan = SpanByte.FromPinnedSpan(value);
+
+            Span<byte> output = stackalloc byte[1];
+            var outputSpan = SpanByte.FromPinnedSpan(output);
+
+            var status = ctx.Upsert(ref keySpan, ref input, ref valueSpan, ref outputSpan);
+            if (status.IsPending)
+            {
+                CompletePending(ref status, ref outputSpan, ref ctx);
+            }
+
+            return status.IsCompletedSuccessfully;
+        }
+
+        private static bool DeleteCallbackManaged(ulong context, ReadOnlySpan<byte> key)
+        {
+            ref var ctx = ref ActiveThreadSession.vectorContext;
+            var keySpan = SpanByte.FromPinnedSpan(key);
+
+            var status = ctx.Delete(ref keySpan);
+            Debug.Assert(!status.IsPending, "Deletes should never go async");
+
+            return status.IsCompletedSuccessfully;
+        }
+
+        private static void CompletePending<TContext>(ref Status status, ref SpanByte output, ref TContext objectContext)
+            where TContext : ITsavoriteContext<SpanByte, SpanByte, VectorInput, SpanByte, long, VectorSessionFunctions, MainStoreFunctions, MainStoreAllocator>
+        {
+            objectContext.CompletePendingWithOutputs(out var completedOutputs, wait: true);
+            var more = completedOutputs.Next();
+            Debug.Assert(more);
+            status = completedOutputs.Current.Status;
+            output = completedOutputs.Current.Output;
+            Debug.Assert(!completedOutputs.Next());
+            completedOutputs.Dispose();
+        }
+
+        /// <summary>
+        /// Construct a new index, and stash enough data to recover it with <see cref="ReadIndex"/>.
+        /// </summary>
+        internal static void CreateIndex(
+            uint dimensions,
+            uint reduceDims,
+            VectorQuantType quantType,
+            uint buildExplorationFactory,
+            uint numLinks,
+            ref SpanByte indexValue)
+        {
+            var context = NextContext();
+
+            // Enforce defaults, which match Redis; see https://redis.io/docs/latest/commands/vadd/
+            quantType = quantType == VectorQuantType.Invalid ? VectorQuantType.Q8 : quantType;
+            buildExplorationFactory = buildExplorationFactory == 0 ? 200 : buildExplorationFactory;
+            numLinks = numLinks == 0 ? 16 : numLinks;
+
+            nint indexPtr;
+            if (Service.UseUnmanagedCallbacks)
+            {
+                unsafe
+                {
+                    indexPtr = Service.CreateIndexUnmanaged(context, dimensions, reduceDims, quantType, buildExplorationFactory, numLinks, ReadCallbackPtr, WriteCallbackPtr, DeleteCallbackPtr);
+                }
+            }
+            else
+            {
+                indexPtr = Service.CreateIndexManaged(context, dimensions, reduceDims, quantType, buildExplorationFactory, numLinks, ReadCallbackDel, WriteCallbackDel, DeleteCallbackDel);
+            }
+
+            ref var asIndex = ref Unsafe.As<byte, Index>(ref MemoryMarshal.GetReference(indexValue.AsSpan()));
+            asIndex.Context = context;
+            asIndex.Dimensions = dimensions;
+            asIndex.ReduceDims = reduceDims;
+            asIndex.QuantType = quantType;
+            asIndex.BuildExplorationFactor = buildExplorationFactory;
+            asIndex.NumLinks = numLinks;
+            asIndex.IndexPtr = (ulong)indexPtr;
+        }
+
+        internal static void ReadIndex(
+            ReadOnlySpan<byte> indexValue,
+            out ulong context,
+            out uint dimensions,
+            out uint reduceDims,
+            out VectorQuantType quantType,
+            out uint buildExplorationFactor,
+            out uint numLinks,
+            out nint indexPtr
+        )
+        {
+            Debug.Assert(indexValue.Length == Index.Size, "Index value is incorrect, implies vector set index is probably corrupted");
+
+            ref var asIndex = ref Unsafe.As<byte, Index>(ref MemoryMarshal.GetReference(indexValue));
+
+            context = asIndex.Context;
+            dimensions = asIndex.Dimensions;
+            reduceDims = asIndex.ReduceDims;
+            quantType = asIndex.QuantType;
+            buildExplorationFactor = asIndex.BuildExplorationFactor;
+            numLinks = asIndex.NumLinks;
+            indexPtr = (nint)asIndex.IndexPtr;
+
+            Debug.Assert((context % 4) == 0, "Context not as expected, vector set index is probably corrupted");
+        }
+
+        /// <summary>
+        /// Add a vector to a vector set encoded by <paramref name="indexValue"/>.
+        /// 
+        /// Assumes that the index is locked in the Tsavorite store.
+        /// </summary>
+        /// <returns>Result of the operaiton.</returns>
+        internal static VectorManagerResult TryAdd(
+            StorageSession currentStorageSession,
+            ReadOnlySpan<byte> indexValue,
+            ReadOnlySpan<byte> element,
+            ReadOnlySpan<float> values,
+            ReadOnlySpan<byte> attributes,
+            uint providedReduceDims,
+            VectorQuantType providedQuantType,
+            uint providedBuildExplorationFactor,
+            uint providedNumLinks
+        )
+        {
+            ActiveThreadSession = currentStorageSession;
+            try
+            {
+                ReadIndex(indexValue, out var context, out var dimensions, out var reduceDims, out var quantType, out var buildExplorationFactor, out var numLinks, out var indexPtr);
+
+                if (dimensions != values.Length)
+                {
+                    return VectorManagerResult.BadParams;
+                }
+
+                if (providedReduceDims != 0 && providedReduceDims != reduceDims)
+                {
+                    return VectorManagerResult.BadParams;
+                }
+
+                if (providedQuantType != VectorQuantType.Invalid && providedQuantType != quantType)
+                {
+                    return VectorManagerResult.BadParams;
+                }
+
+                if (providedBuildExplorationFactor != 0 && providedBuildExplorationFactor != buildExplorationFactor)
+                {
+                    return VectorManagerResult.BadParams;
+                }
+
+                if (providedNumLinks != 0 && providedNumLinks != numLinks)
+                {
+                    return VectorManagerResult.BadParams;
+                }
+
+                var insert =
+                    Service.Insert(
+                        context,
+                        indexPtr,
+                        element,
+                        values,
+                        attributes
+                    );
+
+                if (insert)
+                {
+                    return VectorManagerResult.OK;
+                }
+
+                return VectorManagerResult.Duplicate;
+            }
+            finally
+            {
+                ActiveThreadSession = null;
+            }
+        }
+
+        /// <summary>
+        /// Perform a similarity search given a vector to compare against.
+        /// </summary>
+        internal static VectorManagerResult ValueSimilarity(
+            StorageSession currentStorageSession,
+            ReadOnlySpan<byte> indexValue,
+            ReadOnlySpan<float> values,
+            int count,
+            float delta,
+            int searchExplorationFactor,
+            ReadOnlySpan<byte> filter,
+            int maxFilteringEffort,
+            ref SpanByteAndMemory outputIds,
+            ref SpanByteAndMemory outputDistances
+        )
+        {
+            ActiveThreadSession = currentStorageSession;
+            try
+            {
+                ReadIndex(indexValue, out var context, out var dimensions, out var reduceDims, out var quantType, out var buildExplorationFactor, out var numLinks, out var indexPtr);
+
+                // Make sure enough space in distances for requested count
+                if (count > outputDistances.Length)
+                {
+                    if (!outputDistances.IsSpanByte)
+                    {
+                        outputDistances.Memory.Dispose();
+                    }
+
+                    outputDistances = new SpanByteAndMemory(MemoryPool<byte>.Shared.Rent(count));
+                }
+
+                var found =
+                    Service.SearchVector(
+                        context,
+                        indexPtr,
+                        values,
+                        delta,
+                        searchExplorationFactor,
+                        filter,
+                        maxFilteringEffort,
+                        outputIds.AsSpan(),
+                        MemoryMarshal.Cast<byte, float>(outputDistances.AsSpan()),
+                        out var continuation
+                    );
+
+                if (continuation != 0)
+                {
+                    // TODO: paged results!
+                    throw new NotImplementedException();
+                }
+
+                outputDistances.Length = sizeof(float) * found;
+
+                return VectorManagerResult.OK;
+            }
+            finally
+            {
+                ActiveThreadSession = null;
+            }
+        }
+
+        /// <summary>
+        /// Perform a similarity search given a vector to compare against.
+        /// </summary>
+        internal static VectorManagerResult ElementSimilarity(
+            StorageSession currentStorageSession,
+            ReadOnlySpan<byte> indexValue,
+            ReadOnlySpan<byte> element,
+            int count,
+            float delta,
+            int searchExplorationFactor,
+            ReadOnlySpan<byte> filter,
+            int maxFilteringEffort,
+            ref SpanByteAndMemory outputIds,
+            ref SpanByteAndMemory outputDistances
+        )
+        {
+            ActiveThreadSession = currentStorageSession;
+            try
+            {
+                ReadIndex(indexValue, out var context, out var dimensions, out var reduceDims, out var quantType, out var buildExplorationFactor, out var numLinks, out var indexPtr);
+
+                // Make sure enough space in distances for requested count
+                if (count * sizeof(float) > outputDistances.Length)
+                {
+                    if (!outputDistances.IsSpanByte)
+                    {
+                        outputDistances.Memory.Dispose();
+                    }
+
+                    outputDistances = new SpanByteAndMemory(MemoryPool<byte>.Shared.Rent(count * sizeof(float)));
+                }
+
+                var found =
+                    Service.SearchElement(
+                        context,
+                        indexPtr,
+                        element,
+                        delta,
+                        searchExplorationFactor,
+                        filter,
+                        maxFilteringEffort,
+                        outputIds.AsSpan(),
+                        MemoryMarshal.Cast<byte, float>(outputDistances.AsSpan()),
+                        out var continuation
+                    );
+
+                if (continuation != 0)
+                {
+                    // TODO: paged results!
+                    throw new NotImplementedException();
+                }
+
+                outputDistances.Length = sizeof(float) * found;
+
+                return VectorManagerResult.OK;
+            }
+            finally
+            {
+                ActiveThreadSession = null;
+            }
+        }
+
+        internal static bool TryGetEmbedding(StorageSession currentStorageSession, ReadOnlySpan<byte> indexValue, ReadOnlySpan<byte> element, ref SpanByteAndMemory outputDistances)
+        {
+            ActiveThreadSession = currentStorageSession;
+            try
+            {
+                ReadIndex(indexValue, out var context, out var dimensions, out var reduceDims, out var quantType, out var buildExplorationFactor, out var numLinks, out var indexPtr);
+
+                // Make sure enough space in distances for requested count
+                if (dimensions * sizeof(float) > outputDistances.Length)
+                {
+                    if (!outputDistances.IsSpanByte)
+                    {
+                        outputDistances.Memory.Dispose();
+                    }
+
+                    outputDistances = new SpanByteAndMemory(MemoryPool<byte>.Shared.Rent((int)dimensions * sizeof(float)), (int)dimensions * sizeof(float));
+                }
+                else
+                {
+                    outputDistances.Length = (int)dimensions * sizeof(float);
+                }
+
+                return
+                    Service.TryGetEmbedding(
+                        context,
+                        indexPtr,
+                        element,
+                        MemoryMarshal.Cast<byte, float>(outputDistances.AsSpan())
+                    );
+            }
+            finally
+            {
+                ActiveThreadSession = null;
+            }
+        }
+    }
+}

--- a/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
@@ -118,6 +118,9 @@ namespace Garnet.server
                     value.CopyTo(dst.Memory.Memory.Span);
                     break;
 
+                case RespCommand.VADD:
+                case RespCommand.VSIM:
+                case RespCommand.VEMB:
                 case RespCommand.GET:
                     // Get value without RESP header; exclude expiration
                     if (value.LengthWithoutMetadata <= dst.Length)

--- a/libs/server/Storage/Functions/MainStore/ReadMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/ReadMethods.cs
@@ -137,7 +137,6 @@ namespace Garnet.server
                 return true;
             }
 
-
             if (cmd == RespCommand.NONE)
                 CopyRespTo(ref value, ref dst, functionsState.etagState.etagSkippedStart, functionsState.etagState.etagAccountedLength);
             else

--- a/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
@@ -113,6 +113,9 @@ namespace Garnet.server
                     ndigits = NumUtils.CountCharsInDouble(incrByFloat, out var _, out var _, out var _);
 
                     return sizeof(int) + ndigits;
+                case RespCommand.VADD:
+                    return sizeof(int) + VectorManager.IndexSizeBytes;
+
                 default:
                     if (cmd > RespCommandExtensions.LastValidCommand)
                     {

--- a/libs/server/Storage/Functions/MainStore/VectorSessionFunctions.cs
+++ b/libs/server/Storage/Functions/MainStore/VectorSessionFunctions.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Diagnostics;
+using Tsavorite.core;
+
+namespace Garnet.server
+{
+    /// <summary>
+    /// Functions for operating against the Main Store, but for data stored as part of a Vector Set operation - not a RESP command.
+    /// </summary>
+    public readonly struct VectorSessionFunctions : ISessionFunctions<SpanByte, SpanByte, VectorInput, SpanByte, long>
+    {
+        private readonly FunctionsState functionsState;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        internal VectorSessionFunctions(FunctionsState functionsState)
+        {
+            this.functionsState = functionsState;
+        }
+
+        #region Deletes
+        /// <inheritdoc />
+        public bool SingleDeleter(ref SpanByte key, ref SpanByte value, ref DeleteInfo deleteInfo, ref RecordInfo recordInfo) => throw new NotImplementedException();
+        /// <inheritdoc />
+        public void PostSingleDeleter(ref SpanByte key, ref DeleteInfo deleteInfo) => throw new NotImplementedException();
+        /// <inheritdoc />
+        public bool ConcurrentDeleter(ref SpanByte key, ref SpanByte value, ref DeleteInfo deleteInfo, ref RecordInfo recordInfo) => throw new NotImplementedException();
+        #endregion
+
+        #region Reads
+        /// <inheritdoc />
+        public bool SingleReader(ref SpanByte key, ref VectorInput input, ref SpanByte value, ref SpanByte dst, ref ReadInfo readInfo)
+        {
+            Debug.Assert(dst.Length >= value.Length, "Should always have space for vector point reads");
+
+            dst.Length = value.Length;
+            value.AsReadOnlySpan(functionsState.etagState.etagSkippedStart).CopyTo(dst.AsSpan());
+
+            return true;
+        }
+        /// <inheritdoc />
+        public bool ConcurrentReader(ref SpanByte key, ref VectorInput input, ref SpanByte value, ref SpanByte dst, ref ReadInfo readInfo, ref RecordInfo recordInfo)
+        {
+            Debug.Assert(dst.Length >= value.Length, "Should always have space for vector point reads");
+
+            dst.Length = value.Length;
+            value.AsReadOnlySpan(functionsState.etagState.etagSkippedStart).CopyTo(dst.AsSpan());
+
+            return true;
+        }
+        /// <inheritdoc />
+        public void ReadCompletionCallback(ref SpanByte key, ref VectorInput input, ref SpanByte output, long ctx, Status status, RecordMetadata recordMetadata)
+        {
+        }
+        #endregion
+
+        #region Initial Values
+        /// <inheritdoc />
+        public bool NeedInitialUpdate(ref SpanByte key, ref VectorInput input, ref SpanByte output, ref RMWInfo rmwInfo)
+        => false;
+        /// <inheritdoc />
+        public bool InitialUpdater(ref SpanByte key, ref VectorInput input, ref SpanByte value, ref SpanByte output, ref RMWInfo rmwInfo, ref RecordInfo recordInfo) => throw new NotImplementedException();
+        /// <inheritdoc />
+        public void PostInitialUpdater(ref SpanByte key, ref VectorInput input, ref SpanByte value, ref SpanByte output, ref RMWInfo rmwInfo) => throw new NotImplementedException();
+        #endregion
+
+        #region Writes
+        /// <inheritdoc />
+        public bool SingleWriter(ref SpanByte key, ref VectorInput input, ref SpanByte src, ref SpanByte dst, ref SpanByte output, ref UpsertInfo upsertInfo, WriteReason reason, ref RecordInfo recordInfo)
+        => SpanByteFunctions<VectorInput, SpanByte, long>.DoSafeCopy(ref src, ref dst, ref upsertInfo, ref recordInfo, 0);
+        /// <inheritdoc />
+        public void PostSingleWriter(ref SpanByte key, ref VectorInput input, ref SpanByte src, ref SpanByte dst, ref SpanByte output, ref UpsertInfo upsertInfo, WriteReason reason) { }
+        /// <inheritdoc />
+        public bool ConcurrentWriter(ref SpanByte key, ref VectorInput input, ref SpanByte src, ref SpanByte dst, ref SpanByte output, ref UpsertInfo upsertInfo, ref RecordInfo recordInfo)
+        => SpanByteFunctions<VectorInput, SpanByte, long>.DoSafeCopy(ref src, ref dst, ref upsertInfo, ref recordInfo, 0);
+        #endregion
+
+        #region RMW
+        /// <inheritdoc />
+        public bool CopyUpdater(ref SpanByte key, ref VectorInput input, ref SpanByte oldValue, ref SpanByte newValue, ref SpanByte output, ref RMWInfo rmwInfo, ref RecordInfo recordInfo) => throw new NotImplementedException();
+        /// <inheritdoc />
+        public int GetRMWInitialValueLength(ref VectorInput input) => throw new NotImplementedException();
+        /// <inheritdoc />
+        public int GetRMWModifiedValueLength(ref SpanByte value, ref VectorInput input) => throw new NotImplementedException();
+        /// <inheritdoc />
+        public int GetUpsertValueLength(ref SpanByte value, ref VectorInput input)
+        => sizeof(int) + value.Length;
+        /// <inheritdoc />
+        public bool InPlaceUpdater(ref SpanByte key, ref VectorInput input, ref SpanByte value, ref SpanByte output, ref RMWInfo rmwInfo, ref RecordInfo recordInfo) => throw new NotImplementedException();
+        /// <inheritdoc />
+        public bool NeedCopyUpdate(ref SpanByte key, ref VectorInput input, ref SpanByte oldValue, ref SpanByte output, ref RMWInfo rmwInfo) => throw new NotImplementedException();
+        /// <inheritdoc />
+        public bool PostCopyUpdater(ref SpanByte key, ref VectorInput input, ref SpanByte oldValue, ref SpanByte newValue, ref SpanByte output, ref RMWInfo rmwInfo) => throw new NotImplementedException();
+        /// <inheritdoc />
+        public void RMWCompletionCallback(ref SpanByte key, ref VectorInput input, ref SpanByte output, long ctx, Status status, RecordMetadata recordMetadata) => throw new NotImplementedException();
+        #endregion
+
+        #region Utilities
+        /// <inheritdoc />
+        public void ConvertOutputToHeap(ref VectorInput input, ref SpanByte output) => throw new NotImplementedException();
+        #endregion
+    }
+}

--- a/libs/server/Storage/Session/MainStore/VectorStoreOps.cs
+++ b/libs/server/Storage/Session/MainStore/VectorStoreOps.cs
@@ -1,0 +1,280 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Garnet.common;
+using Tsavorite.core;
+
+namespace Garnet.server
+{
+    public enum VectorQuantType
+    {
+        Invalid = 0,
+
+        Bin,
+        Q8,
+        NoQuant,
+    }
+
+    /// <summary>
+    /// Implementation of Vector Set operations.
+    /// </summary>
+    sealed partial class StorageSession : IDisposable
+    {
+        /// <summary>
+        /// Implement Vector Set Add - this may also create a Vector Set if one does not already exist.
+        /// </summary>
+        public GarnetStatus VectorSetAdd(SpanByte key, int reduceDims, ReadOnlySpan<float> values, ArgSlice element, VectorQuantType quantizer, int buildExplorationFactor, ArgSlice attributes, int numLinks, out VectorManagerResult result)
+        {
+            var dims = values.Length;
+
+            var dimsArg = ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<int, byte>(MemoryMarshal.CreateSpan(ref dims, 1)));
+            var reduceDimsArg = ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<int, byte>(MemoryMarshal.CreateSpan(ref reduceDims, 1)));
+            var valuesArg = ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<float, byte>(values));
+            var elementArg = element;
+            var quantizerArg = ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<VectorQuantType, byte>(MemoryMarshal.CreateSpan(ref quantizer, 1)));
+            var buildExplorationFactorArg = ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<int, byte>(MemoryMarshal.CreateSpan(ref buildExplorationFactor, 1)));
+            var attributesArg = attributes;
+            var numLinksArg = ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<int, byte>(MemoryMarshal.CreateSpan(ref numLinks, 1)));
+
+            parseState.InitializeWithArguments([dimsArg, reduceDimsArg, valuesArg, elementArg, quantizerArg, buildExplorationFactorArg, attributesArg, numLinksArg]);
+
+            var input = new RawStringInput(RespCommand.VADD, ref parseState);
+
+            Span<byte> resSpan = stackalloc byte[128];
+            var indexConfig = SpanByteAndMemory.FromPinnedSpan(resSpan);
+
+            TxnKeyEntry vectorLockEntry = new();
+            vectorLockEntry.isObject = false;
+            vectorLockEntry.keyHash = lockableContext.GetKeyHash(key);
+
+            lockableContext.BeginLockable();
+
+            try
+            {
+            tryAgain:
+                vectorLockEntry.lockType = LockType.Shared;
+
+                // TODO: ew, allocs
+                if (!lockableContext.TryLock([vectorLockEntry]))
+                {
+                    throw new GarnetException("Couldn't acquire shared lock on Vector Set");
+                }
+
+                try
+                {
+
+                    var readRes = Read_MainStore(ref key, ref input, ref indexConfig, ref lockableContext);
+                    if (readRes == GarnetStatus.NOTFOUND)
+                    {
+                        if (!lockableContext.TryPromoteLock(vectorLockEntry))
+                        {
+                            goto tryAgain;
+                        }
+
+                        vectorLockEntry.lockType = LockType.Exclusive;
+
+                        var writeRes = RMW_MainStore(ref key, ref input, ref indexConfig, ref lockableContext);
+                        if (writeRes == GarnetStatus.OK)
+                        {
+                            // Try again so we don't hold an exclusive lock while adding a vector (which might be time consuming)
+                            goto tryAgain;
+                        }
+                    }
+                    else if (readRes != GarnetStatus.OK)
+                    {
+                        result = VectorManagerResult.Invalid;
+                        return readRes;
+                    }
+
+                    Debug.Assert(vectorLockEntry.lockType == LockType.Shared, "Shouldn't hold exclusive lock while adding to vector set");
+
+                    // After a successful read we add the vector while holding a shared lock
+                    // That lock prevents deletion, but everything else can proceed in parallel
+                    result = VectorManager.TryAdd(this, indexConfig.AsReadOnlySpan(), element.ReadOnlySpan, values, attributes.ReadOnlySpan, (uint)reduceDims, quantizer, (uint)buildExplorationFactor, (uint)numLinks);
+
+                    return GarnetStatus.OK;
+                }
+                finally
+                {
+                    lockableContext.Unlock([vectorLockEntry]);
+                }
+            }
+            finally
+            {
+                lockableContext.EndLockable();
+            }
+        }
+
+        /// <summary>
+        /// Perform a similarity search on an existing Vector Set given a vector as a bunch of floats.
+        /// </summary>
+        public GarnetStatus VectorSetValueSimilarity(SpanByte key, ReadOnlySpan<float> values, int count, float delta, int searchExplorationFactor, ReadOnlySpan<byte> filter, int maxFilteringEffort, ref SpanByteAndMemory outputIds, ref SpanByteAndMemory outputDistances, out VectorManagerResult result)
+        {
+            // Need to lock to prevent the index from being dropped while we read against it
+            //
+            // Note that this does not block adding vectors to the set, as that can also be done under
+            // a shared lock
+            lockableContext.BeginLockable();
+            try
+            {
+                TxnKeyEntry vectorLockEntry = new();
+                vectorLockEntry.isObject = false;
+                vectorLockEntry.keyHash = lockableContext.GetKeyHash(key);
+                vectorLockEntry.lockType = LockType.Shared;
+
+                // TODO: allocs, ew
+                if (!lockableContext.TryLock([vectorLockEntry]))
+                {
+                    throw new GarnetException("Couldn't acquire shared lock on Vector Set");
+                }
+
+                try
+                {
+                    parseState.InitializeWithArgument(ArgSlice.FromPinnedSpan(key.AsReadOnlySpan()));
+
+                    // Get the index
+                    var input = new RawStringInput(RespCommand.VSIM, ref parseState);
+
+                    Span<byte> resSpan = stackalloc byte[128];
+                    var indexConfig = SpanByteAndMemory.FromPinnedSpan(resSpan);
+
+                    var readRes = Read_MainStore(ref key, ref input, ref indexConfig, ref lockableContext);
+                    if (readRes != GarnetStatus.OK)
+                    {
+                        result = VectorManagerResult.Invalid;
+                        return readRes;
+                    }
+
+                    // After a successful read we add the vector while holding a shared lock
+                    // That lock prevents deletion, but everything else can proceed in parallel
+                    result = VectorManager.ValueSimilarity(this, indexConfig.AsReadOnlySpan(), values, count, delta, searchExplorationFactor, filter, maxFilteringEffort, ref outputIds, ref outputDistances);
+
+                    return GarnetStatus.OK;
+                }
+                finally
+                {
+                    lockableContext.Unlock([vectorLockEntry]);
+                }
+            }
+            finally
+            {
+                lockableContext.EndLockable();
+            }
+        }
+
+        /// <summary>
+        /// Perform a similarity search on an existing Vector Set given an element that is already in the Vector Set.
+        /// </summary>
+        public GarnetStatus VectorSetElementSimilarity(SpanByte key, ReadOnlySpan<byte> element, int count, float delta, int searchExplorationFactor, ReadOnlySpan<byte> filter, int maxFilteringEffort, ref SpanByteAndMemory outputIds, ref SpanByteAndMemory outputDistances, out VectorManagerResult result)
+        {
+            // Need to lock to prevent the index from being dropped while we read against it
+            //
+            // Note that this does not block adding vectors to the set, as that can also be done under
+            // a shared lock
+            lockableContext.BeginLockable();
+            try
+            {
+                TxnKeyEntry vectorLockEntry = new();
+                vectorLockEntry.isObject = false;
+                vectorLockEntry.keyHash = lockableContext.GetKeyHash(key);
+                vectorLockEntry.lockType = LockType.Shared;
+
+                // TODO: allocs, ew
+                if (!lockableContext.TryLock([vectorLockEntry]))
+                {
+                    throw new GarnetException("Couldn't acquire shared lock on Vector Set");
+                }
+
+                try
+                {
+                    parseState.InitializeWithArgument(ArgSlice.FromPinnedSpan(key.AsReadOnlySpan()));
+
+                    var input = new RawStringInput(RespCommand.VSIM, ref parseState);
+
+                    Span<byte> resSpan = stackalloc byte[128];
+                    var indexConfig = SpanByteAndMemory.FromPinnedSpan(resSpan);
+
+                    var readRes = Read_MainStore(ref key, ref input, ref indexConfig, ref lockableContext);
+                    if (readRes != GarnetStatus.OK)
+                    {
+                        result = VectorManagerResult.Invalid;
+                        return readRes;
+                    }
+
+                    // After a successful read we add the vector while holding a shared lock
+                    // That lock prevents deletion, but everything else can proceed in parallel
+                    result = VectorManager.ElementSimilarity(this, indexConfig.AsReadOnlySpan(), element, count, delta, searchExplorationFactor, filter, maxFilteringEffort, ref outputIds, ref outputDistances);
+
+                    return GarnetStatus.OK;
+                }
+                finally
+                {
+                    lockableContext.Unlock([vectorLockEntry]);
+                }
+            }
+            finally
+            {
+                lockableContext.EndLockable();
+            }
+        }
+
+        /// <inheritdoc/>
+        public GarnetStatus VectorEmbedding(SpanByte key, ReadOnlySpan<byte> element, ref SpanByteAndMemory outputDistances)
+        {
+            // Need to lock to prevent the index from being dropped while we read against it
+            //
+            // Note that this does not block adding vectors to the set, as that can also be done under
+            // a shared lock
+            lockableContext.BeginLockable();
+            try
+            {
+                TxnKeyEntry vectorLockEntry = new();
+                vectorLockEntry.isObject = false;
+                vectorLockEntry.keyHash = lockableContext.GetKeyHash(key);
+                vectorLockEntry.lockType = LockType.Shared;
+
+                // TODO: allocs, ew
+                if (!lockableContext.TryLock([vectorLockEntry]))
+                {
+                    throw new GarnetException("Couldn't acquire shared lock on Vector Set");
+                }
+
+                try
+                {
+                    parseState.InitializeWithArgument(ArgSlice.FromPinnedSpan(key.AsReadOnlySpan()));
+
+                    var input = new RawStringInput(RespCommand.VEMB, ref parseState);
+
+                    Span<byte> resSpan = stackalloc byte[128];
+                    var indexConfig = SpanByteAndMemory.FromPinnedSpan(resSpan);
+
+                    var readRes = Read_MainStore(ref key, ref input, ref indexConfig, ref lockableContext);
+                    if (readRes != GarnetStatus.OK)
+                    {
+                        return readRes;
+                    }
+
+                    // After a successful read we add the vector while holding a shared lock
+                    // That lock prevents deletion, but everything else can proceed in parallel
+                    if (!VectorManager.TryGetEmbedding(this, indexConfig.AsReadOnlySpan(), element, ref outputDistances))
+                    {
+                        return GarnetStatus.NOTFOUND;
+                    }
+
+                    return GarnetStatus.OK;
+                }
+                finally
+                {
+                    lockableContext.Unlock([vectorLockEntry]);
+                }
+            }
+            finally
+            {
+                lockableContext.EndLockable();
+            }
+        }
+    }
+}

--- a/libs/server/Storage/Session/StorageSession.cs
+++ b/libs/server/Storage/Session/StorageSession.cs
@@ -42,6 +42,12 @@ namespace Garnet.server
         public BasicContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions, ObjectStoreFunctions, ObjectStoreAllocator> objectStoreBasicContext;
         public LockableContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions, ObjectStoreFunctions, ObjectStoreAllocator> objectStoreLockableContext;
 
+        /// <summary>
+        /// Session Contexts for vector ops against the main store
+        /// </summary>
+        public BasicContext<SpanByte, SpanByte, VectorInput, SpanByte, long, VectorSessionFunctions, MainStoreFunctions, MainStoreAllocator> vectorContext;
+        public LockableContext<SpanByte, SpanByte, VectorInput, SpanByte, long, VectorSessionFunctions, MainStoreFunctions, MainStoreAllocator> vectorLockableContext;
+
         public readonly ScratchBufferBuilder scratchBufferBuilder;
         public readonly FunctionsState functionsState;
 
@@ -83,6 +89,9 @@ namespace Garnet.server
             var objectStoreFunctions = new ObjectSessionFunctions(functionsState);
             var objectStoreSession = db.ObjectStore?.NewSession<ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions>(objectStoreFunctions);
 
+            var vectorFunctions = new VectorSessionFunctions(functionsState);
+            var vectorSession = db.MainStore.NewSession<VectorInput, SpanByte, long, VectorSessionFunctions>(vectorFunctions);
+
             basicContext = session.BasicContext;
             lockableContext = session.LockableContext;
             if (objectStoreSession != null)
@@ -90,6 +99,8 @@ namespace Garnet.server
                 objectStoreBasicContext = objectStoreSession.BasicContext;
                 objectStoreLockableContext = objectStoreSession.LockableContext;
             }
+            vectorContext = vectorSession.BasicContext;
+            vectorLockableContext = vectorSession.LockableContext;
 
             HeadAddress = db.MainStore.Log.HeadAddress;
             ObjectScanCountLimit = storeWrapper.serverOptions.ObjectScanCountLimit;

--- a/libs/server/Transaction/TransactionManager.cs
+++ b/libs/server/Transaction/TransactionManager.cs
@@ -15,13 +15,19 @@ namespace Garnet.server
             SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>,
         BasicContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions,
             /* ObjectStoreFunctions */ StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>,
-            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>>;
+            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>,
+        BasicContext<SpanByte, SpanByte, VectorInput, SpanByte, long, VectorSessionFunctions,
+            /* VectorStoreFunctions */ StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>,
+            SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>>;
     using LockableGarnetApi = GarnetApi<LockableContext<SpanByte, SpanByte, RawStringInput, SpanByteAndMemory, long, MainSessionFunctions,
             /* MainStoreFunctions */ StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>,
             SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>,
         LockableContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions,
             /* ObjectStoreFunctions */ StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>,
-            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>>;
+            GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>,
+        LockableContext<SpanByte, SpanByte, VectorInput, SpanByte, long, VectorSessionFunctions,
+            /* VectorStoreFunctions */ StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>,
+            SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>>;
 
     using MainStoreAllocator = SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>;
     using MainStoreFunctions = StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>;

--- a/libs/server/Transaction/TxnKeyManager.cs
+++ b/libs/server/Transaction/TxnKeyManager.cs
@@ -235,6 +235,10 @@ namespace Garnet.server
                 RespCommand.ZUNION => SortedSetObjectKeys(command, inputCount),
                 RespCommand.ZUNIONSTORE => SortedSetObjectKeys(command, inputCount),
 
+                // TODO: Actually implement as commands are implemented
+                RespCommand.VADD or RespCommand.VCARD or RespCommand.VDIM or RespCommand.VEMB or RespCommand.VGETATTR or RespCommand.VINFO or
+                RespCommand.VLINKS or RespCommand.VRANDMEMBER or RespCommand.VREM or RespCommand.VSETATTR or RespCommand.VSIM => SingleKey(StoreType.Object, LockType.Exclusive),
+
                 RespCommand.COSCAN => SingleKey(StoreType.Object, LockType.Shared),
                 _ => OtherCommands(command, out error)
             };

--- a/libs/storage/Tsavorite/cs/src/core/VarLen/SpanByteAndMemory.cs
+++ b/libs/storage/Tsavorite/cs/src/core/VarLen/SpanByteAndMemory.cs
@@ -84,6 +84,12 @@ namespace Tsavorite.core
         public ReadOnlySpan<byte> AsReadOnlySpan() => IsSpanByte ? SpanByte.AsReadOnlySpan() : Memory.Memory.Span.Slice(0, Length);
 
         /// <summary>
+        /// As a span of the contained data. Use this when you haven't tested <see cref="IsSpanByte"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<byte> AsSpan() => IsSpanByte ? SpanByte.AsSpan() : Memory.Memory.Span.Slice(0, Length);
+
+        /// <summary>
         /// As a span of the contained data. Use this when you have already tested <see cref="IsSpanByte"/>.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/Garnet.test/Resp/ACL/RespCommandTests.cs
+++ b/test/Garnet.test/Resp/ACL/RespCommandTests.cs
@@ -7469,6 +7469,193 @@ namespace Garnet.test.Resp.ACL
             }
         }
 
+        [Test]
+        public async Task VAddACLsAsync()
+        {
+            await CheckCommandsAsync(
+                "VADD",
+                [DoVAddAsync]
+            );
+
+            static async Task DoVAddAsync(GarnetClient client)
+            {
+                // TODO: this is a placeholder implementation
+
+                string val = await client.ExecuteForStringResultAsync("VADD", ["foo", "REDUCE", "50", "VALUES", "4", "1.0", "2.0", "3.0", "4.0", "bar", "CAS", "Q8", "EF", "16", "SETATTR", "{ 'hello': 'world' }", "M", "32"]);
+                ClassicAssert.AreEqual("OK", val);
+            }
+        }
+
+        [Test]
+        public async Task VCardACLsAsync()
+        {
+            await CheckCommandsAsync(
+                "VCARD",
+                [DoVCardAsync]
+            );
+
+            static async Task DoVCardAsync(GarnetClient client)
+            {
+                // TODO: this is a placeholder implementation
+
+                string val = await client.ExecuteForStringResultAsync("VCARD", ["foo"]);
+                ClassicAssert.AreEqual("OK", val);
+            }
+        }
+
+        [Test]
+        public async Task VDimACLsAsync()
+        {
+            await CheckCommandsAsync(
+                "VDIM",
+                [DoVDimAsync]
+            );
+
+            static async Task DoVDimAsync(GarnetClient client)
+            {
+                // TODO: this is a placeholder implementation
+
+                string val = await client.ExecuteForStringResultAsync("VDIM", ["foo"]);
+                ClassicAssert.AreEqual("OK", val);
+            }
+        }
+
+        [Test]
+        public async Task VEmbACLsAsync()
+        {
+            await CheckCommandsAsync(
+                "VEmb",
+                [DoVEmbAsync]
+            );
+
+            static async Task DoVEmbAsync(GarnetClient client)
+            {
+                // TODO: this is a placeholder implementation
+
+                string val = await client.ExecuteForStringResultAsync("VEMB", ["foo"]);
+                ClassicAssert.AreEqual("OK", val);
+            }
+        }
+
+        [Test]
+        public async Task VGetAttrACLsAsync()
+        {
+            await CheckCommandsAsync(
+                "VGETATTR",
+                [DoVGetAttrAsync]
+            );
+
+            static async Task DoVGetAttrAsync(GarnetClient client)
+            {
+                // TODO: this is a placeholder implementation
+
+                string val = await client.ExecuteForStringResultAsync("VGETATTR", ["foo"]);
+                ClassicAssert.AreEqual("OK", val);
+            }
+        }
+
+        [Test]
+        public async Task VInfoACLsAsync()
+        {
+            await CheckCommandsAsync(
+                "VINFO",
+                [DoVInfoAsync]
+            );
+
+            static async Task DoVInfoAsync(GarnetClient client)
+            {
+                // TODO: this is a placeholder implementation
+
+                string val = await client.ExecuteForStringResultAsync("VINFO", ["foo"]);
+                ClassicAssert.AreEqual("OK", val);
+            }
+        }
+
+        [Test]
+        public async Task VLinksACLsAsync()
+        {
+            await CheckCommandsAsync(
+                "VLINKS",
+                [DoVLinksAsync]
+            );
+
+            static async Task DoVLinksAsync(GarnetClient client)
+            {
+                // TODO: this is a placeholder implementation
+
+                string val = await client.ExecuteForStringResultAsync("VLINKS", ["foo"]);
+                ClassicAssert.AreEqual("OK", val);
+            }
+        }
+
+        [Test]
+        public async Task VRandMemberACLsAsync()
+        {
+            await CheckCommandsAsync(
+                "VRANDMEMBER",
+                [DoVRandMemberAsync]
+            );
+
+            static async Task DoVRandMemberAsync(GarnetClient client)
+            {
+                // TODO: this is a placeholder implementation
+
+                string val = await client.ExecuteForStringResultAsync("VRANDMEMBER", ["foo"]);
+                ClassicAssert.AreEqual("OK", val);
+            }
+        }
+
+        [Test]
+        public async Task VRemACLsAsync()
+        {
+            await CheckCommandsAsync(
+                "VREM",
+                [DoVRemAsync]
+            );
+
+            static async Task DoVRemAsync(GarnetClient client)
+            {
+                // TODO: this is a placeholder implementation
+
+                string val = await client.ExecuteForStringResultAsync("VREM", ["foo"]);
+                ClassicAssert.AreEqual("OK", val);
+            }
+        }
+
+        [Test]
+        public async Task VSetAttrACLsAsync()
+        {
+            await CheckCommandsAsync(
+                "VSETATTR",
+                [DoVSetAttrAsync]
+            );
+
+            static async Task DoVSetAttrAsync(GarnetClient client)
+            {
+                // TODO: this is a placeholder implementation
+
+                string val = await client.ExecuteForStringResultAsync("VSETATTR", ["foo"]);
+                ClassicAssert.AreEqual("OK", val);
+            }
+        }
+
+        [Test]
+        public async Task VSimACLsAsync()
+        {
+            await CheckCommandsAsync(
+                "VSIM",
+                [DoVSimAsync]
+            );
+
+            static async Task DoVSimAsync(GarnetClient client)
+            {
+                // TODO: this is a placeholder implementation
+
+                string val = await client.ExecuteForStringResultAsync("VSIM", ["foo"]);
+                ClassicAssert.AreEqual("OK", val);
+            }
+        }
+
         /// <summary>
         /// Take a command (or subcommand, with a space) and check that adding and removing
         /// command, subcommand, and categories ACLs behaves as expected.

--- a/test/Garnet.test/RespSortedSetTests.cs
+++ b/test/Garnet.test/RespSortedSetTests.cs
@@ -24,7 +24,10 @@ namespace Garnet.test
     SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>,
     BasicContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions,
     /* ObjectStoreFunctions */ StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>,
-    GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>>;
+    GenericAllocator<byte[], IGarnetObject, StoreFunctions<byte[], IGarnetObject, ByteArrayKeyComparer, DefaultRecordDisposer<byte[], IGarnetObject>>>>,
+    BasicContext<SpanByte, SpanByte, VectorInput, SpanByte, long, VectorSessionFunctions,
+    /* VectorStoreFunctions */ StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>,
+    SpanByteAllocator<StoreFunctions<SpanByte, SpanByte, SpanByteComparer, SpanByteRecordDisposer>>>>;
 
     [TestFixture]
     public class RespSortedSetTests
@@ -100,7 +103,7 @@ namespace Garnet.test
             db.SortedSetAdd("key1", "b", 2);
 
             var session = new RespServerSession(0, new EmbeddedNetworkSender(), server.Provider.StoreWrapper, null, null, false);
-            var api = new TestBasicGarnetApi(session.storageSession, session.storageSession.basicContext, session.storageSession.objectStoreBasicContext);
+            var api = new TestBasicGarnetApi(session.storageSession, session.storageSession.basicContext, session.storageSession.objectStoreBasicContext, session.storageSession.vectorContext);
             var key = Encoding.ASCII.GetBytes("key1");
             fixed (byte* keyPtr = key)
             {
@@ -132,7 +135,7 @@ namespace Garnet.test
             Thread.Sleep(200);
 
             var session = new RespServerSession(0, new EmbeddedNetworkSender(), server.Provider.StoreWrapper, null, null, false);
-            var api = new TestBasicGarnetApi(session.storageSession, session.storageSession.basicContext, session.storageSession.objectStoreBasicContext);
+            var api = new TestBasicGarnetApi(session.storageSession, session.storageSession.basicContext, session.storageSession.objectStoreBasicContext, session.storageSession.vectorContext);
             var key = Encoding.ASCII.GetBytes("key1");
             fixed (byte* keyPtr = key)
             {


### PR DESCRIPTION
Redis has recently added a Vector Set API, exploring implementing it.

Some assumptions:
 - Actual Vector Set implementation is outside of .NET, I've mocked it up against as an interface
    * Long term that interface goes away and we just pick an implementation, it's there to keep me honest about the abstraction
 - All Vector Set data is in the MainStore, so replication and checkpoint "just work"
 - While creating a Vector Set is a write op, adding a vector to an existing set is a read op
   * This is modeled as taking Shared locks around `VADD`, `VSIM`, etc., and only upgrading to an exclusive lock when we need create an index

Open questions:
 - [ ] Need to conceal Vector Set data from other MainStore ops
 - [ ] Need to prevent attributes and neighbor lists from clobbering raw vectors, probably also part of ^
 - [ ] Implement remaining vector commands
 - [ ] Pull in an actual implementation to work against
 - [ ] I hate the `[ThreadStatic]` but keeping the context on the stack is hard too; other options?