### PR TITLE
Bump Microsoft.Extensions.Logging

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="NUnit" Version="4.1.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.8" />


### PR DESCRIPTION
this commit will fix CI failure on PR of dependabot's

Dependabot missing update 
'Microsoft.Extensions.Logging' that causing dotnet restore failure

```
/home/runner/work/garnet/garnet/libs/host/Garnet.host.csproj : error NU1605: Warning As Error: Detected package downgrade: Microsoft.Extensions.Logging from 9.0.8 to 9.0.3. Reference the package directly from the project to select a different version.  [/home/runner/work/garnet/garnet/Garnet.sln]
/home/runner/work/garnet/garnet/libs/host/Garnet.host.csproj : error NU1605:  Microsoft.Garnet -> Microsoft.Extensions.Logging.Console 9.0.8 -> Microsoft.Extensions.Logging (>= 9.0.8)  [/home/runner/work/garnet/garnet/Garnet.sln]
/home/runner/work/garnet/garnet/libs/host/Garnet.host.csproj : error NU1605:  Microsoft.Garnet -> Microsoft.Extensions.Logging (>= 9.0.3) [/home/runner/work/garnet/garnet/Garnet.sln]
  Restored /home/runner/work/garnet/garnet/test/Garnet.test.cluster/Garnet.test.cluster.csproj (in 4.35 sec).
```