### PR TITLE
Hide the Allure button until we find a better fix

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -51,9 +51,13 @@ jobs:
           cp ../continuousbenchmark/website/static/charts/* static/charts
           cp ../continuousbenchmark_net80/website/static/charts/data.js static/charts/data_net80.js
 
+      - name: DEBUG Show triggering workflow name
+        run: echo ${{ github.event.workflow_run.name }}
+
       # Download the current allure_report artifact which is big with A LOT of test result files
       # Nightly run does not put full allure_report up in the allure_data_history branch to keep that branch small
       - name: Download Allure artifact
+        if: ${{ github.event.workflow_run.name == 'Garnet Nightly Tests' }}
         uses: actions/download-artifact@v4
         with:
           name: allure-report
@@ -61,6 +65,7 @@ jobs:
       # The one thing that is pulled from allure_data_history branch is the historical test result data
       # This data is then copied into the downloaded allure_report to create a full report with history
       - name: Copy Allure report
+        if: ${{ github.event.workflow_run.name == 'Garnet Nightly Tests' }}
         run: |
           mkdir -p static/allure
 
@@ -68,14 +73,14 @@ jobs:
           if [ -d "allure_artifact/allure-report" ]; then
             cp -R allure_artifact/allure-report/* static/allure
           else
-            echo "Allure artifact not present (likely triggered by BDN run, which does not produce an Allure report); skipping base report copy."
+            echo "Allure artifact missing; skipping base report copy."
           fi
 
-          # Overlay: history from branch (always available)
+          # Overlay: history from branch
           if [ -d "../allure_data_history/test/Allure/history" ]; then
             cp -R ../allure_data_history/test/Allure/history static/allure/history
           else
-            echo "Allure history not present (likely triggered by BDN run, which does not produce Allure history); skipping history overlay."
+            echo "Allure history missing; skipping history overlay."
           fi
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,6 @@ jobs:
   build-test-all:
     name: Test
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![](https://img.shields.io/nuget/dt/microsoft.garnet.svg?label=nuget%20library&color=007edf&logo=nuget)](https://www.nuget.org/packages/microsoft.garnet)
 [![](https://img.shields.io/nuget/dt/garnet-server.svg?label=dotnet%20tool&color=007edf&logo=nuget)](https://www.nuget.org/packages/garnet-server)
 [![BDN Charts](https://img.shields.io/badge/BDN%20Charts-8A2BE2)](https://microsoft.github.io/garnet/charts/)
-[![Allure Report](https://img.shields.io/badge/Allure%20Report-orange)](https://microsoft.github.io/garnet/allure/)
+<!-- [![Allure Report](https://img.shields.io/badge/Allure%20Report-orange)](https://microsoft.github.io/garnet/allure/) -->
 [![Discord Shield](https://discordapp.com/api/guilds/1213937452272582676/widget.png?style=shield)](https://aka.ms/garnet-discord)
 
 Garnet is a new remote cache-store from Microsoft Research, that offers several unique benefits:


### PR DESCRIPTION
I feel I am just missing one little config in the web deployment but I need to step back and isolate it in a fork and work that way, so until then, it is best to hide the Allure button as it just goes to the 404 page.  I also did some message clean up.