### PR TITLE
Vector Set Test Hardening

### DIFF
--- a/libs/cluster/Server/Migration/MigrateSessionTaskStore.cs
+++ b/libs/cluster/Server/Migration/MigrateSessionTaskStore.cs
@@ -39,8 +39,16 @@ namespace Garnet.cluster
 
             for (var i = 0; i < sessions.Length; i++)
             {
-                sessions[i]?.Dispose();
+                try
+                {
+                    sessions[i]?.Dispose();
+                }
+                catch (Exception e)
+                {
+                    logger?.LogError(e, "Exception disposing MigrateSession instance during MigrateSessionTaskStore.Dispose");
+                }
             }
+
             Array.Clear(sessions);
         }
 

--- a/libs/server/ArgSlice/ArgSliceVector.cs
+++ b/libs/server/ArgSlice/ArgSliceVector.cs
@@ -15,6 +15,8 @@ namespace Garnet.server
     /// <param name="maxItemNum"></param>
     public unsafe class ArgSliceVector(int maxItemNum = 1 << 18) : IEnumerable<SpanByte>
     {
+        private bool enumerating;
+
         ScratchBufferBuilder bufferManager = new();
         readonly int maxCount = maxItemNum;
         public int Count => items.Count;
@@ -28,6 +30,8 @@ namespace Garnet.server
         /// <returns>True if it succeeds to add ArgSlice, false if maxCount has been reached.</returns>
         public bool TryAddItem(Span<byte> item)
         {
+            Debug.Assert(!enumerating, "Cannot modify while enumerating");
+
             if (Count + 1 >= maxCount)
                 return false;
 
@@ -47,6 +51,7 @@ namespace Garnet.server
         /// <returns>True if it succeeds to add ArgSlice, false if maxCount has been reached.</returns>
         public bool TryAddItem(ulong ns, Span<byte> item)
         {
+            Debug.Assert(!enumerating, "Cannot modify while enumerating");
             Debug.Assert(ns <= byte.MaxValue, "Only byte-size namespaces supported currently");
 
             if (Count + 1 >= maxCount)
@@ -70,25 +75,37 @@ namespace Garnet.server
         /// </summary>
         public void Clear()
         {
+            Debug.Assert(!enumerating, "Cannot modify while enumerating");
+
             items.Clear();
             bufferManager.Reset();
         }
 
         public IEnumerator<SpanByte> GetEnumerator()
         {
+            Debug.Assert(!enumerating, "Concurrent enumeration is not allwed");
+
             var full = bufferManager.ViewFullArgSlice();
 
-            foreach (var (offset, length, hasNamespace) in items)
+            enumerating = true;
+            try
             {
-                var span = full.ReadOnlySpan.Slice(offset, length);
-                var ret = SpanByte.FromPinnedSpan(span);
-
-                if (hasNamespace)
+                foreach (var (offset, length, hasNamespace) in items)
                 {
-                    ret.MarkNamespace();
-                }
+                    var span = full.ReadOnlySpan.Slice(offset, length);
+                    var ret = SpanByte.FromPinnedSpan(span);
 
-                yield return ret;
+                    if (hasNamespace)
+                    {
+                        ret.MarkNamespace();
+                    }
+
+                    yield return ret;
+                }
+            }
+            finally
+            {
+                enumerating = false;
             }
         }
 

--- a/libs/server/ArgSlice/ArgSliceVector.cs
+++ b/libs/server/ArgSlice/ArgSliceVector.cs
@@ -19,7 +19,7 @@ namespace Garnet.server
         readonly int maxCount = maxItemNum;
         public int Count => items.Count;
         public bool IsEmpty => items.Count == 0;
-        readonly List<SpanByte> items = [];
+        readonly List<(int Offset, int Length, bool HasNamespace)> items = [];
 
         /// <summary>
         /// Try to add ArgSlice
@@ -31,15 +31,18 @@ namespace Garnet.server
             if (Count + 1 >= maxCount)
                 return false;
 
-            var argSlice = bufferManager.CreateArgSlice(item);
+            var insertLoc = bufferManager.ScratchBufferOffset;
 
-            items.Add(argSlice.SpanByte);
+            var sb = bufferManager.CreateArgSlice(item);
+
+            items.Add((insertLoc, sb.Length, HasNamespace: false));
             return true;
         }
 
         /// <summary>
         /// Try to add ArgSlice
         /// </summary>
+        /// <param name="ns"></param>
         /// <param name="item"></param>
         /// <returns>True if it succeeds to add ArgSlice, false if maxCount has been reached.</returns>
         public bool TryAddItem(ulong ns, Span<byte> item)
@@ -49,6 +52,8 @@ namespace Garnet.server
             if (Count + 1 >= maxCount)
                 return false;
 
+            var insertLoc = bufferManager.ScratchBufferOffset;
+
             var argSlice = bufferManager.CreateArgSlice(item.Length + 1);
             var sb = argSlice.SpanByte;
 
@@ -56,7 +61,7 @@ namespace Garnet.server
             sb.SetNamespaceInPayload((byte)ns);
             item.CopyTo(sb.AsSpan());
 
-            items.Add(sb);
+            items.Add((insertLoc, sb.Length, HasNamespace: true));
             return true;
         }
 
@@ -71,8 +76,20 @@ namespace Garnet.server
 
         public IEnumerator<SpanByte> GetEnumerator()
         {
-            foreach (var item in items)
-                yield return item;
+            var full = bufferManager.ViewFullArgSlice();
+
+            foreach (var (offset, length, hasNamespace) in items)
+            {
+                var span = full.ReadOnlySpan.Slice(offset, length);
+                var ret = SpanByte.FromPinnedSpan(span);
+
+                if (hasNamespace)
+                {
+                    ret.MarkNamespace();
+                }
+
+                yield return ret;
+            }
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -1775,6 +1775,14 @@ namespace Garnet.test.cluster
 
                                     var emb = (string[])readWriteDB.Execute("VEMB", [new RedisKey(key), elem]);
 
+                                    if (emb.Length == 0)
+                                    {
+                                        // Migration might make this temporarily unavailable due to connection state/
+                                        //
+                                        // Because we check for presense of all data at the end of test, we can safely ignore this for now
+                                        continue;
+                                    }
+
                                     // If we got data, make sure it's coherent
                                     ClassicAssert.AreEqual(data.Length, emb.Length);
 

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -74,6 +74,7 @@ namespace Garnet.test.cluster
         private const int DefaultShards = 2;
         private const int HighReplicationShards = 6;
         private const int DefaultMultiPrimaryShards = 4;
+        private const string DefaultAOFMemorySize = "2g";  // Very large because CI boxes have low IOPS, so try and flush to disk veeeeeery rarely
 
         private static readonly Dictionary<string, LogLevel> MonitorTests = new()
         {
@@ -120,7 +121,7 @@ namespace Garnet.test.cluster
             ClassicAssert.IsTrue(Enum.TryParse<VectorValueType>(vectorFormat, ignoreCase: true, out var vectorFormatParsed));
             ClassicAssert.IsTrue(Enum.TryParse<VectorQuantType>(quantizer, ignoreCase: true, out var quantTypeParsed));
 
-            context.CreateInstances(DefaultShards, useTLS: true, enableAOF: true);
+            context.CreateInstances(DefaultShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
             context.CreateConnection(useTLS: true);
             _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: 1, replica_count: 1);
 
@@ -209,7 +210,7 @@ namespace Garnet.test.cluster
             const int Vectors = 2_000;
             const string Key = nameof(ConcurrentVADDReplicatedVSimsAsync);
 
-            context.CreateInstances(DefaultShards, useTLS: true, enableAOF: true);
+            context.CreateInstances(DefaultShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
             context.CreateConnection(useTLS: true);
             _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: 1, replica_count: 1);
 
@@ -363,7 +364,7 @@ namespace Garnet.test.cluster
             const int PrimaryIndex = 0;
             const int SecondaryIndex = 1;
 
-            context.CreateInstances(DefaultShards, useTLS: true, enableAOF: true);
+            context.CreateInstances(DefaultShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
             context.CreateConnection(useTLS: true);
             _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: 1, replica_count: 1);
 
@@ -477,7 +478,7 @@ namespace Garnet.test.cluster
             const int Vectors = 2_000;
             const string Key = nameof(MultipleReplicasWithVectorSetsAsync);
 
-            context.CreateInstances(HighReplicationShards, useTLS: true, enableAOF: true);
+            context.CreateInstances(HighReplicationShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
             context.CreateConnection(useTLS: true);
             _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: 1, replica_count: 5);
 
@@ -624,7 +625,7 @@ namespace Garnet.test.cluster
             const int Deletes = Vectors / 10;
             const string Key = nameof(MultipleReplicasWithVectorSetsAndDeletesAsync);
 
-            context.CreateInstances(HighReplicationShards, useTLS: true, enableAOF: true);
+            context.CreateInstances(HighReplicationShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
             context.CreateConnection(useTLS: true);
             _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: 1, replica_count: 5);
 
@@ -818,7 +819,7 @@ namespace Garnet.test.cluster
             const int Secondary0Index = 2;
             const int Secondary1Index = 3;
 
-            context.CreateInstances(DefaultMultiPrimaryShards, useTLS: true, enableAOF: true);
+            context.CreateInstances(DefaultMultiPrimaryShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
             context.CreateConnection(useTLS: true);
             _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: DefaultMultiPrimaryShards / 2, replica_count: 1);
 
@@ -949,7 +950,7 @@ namespace Garnet.test.cluster
             const int ShardCount = 3;
             const int KeyCount = 10;
 
-            context.CreateInstances(ShardCount, useTLS: true, enableAOF: true);
+            context.CreateInstances(ShardCount, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
             context.CreateConnection(useTLS: true);
             _ = context.clusterTestUtils.SimpleSetupCluster();
 
@@ -1086,7 +1087,7 @@ namespace Garnet.test.cluster
 
             const int VectorSetsPerPrimary = 8;
 
-            context.CreateInstances(DefaultMultiPrimaryShards, useTLS: true, enableAOF: true);
+            context.CreateInstances(DefaultMultiPrimaryShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
             context.CreateConnection(useTLS: true);
             _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: DefaultMultiPrimaryShards / 2, replica_count: 1);
 
@@ -1303,7 +1304,7 @@ namespace Garnet.test.cluster
             const int Secondary0Index = 2;
             const int Secondary1Index = 3;
 
-            context.CreateInstances(DefaultMultiPrimaryShards, useTLS: true, enableAOF: true, OnDemandCheckpoint: true, EnableIncrementalSnapshots: true);
+            context.CreateInstances(DefaultMultiPrimaryShards, useTLS: true, enableAOF: true, OnDemandCheckpoint: true, EnableIncrementalSnapshots: true, AofMemorySize: DefaultAOFMemorySize);
             context.CreateConnection(useTLS: true);
             _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: DefaultMultiPrimaryShards / 2, replica_count: 1);
 
@@ -1478,7 +1479,7 @@ namespace Garnet.test.cluster
             const int Primary0Index = 0;
             const int Primary1Index = 1;
 
-            context.CreateInstances(DefaultShards, useTLS: true, enableAOF: true);
+            context.CreateInstances(DefaultShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
             context.CreateConnection(useTLS: true);
             _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: DefaultShards, replica_count: 0);
 
@@ -1628,7 +1629,7 @@ namespace Garnet.test.cluster
 
             try
             {
-                context.CreateInstances(DefaultMultiPrimaryShards, useTLS: true, enableAOF: true);
+                context.CreateInstances(DefaultMultiPrimaryShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
                 context.CreateConnection(useTLS: true);
                 _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: DefaultMultiPrimaryShards / 2, replica_count: 1);
 
@@ -2012,7 +2013,7 @@ namespace Garnet.test.cluster
             const int PrimaryIndex = 0;
             const int ReplicaIndex = 1;
 
-            context.CreateInstances(DefaultShards, useTLS: true, enableAOF: true);
+            context.CreateInstances(DefaultShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
             context.CreateConnection(useTLS: true);
             _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: DefaultShards / 2, replica_count: DefaultShards / 2);
 

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -78,7 +78,7 @@ namespace Garnet.test.cluster
 
         private static readonly Dictionary<string, LogLevel> MonitorTests = new()
         {
-            [nameof(MigrateVectorStressAsync)] = LogLevel.Debug,
+            [nameof(MigrateVectorStressAsync)] = LogLevel.Error,
         };
 
 
@@ -121,9 +121,7 @@ namespace Garnet.test.cluster
             ClassicAssert.IsTrue(Enum.TryParse<VectorValueType>(vectorFormat, ignoreCase: true, out var vectorFormatParsed));
             ClassicAssert.IsTrue(Enum.TryParse<VectorQuantType>(quantizer, ignoreCase: true, out var quantTypeParsed));
 
-            context.CreateInstances(DefaultShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
-            context.CreateConnection(useTLS: true);
-            _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: 1, replica_count: 1);
+            _ = SimpleSetupCluster(DefaultShards, primaryCount: 1, replicaCount: 1);
 
             var primary = (IPEndPoint)context.endpoints[PrimaryIndex];
             var secondary = (IPEndPoint)context.endpoints[SecondaryIndex];
@@ -210,9 +208,7 @@ namespace Garnet.test.cluster
             const int Vectors = 2_000;
             const string Key = nameof(ConcurrentVADDReplicatedVSimsAsync);
 
-            context.CreateInstances(DefaultShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
-            context.CreateConnection(useTLS: true);
-            _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: 1, replica_count: 1);
+            _ = SimpleSetupCluster(DefaultShards, primaryCount: 1, replicaCount: 1);
 
             var primary = (IPEndPoint)context.endpoints[PrimaryIndex];
             var secondary = (IPEndPoint)context.endpoints[SecondaryIndex];
@@ -364,9 +360,7 @@ namespace Garnet.test.cluster
             const int PrimaryIndex = 0;
             const int SecondaryIndex = 1;
 
-            context.CreateInstances(DefaultShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
-            context.CreateConnection(useTLS: true);
-            _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: 1, replica_count: 1);
+            _ = SimpleSetupCluster(DefaultShards, primaryCount: 1, replicaCount: 1);
 
             var primary = (IPEndPoint)context.endpoints[PrimaryIndex];
             var secondary = (IPEndPoint)context.endpoints[SecondaryIndex];
@@ -478,9 +472,7 @@ namespace Garnet.test.cluster
             const int Vectors = 2_000;
             const string Key = nameof(MultipleReplicasWithVectorSetsAsync);
 
-            context.CreateInstances(HighReplicationShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
-            context.CreateConnection(useTLS: true);
-            _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: 1, replica_count: 5);
+            _ = SimpleSetupCluster(HighReplicationShards, primaryCount: 1, replicaCount: 5);
 
             var primary = (IPEndPoint)context.endpoints[PrimaryIndex];
             var secondaries = new IPEndPoint[SecondaryEndIndex - SecondaryStartIndex + 1];
@@ -625,9 +617,7 @@ namespace Garnet.test.cluster
             const int Deletes = Vectors / 10;
             const string Key = nameof(MultipleReplicasWithVectorSetsAndDeletesAsync);
 
-            context.CreateInstances(HighReplicationShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
-            context.CreateConnection(useTLS: true);
-            _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: 1, replica_count: 5);
+            _ = SimpleSetupCluster(HighReplicationShards, primaryCount: 1, replicaCount: 5);
 
             var primary = (IPEndPoint)context.endpoints[PrimaryIndex];
             var secondaries = new IPEndPoint[SecondaryEndIndex - SecondaryStartIndex + 1];
@@ -819,9 +809,7 @@ namespace Garnet.test.cluster
             const int Secondary0Index = 2;
             const int Secondary1Index = 3;
 
-            context.CreateInstances(DefaultMultiPrimaryShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
-            context.CreateConnection(useTLS: true);
-            _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: DefaultMultiPrimaryShards / 2, replica_count: 1);
+            _ = SimpleSetupCluster(DefaultMultiPrimaryShards, primaryCount: DefaultMultiPrimaryShards / 2, replicaCount: 1);
 
             var primary0 = (IPEndPoint)context.endpoints[Primary0Index];
             var primary1 = (IPEndPoint)context.endpoints[Primary1Index];
@@ -950,9 +938,7 @@ namespace Garnet.test.cluster
             const int ShardCount = 3;
             const int KeyCount = 10;
 
-            context.CreateInstances(ShardCount, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
-            context.CreateConnection(useTLS: true);
-            _ = context.clusterTestUtils.SimpleSetupCluster();
+            _ = SimpleSetupCluster(ShardCount, primaryCount: -1, replicaCount: -1);
 
             var otherNodeIndex = 0;
             var sourceNodeIndex = 1;
@@ -1304,9 +1290,7 @@ namespace Garnet.test.cluster
             const int Secondary0Index = 2;
             const int Secondary1Index = 3;
 
-            context.CreateInstances(DefaultMultiPrimaryShards, useTLS: true, enableAOF: true, OnDemandCheckpoint: true, EnableIncrementalSnapshots: true, AofMemorySize: DefaultAOFMemorySize);
-            context.CreateConnection(useTLS: true);
-            _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: DefaultMultiPrimaryShards / 2, replica_count: 1);
+            _ = SimpleSetupCluster(DefaultMultiPrimaryShards, primaryCount: DefaultMultiPrimaryShards / 2, replicaCount: 1, onDemandCheckpoint: true, enableIncrementalSnapshots: true);
 
             var primary0 = (IPEndPoint)context.endpoints[Primary0Index];
             var primary1 = (IPEndPoint)context.endpoints[Primary1Index];
@@ -1479,9 +1463,7 @@ namespace Garnet.test.cluster
             const int Primary0Index = 0;
             const int Primary1Index = 1;
 
-            context.CreateInstances(DefaultShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
-            context.CreateConnection(useTLS: true);
-            _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: DefaultShards, replica_count: 0);
+            _ = SimpleSetupCluster(DefaultShards, primaryCount: DefaultShards, replicaCount: 0);
 
             var primary0 = (IPEndPoint)context.endpoints[Primary0Index];
             var primary1 = (IPEndPoint)context.endpoints[Primary1Index];
@@ -1629,9 +1611,7 @@ namespace Garnet.test.cluster
 
             try
             {
-                context.CreateInstances(DefaultMultiPrimaryShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
-                context.CreateConnection(useTLS: true);
-                _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: DefaultMultiPrimaryShards / 2, replica_count: 1);
+                _ = SimpleSetupCluster(DefaultMultiPrimaryShards, primaryCount: DefaultMultiPrimaryShards / 2, replicaCount: 1);
 
                 var primary0 = (IPEndPoint)context.endpoints[Primary0Index];
                 var primary1 = (IPEndPoint)context.endpoints[Primary1Index];
@@ -2013,9 +1993,7 @@ namespace Garnet.test.cluster
             const int PrimaryIndex = 0;
             const int ReplicaIndex = 1;
 
-            context.CreateInstances(DefaultShards, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize);
-            context.CreateConnection(useTLS: true);
-            _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: DefaultShards / 2, replica_count: DefaultShards / 2);
+            _ = SimpleSetupCluster(DefaultShards, primaryCount: DefaultShards / 2, replicaCount: 1);
 
             var primary = (IPEndPoint)context.endpoints[PrimaryIndex];
             var replica = (IPEndPoint)context.endpoints[ReplicaIndex];
@@ -2052,6 +2030,13 @@ namespace Garnet.test.cluster
 
             var vsimRes = (byte[][])context.clusterTestUtils.Execute(replica, "VSIM", [new RedisKey("foo"), "XB8", vectorData0]);
             ClassicAssert.IsTrue(vsimRes.Length > 0);
+        }
+
+        private (List<ShardInfo> Shards, List<ushort> Slots) SimpleSetupCluster(int shardCount, int primaryCount, int replicaCount, bool onDemandCheckpoint = false, bool enableIncrementalSnapshots = false)
+        {
+            context.CreateInstances(shardCount, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize, OnDemandCheckpoint: onDemandCheckpoint, EnableIncrementalSnapshots: enableIncrementalSnapshots);
+            context.CreateConnection(useTLS: true);
+            return context.clusterTestUtils.SimpleSetupCluster(primary_count: primaryCount, replica_count: replicaCount);
         }
 
         [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "storeWrapper")]

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -1777,7 +1777,7 @@ namespace Garnet.test.cluster
 
                                     if (emb.Length == 0)
                                     {
-                                        // Migration might make this temporarily unavailable due to connection state/
+                                        // Migration might make this temporarily unavailable due to connection state
                                         //
                                         // Because we check for presense of all data at the end of test, we can safely ignore this for now
                                         continue;

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -1796,7 +1796,7 @@ namespace Garnet.test.cluster
                                             var wholeExpected = $"0x{string.Join("", data.Select(static q => q.ToString("X2")))}";
                                             var wholeActual = $"0x{string.Join("", emb.Select(static q => ((byte)float.Parse(q)).ToString("X2")))}";
 
-                                            ClassicAssert.Fail($"Unexpected embedded value, expected {expected} != actual {actual} ({expected} != {actual})");
+                                            ClassicAssert.Fail($"Unexpected embedded value, expected {expected} != actual {actual} ({wholeExpected} != {wholeActual})");
                                         }
                                     }
 

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -1788,7 +1788,16 @@ namespace Garnet.test.cluster
 
                                     for (var i = 0; i < data.Length; i++)
                                     {
-                                        ClassicAssert.AreEqual(data[i], (byte)float.Parse(emb[i]));
+                                        var expected = data[i];
+                                        var actual = (byte)float.Parse(emb[i]);
+
+                                        if (expected != actual)
+                                        {
+                                            var wholeExpected = $"0x{string.Join("", data.Select(static q => q.ToString("X2")))}";
+                                            var wholeActual = $"0x{string.Join("", emb.Select(static q => ((byte)float.Parse(q)).ToString("X2")))}";
+
+                                            ClassicAssert.Fail($"Unexpected embedded value, expected {expected} != actual {actual} ({expected} != {actual})");
+                                        }
                                     }
 
                                     successfulReads++;

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -721,7 +721,7 @@ namespace Garnet.test.cluster
                                 var val = vectors[r.Next(vectors.Length)];
 
                                 var readRes = (byte[][])context.clusterTestUtils.Execute(secondary, "VSIM", [Key, "XB8", val]);
-                                if (readRes.Length > 0)
+                                if ((readRes?.Length ?? 0) > 0)
                                 {
                                     nonZeroReturns++;
                                 }

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -1034,14 +1034,21 @@ namespace Garnet.test.cluster
             // Check migration in progress
             foreach (var _key in keys)
             {
+                var respEndpoint = context.clusterTestUtils.GetEndPoint(targetNodeIndex);
                 var resp = context.clusterTestUtils.GetKey(otherNodeIndex, _key, out var slot, out var endpoint, out var responseState);
-                while (endpoint.Port != context.clusterTestUtils.GetEndPoint(targetNodeIndex).Port && responseState != ResponseState.OK)
+
+
+                while (endpoint.Port != (respEndpoint = context.clusterTestUtils.GetEndPoint(targetNodeIndex)).Port && responseState != ResponseState.OK)
                 {
                     resp = context.clusterTestUtils.GetKey(otherNodeIndex, _key, out slot, out endpoint, out responseState);
                 }
-                ClassicAssert.AreEqual(resp, "MOVED");
-                ClassicAssert.AreEqual(_workingSlot, slot);
-                ClassicAssert.AreEqual(context.clusterTestUtils.GetEndPoint(targetNodeIndex), endpoint);
+
+                // This is inherently race-y, so only validate if we got the "MOVED" response we expected
+                if (resp == "MOVED")
+                {
+                    ClassicAssert.AreEqual(_workingSlot, slot);
+                    ClassicAssert.AreEqual(respEndpoint, endpoint);
+                }
             }
 
             // Finish migration

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -1786,7 +1786,7 @@ namespace Garnet.test.cluster
                                     {
                                         // Migration might make this temporarily unavailable due to connection state
                                         //
-                                        // Because we check for presense of all data at the end of test, we can safely ignore this for now
+                                        // Because we check for presence of all data at the end of test, we can safely ignore this for now
                                         continue;
                                     }
 

--- a/test/Garnet.test/RespVectorSetTests.cs
+++ b/test/Garnet.test/RespVectorSetTests.cs
@@ -22,13 +22,15 @@ namespace Garnet.test
     [TestFixture]
     public class RespVectorSetTests : AllureTestBase
     {
+        private const string DefaultAOFMemorySize = "2g";  // Very large because CI boxes have low IOPS, so try and flush to disk veeeeeery rarely
+
         GarnetServer server;
 
         [SetUp]
         public void Setup()
         {
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
-            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableAOF: true);
+            server = CreateGarnetServer(tryRecover: false);
 
             server.Start();
         }
@@ -47,7 +49,7 @@ namespace Garnet.test
             TearDown();
 
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
-            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableAOF: true, enableVectorSetPreview: false);
+            server = CreateGarnetServer(tryRecover: false, enableVectorSetPreview: false);
 
             server.Start();
 
@@ -879,7 +881,7 @@ namespace Garnet.test
             // Restart Garnet, which should block applying any pending Vector Set deletes
             server.Dispose(deleteDir: false);
 
-            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, tryRecover: true, enableAOF: true);
+            server = CreateGarnetServer(tryRecover: true);
             server.Start();
 
             // Validate that Vector Set index key is gone, even if no Vector Set command ran
@@ -1448,7 +1450,7 @@ namespace Garnet.test
                     ClassicAssert.IsTrue(commit);
                     server.Dispose(deleteDir: false);
 
-                    server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, tryRecover: true, enableAOF: true);
+                    server = CreateGarnetServer(tryRecover: true);
                     server.Start();
                 }
 
@@ -1484,7 +1486,7 @@ namespace Garnet.test
                     ClassicAssert.IsTrue(commit);
                     server.Dispose(deleteDir: false);
 
-                    server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, tryRecover: true, enableAOF: true);
+                    server = CreateGarnetServer(tryRecover: true);
                     server.Start();
                 }
 
@@ -1527,7 +1529,7 @@ namespace Garnet.test
                     ClassicAssert.IsTrue(commit);
                     server.Dispose(deleteDir: false);
 
-                    server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, tryRecover: true, enableAOF: true);
+                    server = CreateGarnetServer(tryRecover: true);
                     server.Start();
                 }
 
@@ -1564,7 +1566,7 @@ namespace Garnet.test
                     ClassicAssert.IsTrue(commit);
                     server.Dispose(deleteDir: false);
 
-                    server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, tryRecover: true, enableAOF: true);
+                    server = CreateGarnetServer(tryRecover: true);
                     server.Start();
                 }
 
@@ -1597,7 +1599,7 @@ namespace Garnet.test
                     ClassicAssert.IsTrue(commit);
                     server.Dispose(deleteDir: false);
 
-                    server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, tryRecover: true, enableAOF: true);
+                    server = CreateGarnetServer(tryRecover: true);
                     server.Start();
                 }
 
@@ -1638,7 +1640,7 @@ namespace Garnet.test
                     ClassicAssert.IsTrue(commit);
                     server.Dispose(deleteDir: false);
 
-                    server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, tryRecover: true, enableAOF: true);
+                    server = CreateGarnetServer(tryRecover: true);
                     server.Start();
                 }
 
@@ -2060,6 +2062,12 @@ namespace Garnet.test
                 }
             }
         }
+
+        /// <summary>
+        /// Create a new GarnetServer instance with common parameters.
+        /// </summary>
+        private static GarnetServer CreateGarnetServer(bool tryRecover, bool enableVectorSetPreview = true)
+        => TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableAOF: true, tryRecover: tryRecover, aofMemorySize: DefaultAOFMemorySize, enableVectorSetPreview: enableVectorSetPreview);
 
         [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "opts")]
         private static extern ref GarnetServerOptions GetOpts(GarnetServer server);

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -981,17 +981,26 @@ namespace Garnet.test
             // Include process id to avoid conflicts between parallel test runs
             var testPath = $"{Environment.ProcessId}_{TestContext.CurrentContext.Test.ClassName}_{TestContext.CurrentContext.Test.MethodName}";
 
+            // Incorporate arguments (as a hash code) so different runs of the same method get different folders
+            //
+            // Using hashes instead of the arugments themselves to keep length down
             if ((TestContext.CurrentContext.Test.Arguments?.Length ?? 0) > 0)
             {
-                var illegalChars = Path.GetInvalidPathChars().Concat(Path.GetInvalidFileNameChars()).ToArray();
-
+                HashCode hash = new();
                 foreach (var arg in TestContext.CurrentContext.Test.Arguments)
                 {
-                    var argStr = arg?.ToString() ?? "--null--";
-                    var safeArgStr = string.Join("-", argStr.Split(illegalChars));
-
-                    testPath += $"_{safeArgStr}";
+                    if (arg is string str)
+                    {
+                        hash.Add(str);
+                    }
+                    else
+                    {
+                        var argAsStr = arg?.ToString() ?? "--EMPTY--";
+                        hash.Add(argAsStr);
+                    }
                 }
+
+                testPath += $"_{hash.ToHashCode()}";
             }
 
             var rootPath = Path.Combine(RootTestsProjectPath, ".tmp", testPath);

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -1190,12 +1190,15 @@ using System.Threading.Tasks;
         {
             DeleteDirectory(MethodTestDir, wait: waitForDelete);
             var count = Tsavorite.core.LightEpoch.ActiveInstanceCount();
+
+            var failMessage = "";
+
             if (count != 0)
             {
                 // Reset all instances to avoid impacting other tests
                 Tsavorite.core.LightEpoch.ResetAllInstances();
                 logger?.LogError("Tsavorite.core.LightEpoch instances still active: {count}", count);
-                Assert.Fail($"Tsavorite.core.LightEpoch instances still active: {count}");
+                failMessage += $"Tsavorite.core.LightEpoch instances still active: {count}; ";
             }
 
             var count2 = client.LightEpoch.ActiveInstanceCount();
@@ -1204,7 +1207,12 @@ using System.Threading.Tasks;
                 // Reset all instances to avoid impacting other tests
                 client.LightEpoch.ResetAllInstances();
                 logger?.LogError("Garnet.client.LightEpoch instances still active: {count2}", count2);
-                Assert.Fail($"Garnet.client.LightEpoch instances still active: {count2}");
+                failMessage += $"Garnet.client.LightEpoch instances still active: {count2}; ";
+            }
+
+            if (failMessage != "")
+            {
+                ClassicAssert.Fail(failMessage);
             }
         }
     }

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -277,7 +277,8 @@ namespace Garnet.test
             bool useReviv = false,
             bool useInChainRevivOnly = false,
             bool useLogNullDevice = false,
-            bool enableVectorSetPreview = true
+            bool enableVectorSetPreview = true,
+            string aofMemorySize = "64m"
         )
         {
             if (useAzureStorage)
@@ -330,6 +331,7 @@ namespace Garnet.test
                 ObjectStoreIndexSize = objectStoreIndexSize,
                 EnableAOF = enableAOF,
                 EnableLua = enableLua,
+                AofMemorySize = aofMemorySize,
                 CommitFrequencyMs = commitFrequencyMs,
                 WaitForCommit = commitWait,
                 TlsOptions = enableTLS ? new GarnetTlsOptions(

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -973,21 +973,30 @@ namespace Garnet.test
             TestContext.CurrentContext.TestDirectory.Split("Garnet.test")[0];
 
         /// <summary>
-        /// Build path for unit test working directory using Guid
+        /// Build path for unit test working directory.
         /// </summary>
-        /// <param name="category"></param>
-        /// <param name="includeGuid"></param>
         /// <returns></returns>
-        internal static string UnitTestWorkingDir(string category = null, bool includeGuid = false)
+        internal static string UnitTestWorkingDir()
         {
             // Include process id to avoid conflicts between parallel test runs
             var testPath = $"{Environment.ProcessId}_{TestContext.CurrentContext.Test.ClassName}_{TestContext.CurrentContext.Test.MethodName}";
+
+            if ((TestContext.CurrentContext.Test.Arguments?.Length ?? 0) > 0)
+            {
+                var illegalChars = Path.GetInvalidPathChars().Concat(Path.GetInvalidFileNameChars()).ToArray();
+
+                foreach (var arg in TestContext.CurrentContext.Test.Arguments)
+                {
+                    var argStr = arg?.ToString() ?? "--null--";
+                    var safeArgStr = string.Join("-", argStr.Split(illegalChars));
+
+                    testPath += $"_{safeArgStr}";
+                }
+            }
+
             var rootPath = Path.Combine(RootTestsProjectPath, ".tmp", testPath);
 
-            if (category != null)
-                rootPath = Path.Combine(rootPath, category);
-
-            return includeGuid ? Path.Combine(rootPath, Guid.NewGuid().ToString()) : rootPath;
+            return rootPath;
         }
 
         /// <summary>


### PR DESCRIPTION
Since merge of the Vector Set preview, test pipelines have been flaky.

Having setup a separate VM for stressing outside of GH, this PR contains changes that may fix that flakiness:
 - Increasing AOF memory size to make IOPS exhaustion less likely
 - DRY up some common creation ops
 - Reduce noisy logging in some tests
 - Update unit test working directory creation to include arguments
 - Harden `TearDown` methods to do more of a reset even in the face of error so subsequent tests can still make progress
 - Modify `MigrateVectorStressAsync` test to be more reliable in the face of connection state lagging cluster state
 - Fix deadlock where disposal of `MigrateSession` could re-enter `MigrateSessionTaskStore` under a write lock
 - Move `RespServerSession` allocation onto `Task` during `VADD` replication
 - Fix a use after free bug in `ArgSliceVector` which could corrupt arbitrary key-value pairs during a migration
 - Assert `ArgSliceVector` is not being enumerated when modified, and that only a single enumeration occurs at once