### PR TITLE
garnet-server: add rollforward

### DIFF
--- a/main/GarnetServer/GarnetServer.csproj
+++ b/main/GarnetServer/GarnetServer.csproj
@@ -8,6 +8,7 @@
     <PackAsTool>true</PackAsTool>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <ImplicitUsings>enable</ImplicitUsings>
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
fixes #1374

Impact: tool runs on future frameworks not explicitly listed in `<TargetFrameworks>`, which is currently `net8.0;net9.0`. The concrete impact is that it works in .NET 10 preview (and GA).