### PR TITLE
Kill AOF BulkConsume When Connection is Dead

### DIFF
--- a/libs/cluster/Server/Replication/PrimaryOps/AofSyncTaskInfo.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/AofSyncTaskInfo.cs
@@ -108,11 +108,12 @@ namespace Garnet.cluster
 
                 iter = clusterProvider.storeWrapper.appendOnlyFile.ScanSingle(startAddress, long.MaxValue, scanUncommitted: true, recover: false, logger: logger);
 
-                while (true)
-                {
-                    if (cts.Token.IsCancellationRequested) break;
-                    await iter.BulkConsumeAllAsync(this, clusterProvider.serverOptions.ReplicaSyncDelayMs, maxChunkSize: 1 << 20, cts.Token);
-                }
+                await iter.BulkConsumeAllAsync(
+                    this,
+                    clusterProvider.serverOptions.ReplicaSyncDelayMs,
+                    maxChunkSize: 1 << 20,
+                    () => garnetClient != null && !garnetClient.IsConnected,
+                    cts.Token).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/libs/cluster/Server/Replication/PrimaryOps/AofSyncTaskInfo.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/AofSyncTaskInfo.cs
@@ -90,6 +90,9 @@ namespace Garnet.cluster
 
         public void Throttle()
         {
+            if (!garnetClient.IsConnected)
+                throw new GarnetException("AOF stream client disconnected!");
+
             // Trigger flush while we are out of epoch protection
             garnetClient.CompletePending(false);
             garnetClient.Throttle();
@@ -112,7 +115,6 @@ namespace Garnet.cluster
                     this,
                     clusterProvider.serverOptions.ReplicaSyncDelayMs,
                     maxChunkSize: 1 << 20,
-                    () => garnetClient != null && !garnetClient.IsConnected,
                     cts.Token).ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/libs/cluster/Server/Replication/PrimaryOps/AofSyncTaskInfo.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/AofSyncTaskInfo.cs
@@ -91,7 +91,7 @@ namespace Garnet.cluster
         public void Throttle()
         {
             if (!garnetClient.IsConnected)
-                throw new GarnetException("AOF stream client disconnected!");
+                ExceptionUtils.ThrowException(new GarnetException("AOF stream client disconnected!"));
 
             // Trigger flush while we are out of epoch protection
             garnetClient.CompletePending(false);

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaReplayTask.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaReplayTask.cs
@@ -95,16 +95,12 @@ namespace Garnet.cluster
             try
             {
                 activeReplay.ReadLock();
-                while (true)
-                {
-                    replicaReplayTaskCts.Token.ThrowIfCancellationRequested();
-                    await replayIterator.BulkConsumeAllAsync(
-                        this,
-                        clusterProvider.serverOptions.ReplicaSyncDelayMs,
-                        maxChunkSize: 1 << 20,
-                        stopConsume: null,
-                        replicaReplayTaskCts.Token);
-                }
+
+                await replayIterator.BulkConsumeAllAsync(
+                    this,
+                    clusterProvider.serverOptions.ReplicaSyncDelayMs,
+                    maxChunkSize: 1 << 20,
+                    replicaReplayTaskCts.Token);
             }
             catch (Exception ex)
             {

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaReplayTask.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaReplayTask.cs
@@ -102,6 +102,7 @@ namespace Garnet.cluster
                         this,
                         clusterProvider.serverOptions.ReplicaSyncDelayMs,
                         maxChunkSize: 1 << 20,
+                        stopConsume: null,
                         replicaReplayTaskCts.Token);
                 }
             }

--- a/libs/common/ExceptionUtils.cs
+++ b/libs/common/ExceptionUtils.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Garnet.common
+{
+    public static class ExceptionUtils
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowException(Exception e) => throw e;
+    }
+}

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogIterator.cs
@@ -127,10 +127,9 @@ namespace Tsavorite.core
         /// <param name="consumer"> consumer </param>
         /// <param name="throttleMs">throttle the iteration speed</param>
         /// <param name="maxChunkSize">max size of returned chunk</param>
-        /// <param name="stopConsume"> custom stop consume signal </param>
         /// <param name="token"> cancellation token </param>
         /// <typeparam name="T"> consumer type </typeparam>
-        public async Task BulkConsumeAllAsync<T>(T consumer, int throttleMs = 0, int maxChunkSize = 0, Func<bool> stopConsume = null, CancellationToken token = default) where T : IBulkLogEntryConsumer
+        public async Task BulkConsumeAllAsync<T>(T consumer, int throttleMs = 0, int maxChunkSize = 0, CancellationToken token = default) where T : IBulkLogEntryConsumer
         {
             while (!disposed)
             {
@@ -138,8 +137,6 @@ namespace Tsavorite.core
                 while (!TryBulkConsumeNext(consumer, maxChunkSize))
                 {
                     await Task.Delay(throttleMs, token).ConfigureAwait(false);
-                    // If monitoring has signaled
-                    if (stopConsume != null && stopConsume()) return;
                 }
             }
         }
@@ -478,6 +475,9 @@ namespace Tsavorite.core
         /// <returns>whether a next entry is present</returns>
         public unsafe bool TryBulkConsumeNext<T>(T consumer, int maxChunkSize = 0) where T : IBulkLogEntryConsumer
         {
+            // Throttle and implicitly check for consumer liveness
+            consumer.Throttle();
+
             if (maxChunkSize == 0) maxChunkSize = allocator.PageSize;
 
             if (disposed)
@@ -503,7 +503,7 @@ namespace Tsavorite.core
                         epoch.ProtectAndDrain();
                     }
 
-                    var hasNext = GetNextInternal(out long startPhysicalAddress, out int newEntryLength, out long startLogicalAddress, out long endLogicalAddress, out bool isCommitRecord, out bool onFrame);
+                    var hasNext = GetNextInternal(out long startPhysicalAddress, out var newEntryLength, out var startLogicalAddress, out var endLogicalAddress, out bool isCommitRecord, out bool onFrame);
 
                     if (!hasNext)
                     {
@@ -512,7 +512,7 @@ namespace Tsavorite.core
                     }
 
                     // GetNextInternal returns only the payload length, so adjust the totalLength
-                    int totalLength = headerSize + Align(newEntryLength);
+                    var totalLength = headerSize + Align(newEntryLength);
 
                     // Expand the records in iteration, as long as as they are on the same physical page
                     while (ExpandGetNextInternal(startPhysicalAddress, ref totalLength, out _, out endLogicalAddress, out isCommitRecord))

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogIterator.cs
@@ -127,9 +127,10 @@ namespace Tsavorite.core
         /// <param name="consumer"> consumer </param>
         /// <param name="throttleMs">throttle the iteration speed</param>
         /// <param name="maxChunkSize">max size of returned chunk</param>
+        /// <param name="stopConsume"> custom stop consume signal </param>
         /// <param name="token"> cancellation token </param>
         /// <typeparam name="T"> consumer type </typeparam>
-        public async Task BulkConsumeAllAsync<T>(T consumer, int throttleMs = 0, int maxChunkSize = 0, CancellationToken token = default) where T : IBulkLogEntryConsumer
+        public async Task BulkConsumeAllAsync<T>(T consumer, int throttleMs = 0, int maxChunkSize = 0, Func<bool> stopConsume = null, CancellationToken token = default) where T : IBulkLogEntryConsumer
         {
             while (!disposed)
             {
@@ -137,6 +138,8 @@ namespace Tsavorite.core
                 while (!TryBulkConsumeNext(consumer, maxChunkSize))
                 {
                     await Task.Delay(throttleMs, token).ConfigureAwait(false);
+                    // If monitoring has signaled
+                    if (stopConsume != null && stopConsume()) return;
                 }
             }
         }


### PR DESCRIPTION
This PR introduces a stopConsume callback that checks the health of the client connection when streaming the AOF.
I used a callback here to avoid maintaining a second background task that monitors the connection and kills the AOF BulkConsume loop.