### PR TITLE
ci: use orphan commits for deploy branches to reduce clone size

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -127,6 +127,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./website/build
+          # Deploy as an orphan commit (single commit, no history) to prevent
+          # the gh-pages branch from accumulating large generated files (charts,
+          # allure reports, search index) across hundreds of commits, which
+          # bloats the repository pack file and slows down git clone.
+          force_orphan: true
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -268,8 +268,9 @@ jobs:
           git rm -rf .
 
           # The generated allure-report/history is untracked and survives git rm.
-          # Move it into the expected path for the allure_data_history branch.
-          Move-Item -Path "${{ github.workspace }}/test/Allure/allure-report/history" -Destination "${{ github.workspace }}/test/Allure/history" -Force
+          # Copy (not move) so the subsequent artifact upload and website publish
+          # steps still have the history directory in allure-report/.
+          Copy-Item -Path "${{ github.workspace }}/test/Allure/allure-report/history" -Destination "${{ github.workspace }}/test/Allure/history" -Recurse -Force
 
           git add test/Allure/history
           git commit -m "Update Allure history [CI]"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -260,15 +260,20 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin allure_data_history
-          git checkout allure_data_history
-          $source = "${{ github.workspace }}/test/Allure/allure-report/history"
-          $target = "${{ github.workspace }}/test/Allure/history"
-          Remove-Item -Recurse -Force $target -ErrorAction SilentlyContinue
-          Copy-Item -Path $source -Destination $target -Recurse -Force
+
+          # Use an orphan commit (no history) to prevent the allure_data_history
+          # branch from accumulating large history.json blobs across hundreds of
+          # commits, which bloats the repository pack file and slows git clone.
+          git checkout --orphan allure_data_history
+          git rm -rf .
+
+          # The generated allure-report/history is untracked and survives git rm.
+          # Move it into the expected path for the allure_data_history branch.
+          Move-Item -Path "${{ github.workspace }}/test/Allure/allure-report/history" -Destination "${{ github.workspace }}/test/Allure/history" -Force
+
           git add test/Allure/history
           git commit -m "Update Allure history [CI]"
-          git push origin allure_data_history
+          git push origin allure_data_history --force
 
       - name: Upload Allure HTML report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/squash-benchmark-branches.yml
+++ b/.github/workflows/squash-benchmark-branches.yml
@@ -39,4 +39,4 @@ jobs:
           git checkout --orphan squashed-temp
           git add -A
           git commit -m "Squash ${{ matrix.branch }} to single commit [CI]"
-          git push origin squashed-temp:${{ matrix.branch }} --force
+          git push origin squashed-temp:${{ matrix.branch }} --force-with-lease

--- a/.github/workflows/squash-benchmark-branches.yml
+++ b/.github/workflows/squash-benchmark-branches.yml
@@ -1,0 +1,42 @@
+name: Squash Benchmark Branches
+
+# The continuousbenchmark and continuousbenchmark_net80 branches accumulate
+# commits from the benchmark-action/github-action-benchmark action (one per
+# benchmark run). Each commit rewrites a ~37 MiB data.js file, which bloats
+# the repository pack file and slows git clone. This workflow periodically
+# squashes each branch to a single orphan commit, keeping only the latest
+# file contents.
+
+on:
+  schedule:
+    - cron: '0 12 * * *' # Daily at noon UTC (offset from benchmark runs)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  squash:
+    name: Squash ${{ matrix.branch }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: [ continuousbenchmark, continuousbenchmark_net80 ]
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Squash to orphan commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Create orphan branch — the working tree and index are preserved
+          # from the current branch, so all files stay as-is and are ready
+          # to be committed without any temp-dir copying.
+          git checkout --orphan squashed-temp
+          git add -A
+          git commit -m "Squash ${{ matrix.branch }} to single commit [CI]"
+          git push origin squashed-temp:${{ matrix.branch }} --force


### PR DESCRIPTION
The gh-pages, allure_data_history, continuousbenchmark, and continuousbenchmark_net80 branches accumulate large generated files (charts data.js ~37 MiB, allure history.json ~100 MiB) across hundreds of commits. This bloats the pack file to 1.3 GiB and makes git clone extremely slow during 'receiving objects'.

Changes:
- deploy-website.yml: add force_orphan: true to peaceiris/actions-gh-pages so gh-pages always has a single commit (was 278 commits / 15 GiB blobs)
- nightly.yml: rewrite allure_data_history push to use an orphan commit instead of appending to history (was 987 commits / 2.15 GiB blobs)
- New squash-benchmark-branches.yml: daily scheduled workflow to squash continuousbenchmark and continuousbenchmark_net80 to single commits (were 114-115 commits / 7 GiB blobs combined)