### PR TITLE
More Vector Set test hardening

### DIFF
--- a/libs/server/AOF/AofProcessor.cs
+++ b/libs/server/AOF/AofProcessor.cs
@@ -87,7 +87,7 @@ namespace Garnet.server
         {
             activeVectorManager?.WaitForVectorOperationsToComplete();
             activeVectorManager?.ShutdownReplayTasks();
-            
+
             var databaseSessionsSnapshot = respServerSession.GetDatabaseSessionsSnapshot();
             foreach (var dbSession in databaseSessionsSnapshot)
             {

--- a/libs/server/AOF/AofProcessor.cs
+++ b/libs/server/AOF/AofProcessor.cs
@@ -85,6 +85,9 @@ namespace Garnet.server
         /// </summary>
         public void Dispose()
         {
+            activeVectorManager?.WaitForVectorOperationsToComplete();
+            activeVectorManager?.ShutdownReplayTasks();
+            
             var databaseSessionsSnapshot = respServerSession.GetDatabaseSessionsSnapshot();
             foreach (var dbSession in databaseSessionsSnapshot)
             {

--- a/libs/server/Resp/Vector/VectorManager.Replication.cs
+++ b/libs/server/Resp/Vector/VectorManager.Replication.cs
@@ -501,6 +501,19 @@ namespace Garnet.server
         }
 
         /// <summary>
+        /// Shuts down replication tasks in a way where they _cannot_ be resumed in the future.
+        /// 
+        /// Intended for general Garnet shutdown.
+        /// </summary>
+        public void ShutdownReplayTasks()
+        {
+            _ = replicationReplayChannel.Writer.TryComplete();
+            Task.WaitAll(replicationReplayTasks);
+
+            _ = Interlocked.Exchange(ref replicationReplayStarted, -1);
+        }
+
+        /// <summary>
         /// Vector Set removes are phrased as reads (once the index is created), so they require special handling.
         /// 
         /// Operations that are faked up by <see cref="ReplicateVectorSetRemove"/> running on the Primary get diverted here on a Replica.

--- a/libs/server/Resp/Vector/VectorManager.cs
+++ b/libs/server/Resp/Vector/VectorManager.cs
@@ -281,7 +281,7 @@ namespace Garnet.server
         public void Dispose()
         {
             // We must drain all these before disposing, otherwise we'll leave replicationBlockEvent unset
-            replicationReplayChannel.Writer.Complete();
+            _ = replicationReplayChannel.Writer.TryComplete();
             replicationReplayChannel.Reader.Completion.Wait();
 
             Task.WhenAll(replicationReplayTasks).Wait();

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -612,6 +612,7 @@ namespace Garnet.test.cluster
         {
             if (cancellationToken.IsCancellationRequested)
                 Assert.Fail(msg ?? "Cancellation Requested");
+
             Thread.Sleep(timeSpan == default ? backoff : timeSpan);
         }
 

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -1984,7 +1984,7 @@ namespace Garnet.test.cluster
                 migrateCancel.Cancel();
                 var migrationTimes = await migrateTask.ConfigureAwait(false);
 
-                ClassicAssert.IsTrue(migrationTimes.Count > 2, "Should have moved back and forth at least twice");
+                ClassicAssert.IsTrue(migrationTimes.Count >= 2, $"Should have moved back and forth, saw: {migrationTimes.Count}");
 
                 writeCancel.Cancel();
                 await Task.WhenAll(writeTasks).ConfigureAwait(false);

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -1410,14 +1410,6 @@ namespace Garnet.test.cluster
                 context.clusterTestUtils.WaitForMigrationCleanup(Primary1Index, cancellationToken: migrateToken.Token);
             }
 
-            using (var replicationToken = new CancellationTokenSource())
-            {
-                replicationToken.CancelAfter(30_000);
-
-                context.clusterTestUtils.WaitForReplicaAofSync(Primary0Index, Secondary0Index, cancellation: replicationToken.Token);
-                context.clusterTestUtils.WaitForReplicaAofSync(Primary1Index, Secondary1Index, cancellation: replicationToken.Token);
-            }
-
             var curPrimary0Slots = context.clusterTestUtils.GetOwnedSlotsFromNode(primary0, NullLogger.Instance);
             var curPrimary1Slots = context.clusterTestUtils.GetOwnedSlotsFromNode(primary1, NullLogger.Instance);
 
@@ -1435,9 +1427,6 @@ namespace Garnet.test.cluster
             await writeTask.ConfigureAwait(false);
 
             var addedLookup = added.ToFrozenDictionary(static t => t.Elem, t => t, ByteArrayComparer.Instance);
-
-            context.clusterTestUtils.WaitForReplicaAofSync(Primary0Index, Secondary0Index);
-            context.clusterTestUtils.WaitForReplicaAofSync(Primary1Index, Secondary1Index);
 
             // Check available on other primary & secondary
 


### PR DESCRIPTION
Looking into some recent failures, and getting some (rare) local reproductions, these failures seem linked to `WaitForReplicaAofSync`.

My current theory is that the asynchronous replay of `VADD` and the background cleanup after `DEL|UNLINK` confuses this test function.  Not all tests trigger it, but `MigrateVectorSetWhileModifyingAsync` seem pretty prone, so removing these calls which don't appear* strictly necessary.

 - [x] Waiting on a CI run (result: 2 failures)

Some null refs still happen after this change... looking at possible use-after-Dispose cases, also in replication.

Found a fixed a bug in `AofProcessor.Dispose` not shutting down `VectorManager` replication tasks.

 - [x] Waiting for CI run (result: pass)
 - [x] Stressing locally (result: occasionally seeing `WaitForMigrationCleanup` timeout, but Vector Set's don't appear to be at fault)
 
 Doing a bit more digging into `WaitForMigrationCleanup` failures...

<sub>*These tests grew from existing cluster tests, so the "wait" calls were not added with any rigor.</sub>