### PR TITLE
bump  diskann-garnet 1.0.23 with crash fix

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,6 +32,6 @@
     <PackageVersion Include="System.Numerics.Tensors" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.8" />
-    <PackageVersion Include="diskann-garnet" Version="1.0.20" />
+    <PackageVersion Include="diskann-garnet" Version="1.0.23" />
   </ItemGroup>
 </Project>

--- a/libs/common/ExceptionInjectionType.cs
+++ b/libs/common/ExceptionInjectionType.cs
@@ -77,5 +77,9 @@ namespace Garnet.common
         /// During deletion of a Vector Set, leaving it partially deleted - at a particular point of execution.
         /// </summary>
         VectorSet_Interrupt_Delete_2,
+        /// <summary>
+        /// Force CreateIndex to simulate a null return, testing the defensive guard.
+        /// </summary>
+        VectorSet_CreateIndex_NullReturn,
     }
 }

--- a/libs/server/Resp/Vector/RespServerSessionVectors.cs
+++ b/libs/server/Resp/Vector/RespServerSessionVectors.cs
@@ -299,13 +299,13 @@ namespace Garnet.server
                 }
 
                 // Default unspecified options
-                quantType ??= VectorQuantType.Q8;
+                quantType ??= VectorQuantType.NoQuant;
                 buildExplorationFactor ??= 200;
                 attributes ??= default;
                 numLinks ??= 16;
 
                 // TODO: Distance metric specification is an extension - still needs to be implemented
-                distanceMetric ??= VectorDistanceMetricType.L2;
+                distanceMetric ??= VectorDistanceMetricType.Cosine;
 
                 // Validate that DiskANN is expected to succeed given data sizes
                 //

--- a/libs/server/Resp/Vector/VectorManager.Locking.cs
+++ b/libs/server/Resp/Vector/VectorManager.Locking.cs
@@ -348,6 +348,18 @@ namespace Garnet.server
                             newlyAllocatedIndex = Service.CreateIndex(indexContext, dims, reduceDims, quantizer, buildExplorationFactor, numLinks, distanceMetric, ReadCallbackPtr, WriteCallbackPtr, DeleteCallbackPtr, ReadModifyWriteCallbackPtr);
                         }
 
+                        if (newlyAllocatedIndex == 0)
+                        {
+                            if (!needsRecreate)
+                            {
+                                CleanupDroppedIndex(ref ActiveThreadSession.vectorContext, indexContext);
+                            }
+
+                            status = GarnetStatus.BADSTATE;
+                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+                            return default;
+                        }
+
                         input.parseState.EnsureCapacity(12);
 
                         // Save off for insertion

--- a/libs/server/Resp/Vector/VectorManager.Locking.cs
+++ b/libs/server/Resp/Vector/VectorManager.Locking.cs
@@ -348,6 +348,16 @@ namespace Garnet.server
                             newlyAllocatedIndex = Service.CreateIndex(indexContext, dims, reduceDims, quantizer, buildExplorationFactor, numLinks, distanceMetric, ReadCallbackPtr, WriteCallbackPtr, DeleteCallbackPtr, ReadModifyWriteCallbackPtr);
                         }
 
+                        // Allow test injection to simulate CreateIndex failure
+                        if (ExceptionInjectionHelper.TriggerCondition(ExceptionInjectionType.VectorSet_CreateIndex_NullReturn))
+                        {
+                            if (newlyAllocatedIndex != 0)
+                            {
+                                Service.DropIndex(indexContext, newlyAllocatedIndex);
+                            }
+                            newlyAllocatedIndex = 0;
+                        }
+
                         if (newlyAllocatedIndex == 0)
                         {
                             if (!needsRecreate)

--- a/test/Garnet.test/RespVectorSetTests.cs
+++ b/test/Garnet.test/RespVectorSetTests.cs
@@ -905,6 +905,44 @@ namespace Garnet.test
         }
 
         [Test]
+        public void CreateIndexNullReturnIsHandledGracefully()
+        {
+#if !DEBUG
+            ClassicAssert.Ignore("Relies on ExceptionInjectionHelper, disabled in non-DEBUG");
+#endif
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase();
+
+            // Enable fault injection so that CreateIndex simulates a null (0) return
+            ExceptionInjectionHelper.EnableException(ExceptionInjectionType.VectorSet_CreateIndex_NullReturn);
+            try
+            {
+                // VADD should return an error rather than crashing the server
+                var exc = ClassicAssert.Throws<RedisServerException>(() =>
+                    db.Execute("VADD", ["foo", "VALUES", "4", "1.0", "2.0", "3.0", "4.0", new byte[] { 0, 0, 0, 0 }, "Q8", "EF", "16", "M", "32"]));
+                ClassicAssert.IsTrue(exc.Message.Contains("partially deleted state"), $"Unexpected error: {exc.Message}");
+            }
+            finally
+            {
+                ExceptionInjectionHelper.DisableException(ExceptionInjectionType.VectorSet_CreateIndex_NullReturn);
+            }
+
+            // After the failed creation, the key should not exist - verify with VDIM
+            var vdimExc = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VDIM", ["foo"]));
+            ClassicAssert.IsTrue(vdimExc.Message.Contains("Key not found"),
+                $"Expected key to not exist after failed CreateIndex, got: {vdimExc.Message}");
+
+            // Verify the server is still healthy - a subsequent VADD (without injection) should succeed
+            var res = (int)db.Execute("VADD", ["foo", "VALUES", "4", "1.0", "2.0", "3.0", "4.0", new byte[] { 0, 0, 0, 0 }, "Q8", "EF", "16", "M", "32"]);
+            ClassicAssert.AreEqual(1, res);
+
+            // Verify the index is usable
+            var dim = (int)db.Execute("VDIM", ["foo"]);
+            ClassicAssert.AreEqual(4, dim);
+        }
+
+        [Test]
         public void RepeatedVectorSetDeletes()
         {
             var bytes1 = new byte[75];

--- a/test/Garnet.test/RespVectorSetTests.cs
+++ b/test/Garnet.test/RespVectorSetTests.cs
@@ -1728,7 +1728,7 @@ namespace Garnet.test
                                 ClassicAssert.AreEqual(14, vinfoRes.Length);
                                 var values = BuildDictionaryFromResponse(vinfoRes);
                                 ClassicAssert.AreEqual(values["quant-type"], expectedQuantType);
-                                ClassicAssert.AreEqual(values["distance-metric"], "l2");
+                                ClassicAssert.AreEqual(values["distance-metric"], "cosine");
                                 ClassicAssert.AreEqual(values["input-vector-dimensions"], vectorDim.ToString());
                                 ClassicAssert.AreEqual(values["reduced-dimensions"], reduceValueToUse.ToString());
                                 ClassicAssert.AreEqual(values["build-exploration-factor"], expectedEf);
@@ -1746,7 +1746,7 @@ namespace Garnet.test
                                 ClassicAssert.AreEqual(14, vinfoRes.Length);
                                 values = BuildDictionaryFromResponse(vinfoRes);
                                 ClassicAssert.AreEqual(values["quant-type"], expectedQuantType);
-                                ClassicAssert.AreEqual(values["distance-metric"], "l2");
+                                ClassicAssert.AreEqual(values["distance-metric"], "cosine");
                                 ClassicAssert.AreEqual(values["input-vector-dimensions"], vectorDim.ToString());
                                 ClassicAssert.AreEqual(values["reduced-dimensions"], reduceValueToUse.ToString());
                                 ClassicAssert.AreEqual(values["build-exploration-factor"], expectedEf);


### PR DESCRIPTION
 bumps the diskann-garnet package from version 1.0.20 to 1.0.23 and includes a crash fix along with changes to default vector set parameters. 

The crash fix adds validation to prevent using an invalid index when CreateIndex fails, while the default parameter changes update the quantization type from Q8 to NoQuant and the distance metric from L2 to Cosine.