### PR TITLE
[Dev] Improve Network/Session Resource Cleanup on Error/Disconnect Paths

### DIFF
--- a/libs/common/ExceptionInjectionType.cs
+++ b/libs/common/ExceptionInjectionType.cs
@@ -81,5 +81,10 @@ namespace Garnet.common
         /// During deletion of a Vector Set, leaving it partially deleted - at a particular point of execution.
         /// </summary>
         VectorSet_Interrupt_Delete_2,
+        /// <summary>
+        /// Failure after handler registered in activeHandlers but before Start() is called.
+        /// This means no SAEA receive loop is running, so the only cleanup path is public Dispose().
+        /// </summary>
+        Dispose_After_Handler_Registered_Before_Start,
     }
 }

--- a/libs/common/Networking/TcpNetworkHandlerBase.cs
+++ b/libs/common/Networking/TcpNetworkHandlerBase.cs
@@ -170,6 +170,7 @@ namespace Garnet.common
                 // Dispose of the socket to free up unmanaged resources
                 socket.Dispose();
             }
+            DisposeImpl();
         }
 
         /// <summary>
@@ -182,7 +183,22 @@ namespace Garnet.common
 
         void Dispose(SocketAsyncEventArgs e)
         {
-            e.AcceptSocket.Dispose();
+            try
+            {
+                if (e.AcceptSocket.Connected)
+                {
+                    e.AcceptSocket.Shutdown(SocketShutdown.Both);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogTrace(ex, "Error shutting down accept socket during SAEA dispose");
+            }
+            finally
+            {
+                e.AcceptSocket.Close();
+                e.AcceptSocket.Dispose();
+            }
             DisposeImpl();
             e.Dispose();
         }

--- a/libs/server/Servers/GarnetServerTcp.cs
+++ b/libs/server/Servers/GarnetServerTcp.cs
@@ -279,6 +279,7 @@ namespace Garnet.server
                     try
                     {
                         IncrementConnectionsReceived();
+                        ExceptionInjectionHelper.TriggerException(ExceptionInjectionType.Dispose_After_Handler_Registered_Before_Start);
                         handler.Start(tlsOptions?.TlsServerOptions, remoteEndpointName);
                     }
                     catch (Exception ex)

--- a/test/Garnet.test/NetworkTests.cs
+++ b/test/Garnet.test/NetworkTests.cs
@@ -233,7 +233,9 @@ namespace Garnet.test
                 ManualResetEventSlim e = new();
                 string val = null;
                 db.StringSet("after_injection", "works", (c, r) => { val = r; e.Set(); });
-                e.Wait();
+                ClassicAssert.IsTrue(
+                    e.Wait(System.TimeSpan.FromSeconds(5)),
+                    "Timed out waiting for StringSet callback after exception-injection cleanup test.");
                 ClassicAssert.AreEqual("OK", val);
 
                 // Safe to dispose — no leaked handlers

--- a/test/Garnet.test/NetworkTests.cs
+++ b/test/Garnet.test/NetworkTests.cs
@@ -205,11 +205,18 @@ namespace Garnet.test
                     ExceptionInjectionHelper.DisableException(ExceptionInjectionType.Dispose_After_Handler_Registered_Before_Start);
                 }
 
-                // Give server a moment to finish processing
-                Thread.Sleep(500);
-
+                // Poll until the server finishes processing accepts/disposals, or time out.
+                const int pollIntervalMs = 50;
+                const int maxWaitMs = 2000;
+                int waitedMs = 0;
                 long activeCount = garnetServerTcp.get_conn_active();
 
+                while (activeCount > 0 && waitedMs < maxWaitMs)
+                {
+                    Thread.Sleep(pollIntervalMs);
+                    waitedMs += pollIntervalMs;
+                    activeCount = garnetServerTcp.get_conn_active();
+                }
                 if (activeCount > 0)
                 {
                     // Bug confirmed: handlers leaked. Don't try to dispose the server

--- a/test/Garnet.test/NetworkTests.cs
+++ b/test/Garnet.test/NetworkTests.cs
@@ -2,9 +2,12 @@
 // Licensed under the MIT license.
 
 #if DEBUG
+using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using Allure.NUnit;
 using Garnet.common;
+using Garnet.server;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 
@@ -83,6 +86,162 @@ namespace Garnet.test
                 e.Set();
             });
             e.Wait();
+        }
+
+        /// <summary>
+        /// Verifies that when a TLS client abruptly disconnects, the server properly
+        /// cleans up the handler and removes it from activeHandlers.
+        /// </summary>
+        [Test]
+        public void TlsClientDisconnectCleansUpHandler()
+        {
+            var garnetServerTcp = (GarnetServerBase)server.Provider.StoreWrapper.Servers[0];
+            var disposedBefore = garnetServerTcp.TotalConnectionsDisposed;
+
+            // Connect multiple clients and verify they register as active handlers
+            const int clientCount = 5;
+            var clients = new Garnet.client.GarnetClient[clientCount];
+            for (int i = 0; i < clientCount; i++)
+            {
+                clients[i] = TestUtils.GetGarnetClient(useTLS: true);
+                clients[i].Connect();
+
+                // Verify the connection works
+                ManualResetEventSlim done = new();
+                string result = null;
+                clients[i].StringSet($"key{i}", $"value{i}", (c, r) => { result = r; done.Set(); });
+                done.Wait();
+                ClassicAssert.AreEqual("OK", result);
+            }
+
+            // Wait for all connections to be registered
+            var deadline = System.Environment.TickCount64 + 5000;
+            while (garnetServerTcp.get_conn_active() < clientCount && System.Environment.TickCount64 < deadline)
+                Thread.Sleep(50);
+            ClassicAssert.GreaterOrEqual(garnetServerTcp.get_conn_active(), clientCount,
+                "Expected all clients to be registered as active handlers");
+
+            // Abruptly dispose all clients (sends FIN, simulating remote peer disconnect)
+            for (int i = 0; i < clientCount; i++)
+            {
+                clients[i].Dispose();
+            }
+
+            // Wait for the server to detect the disconnections and clean up handlers
+            deadline = System.Environment.TickCount64 + 10000;
+            while (garnetServerTcp.get_conn_active() > 0 && System.Environment.TickCount64 < deadline)
+                Thread.Sleep(100);
+
+            ClassicAssert.AreEqual(0, garnetServerTcp.get_conn_active(),
+                "Server still has active handlers after all clients disconnected — handlers were not properly cleaned up (CLOSE-WAIT leak)");
+            ClassicAssert.GreaterOrEqual(garnetServerTcp.TotalConnectionsDisposed - disposedBefore, clientCount,
+                "Expected TotalConnectionsDisposed to increment by at least the number of disconnected clients");
+
+            // Verify the server still accepts new connections after cleanup
+            using var db = TestUtils.GetGarnetClient(useTLS: true);
+            db.Connect();
+            ManualResetEventSlim e = new();
+            string val = null;
+            db.StringSet("after_cleanup", "works", (c, r) => { val = r; e.Set(); });
+            e.Wait();
+            ClassicAssert.AreEqual("OK", val);
+        }
+
+        /// <summary>
+        /// Verifies that Dispose() properly calls DisposeImpl() to remove the handler from
+        /// activeHandlers when no SAEA receive loop is running. This directly tests the
+        /// CLOSE-WAIT fix: the exception fires after the handler is registered but before
+        /// Start() is called, so there is no SAEA backup cleanup path. Without the fix,
+        /// public Dispose() does not call DisposeImpl() and the handler leaks permanently,
+        /// which also causes DisposeActiveHandlers() to spin forever during server shutdown.
+        ///
+        /// This test uses its own server instance (not the shared one from SetUp/TearDown)
+        /// because the bug causes server.Dispose() to hang forever on leaked handlers.
+        /// </summary>
+        [Test]
+        public void DisposeCallsDisposeImplWithoutSaeaBackup()
+        {
+            // Use a separate server on a different port so we don't interfere
+            // with the shared server from SetUp, and so TearDown doesn't hang.
+            var testDir = TestUtils.MethodTestDir + "_injection";
+            TestUtils.DeleteDirectory(testDir, wait: true);
+            var endpoint = new IPEndPoint(IPAddress.Loopback, TestUtils.TestPort + 1000);
+            var testServer = TestUtils.CreateGarnetServer(testDir, enableTLS: true,
+                endpoints: [endpoint]);
+            testServer.Start();
+
+            try
+            {
+                var garnetServerTcp = (GarnetServerBase)testServer.Provider.StoreWrapper.Servers[0];
+
+                // Verify no active connections initially
+                ClassicAssert.AreEqual(0, garnetServerTcp.get_conn_active());
+
+                ExceptionInjectionHelper.EnableException(ExceptionInjectionType.Dispose_After_Handler_Registered_Before_Start);
+                try
+                {
+                    // Use raw TCP sockets to trigger the server's accept loop.
+                    // We can't use GarnetClient here because TLS auth would hang —
+                    // the exception fires before Start(), so the server never begins
+                    // TLS negotiation, and the client would wait forever.
+                    for (int i = 0; i < 3; i++)
+                    {
+                        using var rawSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                        try
+                        {
+                            rawSocket.Connect(endpoint);
+                        }
+                        catch
+                        {
+                            // Connection may fail if server closed socket fast enough
+                        }
+
+                        // Give the server time to process the accept and hit the exception
+                        Thread.Sleep(200);
+                    }
+                }
+                finally
+                {
+                    ExceptionInjectionHelper.DisableException(ExceptionInjectionType.Dispose_After_Handler_Registered_Before_Start);
+                }
+
+                // Give server a moment to finish processing
+                Thread.Sleep(500);
+
+                long activeCount = garnetServerTcp.get_conn_active();
+
+                if (activeCount > 0)
+                {
+                    // Bug confirmed: handlers leaked. Don't try to dispose the server
+                    // (it would hang forever in DisposeActiveHandlers). Just fail.
+                    ClassicAssert.Fail(
+                        $"Leaked {activeCount} handler(s): Dispose() did not call DisposeImpl() to remove handler from activeHandlers. " +
+                        "Server disposal skipped to avoid hanging on the leaked handlers.");
+                }
+
+                // If we get here, the fix is working — handlers were cleaned up properly.
+                // Verify the server still accepts connections after cleanup.
+                using var db = TestUtils.GetGarnetClient(endpoint, useTLS: true);
+                db.Connect();
+                ManualResetEventSlim e = new();
+                string val = null;
+                db.StringSet("after_injection", "works", (c, r) => { val = r; e.Set(); });
+                e.Wait();
+                ClassicAssert.AreEqual("OK", val);
+
+                // Safe to dispose — no leaked handlers
+                testServer.Dispose();
+            }
+            catch
+            {
+                // On failure, don't dispose testServer (it would hang).
+                // Let the OS reclaim resources when the process exits.
+                throw;
+            }
+            finally
+            {
+                TestUtils.DeleteDirectory(testDir);
+            }
         }
     }
 }


### PR DESCRIPTION
# Fix CLOSE-WAIT connection leak in TLS disposal path

## Summary

Fixes a bug where TLS connections cleaned up via public `Dispose()` in `TcpNetworkHandlerBase` were never fully disposed, causing the handler to leak permanently in `activeHandlers`. This resulted in sockets stuck in CLOSE-WAIT state, steadily growing `activeHandlerCount`, and eventual thread pool exhaustion that made affected Garnet nodes unresponsive.

## Problem

### Symptom

When remote peers disconnect from a Garnet server running with TLS enabled, the server-side TCP connections enter and remain in the CLOSE-WAIT state indefinitely. Over time — particularly in environments where connections are frequently established and torn down — this leads to:

- Hundreds of leaked CLOSE-WAIT connections accumulating
- Thread count growing from ~40 to 1,800+ as the .NET thread pool struggles to service blocked work items
- File descriptor exhaustion (5,000+ open FDs)
- Complete node unresponsiveness — the server is running but cannot process any commands

The problem was discovered during extended testing where connections were repeatedly created and destroyed over many hours. Nodes that had been running the longest accumulated the most leaked connections, while recently started nodes had nearly zero.

### Root cause

`TcpNetworkHandlerBase` has two `Dispose` methods:

| Method | Visibility | Called by | Called `DisposeImpl()`? |
|--------|-----------|-----------|------------------------|
| `Dispose()` | public | `SslReaderAsync` catch blocks, server shutdown | **No** (the bug) |
| `Dispose(SocketAsyncEventArgs)` | private | SAEA IOCP callback | Yes |

Each TLS connection has two concurrent loops:

1. **SAEA loop** (IOCP-driven) — receives raw encrypted bytes into `networkReceiveBuffer`
2. **SslReaderAsync loop** (task-based) — reads decrypted plaintext from `SslStream` into `transportReceiveBuffer`

These loops are coordinated by two semaphores (`receivedData` and `expectingData`) and a `NetworkHandlerStream` bridge that feeds encrypted bytes from the SAEA buffer to `SslStream` for decryption.

When a TLS client disconnects, the `SslReaderAsync` loop catches the resulting exception and calls `this.Dispose()`. This resolves to the **public** `Dispose()` on `TcpNetworkHandlerBase`, which closed the socket but **never called `DisposeImpl()`**. As a result:

- `NetworkHandler.DisposeImpl()` never ran
- `serverHook.DisposeMessageConsumer(this)` was never called
- The handler was never removed from the `activeHandlers` dictionary
- `activeHandlerCount` was never decremented
- The socket remained in CLOSE-WAIT because `Shutdown(SocketShutdown.Both)` was never called

The private `Dispose(SocketAsyncEventArgs)` — called by the SAEA IOCP callback when `BytesTransferred == 0` — did call `DisposeImpl()` and worked correctly. But for TLS connections, the SslReaderAsync exception path typically fires first, hits the broken public `Dispose()`, and the SAEA callback never gets a chance to run the cleanup because the `disposeCount` guard in `DisposeImpl()` makes it idempotent (the second call is a no-op — except the first call never happened).

### Disposal path analysis

There are four paths that dispose a network handler:

| Path | Entry point | Which `Dispose`? | Had `DisposeImpl()`? |
|------|------------|----------------|----------------------|
| SAEA disconnect | IOCP callback (`BytesTransferred == 0`) | Private `Dispose(SAEA)` | ✅ Yes — always worked |
| **SslReaderAsync exception** | `NetworkHandler.SslReaderAsync` catch | **Public `Dispose()`** | **❌ No — the bug** |
| **Server shutdown** | `GarnetServerBase.DisposeActiveHandlers()` | **Public `Dispose()`** | **❌ No — also broken** |
| Start exception | `GarnetServerTcp.HandleNewConnection()` catch | `DisposeResources()` direct | ✅ Yes — always worked |

### Safety

- **Idempotent**: `DisposeImpl()` is guarded by `Interlocked.Increment(ref disposeCount) != 1` in `NetworkHandler` — only the first caller performs the actual cleanup. If both Dispose paths fire concurrently (SAEA and SslReaderAsync racing), the second call is a no-op.
- **Existing pattern**: The private `Dispose(SAEA)` already called `DisposeImpl()` after socket cleanup. The public `Dispose()` now mirrors the same sequence.
- **No behavioral change for non-TLS**: Non-TLS connections always go through the SAEA path (Path 1), which was already correct.

## Tests

### `TlsClientDisconnectCleansUpHandler`

Connects 5 TLS clients via `GarnetClient`, verifies they register as active handlers, abruptly disposes all clients, then verifies all handlers are cleaned up and `activeHandlerCount` returns to 0. Also confirms the server still accepts new connections after cleanup.

### `DisposeCallsDisposeImplWithoutSaeaBackup`

Directly tests the bug by isolating the public `Dispose()` path with no SAEA backup. Uses exception injection (`Dispose_After_Handler_Registered_Before_Start`) to trigger a failure after the handler is added to `activeHandlers` but before `Start()` is called. Since `Start()` never runs, no SAEA receive loop exists, so the only cleanup path is public `Dispose()`.

- **Without the fix**: Handlers leak (public `Dispose()` doesn't call `DisposeImpl()`), `activeHandlerCount` stays elevated, and `DisposeActiveHandlers()` would hang forever during server shutdown.
- **With the fix**: Handlers are properly cleaned up and the server remains functional.

This test uses its own server instance on a separate port to avoid hanging the shared test fixture's `TearDown` if the bug is present.

## Files changed

| File | Change |
|------|--------|
| `libs/common/Networking/TcpNetworkHandlerBase.cs` | Added `DisposeImpl()` call to public `Dispose()`. Added `Shutdown(Both)` and `Close()` to private `Dispose(SAEA)`. |
| `libs/common/ExceptionInjectionType.cs` | Added `Dispose_After_Handler_Registered_Before_Start` enum value for test injection. |
| `libs/server/Servers/GarnetServerTcp.cs` | Added exception injection point between handler registration and `Start()` call. |
| `test/Garnet.test/NetworkTests.cs` | Added `TlsClientDisconnectCleansUpHandler` and `DisposeCallsDisposeImplWithoutSaeaBackup` tests. |