### PR TITLE
Migrate: Improved Error Handling on Failed SetSlotRange

### DIFF
--- a/libs/cluster/Server/Migration/MigrateSession.cs
+++ b/libs/cluster/Server/Migration/MigrateSession.cs
@@ -249,61 +249,7 @@ namespace Garnet.cluster
             return slotRanges;
         }
 
-        /// <summary>
-        /// Change remote slot state
-        /// </summary>
-        /// <param name="nodeid"></param>
-        /// <param name="state"></param>
-        /// <returns></returns>
-        public bool TrySetSlotRanges(string nodeid, MigrateState state)
-        {
-            var client = migrateOperation[0].Client;
-            try
-            {
-                if (!CheckConnection(client))
-                {
-                    Status = MigrateState.FAIL;
-                    return false;
-                }
 
-                var stateBytes = state switch
-                {
-                    MigrateState.IMPORT => IMPORTING,
-                    MigrateState.STABLE => STABLE,
-                    MigrateState.NODE => NODE,
-                    _ => throw new Exception("Invalid SETSLOT Operation"),
-                };
-
-                logger?.LogTrace("Sending CLUSTER SETSLOTRANGE {state} {nodeid} {slots}", state, nodeid ?? "null", ClusterManager.GetRange([.. _sslots]));
-
-                // Get the task and wait for it with timeout
-                var task = client.SetSlotRange(stateBytes, nodeid, _slotRanges);
-                var result = task.WaitAsync(_timeout, _cts.Token).GetAwaiter().GetResult();
-
-                // Check if setslotsrange executed correctly
-                if (!result.Equals("OK", StringComparison.Ordinal))
-                {
-                    logger?.LogError("TrySetSlot error: {error}", result);
-                    Status = MigrateState.FAIL;
-                    return false;
-                }
-
-                logger?.LogTrace("[Completed] SETSLOT {slots} {state} {nodeid}", ClusterManager.GetRange([.. _sslots]), state, nodeid ?? "");
-                return true;
-            }
-            catch (TaskCanceledException)
-            {
-                logger?.LogError("SetSlotRange operation timed out or was cancelled after {timeout}ms for slots {slots}", _timeout.TotalMilliseconds, ClusterManager.GetRange([.. _sslots]));
-                Status = MigrateState.FAIL;
-                return false;
-            }
-            catch (Exception ex)
-            {
-                logger?.LogError(ex, "An error occurred during SetSlotRange for slots {slots}", ClusterManager.GetRange([.. _sslots]));
-                Status = MigrateState.FAIL;
-                return false;
-            }
-        }
 
         /// <summary>
         /// Reset local slot state
@@ -336,29 +282,6 @@ namespace Garnet.cluster
             return true;
         }
 
-        /// <summary>
-        /// Try recover to cluster state before migration task.
-        /// Used only for MIGRATE SLOTS option.
-        /// </summary>
-        public bool TryRecoverFromFailure()
-        {
-            // Set slot at target to stable state when migrate slots fails
-            // This issues a SETSLOTRANGE STABLE for the slots of the failed migration task
-            if (!TrySetSlotRanges(null, MigrateState.STABLE))
-            {
-                logger?.LogError("MigrateSession.RecoverFromFailure failed to make slots STABLE");
-                return false;
-            }
 
-            // Set slots at source node to their original state when migrate fails
-            // This will execute the equivalent of SETSLOTRANGE STABLE for the slots of the failed migration task
-            ResetLocalSlot();
-
-            // TODO: Need to relinquish any migrating Vector Set contexts from target node
-
-            // Log explicit migration failure.
-            Status = MigrateState.FAIL;
-            return true;
-        }
     }
 }

--- a/libs/cluster/Server/Migration/MigrateSession.cs
+++ b/libs/cluster/Server/Migration/MigrateSession.cs
@@ -257,12 +257,12 @@ namespace Garnet.cluster
         /// <returns></returns>
         public bool TrySetSlotRanges(string nodeid, MigrateState state)
         {
-            var status = false;
             var client = migrateOperation[0].Client;
             try
             {
                 if (!CheckConnection(client))
                     return false;
+
                 var stateBytes = state switch
                 {
                     MigrateState.IMPORT => IMPORTING,
@@ -271,27 +271,41 @@ namespace Garnet.cluster
                     _ => throw new Exception("Invalid SETSLOT Operation"),
                 };
 
-                status = client.SetSlotRange(stateBytes, nodeid, _slotRanges).ContinueWith(resp =>
+                logger?.LogTrace("Sending CLUSTER SETSLOTRANGE {state} {nodeid} {slots}", state, nodeid ?? "null", ClusterManager.GetRange([.. _sslots]));
+
+                // Get the task and wait for it with timeout
+                var task = client.SetSlotRange(stateBytes, nodeid, _slotRanges);
+                var result = task.WaitAsync(_timeout, _cts.Token).GetAwaiter().GetResult();
+
+                // Check if setslotsrange executed correctly
+                if (!result.Equals("OK", StringComparison.Ordinal))
                 {
-                    // Check if setslotsrange executed correctly
-                    if (!resp.Result.Equals("OK", StringComparison.Ordinal))
-                    {
-                        logger?.LogError("TrySetSlot error: {error}", resp);
-                        Status = MigrateState.FAIL;
-                        return false;
-                    }
-                    logger?.LogTrace("[Completed] SETSLOT {slots} {state} {nodeid}", ClusterManager.GetRange([.. _sslots]), state, nodeid ?? "");
-                    return true;
-                }, TaskContinuationOptions.OnlyOnRanToCompletion)
-                .WaitAsync(_timeout, _cts.Token).Result;
+                    logger?.LogError("TrySetSlot error: {error}", result);
+                    Status = MigrateState.FAIL;
+                    return false;
+                }
+
+                logger?.LogTrace("[Completed] SETSLOT {slots} {state} {nodeid}", ClusterManager.GetRange([.. _sslots]), state, nodeid ?? "");
+                return true;
+            }
+            catch (TaskCanceledException)
+            {
+                logger?.LogError("SetSlotRange operation timed out or was cancelled after {timeout}ms for slots {slots}", _timeout.TotalMilliseconds, ClusterManager.GetRange([.. _sslots]));
+                Status = MigrateState.FAIL;
+                return false;
+            }
+            catch (AggregateException aex) when (aex.InnerException is TaskCanceledException)
+            {
+                logger?.LogError("SetSlotRange operation timed out or was cancelled after {timeout}ms for slots {slots}", _timeout.TotalMilliseconds, ClusterManager.GetRange([.. _sslots]));
+                Status = MigrateState.FAIL;
+                return false;
             }
             catch (Exception ex)
             {
-                logger?.LogError(ex, "An error occurred");
+                logger?.LogError(ex, "An error occurred during SetSlotRange for slots {slots}", ClusterManager.GetRange([.. _sslots]));
+                Status = MigrateState.FAIL;
                 return false;
             }
-
-            return status;
         }
 
         /// <summary>

--- a/libs/cluster/Server/Migration/MigrateSession.cs
+++ b/libs/cluster/Server/Migration/MigrateSession.cs
@@ -261,7 +261,10 @@ namespace Garnet.cluster
             try
             {
                 if (!CheckConnection(client))
+                {
+                    Status = MigrateState.FAIL;
                     return false;
+                }
 
                 var stateBytes = state switch
                 {
@@ -289,12 +292,6 @@ namespace Garnet.cluster
                 return true;
             }
             catch (TaskCanceledException)
-            {
-                logger?.LogError("SetSlotRange operation timed out or was cancelled after {timeout}ms for slots {slots}", _timeout.TotalMilliseconds, ClusterManager.GetRange([.. _sslots]));
-                Status = MigrateState.FAIL;
-                return false;
-            }
-            catch (AggregateException aex) when (aex.InnerException is TaskCanceledException)
             {
                 logger?.LogError("SetSlotRange operation timed out or was cancelled after {timeout}ms for slots {slots}", _timeout.TotalMilliseconds, ClusterManager.GetRange([.. _sslots]));
                 Status = MigrateState.FAIL;

--- a/libs/cluster/Server/Migration/MigrationDriver.cs
+++ b/libs/cluster/Server/Migration/MigrationDriver.cs
@@ -42,7 +42,7 @@ namespace Garnet.cluster
                 // Check if setslotsrange executed correctly
                 if (!result.Equals("OK", StringComparison.Ordinal))
                 {
-                    logger?.LogError("TrySetSlot error: {error}", result);
+                    logger?.LogError("SetSlotRange error: {error}", result);
                     Status = MigrateState.FAIL;
                     return false;
                 }

--- a/libs/cluster/Server/Migration/MigrationDriver.cs
+++ b/libs/cluster/Server/Migration/MigrationDriver.cs
@@ -10,6 +10,86 @@ namespace Garnet.cluster
     internal sealed partial class MigrateSession : IDisposable
     {
         /// <summary>
+        /// Change remote slot state
+        /// </summary>
+        /// <param name="nodeid"></param>
+        /// <param name="state"></param>
+        /// <returns></returns>
+        public async Task<bool> TrySetSlotRangesAsync(string nodeid, MigrateState state)
+        {
+            var client = migrateOperation[0].Client;
+            try
+            {
+                if (!CheckConnection(client))
+                {
+                    Status = MigrateState.FAIL;
+                    return false;
+                }
+
+                var stateBytes = state switch
+                {
+                    MigrateState.IMPORT => IMPORTING,
+                    MigrateState.STABLE => STABLE,
+                    MigrateState.NODE => NODE,
+                    _ => throw new Exception("Invalid SETSLOT Operation"),
+                };
+
+                logger?.LogTrace("Sending CLUSTER SETSLOTRANGE {state} {nodeid} {slots}", state, nodeid ?? "null", ClusterManager.GetRange([.. _sslots]));
+
+                var result = await client.SetSlotRange(stateBytes, nodeid, _slotRanges)
+                    .WaitAsync(_timeout, _cts.Token).ConfigureAwait(false);
+
+                // Check if setslotsrange executed correctly
+                if (!result.Equals("OK", StringComparison.Ordinal))
+                {
+                    logger?.LogError("TrySetSlot error: {error}", result);
+                    Status = MigrateState.FAIL;
+                    return false;
+                }
+
+                logger?.LogTrace("[Completed] SETSLOT {slots} {state} {nodeid}", ClusterManager.GetRange([.. _sslots]), state, nodeid ?? "");
+                return true;
+            }
+            catch (OperationCanceledException)
+            {
+                logger?.LogError("SetSlotRange operation timed out or was cancelled after {timeout}ms for slots {slots}", _timeout.TotalMilliseconds, ClusterManager.GetRange([.. _sslots]));
+                Status = MigrateState.FAIL;
+                return false;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "An error occurred during SetSlotRange for slots {slots}", ClusterManager.GetRange([.. _sslots]));
+                Status = MigrateState.FAIL;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try recover to cluster state before migration task.
+        /// Used only for MIGRATE SLOTS option.
+        /// </summary>
+        public async Task<bool> TryRecoverFromFailureAsync()
+        {
+            // Set slot at target to stable state when migrate slots fails
+            // This issues a SETSLOTRANGE STABLE for the slots of the failed migration task
+            if (!await TrySetSlotRangesAsync(null, MigrateState.STABLE).ConfigureAwait(false))
+            {
+                logger?.LogError("MigrateSession.RecoverFromFailure failed to make slots STABLE");
+                return false;
+            }
+
+            // Set slots at source node to their original state when migrate fails
+            // This will execute the equivalent of SETSLOTRANGE STABLE for the slots of the failed migration task
+            ResetLocalSlot();
+
+            // TODO: Need to relinquish any migrating Vector Set contexts from target node
+
+            // Log explicit migration failure.
+            Status = MigrateState.FAIL;
+            return true;
+        }
+
+        /// <summary>
         /// Begin migration task
         /// </summary>
         /// <param name="errorMessage">The ASCII encoded error message if the method returned <see langword="false"/>; otherwise <see langword="default"/></param>
@@ -57,10 +137,10 @@ namespace Garnet.cluster
                 clusterProvider.storeWrapper.store.PauseRevivification(_timeout, _cts.Token);
 
                 // Set target node to import state
-                if (!TrySetSlotRanges(GetSourceNodeId, MigrateState.IMPORT))
+                if (!await TrySetSlotRangesAsync(GetSourceNodeId, MigrateState.IMPORT).ConfigureAwait(false))
                 {
                     logger?.LogError("Failed to set remote slots {slots} to import state", ClusterManager.GetRange([.. GetSlots]));
-                    TryRecoverFromFailure();
+                    await TryRecoverFromFailureAsync().ConfigureAwait(false);
                     Status = MigrateState.FAIL;
                     return;
                 }
@@ -70,7 +150,7 @@ namespace Garnet.cluster
                 if (!TryPrepareLocalForMigration())
                 {
                     logger?.LogError("Failed to set local slots {slots} to migrate state", string.Join(',', GetSlots));
-                    TryRecoverFromFailure();
+                    await TryRecoverFromFailureAsync().ConfigureAwait(false);
                     Status = MigrateState.FAIL;
                     return;
                 }
@@ -86,7 +166,7 @@ namespace Garnet.cluster
                 if ((_namespaces?.Count ?? 0) > 0 && !await ReserveDestinationVectorSetsAsync())
                 {
                     logger?.LogError("Failed to reserve destination vector sets, migration failed");
-                    TryRecoverFromFailure();
+                    await TryRecoverFromFailureAsync().ConfigureAwait(false);
                     Status = MigrateState.FAIL;
                     return;
                 }
@@ -96,7 +176,7 @@ namespace Garnet.cluster
                 if (!await MigrateSlotsDriverInline())
                 {
                     logger?.LogError("MigrateSlotsDriver failed");
-                    TryRecoverFromFailure();
+                    await TryRecoverFromFailureAsync().ConfigureAwait(false);
                     Status = MigrateState.FAIL;
                     return;
                 }
@@ -110,10 +190,10 @@ namespace Garnet.cluster
                 await clusterProvider.clusterManager.TryMeetAsync(_targetAddress, _targetPort, acquireLock: false);
 
                 // Change ownership of slots to target node.
-                if (!TrySetSlotRanges(GetTargetNodeId, MigrateState.NODE))
+                if (!await TrySetSlotRangesAsync(GetTargetNodeId, MigrateState.NODE).ConfigureAwait(false))
                 {
                     logger?.LogError("Failed to assign ownership to target node:({tgtNodeId}) ({endpoint})", GetTargetNodeId, GetTargetEndpoint);
-                    TryRecoverFromFailure();
+                    await TryRecoverFromFailureAsync().ConfigureAwait(false);
                     Status = MigrateState.FAIL;
                     return;
                 }
@@ -122,7 +202,7 @@ namespace Garnet.cluster
                 if (!RelinquishOwnership())
                 {
                     logger?.LogError("Failed to relinquish ownership from source node:({srcNode}) to target node: ({tgtNode})", GetSourceNodeId, GetTargetNodeId);
-                    TryRecoverFromFailure();
+                    await TryRecoverFromFailureAsync().ConfigureAwait(false);
                     Status = MigrateState.FAIL;
                     return;
                 }

--- a/test/Garnet.test.cluster/ClusterMigrateTests.cs
+++ b/test/Garnet.test.cluster/ClusterMigrateTests.cs
@@ -2331,12 +2331,6 @@ namespace Garnet.test.cluster
             }
         }
 
-        /// <summary>
-        /// Verifies that slot migration via SETSLOTRANGE is resilient end-to-end:
-        /// all keys in the migrated slot are fully transferred to the target node,
-        /// their values are intact, and slot ownership is correctly updated on both
-        /// the source and target nodes.
-        /// </summary>
         [Test, Order(27)]
         [Category("CLUSTER")]
         public void ClusterMigrateSetSlotRangeResilience()

--- a/test/Garnet.test.cluster/ClusterMigrateTests.cs
+++ b/test/Garnet.test.cluster/ClusterMigrateTests.cs
@@ -2331,6 +2331,12 @@ namespace Garnet.test.cluster
             }
         }
 
+        /// <summary>
+        /// Verifies that slot migration via SETSLOTRANGE is resilient end-to-end:
+        /// all keys in the migrated slot are fully transferred to the target node,
+        /// their values are intact, and slot ownership is correctly updated on both
+        /// the source and target nodes.
+        /// </summary>
         [Test, Order(27)]
         [Category("CLUSTER")]
         public void ClusterMigrateSetSlotRangeResilience()

--- a/test/Garnet.test.cluster/ClusterMigrateTests.cs
+++ b/test/Garnet.test.cluster/ClusterMigrateTests.cs
@@ -2330,5 +2330,65 @@ namespace Garnet.test.cluster
                 ClassicAssert.IsNull(value, "Deleted key should not be transmitted during migration");
             }
         }
+
+        [Test, Order(27)]
+        [Category("CLUSTER")]
+        public void ClusterMigrateSetSlotRangeResilience()
+        {
+            context.logger?.LogDebug("0. ClusterMigrateSetSlotRangeResilience started");
+            var Shards = 2;
+            context.CreateInstances(Shards, useTLS: UseTLS);
+            context.CreateConnection(useTLS: UseTLS);
+
+            // Setup: node 0 owns all slots, node 1 owns none
+            _ = context.clusterTestUtils.AddDelSlotsRange(0, [(0, 16383)], addslot: true, logger: context.logger);
+            context.clusterTestUtils.SetConfigEpoch(0, 1, logger: context.logger);
+            context.clusterTestUtils.SetConfigEpoch(1, 2, logger: context.logger);
+            context.clusterTestUtils.Meet(0, 1, logger: context.logger);
+            context.clusterTestUtils.WaitUntilNodeIsKnown(1, 0, logger: context.logger);
+
+            // Create data across multiple slots using the standard helper
+            var keyCount = 50;
+            var slot = CreateSingleSlotData(keyLen: 16, valueLen: 16, keyTagEnd: 6, keyCount, out var data);
+            var sourceNodeIndex = 0;
+            var targetNodeIndex = 1;
+
+            context.logger?.LogDebug("1. Verifying data insertion in slot {slot}", slot);
+            var actualKeyCount = context.clusterTestUtils.CountKeysInSlot(sourceNodeIndex, slot, logger: context.logger);
+            ClassicAssert.AreEqual(keyCount, actualKeyCount, "Keys should be present in source slot before migration");
+
+            context.logger?.LogDebug("2. Initiating migration of slot {slot}", slot);
+            context.clusterTestUtils.MigrateSlotsIndex(sourceNodeIndex, targetNodeIndex, [slot], logger: context.logger);
+
+            context.logger?.LogDebug("3. Waiting for migration completion");
+            context.clusterTestUtils.WaitForMigrationCleanup(sourceNodeIndex, logger: context.logger);
+
+            context.logger?.LogDebug("4. Verifying migrated data on target");
+            var migratedKeyCount = context.clusterTestUtils.CountKeysInSlot(targetNodeIndex, slot, logger: context.logger);
+            ClassicAssert.AreEqual(keyCount, migratedKeyCount, "All keys should be present on target after migration");
+
+            // Verify each key's value on the target
+            var targetEndPoint = context.clusterTestUtils.GetEndPoint(targetNodeIndex);
+            foreach (var entry in data)
+            {
+                var value = context.clusterTestUtils.GetKey(targetEndPoint, entry.Key, out _, out var endPoint, out var responseState);
+                while (responseState != ResponseState.OK || value == null)
+                {
+                    _ = Thread.Yield();
+                    value = context.clusterTestUtils.GetKey(targetEndPoint, entry.Key, out _, out endPoint, out responseState);
+                }
+                ClassicAssert.AreEqual(ResponseState.OK, responseState);
+                ClassicAssert.AreEqual(Encoding.ASCII.GetString(entry.Value), value);
+            }
+
+            context.logger?.LogDebug("5. Verifying slot ownership transfer");
+            var targetSlotMap = context.clusterTestUtils.GetSlotPortMapFromNode(targetNodeIndex, context.logger);
+            var sourceSlotMap = context.clusterTestUtils.GetSlotPortMapFromNode(sourceNodeIndex, context.logger);
+
+            ClassicAssert.IsTrue(targetSlotMap.ContainsKey((ushort)slot), "Target should own the migrated slot");
+            ClassicAssert.IsFalse(sourceSlotMap.ContainsKey((ushort)slot), "Source should no longer own the migrated slot");
+
+            context.logger?.LogDebug("6. ClusterMigrateSetSlotRangeResilience completed");
+        }
     }
 }

--- a/test/Garnet.test.cluster/ClusterMigrateTests.cs
+++ b/test/Garnet.test.cluster/ClusterMigrateTests.cs
@@ -2353,7 +2353,7 @@ namespace Garnet.test.cluster
             var sourceNodeIndex = 0;
             var targetNodeIndex = 1;
 
-            context.logger?.LogDebug("1. Verifying data insertion in slot {slot}", slot);
+            context.logger?.LogDebug("1. Verifying data insertion into slot {slot}", slot);
             var actualKeyCount = context.clusterTestUtils.CountKeysInSlot(sourceNodeIndex, slot, logger: context.logger);
             ClassicAssert.AreEqual(keyCount, actualKeyCount, "Keys should be present in source slot before migration");
 

--- a/test/Garnet.test.cluster/ClusterMigrateTests.cs
+++ b/test/Garnet.test.cluster/ClusterMigrateTests.cs
@@ -2336,8 +2336,8 @@ namespace Garnet.test.cluster
         public void ClusterMigrateSetSlotRangeResilience()
         {
             context.logger?.LogDebug("0. ClusterMigrateSetSlotRangeResilience started");
-            var Shards = 2;
-            context.CreateInstances(Shards, useTLS: UseTLS);
+            var shards = 2;
+            context.CreateInstances(shards, useTLS: UseTLS);
             context.CreateConnection(useTLS: UseTLS);
 
             // Setup: node 0 owns all slots, node 1 owns none
@@ -2347,7 +2347,7 @@ namespace Garnet.test.cluster
             context.clusterTestUtils.Meet(0, 1, logger: context.logger);
             context.clusterTestUtils.WaitUntilNodeIsKnown(1, 0, logger: context.logger);
 
-            // Create data across multiple slots using the standard helper
+            // Create data in a single slot using the standard helper
             var keyCount = 50;
             var slot = CreateSingleSlotData(keyLen: 16, valueLen: 16, keyTagEnd: 6, keyCount, out var data);
             var sourceNodeIndex = 0;
@@ -2371,12 +2371,17 @@ namespace Garnet.test.cluster
             var targetEndPoint = context.clusterTestUtils.GetEndPoint(targetNodeIndex);
             foreach (var entry in data)
             {
-                var value = context.clusterTestUtils.GetKey(targetEndPoint, entry.Key, out _, out var endPoint, out var responseState);
-                while (responseState != ResponseState.OK || value == null)
+                string value = null;
+                ResponseState responseState = default;
+                EndPoint endPoint;
+
+                var success = SpinWait.SpinUntil(() =>
                 {
-                    _ = Thread.Yield();
                     value = context.clusterTestUtils.GetKey(targetEndPoint, entry.Key, out _, out endPoint, out responseState);
-                }
+                    return responseState == ResponseState.OK && value != null;
+                }, TimeSpan.FromSeconds(30));
+
+                ClassicAssert.IsTrue(success, $"Timed out waiting for key {Encoding.ASCII.GetString(entry.Key)} to become available on target");
                 ClassicAssert.AreEqual(ResponseState.OK, responseState);
                 ClassicAssert.AreEqual(Encoding.ASCII.GetString(entry.Value), value);
             }

--- a/test/Garnet.test.cluster/ClusterMigrateTests.cs
+++ b/test/Garnet.test.cluster/ClusterMigrateTests.cs
@@ -2373,7 +2373,7 @@ namespace Garnet.test.cluster
             {
                 string value = null;
                 ResponseState responseState = default;
-                EndPoint endPoint;
+                IPEndPoint endPoint = null;
 
                 var success = SpinWait.SpinUntil(() =>
                 {


### PR DESCRIPTION
## Improve error handling in `TrySetSlotRanges` during slot migration

### Summary

Refactors `MigrateSession.TrySetSlotRanges` to replace  `.ContinueWith(...).WaitAsync().Result` async pattern with a more traceable and debuggable implementation. Adds explicit timeout/cancellation handling and ensures `MigrateState.FAIL` is consistently set on all error paths.

### Motivation

The previous implementation used `ContinueWith(TaskContinuationOptions.OnlyOnRanToCompletion)` chained with `.WaitAsync().Result`. This pattern had several issues:

- **Silent failures**: If the task faulted or was canceled, the `OnlyOnRanToCompletion` continuation never ran, and the resulting `TaskCanceledException` was caught by the generic `catch (Exception)` block — which did **not** set `Status = MigrateState.FAIL`, leaving the migration in an indeterminate state.
- **Poor diagnostics**: The generic catch logged `"An error occurred"` with no context about which slots were affected or whether the failure was a timeout vs. an unexpected error.
- **Unnecessary indirection**: Wrapping the result check in a continuation added complexity without benefit.

### Changes

**MigrateSession.cs**

- Replace `.ContinueWith(...).WaitAsync(_timeout, _cts.Token).Result` with direct `task.WaitAsync(_timeout, _cts.Token).GetAwaiter().GetResult()`
- Add dedicated `catch (TaskCanceledException)` handler for timeout/cancellation scenarios
- Add `catch (AggregateException aex) when (aex.InnerException is TaskCanceledException)` for wrapped timeout exceptions
- Set `Status = MigrateState.FAIL` in **all** error paths (the old generic `catch` missed this)
- Add structured log messages that include the affected slot ranges and timeout values
- Add trace logging before the `SETSLOTRANGE` call for better migration observability

**ClusterMigrateTests.cs**

- Add `ClusterMigrateSetSlotRangeResilience` test that exercises the `TrySetSlotRanges` code path through a full slot migration:
  - Sets up a 2-node cluster and creates 50 keys in a slot
  - Migrates the slot from source to target (internally calls `TrySetSlotRanges` for IMPORTING and NODE states)
  - Verifies key count and data integrity on the target node
  - Verifies slot ownership transferred correctly

### Testing

- New test `ClusterMigrateSetSlotRangeResilience` passes
- Existing migration tests remain green

Fixes #1655 1655