### PR TITLE
Replace PriorityQueue + Dictionary with IndexedPriorityQueue for SortedSet Expiration

### DIFF
--- a/libs/common/Collections/IndexedPriorityQueue.cs
+++ b/libs/common/Collections/IndexedPriorityQueue.cs
@@ -1,0 +1,308 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Garnet.common.Collections
+{
+    /// <summary>
+    /// In-place updatable min-heap. With methods to access priority in constant time.
+    /// </summary>
+    public class IndexedPriorityQueue<TElement, TPriority>
+    {
+        // element -> index in heap
+        private readonly Dictionary<TElement, int> _index;
+
+        private const int DefaultCapacity = 4;
+
+        // binary heap
+        private (TElement element, TPriority priority)[] _heap = [];
+        private int _count;
+
+        /// <summary>
+        /// Number of elements in the priority queue.
+        /// </summary>
+        public int Count => _count;
+
+        /// <summary>
+        /// Creates an IndexedPriorityQueue using the default equality comparer for elements.
+        /// </summary>
+        public IndexedPriorityQueue() : this(null) { }
+
+        /// <summary>
+        /// Creates an IndexedPriorityQueue using the specified equality comparer for elements.
+        /// </summary>
+        public IndexedPriorityQueue(IEqualityComparer<TElement> comparer)
+        {
+            _index = new Dictionary<TElement, int>(comparer);
+        }
+
+        public bool Exists(TElement element) => _index.ContainsKey(element);
+
+        /// <summary>
+        /// O(log N) - Enqueue or update the priority of a key
+        /// </summary>
+        /// <param name="element"></param>
+        /// <param name="value"></param>
+        public void EnqueueOrUpdate(TElement element, TPriority value)
+        {
+            if (_index.TryGetValue(element, out int idxInHeap))
+            {
+                _index[element] = UpdateHeap(idxInHeap, value);
+                return;
+            }
+
+            _index[element] = InsertIntoHeap(element, value);
+        }
+
+        /// <summary>
+        /// O(log N) - Dequeue Key with Lowest Priority
+        /// </summary>
+        /// <returns>Element with lowest priority</returns>
+        public TElement Dequeue()
+        {
+            if (_count == 0)
+                throw new InvalidOperationException("The queue is empty.");
+
+            return DequeueFromHeap();
+        }
+
+        /// 
+        /// <summary>
+        /// O(1) - Try to peek at the element with the lowest priority
+        /// </summary>
+        /// <param name="key">The element with the lowest priority</param>
+        /// <param name="value">The priority of the element</param>
+        /// <returns>True if the queue is not empty, otherwise false</returns>
+        public bool TryPeek(out TElement key, out TPriority value)
+        {
+            if (_count == 0)
+            {
+                key = default!;
+                value = default!;
+                return false;
+            }
+            (key, value) = _heap[0];
+            return true;
+        }
+
+        /// <summary>
+        /// O(log N) - Change the priority of an element
+        /// </summary>
+        /// <param name="key">The element whose priority is to be changed</param>
+        /// <param name="newValue">The new priority value</param>
+        public void ChangePriority(TElement key, TPriority newValue) => _index[key] = UpdateHeap(_index[key], newValue);
+
+        /// <summary>
+        /// O(1) - Get the priority of an element
+        /// </summary>
+        /// <param name="key">The element whose priority is to be retrieved</param>
+        /// <param name="value">The priority of the element</param>
+        public void GetPriority(TElement key, out TPriority value) => value = _heap[_index[key]].priority;
+
+
+        /// <summary>
+        /// O(1) - Try to get the priority of an element. Returns false if the element is not in the queue.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public bool TryGetPriority(TElement key, out TPriority value)
+        {
+            if (_index.TryGetValue(key, out int idxInHeap))
+            {
+                value = _heap[idxInHeap].priority;
+                return true;
+            }
+            value = default!;
+            return false;
+        }
+
+
+        /// <summary>
+        /// O(log N) - Try to remove an element from the queue. Returns false if the element is not in the queue.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public bool TryRemove(TElement key)
+        {
+            if (!_index.TryGetValue(key, out int idxInHeap))
+            {
+                return false;
+            }
+
+            _index.Remove(key);
+            _count--;
+            if (idxInHeap == _count)
+            {
+                // Removing the last element, no need to sift
+                return true;
+            }
+
+            _heap[idxInHeap] = _heap[_count];
+            _index[_heap[idxInHeap].element] = idxInHeap;
+
+            // Try sifting down, if it doesn't move then try sifting up
+            if (SiftDown(idxInHeap) == idxInHeap)
+            {
+                SiftUp(idxInHeap);
+            }
+
+            if (_heap.Length > DefaultCapacity && _count < _heap.Length / 2)
+            {
+                Shrink();
+            }
+            return true;
+        }
+
+
+        // helper - methods
+
+        private int InsertIntoHeap(TElement key, TPriority value)
+        {
+            if (_count == _heap.Length)
+            {
+                Grow(_count + 1);
+            }
+
+            _heap[_count] = (key, value);
+            _index[key] = _count;
+            _count++;
+            return SiftUp(_count - 1);
+        }
+
+        private TElement DequeueFromHeap()
+        {
+            TElement element = _heap[0].element;
+            _index.Remove(element);
+            _count--;
+
+            if (_count > 0)
+            {
+                _heap[0] = _heap[_count];
+                _index[_heap[0].element] = 0;
+                SiftDown(0);
+            }
+
+            if (_heap.Length > DefaultCapacity && _count < _heap.Length / 2)
+            {
+                Shrink();
+            }
+
+            return element;
+        }
+
+        private int UpdateHeap(int idxInHeap, TPriority newValue)
+        {
+            TPriority oldValue = _heap[idxInHeap].priority;
+            TElement element = _heap[idxInHeap].element;
+            _heap[idxInHeap] = (element, newValue);
+
+            int cmp = Comparer<TPriority>.Default.Compare(newValue, oldValue);
+            if (cmp < 0)
+            {
+                // new priority is smaller – sift up
+                return SiftUp(idxInHeap);
+            }
+            else if (cmp > 0)
+            {
+                // new priority is larger – sift down
+                return SiftDown(idxInHeap);
+            }
+
+            return idxInHeap;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int SiftUp(int currIdx)
+        {
+            var entry = _heap[currIdx];
+            while (currIdx > 0)
+            {
+                int parentIdx = GetParentIndex(currIdx);
+                if (Comparer<TPriority>.Default.Compare(_heap[parentIdx].priority, entry.priority) <= 0)
+                    break;
+
+                _heap[currIdx] = _heap[parentIdx];
+                _index[_heap[currIdx].element] = currIdx;
+                currIdx = parentIdx;
+            }
+            _heap[currIdx] = entry;
+            _index[entry.element] = currIdx;
+            return currIdx;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int SiftDown(int currIdx)
+        {
+            var entry = _heap[currIdx];
+            while (true)
+            {
+                int smallerChildIdx = GetLeftChildIndex(currIdx);
+                if (smallerChildIdx >= _count)
+                    break;
+
+                int rightChildIdx = smallerChildIdx + 1;
+                if (rightChildIdx < _count && Comparer<TPriority>.Default.Compare(_heap[rightChildIdx].priority, _heap[smallerChildIdx].priority) < 0)
+                    smallerChildIdx = rightChildIdx;
+
+                if (Comparer<TPriority>.Default.Compare(entry.priority, _heap[smallerChildIdx].priority) <= 0)
+                    break;
+
+                _heap[currIdx] = _heap[smallerChildIdx];
+                _index[_heap[currIdx].element] = currIdx;
+                currIdx = smallerChildIdx;
+            }
+            _heap[currIdx] = entry;
+            _index[entry.element] = currIdx;
+            return currIdx;
+        }
+
+        private int GetParentIndex(int i) => (i - 1) / 2;
+
+        private int GetLeftChildIndex(int i) => (2 * i) + 1;
+
+        /// <summary>
+        /// Grows the priority queue to match the specified min capacity.
+        /// </summary>
+        private void Grow(int minCapacity)
+        {
+            Debug.Assert(_heap.Length < minCapacity);
+
+            const int GrowFactor = 2;
+            const int MinimumGrow = 4;
+
+            int newcapacity = GrowFactor * _heap.Length;
+
+            // Allow the queue to grow to maximum possible capacity (~2G elements) before encountering overflow.
+            // Note that this check works even when _heap.Length overflowed thanks to the (uint) cast
+            if ((uint)newcapacity > Array.MaxLength) newcapacity = Array.MaxLength;
+
+            // Ensure minimum growth is respected.
+            newcapacity = Math.Max(newcapacity, _heap.Length + MinimumGrow);
+
+            // If the computed capacity is still less than specified, set to the original argument.
+            // Capacities exceeding Array.MaxLength will be surfaced as OutOfMemoryException by Array.Resize.
+            if (newcapacity < minCapacity) newcapacity = minCapacity;
+
+            Array.Resize(ref _heap, newcapacity);
+        }
+
+        /// <summary>
+        /// Shrinks the backing array when more than half the space is unoccupied.
+        /// </summary>
+        private void Shrink()
+        {
+            int newCapacity = _heap.Length / 2;
+            newCapacity = Math.Max(newCapacity, DefaultCapacity);
+
+            if (newCapacity < _heap.Length)
+            {
+                Array.Resize(ref _heap, newCapacity);
+            }
+        }
+    }
+}

--- a/libs/server/Objects/SortedSet/SortedSetObject.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObject.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Garnet.common;
+using Garnet.common.Collections;
 using Tsavorite.core;
 
 namespace Garnet.server
@@ -141,8 +142,7 @@ namespace Garnet.server
     {
         private readonly SortedSet<(double Score, byte[] Element)> sortedSet;
         private readonly Dictionary<byte[], double> sortedSetDict;
-        private Dictionary<byte[], long> expirationTimes;
-        private PriorityQueue<byte[], long> expirationQueue;
+        private IndexedPriorityQueue<byte[], long> expirationQueue;
 
         // Byte #31 is used to denote if key has expiration (1) or not (0)
         private const int ExpirationBitMask = 1 << 31;
@@ -192,8 +192,7 @@ namespace Garnet.server
                     if (expiration > 0)
                     {
                         InitializeExpirationStructures();
-                        expirationTimes.Add(item, expiration);
-                        expirationQueue.Enqueue(item, expiration);
+                        expirationQueue.EnqueueOrUpdate(item, expiration);
                         UpdateExpirationSize(item, true);
                     }
                 }
@@ -208,7 +207,6 @@ namespace Garnet.server
         {
             this.sortedSet = sortedSetObject.sortedSet;
             this.sortedSetDict = sortedSetObject.sortedSetDict;
-            this.expirationTimes = sortedSetObject.expirationTimes;
             this.expirationQueue = sortedSetObject.expirationQueue;
         }
 
@@ -252,7 +250,7 @@ namespace Garnet.server
             writer.Write(count);
             foreach (var kvp in sortedSetDict)
             {
-                if (expirationTimes is not null && expirationTimes.TryGetValue(kvp.Key, out var expiration))
+                if (expirationQueue is not null && expirationQueue.TryGetPriority(kvp.Key, out var expiration))
                 {
                     writer.Write(kvp.Key.Length | ExpirationBitMask);
                     writer.Write(kvp.Key);
@@ -277,7 +275,7 @@ namespace Garnet.server
         /// <param name="score"></param>
         public void Add(byte[] item, double score)
         {
-            DeleteExpiredItems();
+            DeleteExpiredItems(bound: 16);
 
             sortedSetDict.Add(item, score);
             sortedSet.Add((score, item));
@@ -513,7 +511,7 @@ namespace Garnet.server
 
             if (sortedSetObject2 == null)
             {
-                if (sortedSetObject1.expirationTimes is null)
+                if (!sortedSetObject1.HasExpirableItems())
                 {
                     return new Dictionary<byte[], double>(sortedSetObject1.sortedSetDict, ByteArrayComparer.Instance);
                 }
@@ -585,9 +583,9 @@ namespace Garnet.server
             }
             var expiredKeysCount = 0;
 
-            foreach (var item in expirationTimes)
+            foreach (var kvp in sortedSetDict)
             {
-                if (IsExpired(item.Key))
+                if (IsExpired(kvp.Key))
                 {
                     expiredKeysCount++;
                 }
@@ -601,7 +599,7 @@ namespace Garnet.server
         /// <param name="key">The key to check for expiration.</param>
         /// <returns>True if the key is expired; otherwise, false.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool IsExpired(byte[] key) => expirationTimes is not null && expirationTimes.TryGetValue(key, out var expiration) && expiration < DateTimeOffset.UtcNow.Ticks;
+        public bool IsExpired(byte[] key) => expirationQueue is not null && expirationQueue.TryGetPriority(key, out var expiration) && expiration < DateTimeOffset.UtcNow.Ticks;
 
         /// <summary>
         /// Determines whether the sorted set has expirable items.
@@ -610,69 +608,61 @@ namespace Garnet.server
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool HasExpirableItems()
         {
-            return expirationTimes is not null;
+            return expirationQueue is not null && expirationQueue.Count > 0;
         }
 
         #endregion
         private void InitializeExpirationStructures()
         {
-            if (expirationTimes is null)
+            if (expirationQueue is null)
             {
-                expirationTimes = new Dictionary<byte[], long>(ByteArrayComparer.Instance);
-                expirationQueue = new PriorityQueue<byte[], long>();
-                this.Size += MemoryUtils.DictionaryOverhead + MemoryUtils.PriorityQueueOverhead;
+                expirationQueue = new IndexedPriorityQueue<byte[], long>(ByteArrayComparer.Instance);
+                this.Size += MemoryUtils.IndexedPriorityQueueOverhead;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void UpdateExpirationSize(ReadOnlySpan<byte> key, bool add = true)
         {
-            var size = IntPtr.Size + sizeof(long) + MemoryUtils.DictionaryEntryOverhead
-                + IntPtr.Size + sizeof(long) + MemoryUtils.PriorityQueueEntryOverhead;
+            var size = MemoryUtils.IndexedPriorityQueueEntryOverhead;
             this.Size += add ? size : -size;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CleanupExpirationStructures()
         {
-            if (expirationTimes.Count == 0)
+            if (expirationQueue.Count == 0)
             {
-                this.Size -= (IntPtr.Size + sizeof(long) + MemoryUtils.PriorityQueueEntryOverhead) * expirationQueue.Count;
-                this.Size -= MemoryUtils.DictionaryOverhead + MemoryUtils.PriorityQueueOverhead;
-                expirationTimes = null;
+                this.Size -= MemoryUtils.IndexedPriorityQueueOverhead;
                 expirationQueue = null;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void DeleteExpiredItems()
+        private void DeleteExpiredItems(int bound = 0)
         {
-            if (expirationTimes is null)
+            if (expirationQueue is null)
                 return;
-            DeleteExpiredItemsWorker();
+            DeleteExpiredItemsWorker(bound);
         }
 
-        private void DeleteExpiredItemsWorker()
+        private void DeleteExpiredItemsWorker(int bound)
         {
+            int i = 0;
             while (expirationQueue.TryPeek(out var key, out var expiration) && expiration < DateTimeOffset.UtcNow.Ticks)
             {
-                if (expirationTimes.TryGetValue(key, out var actualExpiration) && actualExpiration == expiration)
+                if (bound > 0 && i >= bound)
+                    break;
+
+                expirationQueue.Dequeue();
+                UpdateExpirationSize(key, false);
+                if (sortedSetDict.TryGetValue(key, out var value))
                 {
-                    expirationTimes.Remove(key);
-                    expirationQueue.Dequeue();
-                    UpdateExpirationSize(key, false);
-                    if (sortedSetDict.TryGetValue(key, out var value))
-                    {
-                        sortedSetDict.Remove(key);
-                        sortedSet.Remove((value, key));
-                        UpdateSize(key, false);
-                    }
+                    sortedSetDict.Remove(key);
+                    sortedSet.Remove((value, key));
+                    UpdateSize(key, false);
                 }
-                else
-                {
-                    expirationQueue.Dequeue();
-                    this.Size -= MemoryUtils.PriorityQueueEntryOverhead + IntPtr.Size + sizeof(long);
-                }
+                i++;
             }
 
             CleanupExpirationStructures();
@@ -695,7 +685,7 @@ namespace Garnet.server
 
             InitializeExpirationStructures();
 
-            if (expirationTimes.TryGetValue(key, out var currentExpiration))
+            if (expirationQueue.TryGetPriority(key, out var currentExpiration))
             {
                 if (expireOption.HasFlag(ExpireOption.NX) ||
                     (expireOption.HasFlag(ExpireOption.GT) && expiration <= currentExpiration) ||
@@ -704,9 +694,7 @@ namespace Garnet.server
                     return (int)SortedSetExpireResult.ExpireConditionNotMet;
                 }
 
-                expirationTimes[key] = expiration;
-                expirationQueue.Enqueue(key, expiration);
-                this.Size += IntPtr.Size + sizeof(long) + MemoryUtils.PriorityQueueEntryOverhead;
+                expirationQueue.EnqueueOrUpdate(key, expiration);
             }
             else
             {
@@ -715,8 +703,7 @@ namespace Garnet.server
                     return (int)SortedSetExpireResult.ExpireConditionNotMet;
                 }
 
-                expirationTimes[key] = expiration;
-                expirationQueue.Enqueue(key, expiration);
+                expirationQueue.EnqueueOrUpdate(key, expiration);
                 UpdateExpirationSize(key);
             }
 
@@ -736,20 +723,19 @@ namespace Garnet.server
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool TryRemoveExpiration(byte[] key)
         {
-            if (expirationTimes is null)
+            if (expirationQueue is null)
                 return false;
             return TryRemoveExpirationWorker(key);
         }
 
         private bool TryRemoveExpirationWorker(byte[] key)
         {
-            if (!expirationTimes.TryGetValue(key, out _))
+            if (!expirationQueue.TryRemove(key))
             {
                 return false;
             }
 
-            expirationTimes.Remove(key);
-            this.Size -= IntPtr.Size + sizeof(long) + MemoryUtils.DictionaryEntryOverhead;
+            this.Size -= MemoryUtils.IndexedPriorityQueueEntryOverhead;
             CleanupExpirationStructures();
             return true;
         }
@@ -761,7 +747,7 @@ namespace Garnet.server
                 return -2;
             }
 
-            if (expirationTimes is not null && expirationTimes.TryGetValue(key, out var expiration))
+            if (expirationQueue is not null && expirationQueue.TryGetPriority(key, out var expiration))
             {
                 return expiration;
             }

--- a/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
@@ -89,7 +89,7 @@ namespace Garnet.server
 
         private void SortedSetAdd(ref ObjectInput input, ref GarnetObjectStoreOutput output, byte respProtocolVersion)
         {
-            DeleteExpiredItems();
+            DeleteExpiredItems(bound: 16);
 
             var addedOrChanged = 0;
             double incrResult = 0;
@@ -210,7 +210,7 @@ namespace Garnet.server
 
         private void SortedSetRemove(ref ObjectInput input, ref GarnetObjectStoreOutput output)
         {
-            DeleteExpiredItems();
+            DeleteExpiredItems(bound: 16);
 
             for (var i = 0; i < input.parseState.Count; i++)
             {
@@ -313,7 +313,7 @@ namespace Garnet.server
 
         private void SortedSetIncrement(ref ObjectInput input, ref GarnetObjectStoreOutput output, byte respProtocolVersion)
         {
-            DeleteExpiredItems();
+            DeleteExpiredItems(bound: 16);
 
             // It's useful to fix RESP2 in the internal API as that just reads back the output.
             if (input.arg2 > 0)
@@ -496,7 +496,7 @@ namespace Garnet.server
                                 var n = maxIndex - minIndex + 1;
                                 var iterator = options.Reverse ? sortedSet.Reverse() : sortedSet;
 
-                                if (expirationTimes is not null)
+                                if (HasExpirableItems())
                                 {
                                     iterator = iterator.Where(x => !IsExpired(x.Element));
                                 }
@@ -562,7 +562,7 @@ namespace Garnet.server
 
         private void SortedSetRemoveRangeByRank(ref ObjectInput input, ref GarnetObjectStoreOutput output, byte respProtocolVersion)
         {
-            DeleteExpiredItems();
+            DeleteExpiredItems(bound: 16);
 
             using var writer = new RespMemoryWriter(respProtocolVersion, ref output.SpanByteAndMemory);
 
@@ -604,7 +604,7 @@ namespace Garnet.server
 
         private void SortedSetRemoveRangeByScore(ref ObjectInput input, ref GarnetObjectStoreOutput output, byte respProtocolVersion)
         {
-            DeleteExpiredItems();
+            DeleteExpiredItems(bound: 16);
 
             using var writer = new RespMemoryWriter(respProtocolVersion, ref output.SpanByteAndMemory);
 
@@ -687,7 +687,7 @@ namespace Garnet.server
 
             if (isRemove)
             {
-                DeleteExpiredItems();
+                DeleteExpiredItems(bound: 16);
             }
 
             var rem = GetElementsInRangeByLex(minParamBytes, maxParamBytes, false, false, isRemove, out int errorCode);
@@ -755,7 +755,7 @@ namespace Garnet.server
         /// <returns>A tuple containing the score and the element as a byte array.</returns>
         public (double Score, byte[] Element) PopMinOrMax(bool popMaxScoreElement = false)
         {
-            DeleteExpiredItems();
+            DeleteExpiredItems(bound: 16);
 
             if (sortedSet.Count == 0)
                 return default;
@@ -777,7 +777,7 @@ namespace Garnet.server
         /// <param name="op"></param>
         private void SortedSetPopMinOrMaxCount(ref ObjectInput input, ref GarnetObjectStoreOutput output, byte respProtocolVersion, SortedSetOperation op)
         {
-            DeleteExpiredItems();
+            DeleteExpiredItems(bound: 16);
 
             var count = input.arg1;
             var countDone = 0;
@@ -837,7 +837,7 @@ namespace Garnet.server
 
         private void SortedSetPersist(ref ObjectInput input, ref GarnetObjectStoreOutput output, byte respProtocolVersion)
         {
-            DeleteExpiredItems();
+            DeleteExpiredItems(bound: 16);
 
             var numFields = input.parseState.Count;
 
@@ -901,7 +901,7 @@ namespace Garnet.server
 
         private void SortedSetExpire(ref ObjectInput input, ref GarnetObjectStoreOutput output, byte respProtocolVersion)
         {
-            DeleteExpiredItems();
+            DeleteExpiredItems(bound: 16);
 
             var expirationWithOption = new ExpirationWithOption(input.arg1, input.arg2);
 
@@ -918,7 +918,7 @@ namespace Garnet.server
 
         private void SortedSetCollect(ref ObjectInput input, ref GarnetObjectStoreOutput output)
         {
-            DeleteExpiredItems();
+            DeleteExpiredItems(bound: 16);
 
             output.Header.result1 = 1;
         }

--- a/libs/server/Storage/Session/Common/MemoryUtils.cs
+++ b/libs/server/Storage/Session/Common/MemoryUtils.cs
@@ -44,6 +44,18 @@ namespace Garnet.server
         /// <summary>.Net object avg. overhead for holding a priority queue entry</summary>
         public const int PriorityQueueEntryOverhead = 48;
 
+        /// <summary>
+        /// .Net object overhead for IndexedPriorityQueue (Dictionary + array + count).
+        /// Dictionary(80) + array object header(24) + int(4) ≈ 108, rounded to 112.
+        /// </summary>
+        public const int IndexedPriorityQueueOverhead = 112;
+
+        /// <summary>
+        /// .Net object avg. overhead per entry in IndexedPriorityQueue.
+        /// Dictionary entry(64) + heap array slot (ref 8 + long 8 = 16) = 80.
+        /// </summary>
+        public const int IndexedPriorityQueueEntryOverhead = 80;
+
         internal static long CalculateKeyValueSize(byte[] key, IGarnetObject value)
         {
             // Round up key size to account for alignment during allocation 

--- a/test/Garnet.test/IndexedPriorityQueueTests.cs
+++ b/test/Garnet.test/IndexedPriorityQueueTests.cs
@@ -1,0 +1,421 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Garnet.common.Collections;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace Garnet.test
+{
+    [TestFixture]
+    public class IndexedPriorityQueueTests
+    {
+        #region Basic Operations
+
+        [Test]
+        public void EmptyQueueHasCountZero()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            ClassicAssert.AreEqual(0, q.Count);
+        }
+
+        [Test]
+        public void EnqueueIncreasesCount()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            q.EnqueueOrUpdate("a", 10);
+            ClassicAssert.AreEqual(1, q.Count);
+            q.EnqueueOrUpdate("b", 20);
+            ClassicAssert.AreEqual(2, q.Count);
+        }
+
+        [Test]
+        public void DequeueReturnsMinPriority()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            q.EnqueueOrUpdate("high", 100);
+            q.EnqueueOrUpdate("low", 1);
+            q.EnqueueOrUpdate("mid", 50);
+
+            ClassicAssert.AreEqual("low", q.Dequeue());
+            ClassicAssert.AreEqual("mid", q.Dequeue());
+            ClassicAssert.AreEqual("high", q.Dequeue());
+        }
+
+        [Test]
+        public void DequeueOnEmptyThrows()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            Assert.Throws<InvalidOperationException>(() => q.Dequeue());
+        }
+
+        [Test]
+        public void TryPeekReturnsFalseWhenEmpty()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            ClassicAssert.IsFalse(q.TryPeek(out _, out _));
+        }
+
+        [Test]
+        public void TryPeekReturnsMinWithoutRemoving()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            q.EnqueueOrUpdate("a", 5);
+            q.EnqueueOrUpdate("b", 3);
+
+            ClassicAssert.IsTrue(q.TryPeek(out var key, out var priority));
+            ClassicAssert.AreEqual("b", key);
+            ClassicAssert.AreEqual(3, priority);
+            ClassicAssert.AreEqual(2, q.Count);
+        }
+
+        [Test]
+        public void ExistsReturnsTrueForEnqueuedElement()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            q.EnqueueOrUpdate("a", 10);
+
+            ClassicAssert.IsTrue(q.Exists("a"));
+            ClassicAssert.IsFalse(q.Exists("b"));
+        }
+
+        #endregion
+
+        #region In-Place Update
+
+        [Test]
+        public void EnqueueOrUpdateUpdatesExistingElement()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            q.EnqueueOrUpdate("a", 100);
+            q.EnqueueOrUpdate("b", 50);
+
+            // Update "a" to lower priority — should become the new min
+            q.EnqueueOrUpdate("a", 1);
+
+            ClassicAssert.AreEqual(2, q.Count, "Update should not add a new entry");
+            ClassicAssert.IsTrue(q.TryPeek(out var key, out var priority));
+            ClassicAssert.AreEqual("a", key);
+            ClassicAssert.AreEqual(1, priority);
+        }
+
+        [Test]
+        public void ChangePriorityMovesElementDown()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            q.EnqueueOrUpdate("a", 1);
+            q.EnqueueOrUpdate("b", 10);
+            q.EnqueueOrUpdate("c", 20);
+
+            // Move "a" to highest priority value — "b" should become min
+            q.ChangePriority("a", 100);
+
+            q.TryPeek(out var key, out _);
+            ClassicAssert.AreEqual("b", key);
+        }
+
+        [Test]
+        public void ChangePriorityMovesElementUp()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            q.EnqueueOrUpdate("a", 50);
+            q.EnqueueOrUpdate("b", 10);
+            q.EnqueueOrUpdate("c", 30);
+
+            // Move "a" to lowest — should become min
+            q.ChangePriority("a", 1);
+
+            q.TryPeek(out var key, out _);
+            ClassicAssert.AreEqual("a", key);
+        }
+
+        [Test]
+        public void RepeatedUpdatesDoNotBloatCount()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            q.EnqueueOrUpdate("a", 10);
+
+            for (int i = 0; i < 100; i++)
+            {
+                q.EnqueueOrUpdate("a", i);
+            }
+
+            ClassicAssert.AreEqual(1, q.Count, "Repeated updates should not increase count");
+        }
+
+        #endregion
+
+        #region Priority Lookup
+
+        [Test]
+        public void GetPriorityReturnsCurrentPriority()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            q.EnqueueOrUpdate("a", 42);
+
+            q.GetPriority("a", out var priority);
+            ClassicAssert.AreEqual(42, priority);
+        }
+
+        [Test]
+        public void TryGetPriorityReturnsFalseForMissing()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            ClassicAssert.IsFalse(q.TryGetPriority("missing", out _));
+        }
+
+        [Test]
+        public void TryGetPriorityReflectsUpdates()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            q.EnqueueOrUpdate("a", 10);
+            q.EnqueueOrUpdate("a", 99);
+
+            ClassicAssert.IsTrue(q.TryGetPriority("a", out var priority));
+            ClassicAssert.AreEqual(99, priority);
+        }
+
+        #endregion
+
+        #region Removal
+
+        [Test]
+        public void TryRemoveReturnsFalseForMissing()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            ClassicAssert.IsFalse(q.TryRemove("missing"));
+        }
+
+        [Test]
+        public void TryRemoveRemovesElement()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            q.EnqueueOrUpdate("a", 10);
+            q.EnqueueOrUpdate("b", 20);
+
+            ClassicAssert.IsTrue(q.TryRemove("a"));
+            ClassicAssert.AreEqual(1, q.Count);
+            ClassicAssert.IsFalse(q.Exists("a"));
+            ClassicAssert.AreEqual("b", q.Dequeue());
+        }
+
+        [Test]
+        public void TryRemoveMiddleElementMaintainsHeapOrder()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            q.EnqueueOrUpdate("a", 1);
+            q.EnqueueOrUpdate("b", 5);
+            q.EnqueueOrUpdate("c", 3);
+            q.EnqueueOrUpdate("d", 10);
+            q.EnqueueOrUpdate("e", 7);
+
+            q.TryRemove("c");
+
+            // Remaining should dequeue in order: a(1), b(5), e(7), d(10)
+            ClassicAssert.AreEqual("a", q.Dequeue());
+            ClassicAssert.AreEqual("b", q.Dequeue());
+            ClassicAssert.AreEqual("e", q.Dequeue());
+            ClassicAssert.AreEqual("d", q.Dequeue());
+        }
+
+        [Test]
+        public void TryRemoveLastElement()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+            q.EnqueueOrUpdate("only", 1);
+
+            ClassicAssert.IsTrue(q.TryRemove("only"));
+            ClassicAssert.AreEqual(0, q.Count);
+            ClassicAssert.IsFalse(q.TryPeek(out _, out _));
+        }
+
+        #endregion
+
+        #region Custom Comparer (byte[] keys)
+
+        [Test]
+        public void ByteArrayComparerMatchesByContent()
+        {
+            var comparer = new ByteArrayComparer();
+            var q = new IndexedPriorityQueue<byte[], long>(comparer);
+
+            var key1 = new byte[] { 1, 2, 3 };
+            var key1Copy = new byte[] { 1, 2, 3 };
+            var key2 = new byte[] { 4, 5, 6 };
+
+            q.EnqueueOrUpdate(key1, 100);
+            q.EnqueueOrUpdate(key2, 200);
+
+            // Update using a different byte[] with same content
+            q.EnqueueOrUpdate(key1Copy, 50);
+
+            ClassicAssert.AreEqual(2, q.Count, "Should match by content, not reference");
+
+            q.TryPeek(out var minKey, out var minPriority);
+            ClassicAssert.AreEqual(50, minPriority);
+            ClassicAssert.IsTrue(comparer.Equals(key1, minKey));
+        }
+
+        [Test]
+        public void ByteArrayComparerTryGetPriorityByContent()
+        {
+            var comparer = new ByteArrayComparer();
+            var q = new IndexedPriorityQueue<byte[], long>(comparer);
+
+            var key = new byte[] { 10, 20 };
+            var keyCopy = new byte[] { 10, 20 };
+
+            q.EnqueueOrUpdate(key, 42);
+
+            ClassicAssert.IsTrue(q.TryGetPriority(keyCopy, out var priority));
+            ClassicAssert.AreEqual(42, priority);
+        }
+
+        [Test]
+        public void ByteArrayComparerTryRemoveByContent()
+        {
+            var comparer = new ByteArrayComparer();
+            var q = new IndexedPriorityQueue<byte[], long>(comparer);
+
+            var key = new byte[] { 7, 8, 9 };
+            var keyCopy = new byte[] { 7, 8, 9 };
+
+            q.EnqueueOrUpdate(key, 100);
+            ClassicAssert.IsTrue(q.TryRemove(keyCopy));
+            ClassicAssert.AreEqual(0, q.Count);
+        }
+
+        [Test]
+        public void WithoutComparerByteArrayUsesReferenceEquality()
+        {
+            var q = new IndexedPriorityQueue<byte[], long>();
+
+            var key1 = new byte[] { 1, 2, 3 };
+            var key1Copy = new byte[] { 1, 2, 3 };
+
+            q.EnqueueOrUpdate(key1, 100);
+            q.EnqueueOrUpdate(key1Copy, 50);
+
+            // Without comparer, these are different keys
+            ClassicAssert.AreEqual(2, q.Count, "Default comparer uses reference equality for byte[]");
+        }
+
+        #endregion
+
+        #region Stress / Ordering
+
+        [Test]
+        public void LargeInsertDequeueMaintainsOrder()
+        {
+            var q = new IndexedPriorityQueue<int, int>();
+            var rng = new Random(42);
+            var count = 1000;
+
+            for (int i = 0; i < count; i++)
+            {
+                q.EnqueueOrUpdate(i, rng.Next(0, 100000));
+            }
+
+            ClassicAssert.AreEqual(count, q.Count);
+
+            int prev = int.MinValue;
+            while (q.Count > 0)
+            {
+                q.TryPeek(out _, out var priority);
+                ClassicAssert.GreaterOrEqual(priority, prev, "Dequeue order should be non-decreasing");
+                prev = priority;
+                q.Dequeue();
+            }
+        }
+
+        [Test]
+        public void InterleavedInsertUpdateRemoveDequeue()
+        {
+            var q = new IndexedPriorityQueue<string, int>();
+
+            q.EnqueueOrUpdate("a", 50);
+            q.EnqueueOrUpdate("b", 30);
+            q.EnqueueOrUpdate("c", 70);
+            q.EnqueueOrUpdate("d", 10);
+
+            // Update
+            q.EnqueueOrUpdate("c", 5);  // c becomes min
+            q.TryPeek(out var min, out _);
+            ClassicAssert.AreEqual("c", min);
+
+            // Remove min
+            q.TryRemove("c");
+            q.TryPeek(out min, out _);
+            ClassicAssert.AreEqual("d", min);
+
+            // Add new
+            q.EnqueueOrUpdate("e", 1);
+            q.TryPeek(out min, out _);
+            ClassicAssert.AreEqual("e", min);
+
+            // Drain and verify order
+            ClassicAssert.AreEqual("e", q.Dequeue());  // 1
+            ClassicAssert.AreEqual("d", q.Dequeue());  // 10
+            ClassicAssert.AreEqual("b", q.Dequeue());  // 30
+            ClassicAssert.AreEqual("a", q.Dequeue());  // 50
+            ClassicAssert.AreEqual(0, q.Count);
+        }
+
+        [Test]
+        public void GrowAndShrinkBehavior()
+        {
+            var q = new IndexedPriorityQueue<int, int>();
+
+            // Grow
+            for (int i = 0; i < 100; i++)
+                q.EnqueueOrUpdate(i, i);
+
+            ClassicAssert.AreEqual(100, q.Count);
+
+            // Shrink by removing most
+            for (int i = 0; i < 90; i++)
+                q.Dequeue();
+
+            ClassicAssert.AreEqual(10, q.Count);
+
+            // Remaining should still be ordered
+            int prev = int.MinValue;
+            while (q.Count > 0)
+            {
+                q.TryPeek(out _, out var p);
+                ClassicAssert.GreaterOrEqual(p, prev);
+                prev = p;
+                q.Dequeue();
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Simple byte[] equality comparer for tests.
+        /// </summary>
+        private class ByteArrayComparer : IEqualityComparer<byte[]>
+        {
+            public bool Equals(byte[] x, byte[] y)
+            {
+                if (x == null && y == null) return true;
+                if (x == null || y == null) return false;
+                if (x.Length != y.Length) return false;
+                for (int i = 0; i < x.Length; i++)
+                    if (x[i] != y[i]) return false;
+                return true;
+            }
+
+            public int GetHashCode(byte[] obj)
+            {
+                if (obj == null) return 0;
+                int hash = 17;
+                foreach (var b in obj)
+                    hash = hash * 31 + b;
+                return hash;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Replace the separate expirationTimes Dictionary and expirationQueue PriorityQueue with a single IndexedPriorityQueue that supports O(log N) in-place priority updates. This eliminates stale entry accumulation in the expiration queue when member TTLs are frequently refreshed.

Benefits:
- Memory: O(N) always vs O(N + total updates) with stale entries
- Dequeue: Always O(log N) vs O(S * log N) when draining stale entries
- Remove: O(log N) by key vs not supported
- No stale entry validation needed during DeleteExpiredItems