### PR TITLE
Fix copy-paste bug in disk-based replica sync sending wrong AOF address

### DIFF
--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaDiskbasedSync.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaDiskbasedSync.cs
@@ -157,7 +157,7 @@ namespace Garnet.cluster
                         PrimaryReplId,
                         cEntry.ToByteArray(),
                         beginAddress.Span,
-                        beginAddress.Span).WaitAsync(storeWrapper.serverOptions.ReplicaAttachTimeout, linkedCts.Token).ConfigureAwait(false);
+                        tailAddress.Span).WaitAsync(storeWrapper.serverOptions.ReplicaAttachTimeout, linkedCts.Token).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Problem

`ClusterSRNoCheckpointRestartSecondary` tests fail because the replica remains stuck at AOF offset 64 (`kFirstValidAofAddress`) after restart, never syncing with the primary.

Error: `[127.0.0.1:7000]: 1,140288 != [127.0.0.1:7001]: 1,64`

## Root Cause

Copy-paste bug in `ReplicaDiskbasedSync.TryReplicateDiskbasedSync()` introduced in commit `6fb99e58` when converting from `ToByteArray()` to `Span`-based calls. The `aofTailAddress` parameter was accidentally set to `beginAddress.Span` instead of `tailAddress.Span`.

The primary uses the replica's tail address in `ComputeAofSyncReplayAddress()` to determine the AOF sync replay range. With both parameters being the begin address, the primary couldn't determine where the replica's AOF ended, so the replica never received AOF records after restart.

## Fix

One-line fix: `beginAddress.Span` to `tailAddress.Span` for the `aofTailAddress` parameter of `ExecuteClusterInitiateReplicaSync`.

## Testing

All 4 `ClusterReplicationTLS.ClusterSRNoCheckpointRestartSecondary` variants now pass.