### PR TITLE
Fix race in ScanIteratorBase.Dispose causing intermittent ObjectDisposedException

### DIFF
--- a/libs/storage/Tsavorite/cs/src/core/Allocator/ScanIteratorBase.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/ScanIteratorBase.cs
@@ -318,27 +318,25 @@ namespace Tsavorite.core
         {
             for (var i = 0; i < frameSize; i++)
             {
+                // Wait for ongoing reads to complete/fail; if the wait throws (e.g. due to cancellation), we still
+                // need to dispose the event, CTS, and read buffers below.
                 try
                 {
-                    // Wait for ongoing reads to complete/fail
-                    if (loadCompletionEvents != null)
-                    {
-                        if (loadedPages[i] != -1)
-                            loadCompletionEvents[i]?.Wait(loadCTSs[i].Token);
-                        loadCompletionEvents[i]?.Dispose();
-                        loadCompletionEvents = default;
-                    }
-                    if (loadCTSs is not null)
-                    {
-                        loadCTSs[i]?.Dispose();
-                        loadCTSs[i] = null;
-                    }
-                    // Do not null this; we didn't hold onto the hlogBase to recreate. CircularDiskReadBuffer.Dispose() clears
-                    // things and leaves it in an "initialized" state.
-                    objectReadBuffers?[i]?.Dispose();
+                    if (loadCompletionEvents != null && loadedPages[i] != -1)
+                        loadCompletionEvents[i]?.Wait(loadCTSs[i].Token);
                 }
                 catch { }
+
+                // Always dispose resources regardless of whether the wait succeeded.
+                loadCompletionEvents?[i]?.Dispose();
+                loadCTSs?[i]?.Dispose();
+                loadCTSs?[i] = null;
+
+                // Do not null this; we didn't hold onto the hlogBase to recreate. CircularDiskReadBuffer.Dispose() clears
+                // things and leaves it in an "initialized" state.
+                objectReadBuffers?[i]?.Dispose();
             }
+            loadCompletionEvents = default;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes an intermittent test host crash (ObjectDisposedException: Cannot access a disposed object. Object name: 'CircularDiskReadBuffer') observed in CI during InsDelIns_LocalMemory.

Root cause: In ScanIteratorBase.Dispose(), loadCompletionEvents = default was inside the per-frame loop, nulling the entire array after processing frame 0. With DoublePageBuffering (frameSize=2), frame 1's completion event was never waited on, so its CircularDiskReadBuffer was disposed while AsyncReadPageWithObjectsCallback was still using it on a thread pool thread.

Fix: Move loadCompletionEvents = default from inside the loop to after the loop, ensuring all frames are properly awaited before their read buffers are disposed.