### PR TITLE
Allure Fix that allows connecting between GitHub Action runs 

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -16,8 +16,8 @@ on:
       - completed
 permissions:
   contents: write
-  actions: read  
-
+  actions: read
+  
 jobs:
   deploy:
     if: always()
@@ -65,7 +65,6 @@ jobs:
           path: allure_artifact
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
-
       # The one thing that is pulled from allure_data_history branch is the historical test result data
       # This data is then copied into the downloaded allure_report to create a full report with history
       - name: Copy Allure report


### PR DESCRIPTION
Worked with the Allure team on how to fix this.
https://github.com/orgs/allure-framework/discussions/3222

The idea is "Accessing another run's artifacts requires run-id and github-token to be provided:" which I was missing. Also, it is set for Main so even if I test it on my own branch it won't work until ran on main.