### PR TITLE
Parallel ACL test fixes

### DIFF
--- a/test/Garnet.test/Resp/ACL/ParallelTests.cs
+++ b/test/Garnet.test/Resp/ACL/ParallelTests.cs
@@ -82,7 +82,7 @@ namespace Garnet.test.Resp.ACL
         public void ParallelPasswordHashTest(int degreeOfParallelism, int iterationsPerSession)
         {
             // Run multiple sessions that stress password hashing
-            Parallel.For(0, degreeOfParallelism, (t, token) =>
+            Parallel.For(0, degreeOfParallelism, (t, state) =>
             {
                 for (uint i = 0; i < iterationsPerSession; i++)
                 {

--- a/test/Garnet.test/Resp/ACL/ParallelTests.cs
+++ b/test/Garnet.test/Resp/ACL/ParallelTests.cs
@@ -82,7 +82,7 @@ namespace Garnet.test.Resp.ACL
         public void ParallelPasswordHashTest(int degreeOfParallelism, int iterationsPerSession)
         {
             // Run multiple sessions that stress password hashing
-            Parallel.For(0, degreeOfParallelism, (t, state) =>
+            Parallel.For(0, degreeOfParallelism, (t, token) =>
             {
                 for (uint i = 0; i < iterationsPerSession; i++)
                 {

--- a/test/Garnet.test/Resp/ACL/ParallelTests.cs
+++ b/test/Garnet.test/Resp/ACL/ParallelTests.cs
@@ -42,7 +42,7 @@ namespace Garnet.test.Resp.ACL
             ClassicAssert.IsTrue(response.StartsWith("OK"));
 
             // Run multiple sessions that stress AUTH
-            var timeout = TimeSpan.FromSeconds(300);
+            var timeout = TimeSpan.FromSeconds(120);
             await Parallel.ForAsync(0, degreeOfParallelism, async (t, state) =>
             {
                 using var c = TestUtils.GetGarnetClient();
@@ -117,7 +117,7 @@ namespace Garnet.test.Resp.ACL
             var response = await c.ExecuteForStringResultAsync("ACL", activeUserWithGetCommand.Split(" "));
             ClassicAssert.IsTrue(response.StartsWith("OK"));
 
-            var timeout = TimeSpan.FromSeconds(300);
+            var timeout = TimeSpan.FromSeconds(120);
             await Parallel.ForAsync(0, degreeOfParallelism, async (t, state) =>
             {
                 using var c = TestUtils.GetGarnetClient();
@@ -157,7 +157,7 @@ namespace Garnet.test.Resp.ACL
         {
             string setUserCommand = $"SETUSER {TestUserA} on >{DummyPassword}";
 
-            var timeout = TimeSpan.FromSeconds(300);
+            var timeout = TimeSpan.FromSeconds(120);
             await Parallel.ForAsync(0, degreeOfParallelism, async (t, state) =>
             {
                 // Use client with support for single thread.

--- a/test/Garnet.test/Resp/ACL/ParallelTests.cs
+++ b/test/Garnet.test/Resp/ACL/ParallelTests.cs
@@ -51,8 +51,8 @@ namespace Garnet.test.Resp.ACL
                 for (uint i = 0; i < iterationsPerSession; i++)
                 {
                     // Execute two AUTH commands - one that succeeds and one that fails
-                    firstResponseTasks[i] = c.ExecuteForStringResultAsync("AUTH", [ TestUserA, DummyPassword ]);
-                    secondResponseTasks[i] = c.ExecuteForStringResultAsync("AUTH", [ TestUserA, DummyPasswordB ]);
+                    firstResponseTasks[i] = c.ExecuteForStringResultAsync("AUTH", [TestUserA, DummyPassword]);
+                    secondResponseTasks[i] = c.ExecuteForStringResultAsync("AUTH", [TestUserA, DummyPasswordB]);
                 }
 
                 try
@@ -128,7 +128,7 @@ namespace Garnet.test.Resp.ACL
                     var response2 = await c.ExecuteForStringResultAsync("ACL", inactiveUserWithoutGetCommand.Split(" "));
                     ClassicAssert.IsTrue(response2.StartsWith("OK"));
 
-                    var aclListResponse = await c.ExecuteForStringArrayResultAsync("ACL", [ "LIST" ]);
+                    var aclListResponse = await c.ExecuteForStringArrayResultAsync("ACL", ["LIST"]);
 
                     if (aclListResponse.Contains(inactiveUserWithGet))
                     {

--- a/test/Garnet.test/Resp/ACL/ParallelTests.cs
+++ b/test/Garnet.test/Resp/ACL/ParallelTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Allure.NUnit;
@@ -41,6 +42,7 @@ namespace Garnet.test.Resp.ACL
             ClassicAssert.IsTrue(response.StartsWith("OK"));
 
             // Run multiple sessions that stress AUTH
+            var timeout = TimeSpan.FromSeconds(300);
             await Parallel.ForAsync(0, degreeOfParallelism, async (t, state) =>
             {
                 using var c = TestUtils.GetGarnetClient();
@@ -70,7 +72,7 @@ namespace Garnet.test.Resp.ACL
                     ClassicAssert.IsTrue(task.Exception.InnerExceptions.Count == 1);
                     ClassicAssert.IsTrue(task.Exception.InnerExceptions[0].Message.StartsWith("WRONGPASS"));
                 }
-            });
+            }).WaitAsync(timeout).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -115,6 +117,7 @@ namespace Garnet.test.Resp.ACL
             var response = await c.ExecuteForStringResultAsync("ACL", activeUserWithGetCommand.Split(" "));
             ClassicAssert.IsTrue(response.StartsWith("OK"));
 
+            var timeout = TimeSpan.FromSeconds(300);
             await Parallel.ForAsync(0, degreeOfParallelism, async (t, state) =>
             {
                 using var c = TestUtils.GetGarnetClient();
@@ -136,7 +139,7 @@ namespace Garnet.test.Resp.ACL
                         throw new AssertionException($"Invalid ACL: {corruptedAcl}");
                     }
                 }
-            });
+            }).WaitAsync(timeout).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -154,6 +157,7 @@ namespace Garnet.test.Resp.ACL
         {
             string setUserCommand = $"SETUSER {TestUserA} on >{DummyPassword}";
 
+            var timeout = TimeSpan.FromSeconds(300);
             await Parallel.ForAsync(0, degreeOfParallelism, async (t, state) =>
             {
                 // Use client with support for single thread.
@@ -164,7 +168,7 @@ namespace Garnet.test.Resp.ACL
                     var response = await c.ExecuteForStringResultAsync("ACL", setUserCommand.Split(" "));
                     ClassicAssert.IsTrue(response.StartsWith("OK"));
                 }
-            });
+            }).WaitAsync(timeout).ConfigureAwait(false);
         }
     }
 }

--- a/test/Garnet.test/Resp/ACL/ParallelTests.cs
+++ b/test/Garnet.test/Resp/ACL/ParallelTests.cs
@@ -148,9 +148,9 @@ namespace Garnet.test.Resp.ACL
         /// Race conditions are not deterministic so test uses repeat.
         ///
         /// </summary>
-        [TestCase(128)]
+        [TestCase(128, 2048)]
         [Repeat(2)]
-        public async Task ParallelAclSetUserAvoidsMapContentionTest(int degreeOfParallelism)
+        public async Task ParallelAclSetUserAvoidsMapContentionTest(int degreeOfParallelism, int iterationsPerSession)
         {
             string setUserCommand = $"SETUSER {TestUserA} on >{DummyPassword}";
 
@@ -159,8 +159,11 @@ namespace Garnet.test.Resp.ACL
                 // Use client with support for single thread.
                 using var c = TestUtils.GetGarnetClient();
                 await c.ConnectAsync();
-                var response = await c.ExecuteForStringResultAsync("ACL", setUserCommand.Split(" "));
-                ClassicAssert.IsTrue(response.StartsWith("OK"));
+                for (uint i = 0; i < iterationsPerSession; i++)
+                {
+                    var response = await c.ExecuteForStringResultAsync("ACL", setUserCommand.Split(" "));
+                    ClassicAssert.IsTrue(response.StartsWith("OK"));
+                }
             });
         }
     }


### PR DESCRIPTION
Parallel ACL tests sometimes run forever, cleaned up to properly use async and also check server responses. Use GarnetClient for proper async handling.