### PR TITLE
Bugfix: negative return value from `SerializeTo`/`DeserializeFrom`

### DIFF
--- a/libs/server/InputHeader.cs
+++ b/libs/server/InputHeader.cs
@@ -303,7 +303,7 @@ namespace Garnet.server
             var len = parseState.DeserializeFrom(curr);
             curr += len;
 
-            return (int)(src - curr);
+            return (int)(curr - src);
         }
     }
 

--- a/libs/server/Resp/Parser/SessionParseState.cs
+++ b/libs/server/Resp/Parser/SessionParseState.cs
@@ -318,7 +318,7 @@ namespace Garnet.server
                 curr += argument.TotalSize;
             }
 
-            return (int)(dest - curr);
+            return (int)(curr - dest);
         }
 
         /// <summary>
@@ -342,7 +342,7 @@ namespace Garnet.server
                 curr += argument.TotalSize;
             }
 
-            return (int)(src - curr);
+            return (int)(curr - src);
         }
 
         /// <summary>


### PR DESCRIPTION
Fix `SerializeTo` and `DeserializeFrom`: the return value should be the number of bytes (de)serialized and thus, non-negative. 

The prior implementation misordered operands and returned a negative value.