### PR TITLE
Add GarnetJSON.dll to release binaries

### DIFF
--- a/.azure/pipelines/createbinaries.ps1
+++ b/.azure/pipelines/createbinaries.ps1
@@ -66,6 +66,35 @@ function CleanUpFiles {
 	}
 }
 
+################## CopyGarnetJSON ####################
+#
+#  Copies GarnetJSON.dll to the extensions folder in each publish directory
+#
+######################################################
+function CopyGarnetJSON {
+    param ($publishFolder, $framework)
+
+    $publishPath = "$basePath/main/GarnetServer/bin/Release/$framework/publish/$publishFolder"
+    $extensionsPath = "$publishPath/extensions"
+    $jsonModulePath = "$basePath/modules/GarnetJSON/bin/Release/$framework/GarnetJSON.dll"
+
+    if (Test-Path -Path $publishPath) {
+        # Create extensions folder if it doesn't exist
+        if (!(Test-Path $extensionsPath)) {
+            New-Item -ItemType Directory -Path $extensionsPath -Force | Out-Null
+        }
+
+        # Copy GarnetJSON.dll
+        if (Test-Path $jsonModulePath) {
+            Copy-Item -Path $jsonModulePath -Destination $extensionsPath -Force
+        } else {
+            Write-Warning "GarnetJSON.dll not found at: $jsonModulePath"
+        }
+    } else {
+        Write-Host "Publish Path not found: $publishPath"
+    }
+}
+
 $lastPwd = $pwd
 
 # Get base path since paths can differ from machine to machine
@@ -75,6 +104,13 @@ $basePath = $string.Substring(0,$position-1)  # take off slash off end as well
 Set-Location $basePath/main/GarnetServer
 
 if ($mode -eq 0 -or $mode -eq 1) {
+	# Build GarnetJSON module for both frameworks
+	Write-Host "** Building GarnetJSON module ...  **"
+	Set-Location $basePath/modules/GarnetJSON
+	dotnet build GarnetJSON.csproj -c Release -f net8.0
+	dotnet build GarnetJSON.csproj -c Release -f net9.0
+	Set-Location $basePath/main/GarnetServer
+
 	Write-Host "** Publish ... **"
 	dotnet publish GarnetServer.csproj -p:PublishProfile=linux-arm64-based -f:net8.0
 	dotnet publish GarnetServer.csproj -p:PublishProfile=linux-x64-based -f:net8.0 
@@ -110,6 +146,25 @@ if ($mode -eq 0 -or $mode -eq 1) {
 	CleanUpFiles "win-x64\Service" "win-x64" "net9.0" $false
 	CleanUpFiles "win-x64" "win-x64" "net9.0"
 	CleanUpFiles "win-arm64" "win-x64" "net9.0"
+
+	# Copy GarnetJSON.dll to all platforms
+	Write-Host "** Copying GarnetJSON.dll to extensions folders... **"
+	CopyGarnetJSON "linux-arm64" "net8.0"
+	CopyGarnetJSON "linux-x64" "net8.0"
+	CopyGarnetJSON "osx-arm64" "net8.0"
+	CopyGarnetJSON "osx-x64" "net8.0"
+	CopyGarnetJSON "portable" "net8.0"
+	CopyGarnetJSON "win-x64" "net8.0"
+	CopyGarnetJSON "win-arm64" "net8.0"
+
+	CopyGarnetJSON "linux-arm64" "net9.0"
+	CopyGarnetJSON "linux-x64" "net9.0"
+	CopyGarnetJSON "osx-arm64" "net9.0"
+	CopyGarnetJSON "osx-x64" "net9.0"
+	CopyGarnetJSON "portable" "net9.0"
+	CopyGarnetJSON "win-x64" "net9.0"
+	CopyGarnetJSON "win-arm64" "net9.0"
+	Write-Host "** GarnetJSON.dll copied to all extensions folders **"
 }
 
 if ($mode -eq 0 -or $mode -eq 2) {


### PR DESCRIPTION
## Summary
Fixes #1470

This PR adds JSON support to the published release binaries by including GarnetJSON.dll in an extensions folder within each release archive. 

## Changes Made
Modified .azure/pipelines/createbinaries.ps1 to: 

1. Build GarnetJSON module for both net8.0 and net9.0 frameworks before publishing GarnetServer
2. Add CopyGarnetJSON function that creates an extensions folder and copies GarnetJSON.dll to each publish directory
3. Copy GarnetJSON.dll to all 14 platform/framework combinations (7 platforms x 2 frameworks)

## Release Archive Structure

BEFORE (Current):
```
win-x64-based-readytorun.zip
├── net8.0/
│   ├── GarnetServer.exe
│   └── ... (other files)
└── net9.0/
    ├── GarnetServer.exe
    └── ... (other files)
```

AFTER (With This Change):
```
win-x64-based-readytorun.zip
├── net8.0/
│   ├── GarnetServer.exe
│   ├── ... (other files)
│   └── extensions/           ← NEW
│       └── GarnetJSON.dll    ← NEW
└── net9.0/
    ├── GarnetServer.exe
    ├── ... (other files)
    └── extensions/           ← NEW
        └── GarnetJSON.dll    ← NEW
```

## Affected Archives
All 7 release archives now include the extensions folder: 
- win-x64-based-readytorun.zip
- win-arm64-based-readytorun.zip
- linux-x64-based.tar.xz
- linux-arm64-based.tar.xz
- osx-x64-based.tar.xz
- osx-arm64-based.tar.xz
- portable.7z

## Testing
Verified locally by running the full build pipeline: 

1. Clean build from scratch
2. Run:  .\createbinaries.ps1 -mode 0
3. Extracted win-x64-based-readytorun.zip and confirmed GarnetJSON.dll exists in both net8.0/extensions and net9.0/extensions folders