### PR TITLE
Garnet Web Site Accessibility high contrast fix

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -42,19 +42,26 @@ const config = {
   presets: [
     [
       'classic',
-      {
+      /** @type {import('@docusaurus/preset-classic').Options} */
+      ({
         docs: {
           sidebarPath: './sidebars.js',
-          editUrl: 'https://github.com/microsoft/garnet/tree/main/website/',
+          // Please change this to your repo.
+          // Remove this to remove the "edit this page" links.
+          editUrl:
+            'https://github.com/microsoft/garnet/tree/main/website/',
         },
         blog: {
           showReadingTime: true,
-          editUrl: 'https://github.com/microsoft/garnet/tree/main/website/',
+          // Please change this to your repo.
+          // Remove this to remove the "edit this page" links.
+          editUrl:
+            'https://github.com/microsoft/garnet/tree/main/website/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
-      },
+      }),
     ],
   ],
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -57,11 +57,13 @@ html[data-theme="dark"] {
 
 /* Strongest possible overrides for Prism inline colors */
 html[data-theme='light'] .theme-code-block pre code .token.function,
+html[data-theme='light'] .theme-code-block pre code .token.string,
 html[data-theme='light'] .theme-code-block pre code .token.generic-method {
   color: #cc3745 !important;
 }
 
 html[data-theme='light'] .theme-code-block pre code .token.keyword,
+html[data-theme='light'] .theme-code-block pre code .token.boolean,
 html[data-theme='light'] .theme-code-block pre code .token.number {
   color: #257c7a !important;
 }


### PR DESCRIPTION
 The red and teal colors in code samples in Garnet docs are now being flagged in high contrast accessibility issues. Updating the custom.css fixes things.

Manually inspected different colors in different pages and it should have it all covered.