### PR TITLE
Fix nuspec and update signing

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -74,7 +74,7 @@ jobs:
       AuthCertName: 'garnet-codesign-auth-cert'
       ServiceEndpointUrl: 'https://api.esrp.microsoft.com/api/v2'
       FolderPath: .
-      Pattern: Garnet*.dll,Tsavorite*.dll,Garnet*.exe,HdrHistogram.dll,native_device.dll,*Lua.dll
+      Pattern: Garnet*.dll,Tsavorite*.dll,Garnet*.exe,HdrHistogram.dll,native_device.dll
       signConfigType: inlineSignParams
       inlineOperation: >-
         [

--- a/libs/host/Garnet.host.csproj
+++ b/libs/host/Garnet.host.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="KeraLua" />
+    <PackageReference Include="diskann-garnet" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
diskann-garnet isn't ref'd in the Microsoft.Garnet.*.nupkg - fixing that.

We also shouldn't be packaging Lua bits directly, so removing signing of that.