### PR TITLE
Fix Bitmap Test Flakiness

### DIFF
--- a/test/Garnet.test/GarnetBitmapTests.cs
+++ b/test/Garnet.test/GarnetBitmapTests.cs
@@ -45,13 +45,6 @@ namespace Garnet.test
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
-        private GarnetServerTestProcess CreateServerWithEnvironmentVariables(string environment)
-        {
-            var envVars = new[] { environment.Split('=', 2, StringSplitOptions.RemoveEmptyEntries) }.ToDictionary(static t => t[0], static t => t[1]);
-
-            return new GarnetServerTestProcess(envVars);
-        }
-
         private long LongRandom() => r.NextInt64(long.MinValue, long.MaxValue);
 
         private ulong ULongRandom() => (ulong)LongRandom();
@@ -274,12 +267,12 @@ namespace Garnet.test
 
         [Test, Order(6)]
         [Category("BITCOUNT")]
-        [TestCase("DOTNET_EnableAVX2=0")]
-        [TestCase("DOTNET_EnableHWIntrinsic=1")]
-        [TestCase("DOTNET_EnableHWIntrinsic=0")]
-        public void BitmapSimpleBitCountTest(string environment)
+        [TestCase("DOTNET_EnableAVX2", "0")]
+        [TestCase("DOTNET_EnableHWIntrinsic", "1")]
+        [TestCase("DOTNET_EnableHWIntrinsic", "0")]
+        public void BitmapSimpleBitCountTest(string arg, string val)
         {
-            using var server = CreateServerWithEnvironmentVariables(environment);
+            using var server = new GarnetServerTestProcess(new() { [arg] = val });
             using var redis = ConnectionMultiplexer.Connect(server.Options);
 
             var db = redis.GetDatabase(0);
@@ -832,12 +825,18 @@ namespace Garnet.test
         [Test]
         [Category("BITOP")]
         public void BitOp_Binary_SameSize(
-            [Values("DOTNET_EnableHWIntrinsic=1", "DOTNET_PreferredVectorBitWidth=128", "DOTNET_EnableHWIntrinsic=0")] string environment,
+            [Values(new[] { "DOTNET_EnableHWIntrinsic", "1" }, new[] { "DOTNET_PreferredVectorBitWidth", "128" }, new[] { "DOTNET_EnableHWIntrinsic", "0" })] string[] environment,
             [Values(Bitwise.And, Bitwise.Or, Bitwise.Xor, Bitwise.Diff)] Bitwise op,
             [Values(512 + 32 + 3)] int bitmapSize,
             [Values(2, 3, 4)] int keys)
         {
-            using var server = CreateServerWithEnvironmentVariables(environment);
+            Dictionary<string, string> args = [];
+            for (var i = 0; i < environment.Length; i += 2)
+            {
+                args[environment[i]] = environment[i + 1];
+            }
+
+            using var server = new GarnetServerTestProcess(args);
             BitOp_Binary_SameSize(server.Options, op, bitmapSize, keys);
         }
 


### PR DESCRIPTION
Recent PRs I've had these Bitmap tests which spawn external processes flake out a bunch.

This PR attempts to fix that with timeouts, better "Garnet is started" checks, and more robust process killing.

Stress testing suggests this is less flaky, but we'll see how pipelines behave.