### PR TITLE
Fix ZCOUNT error when min bound is higher than set's max score

### DIFF
--- a/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
@@ -297,7 +297,7 @@ namespace Garnet.server
 
             // get the elements within the score range and write the result
             var count = 0;
-            if (sortedSet.Count > 0)
+            if (sortedSet.Count > 0 && minValue <= sortedSet.Max.Score)
             {
                 foreach (var item in sortedSet.GetViewBetween((minValue, null), sortedSet.Max))
                 {

--- a/test/Garnet.test/RespSortedSetTests.cs
+++ b/test/Garnet.test/RespSortedSetTests.cs
@@ -530,6 +530,19 @@ namespace Garnet.test
         }
 
         [Test]
+        public void CanGetScoresZCountWithMinHigherThanMaxScore()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+            var key = "LeaderBoard";
+
+            var added = db.SortedSetAdd(key, "a", 1);
+
+            var card = db.SortedSetLength(new RedisKey(key), min: 2, max: 3);
+            ClassicAssert.IsTrue(0 == card);
+        }
+
+        [Test]
         public async Task ZCountAndZCardWithExpiredAndExpiringItems()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());


### PR DESCRIPTION
Hey 👋 

We encountered this bug where if `ZCOUNT` is called with a min value that's higher than the maximum score of the set, it throws this error:
```
02::14::16 crit: Session[0] [] [00ADA527] ProcessMessages threw an exception: System.ArgumentException: Must be less than or equal to upperValue. (Parameter 'lowerValue')    at Garnet.server.SortedSetObject.SortedSetCount(ObjectInput& input, GarnetObjectStoreOutput& output, Byte respProtocolVersion) in /src/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs:line 285    at Garnet.server.SortedSetObject.Operate(ObjectInput& input, GarnetObjectStoreOutput& output, Byte respProtocolVersion, Int64& sizeChange) in /src/libs/server/Objects/SortedSet/SortedSetObject.cs:line 358    at Garnet.server.ObjectSessionFunctions.SingleReader(Byte[]& key, ObjectInput& input, IGarnetObject& value, GarnetObjectStoreOutput& dst, ReadInfo& readInfo) in /src/libs/server/Storage/Functions/ObjectStore/ReadMethods.cs:line 50    at Garnet.server.StorageSession.ReadObjectStoreOperationWithOutput[TObjectContext](Byte[] key, ObjectInput& input, TObjectContext& objectStoreContext, GarnetObjectStoreOutput& output) in /src/libs/server/Storage/Session/ObjectStore/Common.cs:line 85    at Garnet.server.RespServerSession.SortedSetCount[TGarnetApi](TGarnetApi& storageApi) in /src/libs/server/Resp/Objects/SortedSetCommands.cs:line 555    at Garnet.server.RespServerSession.ProcessArrayCommands[TGarnetApi](RespCommand cmd, TGarnetApi& storageApi) in /src/libs/server/Resp/RespServerSession.cs:line 792    at Garnet.server.RespServerSession.ProcessMessages() in /src/libs/server/Resp/RespServerSession.cs:line 596    at Garnet.server.RespServerSession.TryConsumeMessages(Byte* reqBuffer, Int32 bytesReceived) in /src/libs/server/Resp/RespServerSession.cs:line 458
02::14::16 fail: Session[0] [10.30.0.7:34892] [03B66FE6] Unexpected response, this should never happen
```

I believe a similar issue was fixed by this PR: https://github.com/microsoft/garnet/pull/1324/files#diff-b6264c2334100a19993b90daa6b1afc844ffb98fb730b90bea45b723dbd2119fR964-R965 for `ZRANGE`.

It can be reproduced by the test or just running these commands:
```lua
localhost:7007> ZADD testset 10 a
(integer) 1
localhost:7007> ZCOUNT testset 25 +inf
Error: Server closed the connection
```
