### PR TITLE
Fix CLUSTER NODES and CLUSTER SHARDS metadata output

### DIFF
--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -718,6 +718,7 @@ namespace Garnet.cluster
                 var endpoint = preferredEndpointType switch
                 {
                     ClusterPreferredEndpointType.Hostname => hasHostname ? hostname : "?",
+                    ClusterPreferredEndpointType.Unknown => "?",
                     _ => ip,
                 };
 

--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -664,93 +664,92 @@ namespace Garnet.cluster
         /// <returns>RESP formatted string</returns>
         public string GetShardsInfo(GarnetClusterConnectionStore clusterConnection, ClusterPreferredEndpointType preferredEndpointType)
         {
-            var shardsInfo = "";
+            var sb = new StringBuilder();
             var shardCount = 0;
+            var shardsStart = sb.Length;
             for (ushort i = 1; i <= NumWorkers; i++)
             {
                 if (workers[i].Role == NodeRole.PRIMARY)
                 {
                     var shardRanges = GetShardRanges(i);
                     var replicaWorkerIds = GetWorkerReplicas(i);
-                    shardsInfo += CreateFormattedShardInfo(i, shardRanges, replicaWorkerIds);
+                    AppendFormattedShardInfo(sb, i, shardRanges, replicaWorkerIds);
                     shardCount++;
                 }
             }
-            shardsInfo = $"*{shardCount}\r\n" + shardsInfo;
-            return shardsInfo;
+            sb.Insert(shardsStart, $"*{shardCount}\r\n");
+            return sb.ToString();
 
-            string CreateFormattedShardInfo(int primaryWorkerId, List<(ushort, ushort)> shardRanges, List<int> replicaWorkerIds)
+            void AppendFormattedShardInfo(StringBuilder sb, int primaryWorkerId, List<(ushort, ushort)> shardRanges, List<int> replicaWorkerIds)
             {
-                var shardInfo = $"*4\r\n";
-                shardInfo += $"$5\r\nslots\r\n";
-                shardInfo += $"*{shardRanges.Count * 2}\r\n";
+                sb.Append("*4\r\n");
+                sb.Append("$5\r\nslots\r\n");
+                sb.Append('*').Append(shardRanges.Count * 2).Append("\r\n");
                 for (var i = 0; i < shardRanges.Count; i++)
                 {
                     var range = shardRanges[i];
-                    shardInfo += $":{range.Item1}\r\n";
-                    shardInfo += $":{range.Item2}\r\n";
+                    sb.Append(':').Append(range.Item1).Append("\r\n");
+                    sb.Append(':').Append(range.Item2).Append("\r\n");
                 }
 
-                shardInfo += $"$5\r\nnodes\r\n";
-                shardInfo += $"*{1 + replicaWorkerIds.Count}\r\n";
+                sb.Append("$5\r\nnodes\r\n");
+                sb.Append('*').Append(1 + replicaWorkerIds.Count).Append("\r\n");
                 if (primaryWorkerId == 1)
-                    shardInfo += CreateFormattedNodeInfo(primaryWorkerId, true);
+                    AppendFormattedNodeInfo(sb, primaryWorkerId, true);
                 else
                 {
                     _ = clusterConnection.GetConnectionInfo(workers[primaryWorkerId].Nodeid, out var info);
-                    shardInfo += CreateFormattedNodeInfo(primaryWorkerId, info.connected);
+                    AppendFormattedNodeInfo(sb, primaryWorkerId, info.connected);
                 }
                 foreach (var id in replicaWorkerIds)
                 {
                     _ = clusterConnection.GetConnectionInfo(workers[id].Nodeid, out var info);
-                    shardInfo += CreateFormattedNodeInfo(id, info.connected);
+                    AppendFormattedNodeInfo(sb, id, info.connected);
                 }
+            }
 
-                return shardInfo;
+            void AppendFormattedNodeInfo(StringBuilder sb, int workerId, bool connected)
+            {
+                var ip = workers[workerId].Address;
+                var hostname = workers[workerId].hostname;
+                var hasHostname = !string.IsNullOrEmpty(hostname);
+                var role = workers[workerId].Role == NodeRole.PRIMARY ? "master" : "slave";
 
-                string CreateFormattedNodeInfo(int workerId, bool connected)
+                var endpoint = preferredEndpointType switch
                 {
-                    var ip = workers[workerId].Address;
-                    var hostname = workers[workerId].hostname;
-                    var hasHostname = !string.IsNullOrEmpty(hostname);
-                    var role = workers[workerId].Role == NodeRole.PRIMARY ? "master" : "slave";
+                    ClusterPreferredEndpointType.Hostname => hasHostname ? hostname : "?",
+                    _ => ip,
+                };
 
-                    var endpoint = preferredEndpointType switch
-                    {
-                        ClusterPreferredEndpointType.Hostname => hasHostname ? hostname : "?",
-                        _ => ip,
-                    };
+                // Base fields: id(2) + port(2) + ip(2) + endpoint(2) + role(2) + replication-offset(2) + health(2) = 14
+                // Optional: hostname(2) = +2
+                var fieldCount = hasHostname ? 16 : 14;
 
-                    // Base fields: id(2) + port(2) + ip(2) + endpoint(2) + role(2) + replication-offset(2) + health(2) = 14
-                    // Optional: hostname(2) = +2
-                    var fieldCount = hasHostname ? 16 : 14;
-
-                    var nodeInfo = $"*{fieldCount}\r\n";
-                    nodeInfo += "$2\r\nid\r\n";
-                    nodeInfo += $"$40\r\n{workers[workerId].Nodeid}\r\n";
-                    nodeInfo += "$4\r\nport\r\n";
-                    nodeInfo += $":{workers[workerId].Port}\r\n";
-                    nodeInfo += "$2\r\nip\r\n";
-                    nodeInfo += $"${ip.Length}\r\n{ip}\r\n";
-                    nodeInfo += "$8\r\nendpoint\r\n";
-                    nodeInfo += $"${endpoint.Length}\r\n{endpoint}\r\n";
-                    if (hasHostname)
-                    {
-                        nodeInfo += "$8\r\nhostname\r\n";
-                        nodeInfo += $"${hostname.Length}\r\n{hostname}\r\n";
-                    }
-                    nodeInfo += "$4\r\nrole\r\n";
-                    nodeInfo += $"${role.Length}\r\n{role}\r\n";
-                    nodeInfo += "$18\r\nreplication-offset\r\n";
-                    nodeInfo += $":{workers[workerId].ReplicationOffset}\r\n";
-                    nodeInfo += "$6\r\nhealth\r\n";
-                    nodeInfo += connected ? "$6\r\nonline\r\n" : "$7\r\noffline\r\n";
-                    return nodeInfo;
+                sb.Append('*').Append(fieldCount).Append("\r\n");
+                sb.Append("$2\r\nid\r\n");
+                sb.Append("$40\r\n").Append(workers[workerId].Nodeid).Append("\r\n");
+                sb.Append("$4\r\nport\r\n");
+                sb.Append(':').Append(workers[workerId].Port).Append("\r\n");
+                sb.Append("$2\r\nip\r\n");
+                sb.Append('$').Append(ip.Length).Append("\r\n").Append(ip).Append("\r\n");
+                sb.Append("$8\r\nendpoint\r\n");
+                sb.Append('$').Append(endpoint.Length).Append("\r\n").Append(endpoint).Append("\r\n");
+                if (hasHostname)
+                {
+                    sb.Append("$8\r\nhostname\r\n");
+                    sb.Append('$').Append(hostname.Length).Append("\r\n").Append(hostname).Append("\r\n");
                 }
+                sb.Append("$4\r\nrole\r\n");
+                sb.Append('$').Append(role.Length).Append("\r\n").Append(role).Append("\r\n");
+                sb.Append("$18\r\nreplication-offset\r\n");
+                sb.Append(':').Append(workers[workerId].ReplicationOffset).Append("\r\n");
+                sb.Append("$6\r\nhealth\r\n");
+                sb.Append(connected ? "$6\r\nonline\r\n" : "$7\r\noffline\r\n");
             }
         }
 
-        private string CreateFormattedSlotInfo(
+        private void AppendFormattedSlotInfo(
+            StringBuilder sb,
             int slotStart,
             int slotEnd,
             string ipAddress,
@@ -761,24 +760,23 @@ namespace Garnet.cluster
             ClusterPreferredEndpointType preferredEndpointType)
         {
             int countA = replicaIds.Count == 0 ? 3 : 3 + replicaIds.Count;
-            var rangeInfo = $"*{countA}\r\n";
+            sb.Append('*').Append(countA).Append("\r\n");
 
-            rangeInfo += $":{slotStart}\r\n";
-            rangeInfo += $":{slotEnd}\r\n";
+            sb.Append(':').Append(slotStart).Append("\r\n");
+            sb.Append(':').Append(slotEnd).Append("\r\n");
 
-            rangeInfo += CreateNodeNetworkingInfo(ipAddress, port, nodeid, hostname, preferredEndpointType);
+            AppendNodeNetworkingInfo(sb, ipAddress, port, nodeid, hostname, preferredEndpointType);
 
             foreach (var replicaId in replicaIds)
             {
                 var (replicaIp, replicaPort) = GetWorkerAddressFromNodeId(replicaId);
                 var replicaHostname = GetHostNameFromNodeId(replicaId);
-                rangeInfo += CreateNodeNetworkingInfo(replicaIp, replicaPort, replicaId, replicaHostname, preferredEndpointType);
+                AppendNodeNetworkingInfo(sb, replicaIp, replicaPort, replicaId, replicaHostname, preferredEndpointType);
             }
-
-            return rangeInfo;
         }
 
-        private string CreateNodeNetworkingInfo(
+        private void AppendNodeNetworkingInfo(
+            StringBuilder sb,
             string ipAddress,
             int port,
             string nodeid,
@@ -795,58 +793,59 @@ namespace Garnet.cluster
             //  "ip" is included if preferred endpoint type != Ip
             //  "hostname" is included if preferred endpoint type != Hostname AND hostname is not null or empty
 
-            var sb = new StringBuilder();
             sb.Append("*4\r\n");
             var isNullOrEmptyHostname = string.IsNullOrEmpty(hostname);
 
             switch (preferredEndpointType)
             {
                 case ClusterPreferredEndpointType.Ip:
-                    sb.Append(FormatValueOrNull(ipAddress))
-                        .Append(':').Append(port).Append("\r\n")
+                    AppendValueOrNull(sb, ipAddress);
+                    sb.Append(':').Append(port).Append("\r\n")
                         .Append('$').Append(nodeid.Length).Append("\r\n").Append(nodeid).Append("\r\n")
                         .Append('*').Append(isNullOrEmptyHostname ? 0 : 2).Append("\r\n");
 
                     if (!isNullOrEmptyHostname)
                     {
-                        sb.Append("$8\r\nhostname\r\n")
-                            .Append(FormatValueOrNull(hostname));
+                        sb.Append("$8\r\nhostname\r\n");
+                        AppendValueOrNull(sb, hostname);
                     }
 
-                    return sb.ToString();
+                    break;
                 case ClusterPreferredEndpointType.Hostname:
                     var hostnameForResp = isNullOrEmptyHostname ? "?" : hostname;
 
-                    sb.Append(FormatValueOrNull(hostnameForResp))
-                        .Append(':').Append(port).Append("\r\n")
+                    AppendValueOrNull(sb, hostnameForResp);
+                    sb.Append(':').Append(port).Append("\r\n")
                         .Append('$').Append(nodeid.Length).Append("\r\n").Append(nodeid).Append("\r\n")
                         .Append('*').Append(2).Append("\r\n")
-                        .Append("$2\r\nip\r\n")
-                        .Append(FormatValueOrNull(ipAddress));
+                        .Append("$2\r\nip\r\n");
+                    AppendValueOrNull(sb, ipAddress);
 
-                    return sb.ToString();
+                    break;
                 case ClusterPreferredEndpointType.Unknown:
                 default:
-                    sb.Append(FormatValueOrNull(null))
-                        .Append(':').Append(port).Append("\r\n")
+                    AppendValueOrNull(sb, null);
+                    sb.Append(':').Append(port).Append("\r\n")
                         .Append('$').Append(nodeid.Length).Append("\r\n").Append(nodeid).Append("\r\n")
                         .Append('*').Append(isNullOrEmptyHostname ? 2 : 4).Append("\r\n")
-                        .Append("$2\r\nip\r\n")
-                        .Append(FormatValueOrNull(ipAddress));
+                        .Append("$2\r\nip\r\n");
+                    AppendValueOrNull(sb, ipAddress);
 
                     if (!isNullOrEmptyHostname)
                     {
                         sb.Append("$8\r\nhostname\r\n");
-                        sb.Append(FormatValueOrNull(hostname));
+                        AppendValueOrNull(sb, hostname);
                     }
 
-                    return sb.ToString();
+                    break;
             }
 
-            static string FormatValueOrNull(string value)
+            static void AppendValueOrNull(StringBuilder sb, string value)
             {
-                if (string.IsNullOrEmpty(value)) return CmdStrings.GenericNullValue; // "$-1\r\n"
-                return $"${value.Length}\r\n{value}\r\n";
+                if (string.IsNullOrEmpty(value))
+                    sb.Append(CmdStrings.GenericNullValue); // "$-1\r\n"
+                else
+                    sb.Append('$').Append(value.Length).Append("\r\n").Append(value).Append("\r\n");
             }
         }
 
@@ -863,10 +862,11 @@ namespace Garnet.cluster
         /// <returns>Formatted string.</returns>
         public string GetSlotsInfo(ClusterPreferredEndpointType preferredEndpointType)
         {
-            string completeSlotInfo = "";
+            var sb = new StringBuilder();
             int slotRanges = 0;
             int slotStart;
             int slotEnd;
+            var slotsStart = sb.Length;
 
             for (slotStart = 0; slotStart < slotMap.Length; slotStart++)
             {
@@ -886,14 +886,13 @@ namespace Garnet.cluster
                 var hostname = workers[currSlotWorkerId].hostname;
                 var replicas = GetReplicaIds(nodeid);
                 slotEnd--;
-                completeSlotInfo += CreateFormattedSlotInfo(slotStart, slotEnd, address, port, nodeid, hostname, replicas, preferredEndpointType);
+                AppendFormattedSlotInfo(sb, slotStart, slotEnd, address, port, nodeid, hostname, replicas, preferredEndpointType);
                 slotRanges++;
                 slotStart = slotEnd;
             }
-            completeSlotInfo = $"*{slotRanges}\r\n" + completeSlotInfo;
-            //Console.WriteLine(completeSlotInfo);
+            sb.Insert(slotsStart, $"*{slotRanges}\r\n");
 
-            return completeSlotInfo;
+            return sb.ToString();
         }
 
         /// <summary>

--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -544,7 +544,12 @@ namespace Garnet.cluster
             _ = nodeInfoStringBuilder
                 .Append(workers[workerId].Nodeid).Append(' ')
                 .Append(workers[workerId].Address).Append(':').Append(workers[workerId].Port)
-                .Append('@').Append(workers[workerId].Port + 10000).Append(',').Append(workers[workerId].hostname).Append(' ')
+                .Append('@').Append(workers[workerId].Port + 10000);
+
+            if (!string.IsNullOrEmpty(workers[workerId].hostname))
+                nodeInfoStringBuilder.Append(',').Append(workers[workerId].hostname);
+
+            _ = nodeInfoStringBuilder.Append(' ')
                 .Append(workerId == 1 ? "myself," : "")
                 .Append(workers[workerId].Role == NodeRole.PRIMARY ? "master" : "slave").Append(' ')
                 .Append(workers[workerId].Role == NodeRole.REPLICA ? workers[workerId].ReplicaOfNodeId : '-').Append(' ')
@@ -657,7 +662,7 @@ namespace Garnet.cluster
         /// </summary>
         /// <param name="clusterConnection"></param>
         /// <returns>RESP formatted string</returns>
-        public string GetShardsInfo(GarnetClusterConnectionStore clusterConnection)
+        public string GetShardsInfo(GarnetClusterConnectionStore clusterConnection, ClusterPreferredEndpointType preferredEndpointType)
         {
             var shardsInfo = "";
             var shardCount = 0;
@@ -705,15 +710,37 @@ namespace Garnet.cluster
 
                 string CreateFormattedNodeInfo(int workerId, bool connected)
                 {
-                    var nodeInfo = "*12\r\n";
+                    var ip = workers[workerId].Address;
+                    var hostname = workers[workerId].hostname;
+                    var hasHostname = !string.IsNullOrEmpty(hostname);
+                    var role = workers[workerId].Role == NodeRole.PRIMARY ? "master" : "slave";
+
+                    var endpoint = preferredEndpointType switch
+                    {
+                        ClusterPreferredEndpointType.Hostname => hasHostname ? hostname : "?",
+                        _ => ip,
+                    };
+
+                    // Base fields: id(2) + port(2) + ip(2) + endpoint(2) + role(2) + replication-offset(2) + health(2) = 14
+                    // Optional: hostname(2) = +2
+                    var fieldCount = hasHostname ? 16 : 14;
+
+                    var nodeInfo = $"*{fieldCount}\r\n";
                     nodeInfo += "$2\r\nid\r\n";
                     nodeInfo += $"$40\r\n{workers[workerId].Nodeid}\r\n";
                     nodeInfo += "$4\r\nport\r\n";
                     nodeInfo += $":{workers[workerId].Port}\r\n";
-                    nodeInfo += "$7\r\naddress\r\n";
-                    nodeInfo += $"${workers[workerId].Address.Length}\r\n{workers[workerId].Address}\r\n";
+                    nodeInfo += "$2\r\nip\r\n";
+                    nodeInfo += $"${ip.Length}\r\n{ip}\r\n";
+                    nodeInfo += "$8\r\nendpoint\r\n";
+                    nodeInfo += $"${endpoint.Length}\r\n{endpoint}\r\n";
+                    if (hasHostname)
+                    {
+                        nodeInfo += "$8\r\nhostname\r\n";
+                        nodeInfo += $"${hostname.Length}\r\n{hostname}\r\n";
+                    }
                     nodeInfo += "$4\r\nrole\r\n";
-                    nodeInfo += $"${workers[workerId].Role.ToString().Length}\r\n{workers[workerId].Role}\r\n";
+                    nodeInfo += $"${role.Length}\r\n{role}\r\n";
                     nodeInfo += "$18\r\nreplication-offset\r\n";
                     nodeInfo += $":{workers[workerId].ReplicationOffset}\r\n";
                     nodeInfo += "$6\r\nhealth\r\n";

--- a/libs/cluster/Session/RespClusterBasicCommands.cs
+++ b/libs/cluster/Session/RespClusterBasicCommands.cs
@@ -341,7 +341,8 @@ namespace Garnet.cluster
                 return true;
             }
 
-            var shardsInfo = clusterProvider.clusterManager.CurrentConfig.GetShardsInfo(clusterProvider.clusterManager.clusterConnectionStore);
+            var preferredType = clusterProvider.serverOptions.ClusterPreferredEndpointType;
+            var shardsInfo = clusterProvider.clusterManager.CurrentConfig.GetShardsInfo(clusterProvider.clusterManager.clusterConnectionStore, preferredType);
             while (!RespWriteUtils.TryWriteAsciiDirect(shardsInfo, ref dcurr, dend))
                 SendAndReset();
 

--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -760,7 +760,12 @@ namespace Garnet
             {
                 ClusterAnnouncePort = ClusterAnnouncePort == 0 ? Port : ClusterAnnouncePort;
                 clusterAnnounceEndpoint = Format.TryCreateEndpoint(ClusterAnnounceIp, ClusterAnnouncePort, tryConnect: false, logger: logger).GetAwaiter().GetResult();
-                if (clusterAnnounceEndpoint == null || !endpoints.Any(endpoint => endpoint.Equals(clusterAnnounceEndpoint[0])))
+                if (clusterAnnounceEndpoint == null || !endpoints.Any(endpoint =>
+                    endpoint is IPEndPoint listenEp && clusterAnnounceEndpoint[0] is IPEndPoint announceEp &&
+                    listenEp.Port == announceEp.Port &&
+                    (listenEp.Address.Equals(announceEp.Address) ||
+                     listenEp.Address.Equals(IPAddress.Any) ||
+                     listenEp.Address.Equals(IPAddress.IPv6Any))))
                     throw new GarnetException("Cluster announce endpoint does not match list of listen endpoints provided!");
             }
 

--- a/test/Garnet.test.cluster/ClusterManagementTests.cs
+++ b/test/Garnet.test.cluster/ClusterManagementTests.cs
@@ -156,6 +156,8 @@ namespace Garnet.test.cluster
         [TestCase(ClusterPreferredEndpointType.Ip, false)]
         [TestCase(ClusterPreferredEndpointType.Ip, true)]
         [TestCase(ClusterPreferredEndpointType.Hostname, true)]
+        [TestCase(ClusterPreferredEndpointType.Unknown, false)]
+        [TestCase(ClusterPreferredEndpointType.Unknown, true)]
         public void ClusterShardsTest(
             ClusterPreferredEndpointType preferredType,
             bool useClusterAnnounceHostname)
@@ -179,10 +181,18 @@ namespace Garnet.test.cluster
                     ClassicAssert.AreEqual(expectedAddress, node.ip);
 
                     // endpoint depends on preferred type
-                    if (preferredType == ClusterPreferredEndpointType.Hostname)
-                        ClassicAssert.AreEqual(useClusterAnnounceHostname ? expectedHostname : node.hostname, node.endpoint);
-                    else
-                        ClassicAssert.AreEqual(expectedAddress, node.endpoint);
+                    switch (preferredType)
+                    {
+                        case ClusterPreferredEndpointType.Hostname:
+                            ClassicAssert.AreEqual(useClusterAnnounceHostname ? expectedHostname : node.hostname, node.endpoint);
+                            break;
+                        case ClusterPreferredEndpointType.Unknown:
+                            ClassicAssert.AreEqual("?", node.endpoint);
+                            break;
+                        default:
+                            ClassicAssert.AreEqual(expectedAddress, node.endpoint);
+                            break;
+                    }
 
                     if (useClusterAnnounceHostname)
                         ClassicAssert.AreEqual(expectedHostname, node.hostname);
@@ -224,11 +234,20 @@ namespace Garnet.test.cluster
                 }
                 else
                 {
-                    // Should still contain comma + system hostname (Garnet default behavior)
+                    // Garnet defaults to system hostname; verify format is valid
                     var commaIdx = afterAt.IndexOf(',');
-                    ClassicAssert.IsTrue(commaIdx > 0, $"Expected system hostname in address part: {addressPart}");
-                    var hostname = afterAt[(commaIdx + 1)..];
-                    ClassicAssert.IsNotEmpty(hostname);
+                    if (commaIdx > 0)
+                    {
+                        // System hostname is present: comma + hostname
+                        var hostname = afterAt[(commaIdx + 1)..];
+                        ClassicAssert.IsNotEmpty(hostname);
+                    }
+                    else
+                    {
+                        // No hostname: address is exactly ip:port@cport with no trailing comma
+                        ClassicAssert.IsTrue(afterAt.All(char.IsDigit),
+                            $"Expected numeric cport with no hostname in address part, but got: {addressPart}");
+                    }
                 }
             }
         }

--- a/test/Garnet.test.cluster/ClusterManagementTests.cs
+++ b/test/Garnet.test.cluster/ClusterManagementTests.cs
@@ -153,6 +153,87 @@ namespace Garnet.test.cluster
         }
 
         [Test, Order(3)]
+        [TestCase(ClusterPreferredEndpointType.Ip, false)]
+        [TestCase(ClusterPreferredEndpointType.Ip, true)]
+        [TestCase(ClusterPreferredEndpointType.Hostname, true)]
+        public void ClusterShardsTest(
+            ClusterPreferredEndpointType preferredType,
+            bool useClusterAnnounceHostname)
+        {
+            context.CreateInstances(defaultShards, clusterPreferredEndpointType: preferredType, useClusterAnnounceHostname: useClusterAnnounceHostname);
+            context.CreateConnection();
+            _ = context.clusterTestUtils.SimpleSetupCluster(logger: context.logger);
+
+            var shards = context.clusterTestUtils.ClusterShards(0, context.logger);
+            ClassicAssert.IsNotNull(shards);
+            ClassicAssert.AreEqual(defaultShards, shards.Count);
+
+            var expectedAddress = context.clusterTestUtils.GetEndPoint(0).Address.ToString();
+            var expectedHostname = useClusterAnnounceHostname ? context.nodeOptions[0].ClusterAnnounceHostname : null;
+
+            foreach (var shard in shards)
+            {
+                foreach (var node in shard.nodes)
+                {
+                    // ip is always the address
+                    ClassicAssert.AreEqual(expectedAddress, node.ip);
+
+                    // endpoint depends on preferred type
+                    if (preferredType == ClusterPreferredEndpointType.Hostname)
+                        ClassicAssert.AreEqual(useClusterAnnounceHostname ? expectedHostname : node.hostname, node.endpoint);
+                    else
+                        ClassicAssert.AreEqual(expectedAddress, node.endpoint);
+
+                    if (useClusterAnnounceHostname)
+                        ClassicAssert.AreEqual(expectedHostname, node.hostname);
+                    else
+                        ClassicAssert.IsNotNull(node.hostname);
+                }
+            }
+        }
+
+        [Test, Order(4)]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void ClusterNodesHostnameTest(bool useClusterAnnounceHostname)
+        {
+            context.CreateInstances(defaultShards, useClusterAnnounceHostname: useClusterAnnounceHostname);
+            context.CreateConnection();
+            _ = context.clusterTestUtils.SimpleSetupCluster(logger: context.logger);
+
+            var result = (string)context.clusterTestUtils.Execute(
+                context.clusterTestUtils.GetEndPoint(0), "cluster", ["nodes"]);
+
+            var lines = result.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            foreach (var line in lines)
+            {
+                var parts = line.Split(' ');
+                var addressPart = parts[1];
+
+                // Address format: ip:port@cport[,hostname]
+                var atIdx = addressPart.IndexOf('@');
+                var afterAt = addressPart[(atIdx + 1)..];
+
+                if (useClusterAnnounceHostname)
+                {
+                    // Should contain comma + configured hostname
+                    var commaIdx = afterAt.IndexOf(',');
+                    ClassicAssert.IsTrue(commaIdx > 0, $"Expected hostname in address part: {addressPart}");
+                    var hostname = afterAt[(commaIdx + 1)..];
+                    ClassicAssert.AreEqual(context.nodeOptions[0].ClusterAnnounceHostname, hostname);
+                }
+                else
+                {
+                    // Should still contain comma + system hostname (Garnet default behavior)
+                    var commaIdx = afterAt.IndexOf(',');
+                    ClassicAssert.IsTrue(commaIdx > 0, $"Expected system hostname in address part: {addressPart}");
+                    var hostname = afterAt[(commaIdx + 1)..];
+                    ClassicAssert.IsNotEmpty(hostname);
+                }
+            }
+        }
+
+        [Test, Order(5)]
         public void ClusterForgetTest()
         {
             var node_count = 4;

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -76,7 +76,9 @@ namespace Garnet.test.cluster
     {
         public int nodeIndex;
         public string nodeid;
-        public string address;
+        public string ip;
+        public string endpoint;
+        public string hostname;
         public int port;
         public NodeRole role;
         public long replicationOffset;
@@ -399,7 +401,8 @@ namespace Garnet.test.cluster
                                 {
                                     nodeIndex = i,
                                     nodeid = GetNodeIdFromNode(i, logger),
-                                    address = endpoint.Address.ToString(),
+                                    ip = endpoint.Address.ToString(),
+                                    endpoint = endpoint.Address.ToString(),
                                     port = endpoint.Port,
                                     role = NodeRole.PRIMARY,
                                     replicationOffset = 0
@@ -463,7 +466,8 @@ namespace Garnet.test.cluster
                         {
                             nodeIndex = i,
                             nodeid = GetNodeIdFromNode(i, logger),
-                            address = GetAddressFromNodeIndex(i),
+                            ip = GetAddressFromNodeIndex(i),
+                            endpoint = GetAddressFromNodeIndex(i),
                             port = GetPortFromNodeIndex(i),
                             role = NodeRole.REPLICA,
                             replicationOffset = 0
@@ -2249,16 +2253,38 @@ namespace Garnet.test.cluster
                     shardInfo.nodes = [];
                     foreach (var node in nodes.Select(v => (RedisResult[])v))
                     {
-                        ClassicAssert.AreEqual(12, node.Length);
-                        NodeInfo nodeInfo = new()
+                        // Parse key-value pairs dynamically
+                        var nodeInfo = new NodeInfo();
+                        for (var j = 0; j < node.Length; j += 2)
                         {
-                            nodeIndex = GetNodeIndexFromPort((int)node[3]),
-                            nodeid = (string)node[1],
-                            port = (int)node[3],
-                            address = (string)node[5],
-                            role = Enum.Parse<NodeRole>((string)node[7]),
-                            replicationOffset = (long)node[9]
-                        };
+                            var key = (string)node[j];
+                            switch (key)
+                            {
+                                case "id":
+                                    nodeInfo.nodeid = (string)node[j + 1];
+                                    break;
+                                case "port":
+                                    nodeInfo.port = (int)node[j + 1];
+                                    nodeInfo.nodeIndex = GetNodeIndexFromPort(nodeInfo.port);
+                                    break;
+                                case "ip":
+                                    nodeInfo.ip = (string)node[j + 1];
+                                    break;
+                                case "endpoint":
+                                    nodeInfo.endpoint = (string)node[j + 1];
+                                    break;
+                                case "hostname":
+                                    nodeInfo.hostname = (string)node[j + 1];
+                                    break;
+                                case "role":
+                                    var roleStr = (string)node[j + 1];
+                                    nodeInfo.role = roleStr == "master" ? NodeRole.PRIMARY : NodeRole.REPLICA;
+                                    break;
+                                case "replication-offset":
+                                    nodeInfo.replicationOffset = (long)node[j + 1];
+                                    break;
+                            }
+                        }
                         shardInfo.nodes.Add(nodeInfo);
                     }
 

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -2253,6 +2253,8 @@ namespace Garnet.test.cluster
                     shardInfo.nodes = [];
                     foreach (var node in nodes.Select(v => (RedisResult[])v))
                     {
+                        ClassicAssert.IsTrue(node.Length % 2 == 0, "CLUSTER SHARDS node info must have even number of elements (key-value pairs)");
+
                         // Parse key-value pairs dynamically
                         var nodeInfo = new NodeInfo();
                         for (var j = 0; j < node.Length; j += 2)
@@ -2278,6 +2280,7 @@ namespace Garnet.test.cluster
                                     break;
                                 case "role":
                                     var roleStr = (string)node[j + 1];
+                                    ClassicAssert.IsTrue(roleStr is "master" or "slave", $"Unexpected role value: {roleStr}");
                                     nodeInfo.role = roleStr == "master" ? NodeRole.PRIMARY : NodeRole.REPLICA;
                                     break;
                                 case "replication-offset":


### PR DESCRIPTION
## Summary

Fixes #1650

This PR fixes the metadata output for `CLUSTER NODES`, `CLUSTER SLOTS`, and `CLUSTER SHARDS` commands to align with Redis-compatible field names, ordering, and endpoint type handling.

### Important: `cluster-preferred-endpoint-type` behavior

The `--cluster-preferred-endpoint-type` option does **not** replace IP addresses with hostnames in fields that are defined as IP fields. The `ip` field in `CLUSTER SHARDS` and the `<ip:port@cport>` portion of `CLUSTER NODES` always contain the node's IP address regardless of this setting.

What `cluster-preferred-endpoint-type` **does** control:
- **`CLUSTER SLOTS`**: determines which value appears in the primary endpoint position vs. metadata
- **`CLUSTER SHARDS`**: determines the value of the `endpoint` field (IP, hostname, or `?`)
- **`-MOVED` / `-ASK` redirects**: determines the address used in redirect messages

## Changes

### CLUSTER NODES (`GetNodeInfo`)
- Only append `,hostname` in the address field when hostname is non-empty (was unconditionally appending empty value)
- No change to `<ip:port@cport>` format — this always uses the IP address per Redis specification

### CLUSTER SHARDS (`GetShardsInfo`)
- Replaced `address` field with Redis-compatible `ip`, `endpoint`, and optional `hostname` fields
- Added `ClusterPreferredEndpointType` support — `endpoint` = IP (default), hostname (when Hostname), or `?` (when Unknown)
- Role now outputs `master`/`slave` instead of enum names `PRIMARY`/`REPLICA`
- Dynamic field count (14 base + 2 when hostname present)
- Refactored to use `StringBuilder` to reduce allocations

### CLUSTER SLOTS
- Refactored to use `StringBuilder` to reduce allocations (no behavioral changes)

### Endpoint validation (`Options.cs`)
- Fixed `--cluster-announce-ip` validation to accept any IP when bind address is `0.0.0.0` or `::`, since the server listens on all interfaces

### Tests
- `ClusterShardsTest`: 5 test cases covering Ip/Hostname/Unknown endpoint types with and without announce hostname
- `ClusterNodesHostnameTest`: 2 test cases validating hostname formatting in `CLUSTER NODES` address field
- Improved `ClusterShards` parser with even-length guard and explicit role validation

## CLUSTER SHARDS field ordering

```
id, port, ip, endpoint, [hostname], role, replication-offset, health
```

- `ip`: always present — the node's IP address (never replaced by hostname)
- `endpoint`: always present — equals `ip` (Ip type), `hostname` (Hostname type), or `?` (Unknown type)
- `hostname`: only present when non-empty
