### PR TITLE
[DEV] Improve Failover Restore / Replication Handling

### DIFF
--- a/libs/cluster/Server/Failover/FailoverManager.cs
+++ b/libs/cluster/Server/Failover/FailoverManager.cs
@@ -16,7 +16,7 @@ namespace Garnet.cluster
         readonly TimeSpan clusterTimeout;
         readonly ILogger logger;
         private SingleWriterMultiReaderLock failoverTaskLock;
-        public FailoverStatus lastFailoverStatus = FailoverStatus.NO_FAILOVER;
+        public volatile FailoverStatus lastFailoverStatus = FailoverStatus.NO_FAILOVER;
 
         /// <summary>
         /// Shared epoch instance for failover GarnetClient connections

--- a/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
+++ b/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
@@ -119,11 +119,10 @@ namespace Garnet.cluster
 
             try
             {
-#if DEBUG
                 // Exception injection point for testing: simulates TakeOverAsPrimary failure
                 // after PauseWritesAndWaitForSync has already sent failstopwrites to the primary.
                 ExceptionInjectionHelper.TriggerException(ExceptionInjectionType.Failover_Fail_TakeOverAsPrimary);
-#endif
+
                 // Make replica syncing unavailable by setting recovery flag
                 if (!clusterProvider.replicationManager.BeginRecovery(RecoveryStatus.ClusterFailover, upgradeLock: false))
                 {

--- a/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
+++ b/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
@@ -119,6 +119,11 @@ namespace Garnet.cluster
 
             try
             {
+#if DEBUG
+                // Exception injection point for testing: simulates TakeOverAsPrimary failure
+                // after PauseWritesAndWaitForSync has already sent failstopwrites to the primary.
+                ExceptionInjectionHelper.TriggerException(ExceptionInjectionType.Failover_Fail_TakeOverAsPrimary);
+#endif
                 // Make replica syncing unavailable by setting recovery flag
                 if (!clusterProvider.replicationManager.BeginRecovery(RecoveryStatus.ClusterFailover, upgradeLock: false))
                 {
@@ -273,6 +278,14 @@ namespace Garnet.cluster
         }
 
         /// <summary>
+        /// Returns true if failstopwrites was confirmed by the primary and the primary's
+        /// config was modified (slots given up, role changed to replica). Used to determine
+        /// whether the primary needs to be reset on failover failure.
+        /// </summary>
+        private bool PrimaryNeedsReset()
+            => status is FailoverStatus.WAITING_FOR_SYNC or FailoverStatus.TAKING_OVER_AS_PRIMARY;
+
+        /// <summary>
         /// REPLICA main failover task
         /// </summary>
         /// <returns></returns>
@@ -281,6 +294,7 @@ namespace Garnet.cluster
             // CLUSTER FAILOVER OPTIONS
             // FORCE: Do not await for the primary since it might be unreachable
             // TAKEOVER: Same as force but also do not await for voting from other primaries
+            var failoverSucceeded = false;
             try
             {
                 // Issue stop writes and on ack wait for replica to catch up
@@ -298,14 +312,15 @@ namespace Garnet.cluster
                 // Transition to primary role
                 if (!TakeOverAsPrimary())
                 {
-                    // Request primary to be reset to original state only if DEFAULT option was used
-                    if (primaryClient != null)
-                        _ = await primaryClient?.failstopwrites(Array.Empty<byte>()).WaitAsync(failoverTimeout, cts.Token);
                     return false;
                 }
+                failoverSucceeded = true;
 
                 // Attach to old replicas, and old primary if DEFAULT option
                 await IssueAttachReplicas();
+
+                await clusterProvider.storeWrapper.SuspendReplicaOnlyTasks();
+                clusterProvider.storeWrapper.StartPrimaryTasks();
 
                 return true;
             }
@@ -316,6 +331,24 @@ namespace Garnet.cluster
             }
             finally
             {
+                // If failstopwrites was confirmed by the primary (status reached WAITING_FOR_SYNC
+                // or beyond) but the failover did not succeed, reset the primary back to its
+                // original state. Without this, the primary has already given up its slots
+                // (via TryStopWrites) but the replica never claimed them, leaving the cluster
+                // in an incoherent state where no node owns the slots.
+                if (PrimaryNeedsReset() && !failoverSucceeded)
+                {
+                    try
+                    {
+                        logger?.LogWarning("Attempting to reset primary after failed failover");
+                        _ = await primaryClient?.failstopwrites(Array.Empty<byte>()).WaitAsync(failoverTimeout, cts.Token);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.LogError(ex, "Failed to reset primary after failed failover — cluster may be in an incoherent state");
+                    }
+                }
+
                 primaryClient?.Dispose();
                 status = FailoverStatus.NO_FAILOVER;
             }

--- a/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
+++ b/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
@@ -319,9 +319,6 @@ namespace Garnet.cluster
                 // Attach to old replicas, and old primary if DEFAULT option
                 await IssueAttachReplicas();
 
-                await clusterProvider.storeWrapper.SuspendReplicaOnlyTasks();
-                clusterProvider.storeWrapper.StartPrimaryTasks();
-
                 return true;
             }
             catch (Exception ex)

--- a/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
+++ b/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
@@ -338,7 +338,10 @@ namespace Garnet.cluster
                     try
                     {
                         logger?.LogWarning("Attempting to reset primary after failed failover");
-                        _ = await primaryClient?.failstopwrites(Array.Empty<byte>()).WaitAsync(failoverTimeout, cts.Token);
+                        if (primaryClient != null)
+                        {
+                            _ = await primaryClient.failstopwrites(Array.Empty<byte>()).WaitAsync(failoverTimeout, cts.Token);
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/libs/cluster/Server/Replication/ReplicationManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationManager.cs
@@ -190,6 +190,20 @@ namespace Garnet.cluster
                 return;
             }
 
+            // Suppress auto-resync while a failover is in progress.
+            // Without this guard, EnsureReplication would acquire a ReadRole lock that blocks
+            // TakeOverAsPrimary from obtaining its ClusterFailover write lock, aborting the failover.
+            var failoverStatus = clusterProvider.failoverManager.lastFailoverStatus;
+            if (failoverStatus is FailoverStatus.BEGIN_FAILOVER
+                              or FailoverStatus.ISSUING_PAUSE_WRITES
+                              or FailoverStatus.WAITING_FOR_SYNC
+                              or FailoverStatus.FAILOVER_IN_PROGRESS
+                              or FailoverStatus.TAKING_OVER_AS_PRIMARY)
+            {
+                logger?.LogDebug("Suppressing auto-resync during active failover (status: {failoverStatus})", failoverStatus);
+                return;
+            }
+
             // Now we're going to attempt to re-establish replication
 
             // To avoid a TOCTOU issue, we need to prevent role change while we do this

--- a/libs/common/ExceptionInjectionType.cs
+++ b/libs/common/ExceptionInjectionType.cs
@@ -64,6 +64,10 @@ namespace Garnet.common
         /// <summary>
         /// Replication diskless sync reset cts
         /// </summary>
-        Replication_Diskless_Sync_Reset_Cts
+        Replication_Diskless_Sync_Reset_Cts,
+        /// <summary>
+        /// Fail TakeOverAsPrimary during failover by throwing before BeginRecovery is called.
+        /// </summary>
+        Failover_Fail_TakeOverAsPrimary,
     }
 }

--- a/test/Garnet.test.cluster/ClusterNegativeTests.cs
+++ b/test/Garnet.test.cluster/ClusterNegativeTests.cs
@@ -626,5 +626,217 @@ namespace Garnet.test.cluster
             var exc = Assert.Throws<RedisServerException>(() => replicaServer.Execute("CLUSTER", ["REPLICATE", Guid.NewGuid().ToString()], flags: CommandFlags.NoRedirect));
             ClassicAssert.IsTrue(exc.Message.StartsWith("ERR I don't know about node "));
         }
+
+        [Test, Order(14), CancelAfter(testTimeout)]
+        [Category("REPLICATION")]
+        public void ClusterFailoverSucceedsDuringEnsureReplication(CancellationToken cancellationToken)
+        {
+            // Verify that EnsureReplication does not block an in-flight failover.
+            // EnsureReplication polls for dropped replication sessions and attempts auto-resync.
+            // Without the failover status guard, it could acquire a ReadRole lock that blocks
+            // TakeOverAsPrimary from obtaining its ClusterFailover write lock, aborting the failover.
+            var primaryIndex = 0;
+            var replicaIndex = 1;
+            var nodes_count = 2;
+
+            // Enable EnsureReplication by setting clusterReplicationReestablishmentTimeout to 1 second
+            context.CreateInstances(nodes_count, disableObjects: true, enableAOF: true,
+                timeout: timeout, clusterReplicationReestablishmentTimeout: 1);
+            context.CreateConnection();
+
+            _ = context.clusterTestUtils.AddDelSlotsRange(primaryIndex, [(0, 16383)], addslot: true, logger: context.logger);
+            context.clusterTestUtils.SetConfigEpoch(primaryIndex, primaryIndex + 1, logger: context.logger);
+            context.clusterTestUtils.SetConfigEpoch(replicaIndex, replicaIndex + 1, logger: context.logger);
+            context.clusterTestUtils.Meet(primaryIndex, replicaIndex, logger: context.logger);
+            context.clusterTestUtils.WaitUntilNodeIsKnown(primaryIndex, replicaIndex, logger: context.logger);
+
+            // Set up replication
+            var resp = context.clusterTestUtils.ClusterReplicate(replicaNodeIndex: replicaIndex, primaryNodeIndex: primaryIndex, logger: context.logger);
+            ClassicAssert.AreEqual("OK", resp);
+            context.clusterTestUtils.WaitForReplicaRecovery(replicaIndex, context.logger);
+            context.clusterTestUtils.WaitForConnectedReplicaCount(primaryIndex, 1, context.logger);
+
+            // Populate primary and wait for sync
+            context.kvPairs = [];
+            context.PopulatePrimary(ref context.kvPairs, keyLength: 32, kvpairCount: 16, primaryIndex);
+            context.clusterTestUtils.WaitForReplicaAofSync(primaryIndex, replicaIndex, context.logger);
+
+            // Issue failover — with EnsureReplication enabled (polling every 1s),
+            // the guard should prevent it from interfering with the failover
+            resp = context.clusterTestUtils.ClusterFailover(replicaIndex, logger: context.logger);
+            ClassicAssert.AreEqual("OK", resp);
+
+            // Wait for failover to complete — without the guard this could hang or abort
+            context.clusterTestUtils.WaitForFailoverCompleted(replicaIndex, context.logger);
+
+            // The old primary should become a replica
+            context.clusterTestUtils.WaitForReplicaRecovery(primaryIndex, context.logger);
+
+            // Verify the new primary (formerly replica) is functional
+            var role = context.clusterTestUtils.RoleCommand(replicaIndex, context.logger);
+            ClassicAssert.AreEqual("master", role.Value);
+
+            var oldPrimaryRole = context.clusterTestUtils.RoleCommand(primaryIndex, context.logger);
+            ClassicAssert.AreEqual("slave", oldPrimaryRole.Value);
+
+            // Verify last failover state
+            var infoItem = context.clusterTestUtils.GetReplicationInfo(replicaIndex,
+                [ReplicationInfoItem.LAST_FAILOVER_STATE], logger: context.logger);
+            ClassicAssert.AreEqual("failover-completed", infoItem[0].Item2);
+        }
+
+        [Test, Order(15), CancelAfter(testTimeout)]
+        [Category("REPLICATION")]
+        public void ClusterEnsureReplicationWorksAfterFailover(CancellationToken cancellationToken)
+        {
+            // Verify that EnsureReplication still functions after a failover completes.
+            // The failover guard should only suppress auto-resync during active failover states,
+            // not after failover has completed or aborted.
+            var primaryIndex = 0;
+            var replicaIndex = 1;
+            var nodes_count = 2;
+
+            // Enable EnsureReplication with a 1-second poll frequency
+            context.CreateInstances(nodes_count, disableObjects: true, enableAOF: true,
+                timeout: timeout, clusterReplicationReestablishmentTimeout: 1);
+            context.CreateConnection();
+
+            _ = context.clusterTestUtils.AddDelSlotsRange(primaryIndex, [(0, 16383)], addslot: true, logger: context.logger);
+            context.clusterTestUtils.SetConfigEpoch(primaryIndex, primaryIndex + 1, logger: context.logger);
+            context.clusterTestUtils.SetConfigEpoch(replicaIndex, replicaIndex + 1, logger: context.logger);
+            context.clusterTestUtils.Meet(primaryIndex, replicaIndex, logger: context.logger);
+            context.clusterTestUtils.WaitUntilNodeIsKnown(primaryIndex, replicaIndex, logger: context.logger);
+
+            // Set up replication
+            var resp = context.clusterTestUtils.ClusterReplicate(replicaNodeIndex: replicaIndex, primaryNodeIndex: primaryIndex, logger: context.logger);
+            ClassicAssert.AreEqual("OK", resp);
+            context.clusterTestUtils.WaitForReplicaRecovery(replicaIndex, context.logger);
+            context.clusterTestUtils.WaitForConnectedReplicaCount(primaryIndex, 1, context.logger);
+
+            // Populate primary data and sync
+            context.kvPairs = [];
+            context.PopulatePrimary(ref context.kvPairs, keyLength: 32, kvpairCount: 16, primaryIndex);
+            context.clusterTestUtils.WaitForReplicaAofSync(primaryIndex, replicaIndex, context.logger);
+
+            // Run failover
+            resp = context.clusterTestUtils.ClusterFailover(replicaIndex, logger: context.logger);
+            ClassicAssert.AreEqual("OK", resp);
+            context.clusterTestUtils.WaitForFailoverCompleted(replicaIndex, context.logger);
+
+            // Old primary should now be a replica of the new primary
+            context.clusterTestUtils.WaitForReplicaRecovery(primaryIndex, context.logger);
+
+            // Verify last_failover_state is "failover-completed" — this should NOT suppress EnsureReplication
+            var infoItem = context.clusterTestUtils.GetReplicationInfo(replicaIndex,
+                [ReplicationInfoItem.LAST_FAILOVER_STATE], logger: context.logger);
+            ClassicAssert.AreEqual("failover-completed", infoItem[0].Item2);
+
+            // Verify replication is working in the new topology
+            // The old primary (index 0) is now a replica of the new primary (index 1)
+            // Write to new primary and verify it replicates to old primary (now replica)
+            var slotMap = new int[16384];
+            for (var i = 0; i < 16384; i++)
+                slotMap[i] = replicaIndex;
+
+            var newKvPairs = new Dictionary<string, int>();
+            context.PopulatePrimary(ref newKvPairs, keyLength: 32, kvpairCount: 8, replicaIndex, slotMap: slotMap);
+            context.clusterTestUtils.WaitForReplicaAofSync(replicaIndex, primaryIndex, context.logger);
+            context.ValidateKVCollectionAgainstReplica(ref newKvPairs, primaryIndex);
+        }
+
+#if DEBUG
+        [Test, Order(16), CancelAfter(testTimeout)]
+        [Category("REPLICATION")]
+        public void ClusterFailoverResetsPrimaryOnTakeOverFailure(CancellationToken cancellationToken)
+        {
+            // Verify that when TakeOverAsPrimary fails after PauseWritesAndWaitForSync
+            // has already sent failstopwrites to the primary, the primary is reset back
+            // to its original state (owns slots, is a primary).
+            //
+            // Without the reset in BeginAsyncReplicaFailover's finally block, the primary
+            // would have given up its slots (via TryStopWrites) but the replica never
+            // claimed them, leaving the cluster in an incoherent state.
+            var primaryIndex = 0;
+            var replicaIndex = 1;
+            var nodes_count = 2;
+
+            context.CreateInstances(nodes_count, disableObjects: true, enableAOF: true, timeout: timeout);
+            context.CreateConnection();
+
+            _ = context.clusterTestUtils.AddDelSlotsRange(primaryIndex, [(0, 16383)], addslot: true, logger: context.logger);
+            context.clusterTestUtils.SetConfigEpoch(primaryIndex, primaryIndex + 1, logger: context.logger);
+            context.clusterTestUtils.SetConfigEpoch(replicaIndex, replicaIndex + 1, logger: context.logger);
+            context.clusterTestUtils.Meet(primaryIndex, replicaIndex, logger: context.logger);
+            context.clusterTestUtils.WaitUntilNodeIsKnown(primaryIndex, replicaIndex, logger: context.logger);
+
+            // Set up replication
+            var resp = context.clusterTestUtils.ClusterReplicate(replicaNodeIndex: replicaIndex, primaryNodeIndex: primaryIndex, logger: context.logger);
+            ClassicAssert.AreEqual("OK", resp);
+            context.clusterTestUtils.WaitForReplicaRecovery(replicaIndex, context.logger);
+            context.clusterTestUtils.WaitForConnectedReplicaCount(primaryIndex, 1, context.logger);
+
+            // Populate data and sync
+            context.kvPairs = [];
+            context.PopulatePrimary(ref context.kvPairs, keyLength: 32, kvpairCount: 16, primaryIndex);
+            context.clusterTestUtils.WaitForReplicaAofSync(primaryIndex, replicaIndex, context.logger);
+
+            // Verify primary owns all slots before failover
+            var slotsBefore = context.clusterTestUtils.GetOwnedSlotsFromNode(primaryIndex, context.logger);
+            ClassicAssert.AreEqual(16384, slotsBefore.Count, "Primary should own all slots before failover");
+
+            try
+            {
+                // Enable exception injection to make TakeOverAsPrimary fail.
+                // This simulates the scenario where PauseWritesAndWaitForSync succeeds
+                // (failstopwrites sent to primary, primary gives up slots) but the
+                // subsequent TakeOverAsPrimary fails (e.g., due to lock contention from
+                // EnsureReplication holding the ReadRole lock).
+                ExceptionInjectionHelper.EnableException(ExceptionInjectionType.Failover_Fail_TakeOverAsPrimary);
+
+                // Issue DEFAULT failover — this will:
+                // 1. Send failstopwrites to primary (primary gives up slots)
+                // 2. Wait for sync
+                // 3. TakeOverAsPrimary — FAILS due to injected exception
+                // 4. finally block sends failstopwrites([]) to reset primary
+                resp = context.clusterTestUtils.ClusterFailover(replicaIndex, logger: context.logger);
+                ClassicAssert.AreEqual("OK", resp);
+
+                // Wait for failover to be aborted
+                while (true)
+                {
+                    var infoItem = context.clusterTestUtils.GetReplicationInfo(replicaIndex,
+                        [ReplicationInfoItem.LAST_FAILOVER_STATE], logger: context.logger);
+                    if (infoItem[0].Item2.Equals("failover-aborted"))
+                        break;
+                    ClusterTestUtils.BackOff(cancellationToken: cancellationToken, msg: "Waiting for failover to abort");
+                }
+            }
+            finally
+            {
+                ExceptionInjectionHelper.DisableException(ExceptionInjectionType.Failover_Fail_TakeOverAsPrimary);
+            }
+
+            // Verify primary has been reset: it should own all slots again
+            // Without the reset fix, the primary would have 0 slots here.
+            while (true)
+            {
+                var slotsAfter = context.clusterTestUtils.GetOwnedSlotsFromNode(primaryIndex, context.logger);
+                if (slotsAfter.Count == 16384)
+                    break;
+                ClusterTestUtils.BackOff(cancellationToken: cancellationToken, msg: $"Waiting for primary to reclaim slots (current: {slotsAfter.Count})");
+            }
+
+            // Verify primary is still a primary
+            var role = context.clusterTestUtils.RoleCommand(primaryIndex, logger: context.logger);
+            ClassicAssert.AreEqual("master", role.Value, "Primary should be reset back to master role");
+
+            // Verify replica is still a replica (failover was aborted)
+            role = context.clusterTestUtils.RoleCommand(replicaIndex, logger: context.logger);
+            ClassicAssert.AreEqual("slave", role.Value, "Replica should remain a slave after aborted failover");
+
+            // Verify data is still accessible from the primary
+            context.ValidateKVCollectionAgainstReplica(ref context.kvPairs, primaryIndex);
+        }
+#endif
     }
 }


### PR DESCRIPTION
## Prevent EnsureReplication from sabotaging in-flight failovers and recover from partial failover failures

### Summary

This PR fixes two related bugs in the cluster failover path:

1. **`EnsureReplication` races with `CLUSTER FAILOVER`**: The `ReplicationManager.EnsureReplication` background poller can issue `CLUSTER REPLICATE` during an in-flight failover, sabotaging the promotion and leaving the cluster in an incoherent state.

2. **No recovery when failover fails after `failstopwrites`**: If `TakeOverAsPrimary` fails after `PauseWritesAndWaitForSync` has already sent `failstopwrites` to the primary, the primary is left in a modified state (no slots, replica role) with no node to serve those slots.

### The Core Problem

During a `CLUSTER FAILOVER DEFAULT`, the replica sends `failstopwrites` to its primary, which **immediately and irreversibly** modifies the primary's config — making it a replica and reassigning all its slots. The replica then waits for replication offsets to converge before calling `TakeOverAsPrimary` to claim those slots.

`EnsureReplication` runs on a background polling timer inside the Garnet process. When it detects a broken replication session (which can happen during failover), it acquires a `ReadRole` lock and issues `CLUSTER REPLICATE` to re-establish replication — completely unaware that a failover is in progress.

This creates two failure modes:

- **Lock contention**: `EnsureReplication`'s `ReadRole` read lock blocks `TakeOverAsPrimary`'s `ClusterFailover` write lock (`TryWriteLock` fails non-blockingly, aborting the failover)
- **State corruption**: `EnsureReplication`'s `CLUSTER REPLICATE` re-establishes replication to the primary the replica is trying to take over from, making offset sync impossible

### Race Condition Sequence

| Step | Time | Failover Task (replica) | EnsureReplication (replica) | Primary |
|------|------|------------------------|---------------------------|---------|
| 1 | T+0s | `CLUSTER FAILOVER` received → `status = BEGIN_FAILOVER` | | |
| 2 | T+0s | `PauseWritesAndWaitForSync` → sends `failstopwrites(localNodeId)` to primary | | Receives `failstopwrites` → `TryStopWrites`: gives up all slots, becomes replica of the failover node, bumps epoch, flushes config to disk |
| 3 | T+0s | `status = WAITING_FOR_SYNC` → spinning on `primaryReplicationOffset > ReplicationOffset` | | |
| 4 | T+Ns | | Detects broken replication session (`IsReplicating = false`) | |
| 5 | T+Ns | *(still spinning on offset sync)* | Checks: `IsReplica? ✅` `RemoteNodeId == primaryId? ✅` `IsReplicating? ❌` → all conditions met | |
| 6 | T+Ns | | Calls `PreventRoleChange()` → `BeginRecovery(ReadRole)` → acquires **read lock** on `recoverLock` | |
| 7 | T+Ns | | Spawns `Task.Run` → issues `CLUSTER REPLICATE` back to primary → re-establishes replication session | |
| 8 | T+Ns | Offset sync never converges (active replication makes offsets a moving target) OR failover times out | Holds read lock across entire replication sync | |
| 9 | T+5m | `PauseWritesAndWaitForSync` returns `false` (timeout) → `BeginAsyncReplicaFailover` returns `false` | | |
| 10 | — | `TakeOverAsPrimary` **never called** → replica never claims slots | | |
| 11 | — | `finally`: `status = NO_FAILOVER`, `lastFailoverStatus = FAILOVER_ABORTED` | | |

### Resulting Incoherent Topology

| Node | Role | Slots | Epoch |
|------|------|-------|-------|
| Primary | master (or confused) | **none** — gave them up at step 2 | 153 |
| Replica | replica of Primary | **has slots in config** (as belonging to Primary's worker entry) | 153 |

No node can serve reads or writes for the affected slots. The primary's config is persisted to disk, so this state survives restarts.

### Downstream Impact

Without recovery, this incoherent topology can cause:

- **Slot unavailability**: No primary node owns the affected slots — all reads/writes to keys in those slots fail

### Changes

#### 1. Suppress `EnsureReplication` during active failover (`ReplicationManager.cs`)

Added an early-exit guard in `EnsureReplication` that checks `failoverManager.lastFailoverStatus`. If the failover is in any active state (`BEGIN_FAILOVER`, `ISSUING_PAUSE_WRITES`, `WAITING_FOR_SYNC`, `FAILOVER_IN_PROGRESS`, `TAKING_OVER_AS_PRIMARY`), `EnsureReplication` returns immediately without acquiring any locks. Terminal states (`FAILOVER_COMPLETED`, `FAILOVER_ABORTED`) are intentionally excluded so `EnsureReplication` resumes normal operation after failover completes.

#### 2. Reset primary on failover failure (`ReplicaFailoverSession.cs`)

Moved the primary reset logic (`failstopwrites([])`) from the `TakeOverAsPrimary` failure path into the `finally` block of `BeginAsyncReplicaFailover`. This ensures the primary is reset for **all** failure paths after `failstopwrites` was sent — including timeout in `PauseWritesAndWaitForSync`, exceptions, and `TakeOverAsPrimary` failure. Previously, the reset was only attempted when `TakeOverAsPrimary` explicitly returned `false`, which was unreachable when the failover failed during the sync wait phase.

#### 3. Exception injection for testing (`ExceptionInjectionType.cs`, `ReplicaFailoverSession.cs`)

Added `Failover_Fail_TakeOverAsPrimary` exception injection point (DEBUG only) to simulate `TakeOverAsPrimary` failure after `PauseWritesAndWaitForSync` succeeds, enabling deterministic testing of the recovery path.

### Tests

- **`ClusterFailoverResetsPrimaryOnTakeOverFailure`** (new, DEBUG): Verifies that when `TakeOverAsPrimary` fails after `failstopwrites` was sent, the primary is reset back to its original state — owns all 16384 slots, has `master` role, and data remains accessible.
- **`ClusterFailoverSucceedsDuringEnsureReplication`** (new): Verifies that a `CLUSTER FAILOVER` completes successfully when `EnsureReplication` is actively polling (1-second interval).
- **`ClusterEnsureReplicationWorksAfterFailover`** (new): Verifies that `EnsureReplication` resumes normal operation after failover completes — the guard only suppresses during active failover states.
- **`ClusterFailoverDuringRecovery`** (existing, unmodified): Uses `TAKEOVER` which skips `PauseWritesAndWaitForSync`, so the new reset path doesn't trigger. Unaffected by these changes.