### PR TITLE
Enable codeql for cpp

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,8 @@ jobs:
           build-mode: manual
         - language: javascript-typescript
           build-mode: none
+        - language: c-cpp
+          build-mode: none
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both


### PR DESCRIPTION
There are a few tsavorite files in the repo that aren't getting scanned by CodeQL. This enabled CodeQl on the repo for c-cpp, with build mode none.