### PR TITLE
Full nightly test run that will run on ADO (not the GH repo)

### DIFF
--- a/.azure/pipelines/azure-pipelines-nightly.yml
+++ b/.azure/pipelines/azure-pipelines-nightly.yml
@@ -1,0 +1,244 @@
+trigger: none  
+
+schedules:
+  - cron: "0 9 * * *"  
+    displayName: "Nightly Garnet Tests on ADO"
+    branches:
+      include:
+        - main
+    always: true  
+variables:
+  solution: 'Garnet.sln'
+  RunAzureTests: 'yes'
+
+jobs:
+- job: 'Windows_Latest'
+  pool:
+    vmImage: windows-latest
+  displayName: 'Windows'
+  timeoutInMinutes: '175'
+
+  strategy:
+    maxParallel: '4'
+    matrix:
+      AnyCPU-Debug-Net8:
+        buildPlatform: 'Any CPU'
+        buildConfiguration: 'Debug'
+        buildFramework: 'net8.0'
+      AnyCPU-Release-Net8:
+        buildPlatform: 'Any CPU'
+        buildConfiguration: 'Release'
+        buildFramework: 'net8.0'
+      AnyCPU-Debug-Net9:
+        buildPlatform: 'Any CPU'
+        buildConfiguration: 'Debug'
+        buildFramework: 'net9.0'
+      AnyCPU-Release-Net9:
+        buildPlatform: 'Any CPU'
+        buildConfiguration: 'Release'
+        buildFramework: 'net9.0'
+
+  steps:
+  - task: UseDotNet@2
+    displayName: Use .NET 8.0
+    inputs:
+      packageType: 'sdk'
+      version: '8.0.x'
+
+  - task: UseDotNet@2
+    displayName: Use .NET 9.0
+    inputs:
+      packageType: 'sdk'
+      version: '9.0.x'
+
+  - task: NodeTool@0
+    displayName: Node Tool
+    inputs:
+      versionSpec: 14.x
+
+  - script : npm install -g azurite
+    displayName: Install Azurite
+
+  - script : start /B azurite
+    displayName: Start Azurite
+
+  - task: NuGetAuthenticate@1
+    displayName: 'NuGet Authenticate (Force Reinstall)'
+    inputs:
+      forceReinstallCredentialProvider: true
+
+  - task: NuGetToolInstaller@1
+    displayName: Nuget Tool Installer
+    inputs:
+      versionspec: '*'
+      checkLatest: true
+
+  - script: nuget restore
+    displayName: Nuget Restore
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Build Tsavorite binaries and tests $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: 'build'
+      projects: '**/Tsavorite.test.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Tests for Tsavorite on $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: test
+      projects: '**/Tsavorite.test.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework) --property:TestTfmsInParallel=false --logger:"console;verbosity=detailed" -- NUnit.DisplayName=FullName'
+    continueOnError: true
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Build Garnet Cluster binaries and tests $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: 'build'
+      projects: '**/Garnet.test.cluster.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Tests for Garnet Cluster on $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: test
+      projects: '**/Garnet.test.cluster.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework) --property:TestTfmsInParallel=false --logger:"console;verbosity=detailed" -- NUnit.DisplayName=FullName'
+    continueOnError: true
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Build Garnet binaries and tests $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: 'build'
+      projects: '**/Garnet.test.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Tests for Garnet on $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: test
+      projects: '**/Garnet.test.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework) --property:TestTfmsInParallel=false --logger:"console;verbosity=detailed" -- NUnit.DisplayName=FullName'
+    continueOnError: true
+
+  - task: NuGetCommand@2
+    displayName: Pack nuget package to test nuspec is correct - will not publish it though
+    inputs:
+      workingDirectory: $(System.DefaultWorkingDirectory)
+      script: 'dotnet pack --no-build --no-restore --output $(Build.ArtifactStagingDirectory) -p:PackageVersion=$(Build.BuildNumber) /p:Configuration=Release libs/host/Garnet.host.csproj'
+
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results'
+    inputs:
+      testRunner: VSTest
+      testResultsFiles: '**/*.trx'
+      searchFolder: '$(Agent.TempDirectory)'
+
+- job: 'Ubuntu_Latest'
+  pool:
+    vmImage: ubuntu-latest
+  displayName: 'Ubuntu'
+  timeoutInMinutes: '175'
+
+  strategy:
+    maxParallel: '4'
+    matrix:
+      AnyCPU-Debug-Net8:
+        buildPlatform: 'Any CPU'
+        buildConfiguration: 'Debug'
+        buildFramework: 'net8.0'
+      AnyCPU-Release-Net8:
+        buildPlatform: 'Any CPU'
+        buildConfiguration: 'Release'
+        buildFramework: 'net8.0'
+      AnyCPU-Debug-Net9:
+        buildPlatform: 'Any CPU'
+        buildConfiguration: 'Debug'
+        buildFramework: 'net9.0'
+      AnyCPU-Release-Net9:
+        buildPlatform: 'Any CPU'
+        buildConfiguration: 'Release'
+        buildFramework: 'net9.0'
+
+  steps:
+  - task: UseDotNet@2
+    displayName: Use .NET 8.0
+    inputs:
+      packageType: 'sdk'
+      version: '8.0.x'
+
+  - task: UseDotNet@2
+    displayName: Use .NET 9.0
+    inputs:
+      packageType: 'sdk'
+      version: '9.0.x'
+
+  - bash: |
+      sudo npm install -g azurite
+      sudo mkdir azurite
+      sudo azurite --silent --location azurite --debug azurite\debug.log &
+    displayName: 'Install and Run Azurite'
+      
+  - task: NuGetAuthenticate@1
+    displayName: 'NuGet Authenticate (Force Reinstall)'
+    inputs:
+      forceReinstallCredentialProvider: true
+
+  - task: UseDotNet@2 # Optional if the .NET Core SDK is already installed
+    displayName: Use .NET
+
+  - script: dotnet restore
+    displayName: .NET Restore
+
+  - task: DotNetCoreCLI@2
+    displayName: '.NET Core build Tsavorite binaries and tests $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: 'build'
+      projects: '**/Tsavorite.test.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Tests for Tsavorite on $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: test
+      projects: '**/Tsavorite.test.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework) --logger:"console;verbosity=detailed"'
+    continueOnError: true
+
+  - task: DotNetCoreCLI@2
+    displayName: '.NET Core build Garnet binaries and tests $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: 'build'
+      projects: '**/Garnet.test.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Tests for Garnet on $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: test
+      projects: '**/Garnet.test.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework) --property:TestTfmsInParallel=false --logger:"console;verbosity=detailed" -- NUnit.DisplayName=FullName'
+    continueOnError: true
+
+
+  - task: DotNetCoreCLI@2
+    displayName: '.NET Core build Cluster binaries and tests $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: 'build'
+      projects: '**/Garnet.test.cluster.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework)'
+  
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Tests for Garnet Cluster on $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: test
+      projects: '**/Garnet.test.cluster.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework) --property:TestTfmsInParallel=false --logger:"console;verbosity=detailed" -- NUnit.DisplayName=FullName'
+    continueOnError: true
+
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results'
+    inputs:
+      testResultsFormat: 'VSTest'
+      testResultsFiles: '*.trx'
+      searchFolder: '$(Agent.TempDirectory)'

--- a/.azure/pipelines/azure-pipelines-nightly.yml
+++ b/.azure/pipelines/azure-pipelines-nightly.yml
@@ -217,7 +217,7 @@ jobs:
     inputs:
       command: test
       projects: '**/Tsavorite.test.csproj'
-      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework) --logger:"console;verbosity=detailed"'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework) --property:TestTfmsInParallel=false --logger:"console;verbosity=detailed" -- NUnit.DisplayName=FullName'
     continueOnError: true
 
   - task: DotNetCoreCLI@2

--- a/.azure/pipelines/azure-pipelines-nightly.yml
+++ b/.azure/pipelines/azure-pipelines-nightly.yml
@@ -77,6 +77,21 @@ jobs:
     displayName: Nuget Restore
 
   - task: DotNetCoreCLI@2
+    displayName: 'Build Garnet binaries and tests $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: 'build'
+      projects: '**/Garnet.test.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Tests for Garnet on $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: test
+      projects: '**/Garnet.test.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework) --property:TestTfmsInParallel=false --logger:"console;verbosity=detailed" -- NUnit.DisplayName=FullName'
+    continueOnError: true
+
+  - task: DotNetCoreCLI@2
     displayName: 'Build Tsavorite binaries and tests $(buildConfiguration) targeting $(buildFramework)'
     inputs:
       command: 'build'
@@ -103,21 +118,6 @@ jobs:
     inputs:
       command: test
       projects: '**/Garnet.test.cluster.csproj'
-      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework) --property:TestTfmsInParallel=false --logger:"console;verbosity=detailed" -- NUnit.DisplayName=FullName'
-    continueOnError: true
-
-  - task: DotNetCoreCLI@2
-    displayName: 'Build Garnet binaries and tests $(buildConfiguration) targeting $(buildFramework)'
-    inputs:
-      command: 'build'
-      projects: '**/Garnet.test.csproj'
-      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework)'
-
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Tests for Garnet on $(buildConfiguration) targeting $(buildFramework)'
-    inputs:
-      command: test
-      projects: '**/Garnet.test.csproj'
       arguments: '--configuration $(buildConfiguration) --framework $(buildFramework) --property:TestTfmsInParallel=false --logger:"console;verbosity=detailed" -- NUnit.DisplayName=FullName'
     continueOnError: true
 
@@ -191,21 +191,6 @@ jobs:
     displayName: .NET Restore
 
   - task: DotNetCoreCLI@2
-    displayName: '.NET Core build Tsavorite binaries and tests $(buildConfiguration) targeting $(buildFramework)'
-    inputs:
-      command: 'build'
-      projects: '**/Tsavorite.test.csproj'
-      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework)'
-
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Tests for Tsavorite on $(buildConfiguration) targeting $(buildFramework)'
-    inputs:
-      command: test
-      projects: '**/Tsavorite.test.csproj'
-      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework) --logger:"console;verbosity=detailed"'
-    continueOnError: true
-
-  - task: DotNetCoreCLI@2
     displayName: '.NET Core build Garnet binaries and tests $(buildConfiguration) targeting $(buildFramework)'
     inputs:
       command: 'build'
@@ -220,6 +205,20 @@ jobs:
       arguments: '--configuration $(buildConfiguration) --framework $(buildFramework) --property:TestTfmsInParallel=false --logger:"console;verbosity=detailed" -- NUnit.DisplayName=FullName'
     continueOnError: true
 
+  - task: DotNetCoreCLI@2
+    displayName: '.NET Core build Tsavorite binaries and tests $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: 'build'
+      projects: '**/Tsavorite.test.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Tests for Tsavorite on $(buildConfiguration) targeting $(buildFramework)'
+    inputs:
+      command: test
+      projects: '**/Tsavorite.test.csproj'
+      arguments: '--configuration $(buildConfiguration) --framework $(buildFramework) --logger:"console;verbosity=detailed"'
+    continueOnError: true
 
   - task: DotNetCoreCLI@2
     displayName: '.NET Core build Cluster binaries and tests $(buildConfiguration) targeting $(buildFramework)'


### PR DESCRIPTION
This is a Nightly run that will run an ADO pipeline  in ADO environment against the ADO repo. Even if we go with another test reporting solution, this will be good to have since it will run all the tests every night and not just on CI. Also, there will be some consistency that it only runs on Main so that gives us consistent reporting.

ADO doesn't make it very easy to do multiple OS skus, so just doing Ubuntu latest and Windows latest. 

Ubuntu  latest
Windows latest
Debug / Release
Net 8 / Net 9

This still gives us almost 42k tests ran every night on the ADO repo