### PR TITLE
Fix Stored Proc Replay

### DIFF
--- a/libs/cluster/Session/SlotVerification/ClusterSlotVerificationResult.cs
+++ b/libs/cluster/Session/SlotVerification/ClusterSlotVerificationResult.cs
@@ -18,8 +18,5 @@ namespace Garnet.cluster
             this.state = state;
             this.slot = slot;
         }
-
-        public override string ToString()
-            => $"{state},{slot}";
     }
 }

--- a/libs/cluster/Session/SlotVerification/ClusterSlotVerificationResult.cs
+++ b/libs/cluster/Session/SlotVerification/ClusterSlotVerificationResult.cs
@@ -18,5 +18,8 @@ namespace Garnet.cluster
             this.state = state;
             this.slot = slot;
         }
+
+        public override string ToString()
+            => $"{state},{slot}";
     }
 }

--- a/libs/cluster/Session/SlotVerification/RespClusterIterativeSlotVerify.cs
+++ b/libs/cluster/Session/SlotVerification/RespClusterIterativeSlotVerify.cs
@@ -3,7 +3,6 @@
 
 using Garnet.common;
 using Garnet.server;
-using Microsoft.Extensions.Logging;
 
 namespace Garnet.cluster
 {
@@ -74,7 +73,6 @@ namespace Garnet.cluster
         {
             if (cachedVerificationResult.state != SlotVerifiedState.OK)
             {
-                logger?.LogError("Slot verification failed {cachedVerificationResult}!", cachedVerificationResult.ToString());
                 var errorMessage = GetSlotVerificationMessage(configSnapshot, cachedVerificationResult);
                 _ = RespWriteUtils.TryWriteError(errorMessage, ref output);
             }

--- a/libs/cluster/Session/SlotVerification/RespClusterIterativeSlotVerify.cs
+++ b/libs/cluster/Session/SlotVerification/RespClusterIterativeSlotVerify.cs
@@ -3,6 +3,7 @@
 
 using Garnet.common;
 using Garnet.server;
+using Microsoft.Extensions.Logging;
 
 namespace Garnet.cluster
 {
@@ -27,6 +28,7 @@ namespace Garnet.cluster
         /// <param name="keySlice"></param>
         /// <param name="readOnly"></param>
         /// <param name="SessionAsking"></param>
+        /// <param name="waitForStableSlot"></param>
         /// <returns></returns>
         public bool NetworkIterativeSlotVerify(ArgSlice keySlice, bool readOnly, byte SessionAsking, bool waitForStableSlot)
         {
@@ -70,8 +72,12 @@ namespace Garnet.cluster
         /// <param name="output"></param>
         public void WriteCachedSlotVerificationMessage(ref MemoryResult<byte> output)
         {
-            var errorMessage = GetSlotVerificationMessage(configSnapshot, cachedVerificationResult);
-            RespWriteUtils.TryWriteError(errorMessage, ref output);
+            if (cachedVerificationResult.state != SlotVerifiedState.OK)
+            {
+                logger?.LogError("Slot verification failed {cachedVerificationResult}!", cachedVerificationResult.ToString());
+                var errorMessage = GetSlotVerificationMessage(configSnapshot, cachedVerificationResult);
+                _ = RespWriteUtils.TryWriteError(errorMessage, ref output);
+            }
         }
     }
 }

--- a/libs/server/AOF/ReplayCoordinator/AofReplayCoordinator.cs
+++ b/libs/server/AOF/ReplayCoordinator/AofReplayCoordinator.cs
@@ -279,7 +279,7 @@ namespace Garnet.server
 
                     // Run the stored procedure with the reconstructed input                    
                     var output = aofReplayContext.output;
-                    _ = aofProcessor.respServerSession.RunTransactionProc(id, ref aofReplayContext.customProcInput, ref output, isRecovering: true);
+                    _ = aofProcessor.respServerSession.RunTransactionProc(id, ref aofReplayContext.customProcInput, ref output, isReplaying: true);
                 }
             }
         }

--- a/libs/server/Custom/CustomRespCommands.cs
+++ b/libs/server/Custom/CustomRespCommands.cs
@@ -53,11 +53,11 @@ namespace Garnet.server
             return true;
         }
 
-        public bool RunTransactionProc(byte id, ref CustomProcedureInput procInput, ref MemoryResult<byte> output, bool isRecovering = false)
+        public bool RunTransactionProc(byte id, ref CustomProcedureInput procInput, ref MemoryResult<byte> output, bool isReplaying)
         {
             var proc = customCommandManagerSession
                 .GetCustomTransactionProcedure(id, this, txnManager, scratchBufferAllocator, out _);
-            return txnManager.RunTransactionProc(id, ref procInput, proc, ref output, isRecovering);
+            return txnManager.RunTransactionProc(id, ref procInput, proc, ref output, isReplaying);
         }
 
         private void TryCustomProcedure(CustomProcedure proc, int startIdx = 0)

--- a/libs/server/Transaction/TransactionManager.cs
+++ b/libs/server/Transaction/TransactionManager.cs
@@ -100,6 +100,8 @@ namespace Garnet.server
         internal LockableContext<byte[], IGarnetObject, ObjectInput, GarnetObjectStoreOutput, long, ObjectSessionFunctions, ObjectStoreFunctions, ObjectStoreAllocator> ObjectStoreLockableContext
             => objectStoreLockableContext;
 
+        bool IsReplaying { get; set; } = false;
+
         /// <summary>
         /// Array to keep pointer keys in keyBuffer
         /// </summary>
@@ -188,10 +190,11 @@ namespace Garnet.server
             this.keyCount = 0;
         }
 
-        internal bool RunTransactionProc(byte id, ref CustomProcedureInput procInput, CustomTransactionProcedure proc, ref MemoryResult<byte> output, bool isRecovering = false)
+        internal bool RunTransactionProc(byte id, ref CustomProcedureInput procInput, CustomTransactionProcedure proc, ref MemoryResult<byte> output, bool isReplaying = false)
         {
             var running = false;
             scratchBufferAllocator.Reset();
+            IsReplaying = isReplaying;
             try
             {
                 // If cluster is enabled reset slot verification state cache
@@ -244,7 +247,7 @@ namespace Garnet.server
                     // If the transaction was invoked during AOF replay skip the finalize step altogether
                     // Finalize logs to AOF accordingly, so let the replay pick up the commits from AOF as
                     // part of normal AOF replay.
-                    if (!isRecovering)
+                    if (!isReplaying)
                     {
                         proc.Finalize(garnetTxFinalizeApi, ref procInput, ref output);
                     }

--- a/libs/server/Transaction/TxnKeyManager.cs
+++ b/libs/server/Transaction/TxnKeyManager.cs
@@ -45,9 +45,9 @@ namespace Garnet.server
         /// </summary>
         /// <param name="key"></param>
         /// <param name="type"></param>
-        public unsafe void VerifyKeyOwnership(ArgSlice key, LockType type)
+        public void VerifyKeyOwnership(ArgSlice key, LockType type)
         {
-            if (!clusterEnabled) return;
+            if (!clusterEnabled || IsReplaying) return;
 
             var readOnly = type == LockType.Shared;
             if (!respSession.clusterSession.NetworkIterativeSlotVerify(key, readOnly, respSession.SessionAsking, waitForStableSlot: false))

--- a/test/Garnet.test.cluster/ReplicationTests/ClusterReplicationBaseTests.cs
+++ b/test/Garnet.test.cluster/ReplicationTests/ClusterReplicationBaseTests.cs
@@ -92,7 +92,8 @@ namespace Garnet.test.cluster
         public Dictionary<string, LogLevel> monitorTests = new()
         {
             {"ClusterReplicationSimpleFailover", LogLevel.Warning},
-            {"ClusterReplicationMultiRestartRecover", LogLevel.Trace}
+            {"ClusterReplicationMultiRestartRecover", LogLevel.Trace},
+            {"ClusterReplicationStoredProc", LogLevel.Error}
         };
 
         [SetUp]
@@ -1217,7 +1218,7 @@ namespace Garnet.test.cluster
 
         [Test, Order(24)]
         [Category("REPLICATION")]
-        public void ClusterReplicationStoredProc([Values] bool enableDisklessSync, [Values] bool attachFirst)
+        public void ClusterReplicationStoredProc([Values] bool enableDisklessSync, [Values] bool attachFirst, [Values] bool objectStore)
         {
             var replica_count = 1;// Per primary
             var primary_count = 1;
@@ -1235,8 +1236,16 @@ namespace Garnet.test.cluster
             var replicaServer = context.clusterTestUtils.GetServer(replicaNodeIndex);
 
             // Register custom procedure
-            context.nodes[primaryNodeIndex].Register.NewTransactionProc("RATELIMIT", () => new RateLimiterTxn(), new RespCommandsInfo { Arity = 4 });
-            context.nodes[replicaNodeIndex].Register.NewTransactionProc("RATELIMIT", () => new RateLimiterTxn(), new RespCommandsInfo { Arity = 4 });
+            if (objectStore)
+            {
+                _ = context.nodes[primaryNodeIndex].Register.NewTransactionProc("RATELIMIT", () => new RateLimiterTxn(), new RespCommandsInfo { Arity = 4 });
+                _ = context.nodes[replicaNodeIndex].Register.NewTransactionProc("RATELIMIT", () => new RateLimiterTxn(), new RespCommandsInfo { Arity = 4 });
+            }
+            else
+            {
+                _ = context.nodes[primaryNodeIndex].Register.NewTransactionProc("BULKINCRBY", () => new BulkIncrementBy(), BulkIncrementBy.CommandInfo);
+                _ = context.nodes[replicaNodeIndex].Register.NewTransactionProc("BULKINCRBY", () => new BulkIncrementBy(), BulkIncrementBy.CommandInfo);
+            }
 
             // Setup cluster
             context.clusterTestUtils.AddDelSlotsRange(primaryNodeIndex, [(0, 16383)], addslot: true, logger: context.logger);
@@ -1247,21 +1256,19 @@ namespace Garnet.test.cluster
             context.clusterTestUtils.WaitUntilNodeIsKnown(replicaNodeIndex, primaryNodeIndex, logger: context.logger);
 
             if (attachFirst)
-            {
-                // Issue replicate
-                context.clusterTestUtils.ClusterReplicate(replicaNodeIndex, primaryNodeIndex, logger: context.logger);
-                context.clusterTestUtils.WaitForReplicaRecovery(replicaNodeIndex, logger: context.logger);
-            }
+                ClusterReplicate();
 
-            // Execute custom proc before replicat attach
-            ExecuteRateLimit();
+            if (objectStore)
+                ExecuteRateLimit();
+            else
+            {
+                string[] increment = ["10", "15"];
+                ClusterTestContext.ExecuteStoredProcBulkIncrement(primaryServer, [expectedKeys[0]], [increment[0]]);
+                ClusterTestContext.ExecuteStoredProcBulkIncrement(primaryServer, [expectedKeys[1]], [increment[1]]);
+            }
 
             if (!attachFirst)
-            {
-                // Issue replicate
-                context.clusterTestUtils.ClusterReplicate(replicaNodeIndex, primaryNodeIndex, logger: context.logger);
-                context.clusterTestUtils.WaitForReplicaRecovery(replicaNodeIndex, logger: context.logger);
-            }
+                ClusterReplicate();
 
             // Validate primary keys
             var resp = primaryServer.Execute("KEYS", ["*"]);
@@ -1274,11 +1281,18 @@ namespace Garnet.test.cluster
 
             void ExecuteRateLimit()
             {
-                primaryServer = context.clusterTestUtils.GetServer(primaryNodeIndex);
                 var resp = primaryServer.Execute("RATELIMIT", [expectedKeys[0], "1000000000", "1000000000"]);
                 ClassicAssert.AreEqual("ALLOWED", (string)resp);
                 resp = primaryServer.Execute("RATELIMIT", [expectedKeys[1], "1000000000", "1000000000"]);
                 ClassicAssert.AreEqual("ALLOWED", (string)resp);
+            }
+
+            void ClusterReplicate()
+            {
+                // Issue replicate
+                var resp = context.clusterTestUtils.ClusterReplicate(replicaNodeIndex, primaryNodeIndex, logger: context.logger);
+                ClassicAssert.AreEqual("OK", resp);
+                context.clusterTestUtils.WaitForReplicaRecovery(replicaNodeIndex, logger: context.logger);
             }
         }
 


### PR DESCRIPTION
This PR resolves an issue with slot verification during custom transaction procedure replay. 
The replica does not need to re-verify slots because verification is handled by the primary. 

Any write that fails verification on the primary is never written to the AOF and therefore cannot reach the replica.
Note: The same invariant applies during migration, where the primary transfers slots and their associated keys to another primary.