### PR TITLE
[Storage] Fix use-after-free in ProcessResp*Output; use ScratchBufferAllocator for API-returned PinnedSpanByte

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -205,6 +205,23 @@ To add a new Garnet server setting:
 - `LightEpoch` instances track ownership — only dispose if owned
 - In parallel tests, share a `LightEpoch` instance across `GarnetClient` instances
 
+### Scratch Buffer Conventions
+
+`StorageSession` has two scratch buffer types — use the right one:
+
+- **`ScratchBufferBuilder` (SBB)** — Single contiguous buffer for temporary workspace. Reallocates in place (old buffer is freed). Use for building command inputs, Lua serialization, or any data that is consumed immediately and then rewound. **Do not** return `PinnedSpanByte` from SBB to callers — it may be invalidated by subsequent allocations. Always rewind after use. Debug builds enforce single-outstanding-slice discipline via asserts.
+  - Key APIs: `CreateArgSlice` (returns `PinnedSpanByte`, must rewind), `CreateArgSliceAsOffset` (returns `(Offset, Length)`, safe for multi-alloc), `ViewRemainingArgSlice`/`ViewFullArgSlice` (immediate-use views, do not store), `MoveOffset`, `Reset`, `RewindScratchBuffer`.
+
+- **`ScratchBufferAllocator` (SBA)** — Multi-buffer allocator that keeps old buffers rooted (pinned arrays via `GC.AllocateArray(_, true)`). Use for `PinnedSpanByte` values returned via `out` parameters or `IGarnetApi` that callers retain across multiple API calls. Reset between batches.
+  - Key APIs: `CreateArgSlice`, `ViewRemainingArgSlice`, `Reset`.
+
+**Rules:**
+1. Any `StorageSession` or `IGarnetApi` method returning `PinnedSpanByte` via `out` must use SBA, not SBB.
+2. When using SBB's `CreateArgSlice`, always `RewindScratchBuffer` after use — debug asserts enforce at most one outstanding slice.
+3. For multiple allocations without rewind, use `CreateArgSliceAsOffset` (returns offsets that survive reallocation).
+4. When copying from `IMemoryOwner<byte>` (e.g., `ObjectOutput.SpanByteAndMemory.Memory`), always `Dispose()` after copying — do not leak pooled buffers.
+5. `ViewFullArgSlice` and `ViewRemainingArgSlice` return immediate-use views — do not store or return them.
+
 ### Releasing a New Version
 
 To update the version and make a new release, increment the `VersionPrefix` in `Version.props` at the repo root and submit a PR with that change.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -209,10 +209,10 @@ To add a new Garnet server setting:
 
 `StorageSession` has two scratch buffer types — use the right one:
 
-- **`ScratchBufferBuilder` (SBB)** — Single contiguous buffer for temporary workspace. Reallocates in place (old buffer is freed). Use for building command inputs, Lua serialization, or any data that is consumed immediately and then rewound. **Do not** return `PinnedSpanByte` from SBB to callers — it may be invalidated by subsequent allocations. Always rewind after use. Debug builds enforce single-outstanding-slice discipline via asserts.
-  - Key APIs: `CreateArgSlice` (returns `PinnedSpanByte`, must rewind), `CreateArgSliceAsOffset` (returns `(Offset, Length)`, safe for multi-alloc), `ViewRemainingArgSlice`/`ViewFullArgSlice` (immediate-use views, do not store), `MoveOffset`, `Reset`, `RewindScratchBuffer`.
+- **`ScratchBufferBuilder` (SBB)** — Single contiguous buffer for temporary workspace. All data is laid out sequentially in one buffer. On expansion, the previous data is copied into a new larger buffer and the old buffer is freed — **any existing pointers into the old buffer become invalid**. Use for building command inputs, Lua serialization, or any data that is consumed immediately and then rewound. **Do not** return `PinnedSpanByte` from SBB to callers — it may be invalidated by subsequent allocations. Always rewind after use. Debug builds enforce single-outstanding-slice discipline via asserts.
+  - Key APIs: `CreateArgSlice` (returns `PinnedSpanByte`, must rewind), `CreateArgSliceAsOffset` (returns `(Offset, Length)`, safe for multi-alloc since offsets survive reallocation), `ViewRemainingArgSlice`/`ViewFullArgSlice` (immediate-use views, do not store), `MoveOffset`, `Reset`, `RewindScratchBuffer`.
 
-- **`ScratchBufferAllocator` (SBA)** — Multi-buffer allocator that keeps old buffers rooted (pinned arrays via `GC.AllocateArray(_, true)`). Use for `PinnedSpanByte` values returned via `out` parameters or `IGarnetApi` that callers retain across multiple API calls. Reset between batches.
+- **`ScratchBufferAllocator` (SBA)** — Maintains a collection of fragmented pinned buffers (via `GC.AllocateArray(_, true)`). When the current buffer fills, a new one is allocated and the old buffer is kept rooted in a stack — so previously returned `PinnedSpanByte` values remain valid. Use for `PinnedSpanByte` values returned via `out` parameters or `IGarnetApi` that callers retain across multiple API calls. Reset between batches.
   - Key APIs: `CreateArgSlice`, `ViewRemainingArgSlice`, `Reset`.
 
 **Rules:**

--- a/libs/server/API/GarnetApi.cs
+++ b/libs/server/API/GarnetApi.cs
@@ -368,6 +368,14 @@ namespace Garnet.server
         /// <inheritdoc />
         public bool ResetScratchBuffer(int offset)
             => storageSession.scratchBufferBuilder.ResetScratchBuffer(offset);
+
+        /// <inheritdoc />
+        public int GetScratchBufferAllocatorOffset()
+            => storageSession.scratchBufferAllocator.ScratchBufferOffset;
+
+        /// <inheritdoc />
+        public void ResetScratchBufferAllocator()
+            => storageSession.scratchBufferAllocator.Reset();
         #endregion
     }
 }

--- a/libs/server/API/GarnetApi.cs
+++ b/libs/server/API/GarnetApi.cs
@@ -362,19 +362,7 @@ namespace Garnet.server
          => storageSession.ObjectScan(key.ReadOnlySpan, ref input, ref output, ref objectContext);
 
         /// <inheritdoc />
-        public int GetScratchBufferOffset()
-            => storageSession.scratchBufferBuilder.ScratchBufferOffset;
-
-        /// <inheritdoc />
-        public bool ResetScratchBuffer(int offset)
-            => storageSession.scratchBufferBuilder.ResetScratchBuffer(offset);
-
-        /// <inheritdoc />
-        public int GetScratchBufferAllocatorOffset()
-            => storageSession.scratchBufferAllocator.ScratchBufferOffset;
-
-        /// <inheritdoc />
-        public void ResetScratchBufferAllocator()
+        public void ResetScratchBuffer()
             => storageSession.scratchBufferAllocator.Reset();
         #endregion
     }

--- a/libs/server/API/GarnetWatchApi.cs
+++ b/libs/server/API/GarnetWatchApi.cs
@@ -616,20 +616,8 @@ namespace Garnet.server
         }
 
         /// <inheritdoc />
-        public int GetScratchBufferOffset()
-            => garnetApi.GetScratchBufferOffset();
-
-        /// <inheritdoc />
-        public bool ResetScratchBuffer(int offset)
-            => garnetApi.ResetScratchBuffer(offset);
-
-        /// <inheritdoc />
-        public int GetScratchBufferAllocatorOffset()
-            => garnetApi.GetScratchBufferAllocatorOffset();
-
-        /// <inheritdoc />
-        public void ResetScratchBufferAllocator()
-            => garnetApi.ResetScratchBufferAllocator();
+        public void ResetScratchBuffer()
+            => garnetApi.ResetScratchBuffer();
 
         #endregion
     }

--- a/libs/server/API/GarnetWatchApi.cs
+++ b/libs/server/API/GarnetWatchApi.cs
@@ -623,6 +623,14 @@ namespace Garnet.server
         public bool ResetScratchBuffer(int offset)
             => garnetApi.ResetScratchBuffer(offset);
 
+        /// <inheritdoc />
+        public int GetScratchBufferAllocatorOffset()
+            => garnetApi.GetScratchBufferAllocatorOffset();
+
+        /// <inheritdoc />
+        public void ResetScratchBufferAllocator()
+            => garnetApi.ResetScratchBufferAllocator();
+
         #endregion
     }
 }

--- a/libs/server/API/IGarnetApi.cs
+++ b/libs/server/API/IGarnetApi.cs
@@ -1953,28 +1953,9 @@ namespace Garnet.server
         GarnetStatus ObjectScan(PinnedSpanByte key, ref ObjectInput input, ref ObjectOutput output);
 
         /// <summary>
-        /// Retrieve the current scratch buffer offset.
+        /// Resets the scratch buffer, releasing all allocated slices.
         /// </summary>
-        /// <returns>Current offset</returns>
-        int GetScratchBufferOffset();
-
-        /// <summary>
-        /// Resets the scratch buffer to the given offset.
-        /// </summary>
-        /// <param name="offset">Offset to reset to</param>
-        /// <returns>True if successful, else false</returns>
-        bool ResetScratchBuffer(int offset);
-
-        /// <summary>
-        /// Retrieve the current scratch buffer allocator offset.
-        /// </summary>
-        /// <returns>Current offset</returns>
-        int GetScratchBufferAllocatorOffset();
-
-        /// <summary>
-        /// Resets the scratch buffer allocator, releasing all allocated slices.
-        /// </summary>
-        void ResetScratchBufferAllocator();
+        void ResetScratchBuffer();
 
         #endregion
 

--- a/libs/server/API/IGarnetApi.cs
+++ b/libs/server/API/IGarnetApi.cs
@@ -1965,6 +1965,17 @@ namespace Garnet.server
         /// <returns>True if successful, else false</returns>
         bool ResetScratchBuffer(int offset);
 
+        /// <summary>
+        /// Retrieve the current scratch buffer allocator offset.
+        /// </summary>
+        /// <returns>Current offset</returns>
+        int GetScratchBufferAllocatorOffset();
+
+        /// <summary>
+        /// Resets the scratch buffer allocator, releasing all allocated slices.
+        /// </summary>
+        void ResetScratchBufferAllocator();
+
         #endregion
 
     }

--- a/libs/server/ArgSlice/ArgSliceVector.cs
+++ b/libs/server/ArgSlice/ArgSliceVector.cs
@@ -35,11 +35,8 @@ namespace Garnet.server
             if (Count + 1 >= maxCount)
                 return false;
 
-            var insertLoc = bufferManager.ScratchBufferOffset;
-
-            var sb = bufferManager.CreateArgSlice(item);
-
-            items.Add((insertLoc, sb.Length));
+            var entry = bufferManager.CreateArgSliceAsOffset(item);
+            items.Add(entry);
             return true;
         }
 

--- a/libs/server/ArgSlice/ScratchBufferAllocator.cs
+++ b/libs/server/ArgSlice/ScratchBufferAllocator.cs
@@ -100,7 +100,7 @@ namespace Garnet.server
         /// <summary>
         /// Creates an instance of <see cref="ScratchBufferAllocator"/>
         /// </summary>
-        /// <param name="minSizeBuffer">Min size that can be allocated for a single buffer (Default: 2)</param>
+        /// <param name="minSizeBuffer">Min size that can be allocated for a single buffer (Default: 64)</param>
         /// <param name="maxInitialCapacity">Max size of previously allocated unused buffer to keep upon reset (Default: no limit)</param>
         public ScratchBufferAllocator(int minSizeBuffer = 64, int maxInitialCapacity = int.MaxValue)
         {

--- a/libs/server/ArgSlice/ScratchBufferAllocator.cs
+++ b/libs/server/ArgSlice/ScratchBufferAllocator.cs
@@ -90,7 +90,7 @@ namespace Garnet.server
         /// <summary>
         /// Combined offset in all managed scratch buffers
         /// </summary>
-        internal int ScratchBufferOffset => prevScratchBuffersOffset + currScratchBuffer.scratchBufferOffset;
+        public int ScratchBufferOffset => prevScratchBuffersOffset + currScratchBuffer.scratchBufferOffset;
 
         /// <summary>
         /// Total length of all currently managed buffers

--- a/libs/server/ArgSlice/ScratchBufferAllocator.cs
+++ b/libs/server/ArgSlice/ScratchBufferAllocator.cs
@@ -255,7 +255,7 @@ namespace Garnet.server
         }
 
         /// <summary>
-        /// View remaining scratch space (of specified minimum length) as an ArgSlice.
+        /// View remaining scratch space (of specified minimum length) as a <see cref="PinnedSpanByte"/>.
         /// Does NOT move the offset forward.
         /// </summary>
         /// <param name="minLength">Minimum length of remaining space</param>

--- a/libs/server/ArgSlice/ScratchBufferAllocator.cs
+++ b/libs/server/ArgSlice/ScratchBufferAllocator.cs
@@ -90,7 +90,7 @@ namespace Garnet.server
         /// <summary>
         /// Combined offset in all managed scratch buffers
         /// </summary>
-        public int ScratchBufferOffset => prevScratchBuffersOffset + currScratchBuffer.scratchBufferOffset;
+        internal int ScratchBufferOffset => prevScratchBuffersOffset + currScratchBuffer.scratchBufferOffset;
 
         /// <summary>
         /// Total length of all currently managed buffers
@@ -252,6 +252,20 @@ namespace Garnet.server
             currScratchBuffer.scratchBufferOffset += length;
             Debug.Assert(currScratchBuffer.scratchBufferOffset <= currScratchBuffer.Length);
             return retVal;
+        }
+
+        /// <summary>
+        /// View remaining scratch space (of specified minimum length) as an ArgSlice.
+        /// Does NOT move the offset forward.
+        /// </summary>
+        /// <param name="minLength">Minimum length of remaining space</param>
+        /// <returns>A <see cref="PinnedSpanByte"/> covering the remaining space</returns>
+        public PinnedSpanByte ViewRemainingArgSlice(int minLength = 0)
+        {
+            ExpandScratchBufferIfNeeded(minLength);
+            return PinnedSpanByte.FromPinnedPointer(
+                currScratchBuffer.scratchBufferHead + currScratchBuffer.scratchBufferOffset,
+                currScratchBuffer.Length - currScratchBuffer.scratchBufferOffset);
         }
 
         void ExpandScratchBufferIfNeeded(int requiredLength)

--- a/libs/server/ArgSlice/ScratchBufferAllocator.cs
+++ b/libs/server/ArgSlice/ScratchBufferAllocator.cs
@@ -279,8 +279,8 @@ namespace Garnet.server
             var currLength = currScratchBuffer.IsDefault ? 0 : currScratchBuffer.Length;
 
             ScratchBuffer newScratchBuffer = default;
-            InitializeScratchBuffer(ref newScratchBuffer, requiredLength: Math.Max(minSizeBuffer, requiredLength),
-                currentLength: currLength);
+            InitializeScratchBuffer(ref newScratchBuffer, requiredLength,
+                currentLength: currLength, minSizeBuffer);
 
             totalLength += newScratchBuffer.Length;
 
@@ -302,7 +302,7 @@ namespace Garnet.server
             currScratchBuffer = newScratchBuffer;
         }
 
-        private static void InitializeScratchBuffer(ref ScratchBuffer buffer, int requiredLength, int currentLength = 0)
+        private static void InitializeScratchBuffer(ref ScratchBuffer buffer, int requiredLength, int currentLength, int minSizeBuffer)
         {
             // Length of new buffer is:
             // If there is no current buffer - the closest power of 2 to the data length
@@ -310,6 +310,9 @@ namespace Garnet.server
             var newLength = currentLength == 0
                 ? (int)BitOperations.RoundUpToPowerOf2((uint)requiredLength + 1)
                 : (int)BitOperations.RoundUpToPowerOf2((uint)Math.Max(currentLength, requiredLength) + 1);
+
+            // Ensure minimum buffer size
+            newLength = Math.Max(newLength, minSizeBuffer);
 
             buffer.Initialize(newLength);
         }

--- a/libs/server/ArgSlice/ScratchBufferAllocator.cs
+++ b/libs/server/ArgSlice/ScratchBufferAllocator.cs
@@ -102,7 +102,7 @@ namespace Garnet.server
         /// </summary>
         /// <param name="minSizeBuffer">Min size that can be allocated for a single buffer (Default: 2)</param>
         /// <param name="maxInitialCapacity">Max size of previously allocated unused buffer to keep upon reset (Default: no limit)</param>
-        public ScratchBufferAllocator(int minSizeBuffer = 2, int maxInitialCapacity = int.MaxValue)
+        public ScratchBufferAllocator(int minSizeBuffer = 64, int maxInitialCapacity = int.MaxValue)
         {
             this.minSizeBuffer = minSizeBuffer;
             this.maxInitialCapacity = maxInitialCapacity;

--- a/libs/server/ArgSlice/ScratchBufferBuilder.cs
+++ b/libs/server/ArgSlice/ScratchBufferBuilder.cs
@@ -184,64 +184,6 @@ namespace Garnet.server
         }
 
         /// <summary>
-        /// Create an ArgSlice that includes a header of specified size, followed by RESP Bulk-String formatted versions of the specified ArgSlice values (arg1 and arg2)
-        /// </summary>
-        public PinnedSpanByte FormatScratchAsResp(int headerSize, PinnedSpanByte arg1, PinnedSpanByte arg2)
-        {
-#if DEBUG
-            Debug.Assert(outstandingSlices == 0,
-                "ScratchBufferBuilder already has an outstanding slice. " +
-                "Rewind or reset before creating a new one, or use ScratchBufferAllocator.");
-#endif
-            int length = headerSize + GetRespFormattedStringLength(arg1) + GetRespFormattedStringLength(arg2);
-            ExpandScratchBufferIfNeeded(length);
-
-            var retVal = PinnedSpanByte.FromPinnedPointer(scratchBufferHead + scratchBufferOffset, length);
-            retVal.Span[..headerSize].Clear(); // Clear the header
-
-            byte* ptr = scratchBufferHead + scratchBufferOffset + headerSize;
-            var success = RespWriteUtils.TryWriteBulkString(arg1.Span, ref ptr, scratchBufferHead + scratchBuffer.Length);
-            Debug.Assert(success);
-            success = RespWriteUtils.TryWriteBulkString(arg2.Span, ref ptr, scratchBufferHead + scratchBuffer.Length);
-            Debug.Assert(success);
-
-            scratchBufferOffset += length;
-            Debug.Assert(scratchBufferOffset <= scratchBuffer.Length);
-#if DEBUG
-            outstandingSlices++;
-#endif
-            return retVal;
-        }
-
-        /// <summary>
-        /// Create an ArgSlice that includes a header of specified size, followed by RESP Bulk-String formatted versions of the specified ArgSlice value arg1
-        /// </summary>
-        public PinnedSpanByte FormatScratchAsResp(int headerSize, PinnedSpanByte arg1)
-        {
-#if DEBUG
-            Debug.Assert(outstandingSlices == 0,
-                "ScratchBufferBuilder already has an outstanding slice. " +
-                "Rewind or reset before creating a new one, or use ScratchBufferAllocator.");
-#endif
-            int length = headerSize + GetRespFormattedStringLength(arg1);
-            ExpandScratchBufferIfNeeded(length);
-
-            var retVal = PinnedSpanByte.FromPinnedPointer(scratchBufferHead + scratchBufferOffset, length);
-            retVal.Span[..headerSize].Clear(); // Clear the header
-
-            byte* ptr = scratchBufferHead + scratchBufferOffset + headerSize;
-            var success = RespWriteUtils.TryWriteBulkString(arg1.Span, ref ptr, scratchBufferHead + scratchBuffer.Length);
-            Debug.Assert(success);
-
-            scratchBufferOffset += length;
-            Debug.Assert(scratchBufferOffset <= scratchBuffer.Length);
-#if DEBUG
-            outstandingSlices++;
-#endif
-            return retVal;
-        }
-
-        /// <summary>
         /// Create an ArgSlice that includes a header of specified size, followed by the specified ArgSlice (arg)
         /// </summary>
         public PinnedSpanByte FormatScratch(int headerSize, PinnedSpanByte arg)
@@ -397,16 +339,6 @@ namespace Garnet.server
             scratchBufferOffset = (int)(ptr - scratchBufferHead);
         }
 
-        /// <summary>
-        /// Get length of a RESP Bulk-String formatted version of the specified ArgSlice
-        /// RESP format: $[size]\r\n[value]\r\n
-        /// Total size: 1 + [number of digits in the size value] + 2 + [size of value] + 2
-        /// </summary>
-        /// <param name="slice"></param>
-        /// <returns></returns>
-        static int GetRespFormattedStringLength(PinnedSpanByte slice)
-            => 1 + NumUtils.CountDigits(slice.Length) + 2 + slice.Length + 2;
-
         void ExpandScratchBufferIfNeeded(int newLength)
         {
             if (scratchBuffer == null || newLength > scratchBuffer.Length - scratchBufferOffset)
@@ -435,20 +367,6 @@ namespace Garnet.server
             }
             scratchBuffer = _scratchBuffer;
             scratchBufferHead = _scratchBufferHead;
-        }
-
-        /// <summary>
-        /// Returns a new <see cref="PinnedSpanByte"/>
-        /// with the <paramref name="length"/> bytes of the buffer;
-        /// these are the most recently added bytes.
-        /// </summary>
-        /// <param name="length">Length for the new slice</param>
-        /// <remarks>This is called by functions that add multiple items to the buffer,
-        /// after all items have been added and all reallocations have been done.
-        /// </remarks>
-        public PinnedSpanByte GetSliceFromTail(int length)
-        {
-            return PinnedSpanByte.FromPinnedPointer(scratchBufferHead + scratchBufferOffset - length, length);
         }
 
         /// <summary>

--- a/libs/server/ArgSlice/ScratchBufferBuilder.cs
+++ b/libs/server/ArgSlice/ScratchBufferBuilder.cs
@@ -43,6 +43,14 @@ namespace Garnet.server
         /// </summary>
         int scratchBufferOffset;
 
+#if DEBUG
+        /// <summary>
+        /// Number of outstanding PinnedSpanByte slices that have been created but not rewound.
+        /// Used to detect unsafe multi-alloc patterns where buffer expansion could invalidate earlier pointers.
+        /// </summary>
+        int outstandingSlices;
+#endif
+
         /// <summary>Current offset in scratch buffer</summary>
         internal int ScratchBufferOffset => scratchBufferOffset;
 
@@ -53,7 +61,13 @@ namespace Garnet.server
         /// <summary>
         /// Reset scratch buffer - loses all ArgSlice instances created on the scratch buffer
         /// </summary>
-        public void Reset() => scratchBufferOffset = 0;
+        public void Reset()
+        {
+            scratchBufferOffset = 0;
+#if DEBUG
+            outstandingSlices = 0;
+#endif
+        }
 
         /// <summary>
         /// Return the full buffer managed by this <see cref="ScratchBufferBuilder"/>.
@@ -70,6 +84,9 @@ namespace Garnet.server
             if (slice.ptr + slice.Length == scratchBufferHead + scratchBufferOffset)
             {
                 scratchBufferOffset -= slice.Length;
+#if DEBUG
+                outstandingSlices--;
+#endif
                 slice = default; // invalidate the given ArgSlice
                 return true;
             }
@@ -87,7 +104,26 @@ namespace Garnet.server
                 return false;
 
             scratchBufferOffset = offset;
+#if DEBUG
+            outstandingSlices = 0;
+#endif
             return true;
+        }
+
+        /// <summary>
+        /// Create an arg slice in scratch buffer, from given ReadOnlySpan, returning the
+        /// offset and length instead of a PinnedSpanByte. Safe for multiple calls without
+        /// rewind — use <see cref="ViewFullArgSlice"/> to resolve offsets later.
+        /// </summary>
+        public (int Offset, int Length) CreateArgSliceAsOffset(ReadOnlySpan<byte> bytes)
+        {
+            ExpandScratchBufferIfNeeded(bytes.Length);
+
+            var offset = scratchBufferOffset;
+            var dest = new Span<byte>(scratchBufferHead + scratchBufferOffset, bytes.Length);
+            bytes.CopyTo(dest);
+            scratchBufferOffset += bytes.Length;
+            return (offset, bytes.Length);
         }
 
         /// <summary>
@@ -95,11 +131,20 @@ namespace Garnet.server
         /// </summary>
         public PinnedSpanByte CreateArgSlice(ReadOnlySpan<byte> bytes)
         {
+#if DEBUG
+            Debug.Assert(outstandingSlices == 0,
+                "ScratchBufferBuilder already has an outstanding slice. " +
+                "Rewind or reset before creating a new one, or use CreateArgSliceAsOffset, " +
+                "or use ScratchBufferAllocator for slices that must coexist.");
+#endif
             ExpandScratchBufferIfNeeded(bytes.Length);
 
             var retVal = PinnedSpanByte.FromPinnedPointer(scratchBufferHead + scratchBufferOffset, bytes.Length);
             bytes.CopyTo(retVal.Span);
             scratchBufferOffset += bytes.Length;
+#if DEBUG
+            outstandingSlices++;
+#endif
             return retVal;
         }
 
@@ -117,12 +162,20 @@ namespace Garnet.server
         /// </summary>
         public PinnedSpanByte CreateArgSlice(string str)
         {
+#if DEBUG
+            Debug.Assert(outstandingSlices == 0,
+                "ScratchBufferBuilder already has an outstanding slice. " +
+                "Rewind or reset before creating a new one, or use ScratchBufferAllocator.");
+#endif
             int length = Encoding.UTF8.GetByteCount(str);
             ExpandScratchBufferIfNeeded(length);
 
             var retVal = PinnedSpanByte.FromPinnedPointer(scratchBufferHead + scratchBufferOffset, length);
             Encoding.UTF8.GetBytes(str, retVal.Span);
             scratchBufferOffset += length;
+#if DEBUG
+            outstandingSlices++;
+#endif
             return retVal;
         }
 
@@ -152,6 +205,11 @@ namespace Garnet.server
         /// </summary>
         public PinnedSpanByte FormatScratchAsResp(int headerSize, PinnedSpanByte arg1, PinnedSpanByte arg2)
         {
+#if DEBUG
+            Debug.Assert(outstandingSlices == 0,
+                "ScratchBufferBuilder already has an outstanding slice. " +
+                "Rewind or reset before creating a new one, or use ScratchBufferAllocator.");
+#endif
             int length = headerSize + GetRespFormattedStringLength(arg1) + GetRespFormattedStringLength(arg2);
             ExpandScratchBufferIfNeeded(length);
 
@@ -166,6 +224,9 @@ namespace Garnet.server
 
             scratchBufferOffset += length;
             Debug.Assert(scratchBufferOffset <= scratchBuffer.Length);
+#if DEBUG
+            outstandingSlices++;
+#endif
             return retVal;
         }
 
@@ -174,6 +235,11 @@ namespace Garnet.server
         /// </summary>
         public PinnedSpanByte FormatScratchAsResp(int headerSize, PinnedSpanByte arg1)
         {
+#if DEBUG
+            Debug.Assert(outstandingSlices == 0,
+                "ScratchBufferBuilder already has an outstanding slice. " +
+                "Rewind or reset before creating a new one, or use ScratchBufferAllocator.");
+#endif
             int length = headerSize + GetRespFormattedStringLength(arg1);
             ExpandScratchBufferIfNeeded(length);
 
@@ -186,6 +252,9 @@ namespace Garnet.server
 
             scratchBufferOffset += length;
             Debug.Assert(scratchBufferOffset <= scratchBuffer.Length);
+#if DEBUG
+            outstandingSlices++;
+#endif
             return retVal;
         }
 
@@ -194,6 +263,11 @@ namespace Garnet.server
         /// </summary>
         public PinnedSpanByte FormatScratch(int headerSize, PinnedSpanByte arg)
         {
+#if DEBUG
+            Debug.Assert(outstandingSlices == 0,
+                "ScratchBufferBuilder already has an outstanding slice. " +
+                "Rewind or reset before creating a new one, or use ScratchBufferAllocator.");
+#endif
             int length = headerSize + arg.Length;
             ExpandScratchBufferIfNeeded(length);
 
@@ -205,6 +279,9 @@ namespace Garnet.server
 
             scratchBufferOffset += length;
             Debug.Assert(scratchBufferOffset <= scratchBuffer.Length);
+#if DEBUG
+            outstandingSlices++;
+#endif
             return retVal;
         }
 
@@ -213,11 +290,19 @@ namespace Garnet.server
         /// </summary>
         public PinnedSpanByte CreateArgSlice(int length)
         {
+#if DEBUG
+            Debug.Assert(outstandingSlices == 0,
+                "ScratchBufferBuilder already has an outstanding slice. " +
+                "Rewind or reset before creating a new one, or use ScratchBufferAllocator.");
+#endif
             ExpandScratchBufferIfNeeded(length);
 
             var retVal = PinnedSpanByte.FromPinnedPointer(scratchBufferHead + scratchBufferOffset, length);
             scratchBufferOffset += length;
             Debug.Assert(scratchBufferOffset <= scratchBuffer.Length);
+#if DEBUG
+            outstandingSlices++;
+#endif
             return retVal;
         }
 
@@ -242,6 +327,11 @@ namespace Garnet.server
         /// </summary>
         public PinnedSpanByte FormatScratch(int headerSize, ReadOnlySpan<byte> arg)
         {
+#if DEBUG
+            Debug.Assert(outstandingSlices == 0,
+                "ScratchBufferBuilder already has an outstanding slice. " +
+                "Rewind or reset before creating a new one, or use ScratchBufferAllocator.");
+#endif
             int length = headerSize + arg.Length;
             ExpandScratchBufferIfNeeded(length);
 
@@ -253,6 +343,9 @@ namespace Garnet.server
 
             scratchBufferOffset += length;
             Debug.Assert(scratchBufferOffset <= scratchBuffer.Length);
+#if DEBUG
+            outstandingSlices++;
+#endif
             return retVal;
         }
 
@@ -333,6 +426,13 @@ namespace Garnet.server
 
         void ExpandScratchBuffer(int newLength, int? copyLengthOverride = null)
         {
+#if DEBUG
+            Debug.Assert(outstandingSlices == 0,
+                "ScratchBufferBuilder is expanding with outstanding slices. " +
+                "Previously returned PinnedSpanByte values will be invalidated. " +
+                "Use ScratchBufferAllocator for slices that must remain valid across allocations, " +
+                "or use a single CreateArgSlice and partition the buffer manually.");
+#endif
             if (newLength < 64) newLength = 64;
             else newLength = (int)BitOperations.RoundUpToPowerOf2((uint)newLength + 1);
 

--- a/libs/server/ArgSlice/ScratchBufferBuilder.cs
+++ b/libs/server/ArgSlice/ScratchBufferBuilder.cs
@@ -290,16 +290,22 @@ namespace Garnet.server
         }
 
         /// <summary>
-        /// View remaining scratch space (of specified minimum length) as an ArgSlice
-        /// Does NOT move the offset forward
+        /// View remaining scratch space (of specified minimum length) as a PinnedSpanByte.
+        /// Does NOT move the offset forward. The returned value is an immediate-use view
+        /// that may be invalidated by any subsequent allocation or expansion — do not store
+        /// or return it. Use <see cref="MoveOffset"/> to claim space after writing.
         /// </summary>
-        /// <returns></returns>
         public PinnedSpanByte ViewRemainingArgSlice(int minLength = 0)
         {
             ExpandScratchBufferIfNeeded(minLength);
             return PinnedSpanByte.FromPinnedPointer(scratchBufferHead + scratchBufferOffset, scratchBuffer.Length - scratchBufferOffset);
         }
 
+        /// <summary>
+        /// View the full scratch buffer contents (up to current offset) as a PinnedSpanByte.
+        /// The returned value is an immediate-use view that may be invalidated by any
+        /// subsequent allocation or expansion — do not store or return it.
+        /// </summary>
         public PinnedSpanByte ViewFullArgSlice()
         {
             return PinnedSpanByte.FromPinnedPointer(scratchBufferHead, scratchBufferOffset);

--- a/libs/server/ArgSlice/ScratchBufferBuilder.cs
+++ b/libs/server/ArgSlice/ScratchBufferBuilder.cs
@@ -94,23 +94,6 @@ namespace Garnet.server
         }
 
         /// <summary>
-        /// Resets scratch buffer offset to the specified offset.
-        /// </summary>
-        /// <param name="offset">Offset to reset to</param>
-        /// <returns>True if successful, else false</returns>
-        public bool ResetScratchBuffer(int offset)
-        {
-            if (offset < 0 || offset > scratchBufferOffset)
-                return false;
-
-            scratchBufferOffset = offset;
-#if DEBUG
-            outstandingSlices = 0;
-#endif
-            return true;
-        }
-
-        /// <summary>
         /// Create an arg slice in scratch buffer, from given ReadOnlySpan, returning the
         /// offset and length instead of a PinnedSpanByte. Safe for multiple calls without
         /// rewind — use <see cref="ViewFullArgSlice"/> to resolve offsets later.

--- a/libs/server/Custom/CustomRespCommands.cs
+++ b/libs/server/Custom/CustomRespCommands.cs
@@ -236,12 +236,12 @@ namespace Garnet.server
 
                 if (_output.SpanByteAndMemory.Memory != null)
                 {
-                    output = scratchBufferBuilder.FormatScratch(0, _output.SpanByteAndMemory.ReadOnlySpan);
+                    output = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan);
                     _output.SpanByteAndMemory.Memory.Dispose();
                 }
                 else
                 {
-                    output = scratchBufferBuilder.CreateArgSlice(CmdStrings.RESP_OK);
+                    output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP_OK);
                 }
             }
             else
@@ -253,21 +253,21 @@ namespace Garnet.server
                 {
                     if (_output.SpanByteAndMemory.Memory != null)
                     {
-                        output = scratchBufferBuilder.FormatScratch(0, _output.SpanByteAndMemory.ReadOnlySpan);
+                        output = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan);
                         _output.SpanByteAndMemory.Memory.Dispose();
                     }
                     else
                     {
-                        output = scratchBufferBuilder.CreateArgSlice(CmdStrings.RESP_OK);
+                        output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP_OK);
                     }
                 }
                 else
                 {
                     Debug.Assert(_output.SpanByteAndMemory.Memory == null);
                     if (respProtocolVersion >= 3)
-                        output = scratchBufferBuilder.CreateArgSlice(CmdStrings.RESP3_NULL_REPLY);
+                        output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP3_NULL_REPLY);
                     else
-                        output = scratchBufferBuilder.CreateArgSlice(CmdStrings.RESP_ERRNOTFOUND);
+                        output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP_ERRNOTFOUND);
                 }
             }
 
@@ -305,13 +305,13 @@ namespace Garnet.server
                 switch (status)
                 {
                     case GarnetStatus.WRONGTYPE:
-                        output = scratchBufferBuilder.CreateArgSlice(CmdStrings.RESP_ERR_WRONG_TYPE);
+                        output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP_ERR_WRONG_TYPE);
                         break;
                     default:
                         if (_output.SpanByteAndMemory.Memory != null)
-                            output = scratchBufferBuilder.FormatScratch(0, _output.SpanByteAndMemory.ReadOnlySpan);
+                            output = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan);
                         else
-                            output = scratchBufferBuilder.CreateArgSlice(CmdStrings.RESP_OK);
+                            output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP_OK);
                         break;
                 }
             }
@@ -324,19 +324,19 @@ namespace Garnet.server
                 {
                     case GarnetStatus.OK:
                         if (_output.SpanByteAndMemory.Memory != null)
-                            output = scratchBufferBuilder.FormatScratch(0, _output.SpanByteAndMemory.ReadOnlySpan);
+                            output = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan);
                         else
-                            output = scratchBufferBuilder.CreateArgSlice(CmdStrings.RESP_OK);
+                            output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP_OK);
                         break;
                     case GarnetStatus.NOTFOUND:
                         Debug.Assert(_output.SpanByteAndMemory.Memory == null);
                         if (respProtocolVersion >= 3)
-                            output = scratchBufferBuilder.CreateArgSlice(CmdStrings.RESP3_NULL_REPLY);
+                            output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP3_NULL_REPLY);
                         else
-                            output = scratchBufferBuilder.CreateArgSlice(CmdStrings.RESP_ERRNOTFOUND);
+                            output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP_ERRNOTFOUND);
                         break;
                     case GarnetStatus.WRONGTYPE:
-                        output = scratchBufferBuilder.CreateArgSlice(CmdStrings.RESP_ERR_WRONG_TYPE);
+                        output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP_ERR_WRONG_TYPE);
                         break;
                 }
             }

--- a/libs/server/Custom/CustomRespCommands.cs
+++ b/libs/server/Custom/CustomRespCommands.cs
@@ -309,7 +309,10 @@ namespace Garnet.server
                         break;
                     default:
                         if (_output.SpanByteAndMemory.Memory != null)
+                        {
                             output = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan);
+                            _output.SpanByteAndMemory.Memory.Dispose();
+                        }
                         else
                             output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP_OK);
                         break;
@@ -324,7 +327,10 @@ namespace Garnet.server
                 {
                     case GarnetStatus.OK:
                         if (_output.SpanByteAndMemory.Memory != null)
+                        {
                             output = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan);
+                            _output.SpanByteAndMemory.Memory.Dispose();
+                        }
                         else
                             output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP_OK);
                         break;

--- a/libs/server/Databases/DatabaseManagerBase.cs
+++ b/libs/server/Databases/DatabaseManagerBase.cs
@@ -356,7 +356,7 @@ namespace Garnet.server
             if (db.StoreCollectionDbStorageSession == null)
             {
                 var scratchBufferBuilder = new ScratchBufferBuilder();
-                var scratchBufferAllocator = new ScratchBufferAllocator(minSizeBuffer: 64);
+                var scratchBufferAllocator = new ScratchBufferAllocator();
                 db.StoreCollectionDbStorageSession =
                     new StorageSession(StoreWrapper, scratchBufferBuilder, scratchBufferAllocator, null, null, db.Id, Logger);
             }
@@ -602,7 +602,7 @@ namespace Garnet.server
             if (db.StoreExpiredKeyDeletionDbStorageSession == null)
             {
                 var scratchBufferBuilder = new ScratchBufferBuilder();
-                var scratchBufferAllocator = new ScratchBufferAllocator(minSizeBuffer: 64);
+                var scratchBufferAllocator = new ScratchBufferAllocator();
                 db.StoreExpiredKeyDeletionDbStorageSession = new StorageSession(StoreWrapper, scratchBufferBuilder, scratchBufferAllocator, null, null, db.Id, Logger);
             }
 
@@ -641,7 +641,7 @@ namespace Garnet.server
             if (db.HybridLogStatScanStorageSession == null)
             {
                 var scratchBufferBuilder = new ScratchBufferBuilder();
-                var scratchBufferAllocator = new ScratchBufferAllocator(minSizeBuffer: 64);
+                var scratchBufferAllocator = new ScratchBufferAllocator();
                 db.HybridLogStatScanStorageSession = new StorageSession(StoreWrapper, scratchBufferBuilder, scratchBufferAllocator, null, null, db.Id, Logger);
             }
 

--- a/libs/server/Databases/DatabaseManagerBase.cs
+++ b/libs/server/Databases/DatabaseManagerBase.cs
@@ -356,7 +356,7 @@ namespace Garnet.server
             if (db.StoreCollectionDbStorageSession == null)
             {
                 var scratchBufferBuilder = new ScratchBufferBuilder();
-                var scratchBufferAllocator = new ScratchBufferAllocator();
+                var scratchBufferAllocator = new ScratchBufferAllocator(minSizeBuffer: 64);
                 db.StoreCollectionDbStorageSession =
                     new StorageSession(StoreWrapper, scratchBufferBuilder, scratchBufferAllocator, null, null, db.Id, Logger);
             }
@@ -602,7 +602,7 @@ namespace Garnet.server
             if (db.StoreExpiredKeyDeletionDbStorageSession == null)
             {
                 var scratchBufferBuilder = new ScratchBufferBuilder();
-                var scratchBufferAllocator = new ScratchBufferAllocator();
+                var scratchBufferAllocator = new ScratchBufferAllocator(minSizeBuffer: 64);
                 db.StoreExpiredKeyDeletionDbStorageSession = new StorageSession(StoreWrapper, scratchBufferBuilder, scratchBufferAllocator, null, null, db.Id, Logger);
             }
 
@@ -641,7 +641,7 @@ namespace Garnet.server
             if (db.HybridLogStatScanStorageSession == null)
             {
                 var scratchBufferBuilder = new ScratchBufferBuilder();
-                var scratchBufferAllocator = new ScratchBufferAllocator();
+                var scratchBufferAllocator = new ScratchBufferAllocator(minSizeBuffer: 64);
                 db.HybridLogStatScanStorageSession = new StorageSession(StoreWrapper, scratchBufferBuilder, scratchBufferAllocator, null, null, db.Id, Logger);
             }
 

--- a/libs/server/Databases/DatabaseManagerBase.cs
+++ b/libs/server/Databases/DatabaseManagerBase.cs
@@ -356,8 +356,9 @@ namespace Garnet.server
             if (db.StoreCollectionDbStorageSession == null)
             {
                 var scratchBufferManager = new ScratchBufferBuilder();
+                var scratchBufferAllocator = new ScratchBufferAllocator();
                 db.StoreCollectionDbStorageSession =
-                    new StorageSession(StoreWrapper, scratchBufferManager, null, null, db.Id, Logger);
+                    new StorageSession(StoreWrapper, scratchBufferManager, scratchBufferAllocator, null, null, db.Id, Logger);
             }
 
             ExecuteHashCollect(db.StoreCollectionDbStorageSession);
@@ -598,7 +599,8 @@ namespace Garnet.server
             if (db.StoreExpiredKeyDeletionDbStorageSession == null)
             {
                 var scratchBufferManager = new ScratchBufferBuilder();
-                db.StoreExpiredKeyDeletionDbStorageSession = new StorageSession(StoreWrapper, scratchBufferManager, null, null, db.Id, Logger);
+                var scratchBufferAllocator = new ScratchBufferAllocator();
+                db.StoreExpiredKeyDeletionDbStorageSession = new StorageSession(StoreWrapper, scratchBufferManager, scratchBufferAllocator, null, null, db.Id, Logger);
             }
 
             var scanFrom = StoreWrapper.store.Log.ReadOnlyAddress;
@@ -636,7 +638,8 @@ namespace Garnet.server
             if (db.HybridLogStatScanStorageSession == null)
             {
                 var scratchBufferManager = new ScratchBufferBuilder();
-                db.HybridLogStatScanStorageSession = new StorageSession(StoreWrapper, scratchBufferManager, null, null, db.Id, Logger);
+                var scratchBufferAllocator = new ScratchBufferAllocator();
+                db.HybridLogStatScanStorageSession = new StorageSession(StoreWrapper, scratchBufferManager, scratchBufferAllocator, null, null, db.Id, Logger);
             }
 
             using var session = store.NewSession<FixedSpanByteKey, TInput, TOutput, long, ISessionFunctions<TInput, TOutput, long>>(sessionFunctions);

--- a/libs/server/Databases/DatabaseManagerBase.cs
+++ b/libs/server/Databases/DatabaseManagerBase.cs
@@ -355,10 +355,10 @@ namespace Garnet.server
         {
             if (db.StoreCollectionDbStorageSession == null)
             {
-                var scratchBufferManager = new ScratchBufferBuilder();
+                var scratchBufferBuilder = new ScratchBufferBuilder();
                 var scratchBufferAllocator = new ScratchBufferAllocator();
                 db.StoreCollectionDbStorageSession =
-                    new StorageSession(StoreWrapper, scratchBufferManager, scratchBufferAllocator, null, null, db.Id, Logger);
+                    new StorageSession(StoreWrapper, scratchBufferBuilder, scratchBufferAllocator, null, null, db.Id, Logger);
             }
 
             ExecuteHashCollect(db.StoreCollectionDbStorageSession);
@@ -598,9 +598,9 @@ namespace Garnet.server
         {
             if (db.StoreExpiredKeyDeletionDbStorageSession == null)
             {
-                var scratchBufferManager = new ScratchBufferBuilder();
+                var scratchBufferBuilder = new ScratchBufferBuilder();
                 var scratchBufferAllocator = new ScratchBufferAllocator();
-                db.StoreExpiredKeyDeletionDbStorageSession = new StorageSession(StoreWrapper, scratchBufferManager, scratchBufferAllocator, null, null, db.Id, Logger);
+                db.StoreExpiredKeyDeletionDbStorageSession = new StorageSession(StoreWrapper, scratchBufferBuilder, scratchBufferAllocator, null, null, db.Id, Logger);
             }
 
             var scanFrom = StoreWrapper.store.Log.ReadOnlyAddress;
@@ -637,9 +637,9 @@ namespace Garnet.server
         {
             if (db.HybridLogStatScanStorageSession == null)
             {
-                var scratchBufferManager = new ScratchBufferBuilder();
+                var scratchBufferBuilder = new ScratchBufferBuilder();
                 var scratchBufferAllocator = new ScratchBufferAllocator();
-                db.HybridLogStatScanStorageSession = new StorageSession(StoreWrapper, scratchBufferManager, scratchBufferAllocator, null, null, db.Id, Logger);
+                db.HybridLogStatScanStorageSession = new StorageSession(StoreWrapper, scratchBufferBuilder, scratchBufferAllocator, null, null, db.Id, Logger);
             }
 
             using var session = store.NewSession<FixedSpanByteKey, TInput, TOutput, long, ISessionFunctions<TInput, TOutput, long>>(sessionFunctions);

--- a/libs/server/Lua/LuaRunner.Functions.cs
+++ b/libs/server/Lua/LuaRunner.Functions.cs
@@ -3004,7 +3004,7 @@ namespace Garnet.server
             static (RespCommand Parsed, bool BadArg) PrepareAndCheckRespRequest(
                 ref LuaStateWrapper state,
                 RespServerSession respServerSession,
-                ScratchBufferBuilder scratchBufferManager,
+                ScratchBufferBuilder scratchBufferBuilder,
                 RespCommandsInfo cmdInfo,
                 ReadOnlySpan<byte> cmdSpan,
                 int luaArgCount
@@ -3019,8 +3019,8 @@ namespace Garnet.server
 
                 // RESP format the args so we can parse the command (and sub-command, and maybe keys down the line?)
 
-                scratchBufferManager.Reset();
-                scratchBufferManager.StartCommand(cmdSpan, actualRespArgCount);
+                scratchBufferBuilder.Reset();
+                scratchBufferBuilder.StartCommand(cmdSpan, actualRespArgCount);
 
                 for (var i = 0; i < actualRespArgCount; i++)
                 {
@@ -3032,7 +3032,7 @@ namespace Garnet.server
                         var argType = state.Type(stackIx);
                         if (argType == LuaType.Nil)
                         {
-                            scratchBufferManager.WriteNullArgument();
+                            scratchBufferBuilder.WriteNullArgument();
                         }
                         else if (argType is LuaType.String or LuaType.Number)
                         {
@@ -3042,7 +3042,7 @@ namespace Garnet.server
                             state.KnownStringToBuffer(stackIx, out var span);
 
                             // Span remains pinned so long as we don't pop the stack
-                            scratchBufferManager.WriteArgument(span);
+                            scratchBufferBuilder.WriteArgument(span);
                         }
                         else
                         {
@@ -3052,11 +3052,11 @@ namespace Garnet.server
                     else
                     {
                         // For args we don't have, shove in an empty string
-                        scratchBufferManager.WriteArgument(default);
+                        scratchBufferBuilder.WriteArgument(default);
                     }
                 }
 
-                var request = scratchBufferManager.ViewFullArgSlice();
+                var request = scratchBufferBuilder.ViewFullArgSlice();
                 var parsedCommand = respServerSession.ParseRespCommandBuffer(request.ReadOnlySpan);
 
                 return (parsedCommand, false);

--- a/libs/server/Lua/LuaRunner.cs
+++ b/libs/server/Lua/LuaRunner.cs
@@ -1239,6 +1239,7 @@ namespace Garnet.server
                     {
                         var _key = scratchBufferBuilder.CreateArgSlice(key);
                         txnKeyEntries.AddKey(_key, Tsavorite.core.LockType.Exclusive);
+                        scratchBufferBuilder.RewindScratchBuffer(_key);
                     }
 
                     adapter = new(scratchBufferBuilder);

--- a/libs/server/Objects/ItemBroker/CollectionItemBroker.cs
+++ b/libs/server/Objects/ItemBroker/CollectionItemBroker.cs
@@ -668,6 +668,7 @@ namespace Garnet.server
             }
             finally
             {
+                storageSession.scratchBufferBuilder.RewindScratchBuffer(asKey);
                 if (createTransaction)
                     storageSession.txnManager.Commit(true);
             }

--- a/libs/server/Resp/KeyAdminCommands.cs
+++ b/libs/server/Resp/KeyAdminCommands.cs
@@ -111,6 +111,8 @@ namespace Garnet.server
 
             var status = storageApi.SET_Conditional(key, ref input);
 
+            scratchBufferBuilder.RewindScratchBuffer(valArgSlice);
+
             if (status is GarnetStatus.NOTFOUND)
             {
                 while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))

--- a/libs/server/Resp/LocalServerSession.cs
+++ b/libs/server/Resp/LocalServerSession.cs
@@ -39,7 +39,7 @@ namespace Garnet.server
 
             // Initialize session-local scratch buffer of size 64 bytes, used for constructing arguments in GarnetApi
             this.scratchBufferBuilder = new ScratchBufferBuilder();
-            this.scratchBufferAllocator = new ScratchBufferAllocator(minSizeBuffer: 64);
+            this.scratchBufferAllocator = new ScratchBufferAllocator();
 
             // Create storage session and API
             this.storageSession = new StorageSession(storeWrapper, scratchBufferBuilder, scratchBufferAllocator, sessionMetrics, LatencyMetrics, dbId: 0, logger);

--- a/libs/server/Resp/LocalServerSession.cs
+++ b/libs/server/Resp/LocalServerSession.cs
@@ -17,6 +17,7 @@ namespace Garnet.server
         readonly StoreWrapper storeWrapper;
         readonly StorageSession storageSession;
         readonly ScratchBufferBuilder scratchBufferBuilder;
+        readonly ScratchBufferAllocator scratchBufferAllocator;
 
         /// <summary>
         /// Basic Garnet API
@@ -38,9 +39,10 @@ namespace Garnet.server
 
             // Initialize session-local scratch buffer of size 64 bytes, used for constructing arguments in GarnetApi
             this.scratchBufferBuilder = new ScratchBufferBuilder();
+            this.scratchBufferAllocator = new ScratchBufferAllocator();
 
             // Create storage session and API
-            this.storageSession = new StorageSession(storeWrapper, scratchBufferBuilder, sessionMetrics, LatencyMetrics, dbId: 0, logger);
+            this.storageSession = new StorageSession(storeWrapper, scratchBufferBuilder, scratchBufferAllocator, sessionMetrics, LatencyMetrics, dbId: 0, logger);
 
             this.BasicGarnetApi = new BasicGarnetApi(storageSession, storageSession.stringBasicContext, storageSession.objectBasicContext, storageSession.unifiedBasicContext);
         }

--- a/libs/server/Resp/LocalServerSession.cs
+++ b/libs/server/Resp/LocalServerSession.cs
@@ -39,7 +39,7 @@ namespace Garnet.server
 
             // Initialize session-local scratch buffer of size 64 bytes, used for constructing arguments in GarnetApi
             this.scratchBufferBuilder = new ScratchBufferBuilder();
-            this.scratchBufferAllocator = new ScratchBufferAllocator();
+            this.scratchBufferAllocator = new ScratchBufferAllocator(minSizeBuffer: 64);
 
             // Create storage session and API
             this.storageSession = new StorageSession(storeWrapper, scratchBufferBuilder, scratchBufferAllocator, sessionMetrics, LatencyMetrics, dbId: 0, logger);

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -242,7 +242,7 @@ namespace Garnet.server
             this.scratchBufferBuilder = new ScratchBufferBuilder();
 
             // Initialize session-local scratch allocation of size 64 bytes, used for constructing arguments in GarnetApi
-            this.scratchBufferAllocator = new ScratchBufferAllocator(minSizeBuffer: 64);
+            this.scratchBufferAllocator = new ScratchBufferAllocator();
 
             this.storeWrapper = storeWrapper;
             this.subscribeBroker = subscribeBroker;

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -1478,7 +1478,7 @@ namespace Garnet.server
         /// <returns>New database session</returns>
         private GarnetDatabaseSession CreateDatabaseSession(int dbId)
         {
-            var dbStorageSession = new StorageSession(storeWrapper, scratchBufferBuilder, sessionMetrics, LatencyMetrics, dbId, logger, respProtocolVersion);
+            var dbStorageSession = new StorageSession(storeWrapper, scratchBufferBuilder, scratchBufferAllocator, sessionMetrics, LatencyMetrics, dbId, logger, respProtocolVersion);
             var dbGarnetApi = new BasicGarnetApi(dbStorageSession, dbStorageSession.stringBasicContext,
                 dbStorageSession.objectBasicContext, dbStorageSession.unifiedBasicContext);
             var dbLockableGarnetApi = new TransactionalGarnetApi(dbStorageSession,

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -242,7 +242,7 @@ namespace Garnet.server
             this.scratchBufferBuilder = new ScratchBufferBuilder();
 
             // Initialize session-local scratch allocation of size 64 bytes, used for constructing arguments in GarnetApi
-            this.scratchBufferAllocator = new ScratchBufferAllocator();
+            this.scratchBufferAllocator = new ScratchBufferAllocator(minSizeBuffer: 64);
 
             this.storeWrapper = storeWrapper;
             this.subscribeBroker = subscribeBroker;

--- a/libs/server/Storage/Session/MainStore/MainStoreOps.cs
+++ b/libs/server/Storage/Session/MainStore/MainStoreOps.cs
@@ -76,16 +76,22 @@ namespace Garnet.server
             var input = new StringInput(RespCommand.GET);
             value = default;
 
-            var _output = new StringOutput(new SpanByteAndMemory { SpanByte = scratchBufferBuilder.ViewRemainingArgSlice() });
+            var _output = new StringOutput(new SpanByteAndMemory { SpanByte = scratchBufferAllocator.ViewRemainingArgSlice() });
 
             var ret = GET(key, ref input, ref _output, ref context);
             if (ret == GarnetStatus.OK)
             {
-                // Copy result to SBA so the returned PinnedSpanByte remains valid across calls
-                value = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan);
-
                 if (!_output.SpanByteAndMemory.IsSpanByte)
+                {
+                    // Output overflowed to heap Memory — copy to SBA and dispose
+                    value = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan);
                     _output.SpanByteAndMemory.Memory.Dispose();
+                }
+                else
+                {
+                    // Output fit in SBA's remaining space — just claim it (zero copy)
+                    value = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.Length);
+                }
             }
             return ret;
         }

--- a/libs/server/Storage/Session/MainStore/MainStoreOps.cs
+++ b/libs/server/Storage/Session/MainStore/MainStoreOps.cs
@@ -81,15 +81,11 @@ namespace Garnet.server
             var ret = GET(key, ref input, ref _output, ref context);
             if (ret == GarnetStatus.OK)
             {
+                // Copy result to SBA so the returned PinnedSpanByte remains valid across calls
+                value = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan);
+
                 if (!_output.SpanByteAndMemory.IsSpanByte)
-                {
-                    value = scratchBufferBuilder.FormatScratch(0, _output.SpanByteAndMemory.ReadOnlySpan);
                     _output.SpanByteAndMemory.Memory.Dispose();
-                }
-                else
-                {
-                    value = scratchBufferBuilder.CreateArgSlice(_output.SpanByteAndMemory.Length);
-                }
             }
             return ret;
         }

--- a/libs/server/Storage/Session/ObjectStore/Common.cs
+++ b/libs/server/Storage/Session/ObjectStore/Common.cs
@@ -253,6 +253,8 @@ namespace Garnet.server
                             return default;
                         elements = [PinnedSpanByte.FromPinnedPointer(result, len)];
                     }
+
+                    CopyPinnedSpanByteArrayToScratchBuffer(elements, ref output);
                 }
             }
             finally
@@ -385,6 +387,8 @@ namespace Garnet.server
                             return default;
                         elements = [PinnedSpanByte.FromPinnedPointer(result, len)];
                     }
+
+                    CopyPinnedSpanByteArrayToScratchBuffer(elements, ref output);
                 }
             }
             finally
@@ -533,6 +537,78 @@ namespace Garnet.server
         }
 
         /// <summary>
+        /// When output uses heap Memory (which is not pinned), copies PinnedSpanByte array data
+        /// to the scratch buffer (which uses pinned arrays) so that pointers remain valid.
+        /// Must be called inside the fixed block while source memory is still pinned.
+        /// Uses a single allocation to avoid scratch buffer reallocation during the copy.
+        /// </summary>
+        unsafe void CopyPinnedSpanByteArrayToScratchBuffer(PinnedSpanByte[] elements, ref ObjectOutput output)
+        {
+            if (elements == null || elements.Length == 0 || output.SpanByteAndMemory.IsSpanByte)
+                return;
+
+            var totalSize = 0;
+            for (var i = 0; i < elements.Length; i++)
+                totalSize += elements[i].Length;
+
+            if (totalSize == 0)
+                return;
+
+            var buf = scratchBufferAllocator.CreateArgSlice(totalSize);
+            var bufPtr = buf.ptr;
+            for (var i = 0; i < elements.Length; i++)
+            {
+                var elemLen = elements[i].Length;
+                if (elemLen > 0)
+                {
+                    elements[i].ReadOnlySpan.CopyTo(new Span<byte>(bufPtr, elemLen));
+                    elements[i] = PinnedSpanByte.FromPinnedPointer(bufPtr, elemLen);
+                    bufPtr += elemLen;
+                }
+            }
+        }
+
+        /// <summary>
+        /// When output uses heap Memory (which is not pinned), copies PinnedSpanByte pair data
+        /// to the scratch buffer (which uses pinned arrays) so that pointers remain valid.
+        /// Must be called inside the fixed block while source memory is still pinned.
+        /// Uses a single allocation to avoid scratch buffer reallocation during the copy.
+        /// </summary>
+        unsafe void CopyPinnedSpanBytePairsToScratchBuffer((PinnedSpanByte member, PinnedSpanByte score)[] pairs, ref ObjectOutput output)
+        {
+            if (pairs == null || pairs.Length == 0 || output.SpanByteAndMemory.IsSpanByte)
+                return;
+
+            var totalSize = 0;
+            for (var i = 0; i < pairs.Length; i++)
+                totalSize += pairs[i].member.Length + pairs[i].score.Length;
+
+            if (totalSize == 0)
+                return;
+
+            var buf = scratchBufferAllocator.CreateArgSlice(totalSize);
+            var bufPtr = buf.ptr;
+            for (var i = 0; i < pairs.Length; i++)
+            {
+                var memberLen = pairs[i].member.Length;
+                if (memberLen > 0)
+                {
+                    pairs[i].member.ReadOnlySpan.CopyTo(new Span<byte>(bufPtr, memberLen));
+                    pairs[i].member = PinnedSpanByte.FromPinnedPointer(bufPtr, memberLen);
+                    bufPtr += memberLen;
+                }
+
+                var scoreLen = pairs[i].score.Length;
+                if (scoreLen > 0)
+                {
+                    pairs[i].score.ReadOnlySpan.CopyTo(new Span<byte>(bufPtr, scoreLen));
+                    pairs[i].score = PinnedSpanByte.FromPinnedPointer(bufPtr, scoreLen);
+                    bufPtr += scoreLen;
+                }
+            }
+        }
+
+        /// <summary>
         /// Processes RESP output as pairs of score and member.
         /// </summary>
         unsafe (PinnedSpanByte member, PinnedSpanByte score)[] ProcessRespArrayOutputAsPairs(ObjectOutput output, out string error)
@@ -577,6 +653,8 @@ namespace Garnet.server
                             result[i].score = PinnedSpanByte.FromPinnedPointer(element, len);
                         }
                     }
+
+                    CopyPinnedSpanBytePairsToScratchBuffer(result, ref output);
                 }
             }
             finally
@@ -611,6 +689,12 @@ namespace Garnet.server
                         || len < 0)
                         return default;
                     result = PinnedSpanByte.FromPinnedPointer(element, len);
+
+                    // When output uses heap Memory, the finally block will dispose it, invalidating
+                    // the PinnedSpanByte pointer. Copy data to scratch buffer while still pinned.
+                    // CreateArgSlice allocates pinned space and copies the data into it.
+                    if (result.Length > 0 && !output.SpanByteAndMemory.IsSpanByte)
+                        result = scratchBufferAllocator.CreateArgSlice(result.ReadOnlySpan);
                 }
             }
             finally

--- a/libs/server/Storage/Session/ObjectStore/SortedSetOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/SortedSetOps.cs
@@ -388,6 +388,8 @@ namespace Garnet.server
             var status = RMWObjectStoreOperation(key.ReadOnlySpan, ref input, ref objectContext,
                 ref output);
 
+            scratchBufferBuilder.RewindScratchBuffer(incrSlice);
+
             // Process output
             if (status == GarnetStatus.OK)
             {
@@ -475,19 +477,32 @@ namespace Garnet.server
                 rangeOpts |= SortedSetRangeOpts.Reverse;
             }
 
-            // Limit parameter
+            // Limit parameter — single contiguous allocation to avoid
+            // ScratchBufferBuilder reallocation invalidating earlier pointers.
+            PinnedSpanByte paramsSlice = default;
             if (limit != default && (sortedSetOrderOperation == SortedSetOrderOperation.ByScore || sortedSetOrderOperation == SortedSetOrderOperation.ByLex))
             {
-                arguments.Add(scratchBufferBuilder.CreateArgSlice("LIMIT"u8));
+                var limitKeywordBytes = "LIMIT"u8;
+                var offsetLength = Encoding.UTF8.GetByteCount(limit.Item1);
+                var countLength = NumUtils.CountDigits(limit.Item2);
+                var totalSize = limitKeywordBytes.Length + offsetLength + countLength;
+
+                paramsSlice = scratchBufferBuilder.CreateArgSlice(totalSize);
+                var ptr = paramsSlice.ptr;
+
+                // LIMIT keyword
+                limitKeywordBytes.CopyTo(new Span<byte>(ptr, limitKeywordBytes.Length));
+                arguments.Add(PinnedSpanByte.FromPinnedPointer(ptr, limitKeywordBytes.Length));
+                ptr += limitKeywordBytes.Length;
 
                 // Offset
-                arguments.Add(scratchBufferBuilder.CreateArgSlice(limit.Item1));
+                Encoding.UTF8.GetBytes(limit.Item1, new Span<byte>(ptr, offsetLength));
+                arguments.Add(PinnedSpanByte.FromPinnedPointer(ptr, offsetLength));
+                ptr += offsetLength;
 
                 // Count
-                var limitCountLength = NumUtils.CountDigits(limit.Item2);
-                var limitCountSlice = scratchBufferBuilder.CreateArgSlice(limitCountLength);
-                NumUtils.WriteInt64(limit.Item2, limitCountSlice.Span);
-                arguments.Add(limitCountSlice);
+                NumUtils.WriteInt64(limit.Item2, new Span<byte>(ptr, countLength));
+                arguments.Add(PinnedSpanByte.FromPinnedPointer(ptr, countLength));
             }
 
             parseState.InitializeWithArguments([.. arguments]);
@@ -499,11 +514,8 @@ namespace Garnet.server
             var output = new ObjectOutput();
             var status = ReadObjectStoreOperation(key.ReadOnlySpan, ref input, ref objectContext, ref output);
 
-            for (var i = arguments.Count - 1; i > 1; i--)
-            {
-                var currSlice = arguments[i];
-                scratchBufferBuilder.RewindScratchBuffer(currSlice);
-            }
+            if (paramsSlice.Length > 0)
+                scratchBufferBuilder.RewindScratchBuffer(paramsSlice);
 
             if (status == GarnetStatus.OK)
                 elements = ProcessRespArrayOutput(output, out error);

--- a/libs/server/Storage/Session/StorageSession.cs
+++ b/libs/server/Storage/Session/StorageSession.cs
@@ -46,6 +46,7 @@ namespace Garnet.server
 
         public readonly ScratchBufferBuilder scratchBufferBuilder;
         public readonly FunctionsState functionsState;
+        readonly ScratchBufferAllocator scratchBufferAllocator;
 
         public TransactionManager txnManager;
         public StateMachineDriver stateMachineDriver;
@@ -59,6 +60,7 @@ namespace Garnet.server
 
         public StorageSession(StoreWrapper storeWrapper,
             ScratchBufferBuilder scratchBufferBuilder,
+            ScratchBufferAllocator scratchBufferAllocator,
             GarnetSessionMetrics sessionMetrics,
             GarnetLatencyMetricsSession LatencyMetrics,
             int dbId,
@@ -68,6 +70,7 @@ namespace Garnet.server
             this.sessionMetrics = sessionMetrics;
             this.LatencyMetrics = LatencyMetrics;
             this.scratchBufferBuilder = scratchBufferBuilder;
+            this.scratchBufferAllocator = scratchBufferAllocator;
             this.logger = logger;
             this.itemBroker = storeWrapper.itemBroker;
             parseState.Initialize();

--- a/libs/server/Storage/Session/StorageSession.cs
+++ b/libs/server/Storage/Session/StorageSession.cs
@@ -46,7 +46,7 @@ namespace Garnet.server
 
         public readonly ScratchBufferBuilder scratchBufferBuilder;
         public readonly FunctionsState functionsState;
-        readonly ScratchBufferAllocator scratchBufferAllocator;
+        public readonly ScratchBufferAllocator scratchBufferAllocator;
 
         public TransactionManager txnManager;
         public StateMachineDriver stateMachineDriver;

--- a/libs/server/Storage/Session/StorageSession.cs
+++ b/libs/server/Storage/Session/StorageSession.cs
@@ -44,9 +44,9 @@ namespace Garnet.server
         public UnifiedBasicContext unifiedBasicContext;
         public UnifiedTransactionalContext unifiedTransactionalContext;
 
-        public readonly ScratchBufferBuilder scratchBufferBuilder;
+        internal readonly ScratchBufferBuilder scratchBufferBuilder;
         public readonly FunctionsState functionsState;
-        public readonly ScratchBufferAllocator scratchBufferAllocator;
+        internal readonly ScratchBufferAllocator scratchBufferAllocator;
 
         public TransactionManager txnManager;
         public StateMachineDriver stateMachineDriver;

--- a/test/Garnet.test/RespCustomCommandTests.cs
+++ b/test/Garnet.test/RespCustomCommandTests.cs
@@ -22,6 +22,23 @@ using Tsavorite.core;
 
 namespace Garnet.test
 {
+    /// <summary>
+    /// Validates that data matches the deterministic pattern (i % 251) used by scratch buffer tests.
+    /// </summary>
+    internal static class ScratchBufferTestHelper
+    {
+        internal static bool ValidateContent(ReadOnlySpan<byte> data)
+        {
+            if (data.Length == 0) return false;
+            for (int i = 0; i < data.Length; i++)
+            {
+                if (data[i] != (byte)(i % 251))
+                    return false;
+            }
+            return true;
+        }
+    }
+
     public class LargeGet : CustomProcedure
     {
         public override bool Execute<TGarnetApi>(TGarnetApi garnetApi, ref CustomProcedureInput procInput, ref MemoryResult<byte> output)
@@ -44,13 +61,11 @@ namespace Garnet.test
             var hashKey = GetNextArg(ref procInput, ref offset);
             var field = GetNextArg(ref procInput, ref offset);
             garnetApi.HashGet(hashKey, field, out var value);
-            if (value.Length == 0)
+            if (!ScratchBufferTestHelper.ValidateContent(value.ReadOnlySpan))
             {
-                WriteError(ref output, "ERR HashGet returned empty value");
+                WriteError(ref output, "ERR HashGet returned corrupted data");
                 return false;
             }
-            // Validate data is accessible (not dangling pointer)
-            _ = value.ReadOnlySpan.ToArray();
             garnetApi.ResetScratchBuffer();
 
             return true;
@@ -92,10 +107,10 @@ namespace Garnet.test
             garnetApi.GET(key, out PinnedSpanByte outval1);
             garnetApi.GET(key, out PinnedSpanByte outval2);
 
-            // Verify GET results contain valid accessible data (not dangling pointers)
-            if (outval1.Length == 0 || outval2.Length == 0)
+            // Verify GET results contain valid data (i % 251 pattern)
+            if (!ScratchBufferTestHelper.ValidateContent(outval1.ReadOnlySpan))
             {
-                WriteError(ref output, "ERR GET returned empty value");
+                WriteError(ref output, "ERR GET returned corrupted data for outval1");
                 return false;
             }
 
@@ -814,6 +829,8 @@ namespace Garnet.test
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = redis.GetDatabase(0);
             byte[] value = new byte[10_000];
+            for (int i = 0; i < value.Length; i++)
+                value[i] = (byte)(i % 251); // deterministic pattern for content validation
             db.StringSet(key, value);
             db.HashSet(hashKey, [new HashEntry(hashField, value)]);
 
@@ -838,6 +855,8 @@ namespace Garnet.test
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = redis.GetDatabase(0);
             byte[] value = new byte[10_000];
+            for (int i = 0; i < value.Length; i++)
+                value[i] = (byte)(i % 251); // deterministic pattern for content validation
             db.StringSet(key, value);
             db.HashSet(hashKey, [new HashEntry(hashField, value)]);
 
@@ -860,6 +879,8 @@ namespace Garnet.test
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = redis.GetDatabase(0);
             byte[] value = new byte[10_000];
+            for (int i = 0; i < value.Length; i++)
+                value[i] = (byte)(i % 251); // deterministic pattern for content validation
             db.StringSet(key, value);
 
             var result = db.Execute("OUTOFORDERFREE", key);

--- a/test/Garnet.test/RespCustomCommandTests.cs
+++ b/test/Garnet.test/RespCustomCommandTests.cs
@@ -34,17 +34,17 @@ namespace Garnet.test
             {
                 garnetApi.GET(key, out PinnedSpanByte outval);
                 if (i % 100 == 0)
-                    garnetApi.ResetScratchBufferAllocator();
+                    garnetApi.ResetScratchBuffer();
             }
 
             garnetApi.GET(key, out PinnedSpanByte outval1);
             garnetApi.GET(key, out PinnedSpanByte outval2);
-            garnetApi.ResetScratchBufferAllocator();
+            garnetApi.ResetScratchBuffer();
 
             var hashKey = GetNextArg(ref procInput, ref offset);
             var field = GetNextArg(ref procInput, ref offset);
             garnetApi.HashGet(hashKey, field, out var value);
-            garnetApi.ResetScratchBufferAllocator();
+            garnetApi.ResetScratchBuffer();
 
             return true;
         }
@@ -69,7 +69,7 @@ namespace Garnet.test
             {
                 garnetApi.GET(key, out PinnedSpanByte outval);
                 if (i % 100 == 0)
-                    garnetApi.ResetScratchBufferAllocator();
+                    garnetApi.ResetScratchBuffer();
             }
         }
     }
@@ -81,11 +81,8 @@ namespace Garnet.test
             var offset = 0;
             var key = GetNextArg(ref procInput, ref offset);
 
-            // Test SBA offset management with GET (output goes to ScratchBufferAllocator)
-            var sbaOffset1 = garnetApi.GetScratchBufferAllocatorOffset();
+            // Test scratch buffer reset with GET (output goes to ScratchBufferAllocator)
             garnetApi.GET(key, out PinnedSpanByte outval1);
-
-            var sbaOffset2 = garnetApi.GetScratchBufferAllocatorOffset();
             garnetApi.GET(key, out PinnedSpanByte outval2);
 
             // Verify GET results are valid
@@ -95,23 +92,8 @@ namespace Garnet.test
                 return false;
             }
 
-            // SBA offset should have advanced after each GET
-            if (sbaOffset2 <= sbaOffset1)
-            {
-                WriteError(ref output, "ERR SBA offset should advance after GET");
-                return false;
-            }
-
-            // Reset SBA (full reset, discards all GET results)
-            garnetApi.ResetScratchBufferAllocator();
-
-            // Verify offset is back to initial
-            var sbaOffsetAfterReset = garnetApi.GetScratchBufferAllocatorOffset();
-            if (sbaOffsetAfterReset != sbaOffset1)
-            {
-                WriteError(ref output, "ERR SBA offset should be back to initial after reset");
-                return false;
-            }
+            // Reset scratch buffer (full reset, discards all GET results)
+            garnetApi.ResetScratchBuffer();
 
             return true;
         }

--- a/test/Garnet.test/RespCustomCommandTests.cs
+++ b/test/Garnet.test/RespCustomCommandTests.cs
@@ -26,39 +26,25 @@ namespace Garnet.test
     {
         public override bool Execute<TGarnetApi>(TGarnetApi garnetApi, ref CustomProcedureInput procInput, ref MemoryResult<byte> output)
         {
-            static bool ResetBuffer(TGarnetApi garnetApi, ref MemoryResult<byte> output, int buffOffset)
-            {
-                bool status = garnetApi.ResetScratchBuffer(buffOffset);
-                if (!status)
-                    WriteError(ref output, "ERR ResetScratchBuffer failed");
-
-                return status;
-            }
-
             var offset = 0;
             var key = GetNextArg(ref procInput, ref offset);
 
-            var buffOffset = garnetApi.GetScratchBufferOffset();
+            // Test SBA offset management: GET output goes to ScratchBufferAllocator
             for (var i = 0; i < 120_000; i++)
             {
                 garnetApi.GET(key, out PinnedSpanByte outval);
                 if (i % 100 == 0)
-                {
-                    if (!ResetBuffer(garnetApi, ref output, buffOffset))
-                        return false;
-                }
+                    garnetApi.ResetScratchBufferAllocator();
             }
 
-            buffOffset = garnetApi.GetScratchBufferOffset();
             garnetApi.GET(key, out PinnedSpanByte outval1);
             garnetApi.GET(key, out PinnedSpanByte outval2);
-            if (!ResetBuffer(garnetApi, ref output, buffOffset)) return false;
+            garnetApi.ResetScratchBufferAllocator();
 
-            buffOffset = garnetApi.GetScratchBufferOffset();
             var hashKey = GetNextArg(ref procInput, ref offset);
             var field = GetNextArg(ref procInput, ref offset);
             garnetApi.HashGet(hashKey, field, out var value);
-            if (!ResetBuffer(garnetApi, ref output, buffOffset)) return false;
+            garnetApi.ResetScratchBufferAllocator();
 
             return true;
         }
@@ -77,18 +63,13 @@ namespace Garnet.test
         {
             int offset = 0;
             var key = GetNextArg(ref procInput, ref offset);
-            var buffOffset = garnetApi.GetScratchBufferOffset();
+
+            // Test SBA offset management: GET output goes to ScratchBufferAllocator
             for (int i = 0; i < 120_000; i++)
             {
                 garnetApi.GET(key, out PinnedSpanByte outval);
                 if (i % 100 == 0)
-                {
-                    if (!garnetApi.ResetScratchBuffer(buffOffset))
-                    {
-                        WriteError(ref output, "ERR ResetScratchBuffer failed");
-                        return;
-                    }
-                }
+                    garnetApi.ResetScratchBufferAllocator();
             }
         }
     }
@@ -100,12 +81,11 @@ namespace Garnet.test
             var offset = 0;
             var key = GetNextArg(ref procInput, ref offset);
 
-            // GET output goes to ScratchBufferAllocator (not ScratchBufferBuilder),
-            // so SBB offset does not advance after GET calls.
-            var buffOffset1 = garnetApi.GetScratchBufferOffset();
+            // Test SBA offset management with GET (output goes to ScratchBufferAllocator)
+            var sbaOffset1 = garnetApi.GetScratchBufferAllocatorOffset();
             garnetApi.GET(key, out PinnedSpanByte outval1);
 
-            var buffOffset2 = garnetApi.GetScratchBufferOffset();
+            var sbaOffset2 = garnetApi.GetScratchBufferAllocatorOffset();
             garnetApi.GET(key, out PinnedSpanByte outval2);
 
             // Verify GET results are valid
@@ -115,17 +95,21 @@ namespace Garnet.test
                 return false;
             }
 
-            // Since GET uses SBA, both offsets should be equal (SBB unchanged)
-            if (buffOffset1 != buffOffset2)
+            // SBA offset should have advanced after each GET
+            if (sbaOffset2 <= sbaOffset1)
             {
-                WriteError(ref output, "ERR SBB offset should not change after GET");
+                WriteError(ref output, "ERR SBA offset should advance after GET");
                 return false;
             }
 
-            // ResetScratchBuffer should succeed (offset unchanged)
-            if (!garnetApi.ResetScratchBuffer(buffOffset1))
+            // Reset SBA (full reset, discards all GET results)
+            garnetApi.ResetScratchBufferAllocator();
+
+            // Verify offset is back to initial
+            var sbaOffsetAfterReset = garnetApi.GetScratchBufferAllocatorOffset();
+            if (sbaOffsetAfterReset != sbaOffset1)
             {
-                WriteError(ref output, "ERR ResetScratchBuffer failed");
+                WriteError(ref output, "ERR SBA offset should be back to initial after reset");
                 return false;
             }
 

--- a/test/Garnet.test/RespCustomCommandTests.cs
+++ b/test/Garnet.test/RespCustomCommandTests.cs
@@ -44,6 +44,13 @@ namespace Garnet.test
             var hashKey = GetNextArg(ref procInput, ref offset);
             var field = GetNextArg(ref procInput, ref offset);
             garnetApi.HashGet(hashKey, field, out var value);
+            if (value.Length == 0)
+            {
+                WriteError(ref output, "ERR HashGet returned empty value");
+                return false;
+            }
+            // Validate data is accessible (not dangling pointer)
+            _ = value.ReadOnlySpan.ToArray();
             garnetApi.ResetScratchBuffer();
 
             return true;
@@ -85,10 +92,17 @@ namespace Garnet.test
             garnetApi.GET(key, out PinnedSpanByte outval1);
             garnetApi.GET(key, out PinnedSpanByte outval2);
 
-            // Verify GET results are valid
+            // Verify GET results contain valid accessible data (not dangling pointers)
             if (outval1.Length == 0 || outval2.Length == 0)
             {
                 WriteError(ref output, "ERR GET returned empty value");
+                return false;
+            }
+
+            // Verify both results are identical (validates data integrity)
+            if (!outval1.ReadOnlySpan.SequenceEqual(outval2.ReadOnlySpan))
+            {
+                WriteError(ref output, "ERR GET results should be identical");
                 return false;
             }
 

--- a/test/Garnet.test/RespCustomCommandTests.cs
+++ b/test/Garnet.test/RespCustomCommandTests.cs
@@ -100,22 +100,32 @@ namespace Garnet.test
             var offset = 0;
             var key = GetNextArg(ref procInput, ref offset);
 
+            // GET output goes to ScratchBufferAllocator (not ScratchBufferBuilder),
+            // so SBB offset does not advance after GET calls.
             var buffOffset1 = garnetApi.GetScratchBufferOffset();
             garnetApi.GET(key, out PinnedSpanByte outval1);
 
             var buffOffset2 = garnetApi.GetScratchBufferOffset();
             garnetApi.GET(key, out PinnedSpanByte outval2);
 
-            if (!garnetApi.ResetScratchBuffer(buffOffset1))
+            // Verify GET results are valid
+            if (outval1.Length == 0 || outval2.Length == 0)
             {
-                WriteError(ref output, "ERR ResetScratchBuffer failed");
+                WriteError(ref output, "ERR GET returned empty value");
                 return false;
             }
 
-            // Previous reset call would have shrunk the buffer. This call should fail otherwise it will expand the buffer.
-            if (garnetApi.ResetScratchBuffer(buffOffset2))
+            // Since GET uses SBA, both offsets should be equal (SBB unchanged)
+            if (buffOffset1 != buffOffset2)
             {
-                WriteError(ref output, "ERR ResetScratchBuffer shouldn't expand the buffer");
+                WriteError(ref output, "ERR SBB offset should not change after GET");
+                return false;
+            }
+
+            // ResetScratchBuffer should succeed (offset unchanged)
+            if (!garnetApi.ResetScratchBuffer(buffOffset1))
+            {
+                WriteError(ref output, "ERR ResetScratchBuffer failed");
                 return false;
             }
 

--- a/test/Garnet.test/ScratchBufferAllocatorTests.cs
+++ b/test/Garnet.test/ScratchBufferAllocatorTests.cs
@@ -20,7 +20,7 @@ namespace Garnet.test
             var string2 = new string('b', 65);
             var string3 = new string('c', 6000);
 
-            var sam = new ScratchBufferAllocator(maxInitialCapacity: maxInitialCapacity);
+            var sam = new ScratchBufferAllocator(minSizeBuffer: 2, maxInitialCapacity: maxInitialCapacity);
 
             // Data of length 5 - SAM creates a buffer of size 8
             var as1 = sam.CreateArgSlice(string1);


### PR DESCRIPTION
### Root Cause

`ProcessResp2ArrayOutput`, `ProcessResp3ArrayOutput`, `ProcessRespArrayOutputAsPairs`, and `ProcessRespSingleTokenOutput` in `StorageSession` return `PinnedSpanByte` values pointing into `IMemoryOwner<byte>` buffers from `MemoryPool<byte>.Shared`. These buffers are **not pinned** — `RespMemoryWriter` pins them temporarily via `MemoryHandle` during write, but unpins on dispose. The `ProcessResp*` methods then dispose the `IMemoryOwner` in their `finally` blocks, returning dangling pointers into freed, unpinned memory.

This only affects the `new ObjectOutput()` code path (SpanByte invalidated, forcing IMemory allocation). The RESP handler path uses `GetObjectOutput()` backed by the pinned session network buffer, so it is unaffected.

Same bug exists on `main` with `ArgSlice`/`GarnetObjectStoreOutput` types.

### Affected Commands

ZMPOP, LMPOP, BLMPOP, BZMPOP, and any custom procedures or Lua scripts calling `HashGet`, `HashGetAll`, `HashGetMultiple`, `HashRandomField`, `SetMembers`, `SetPop`, `SortedSetPop`, `SortedSetRange`, `SortedSetIncrement`, `GET`, or `ObjectScan` through `IGarnetApi`.

### Description of Change

Use existing `ScratchBufferAllocator` (SBA) alongside existing `ScratchBufferBuilder` (SBB) in `StorageSession`. SBA uses pinned arrays (`GC.AllocateArray(_, true)`) and keeps old buffers rooted, so returned `PinnedSpanByte` values remain valid across multiple API calls within a batch.

**Key changes:**
- **Core fix** (`Common.cs`): Copy parsed output to SBA inside `fixed` block before `IMemoryOwner` disposal
- **GET fix** (`MainStoreOps.cs`): Use SBA `ViewRemainingArgSlice` for zero-copy common case; copy on IMemory overflow
- **Custom command fix** (`CustomRespCommands.cs`): All returned `PinnedSpanByte` output uses SBA + proper Memory disposal
- **SBA wiring**: Added to `StorageSession`, `DatabaseManagerBase`, `RespServerSession`, `LocalServerSession`
- **API cleanup** (`IGarnetApi`): Removed `GetScratchBufferOffset()` and `ResetScratchBuffer(int)`, added `ResetScratchBuffer()` (full SBA reset)
- **SBB debug safety** (`ScratchBufferBuilder.cs`): Debug-only `outstandingSlices` counter asserts no more than one live `PinnedSpanByte` at a time
- **SBB safety fixes**: Added missing rewinds in `SortedSetIncrement`, `KeyAdminCommands`, `CollectionItemBroker`; single contiguous allocation for `SortedSetRange LIMIT`; create+use+rewind for Lua `AddKey`
- **New API**: `CreateArgSliceAsOffset` returns `(Offset, Length)` instead of `PinnedSpanByte` — safe for multi-alloc (used by `ArgSliceVector`)
- **Visibility**: `scratchBufferBuilder` and `scratchBufferAllocator` marked `internal` on `StorageSession`
- **Cleanup**: Removed unused `FormatScratchAsResp`, `GetSliceFromTail`, `ResetScratchBuffer(int)` from SBB

### Key Technical Details

**SBB vs SBA roles:**
- `ScratchBufferBuilder` — contiguous temporary workspace (Lua serialization, command input building with rewind). Single buffer, reallocates in place.
- `ScratchBufferAllocator` — persistent output storage for API-returned `PinnedSpanByte`. Keeps old buffers rooted in a stack. Reset between batches.

**Affected types:**
- `StorageSession` — new `scratchBufferAllocator` field
- `IGarnetApi` / `GarnetApi` / `GarnetWatchApi` — simplified scratch buffer API
- `ScratchBufferBuilder` — debug counter, `CreateArgSliceAsOffset`, doc comments on view APIs, removed unused APIs

### What NOT to Do

- ❌ **Do not return `PinnedSpanByte` from `ScratchBufferBuilder`** for values that must survive across multiple API calls — use `ScratchBufferAllocator`
- ❌ **Do not call `CreateArgSlice` on SBB without rewinding** before the next `CreateArgSlice` — debug asserts enforce this
- ❌ **Do not skip `Memory.Dispose()`** after copying from `IMemoryOwner` to SBA — causes pool buffer leaks
- ❌ **Do not store `ViewFullArgSlice` / `ViewRemainingArgSlice` results** — they are immediate-use views invalidated by subsequent operations
