### PR TITLE
Set up release pipeline to work with Dev branch as well as Main

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -186,13 +186,6 @@ jobs:
       }
     displayName: 'Set releaseTitle variable'
 
-  - task: PowerShell@2
-    displayName: 'DEBUG DEBUG DEBUG DEBUG Show release title'
-    inputs:
-      targetType: 'inline'
-      script: |
-        Write-Host "DEBUG Release title is: $(releaseTitle)"
-
   - task: GitHubRelease@1
     displayName: 'Create the GitHub release'
     condition: or(

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- VersionPrefix property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>2.0.0-alpha</VersionPrefix>
+		<VersionPrefix>1.0.87</VersionPrefix>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
To allow a preview Nuget package from the dev branch, the release pipeline needed to change:
1) Update ADO external release YML file to include "dev" branch in the trigger
2) Update ADO external release YML file GitHubRelease section dynamically set title based on branch "Garnet Preview (buildnumber)" for dev etc.
3) Set the two publishes (to GH Release and to Nuget) be contingent ONLY on dev branch or main branch
