### PR TITLE
Improve Network Resource Cleanup on TLS Disconnect/Fail Paths

### DIFF
--- a/libs/common/ExceptionInjectionType.cs
+++ b/libs/common/ExceptionInjectionType.cs
@@ -66,6 +66,10 @@ namespace Garnet.common
         /// </summary>
         Replication_Diskless_Sync_Reset_Cts,
         /// <summary>
+        /// Fail TakeOverAsPrimary during failover by throwing before BeginRecovery is called.
+        /// </summary>
+        Failover_Fail_TakeOverAsPrimary,
+        /// <summary>
         /// During deletion of a Vector Set, leaving it partially deleted - at a particular point of execution.
         /// </summary>
         VectorSet_Interrupt_Delete_0,
@@ -78,8 +82,9 @@ namespace Garnet.common
         /// </summary>
         VectorSet_Interrupt_Delete_2,
         /// <summary>
-        /// Fail TakeOverAsPrimary during failover by throwing before BeginRecovery is called.
+        /// Failure after handler registered in activeHandlers but before Start() is called.
+        /// This means no SAEA receive loop is running, so the only cleanup path is public Dispose().
         /// </summary>
-        Failover_Fail_TakeOverAsPrimary,
+        Dispose_After_Handler_Registered_Before_Start,
     }
 }

--- a/libs/common/Networking/TcpNetworkHandlerBase.cs
+++ b/libs/common/Networking/TcpNetworkHandlerBase.cs
@@ -170,6 +170,7 @@ namespace Garnet.common
                 // Dispose of the socket to free up unmanaged resources
                 socket.Dispose();
             }
+            DisposeImpl();
         }
 
         /// <summary>
@@ -182,7 +183,22 @@ namespace Garnet.common
 
         void Dispose(SocketAsyncEventArgs e)
         {
-            e.AcceptSocket.Dispose();
+            try
+            {
+                if (e.AcceptSocket.Connected)
+                {
+                    e.AcceptSocket.Shutdown(SocketShutdown.Both);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogTrace(ex, "Error shutting down accept socket during SAEA dispose");
+            }
+            finally
+            {
+                e.AcceptSocket.Close();
+                e.AcceptSocket.Dispose();
+            }
             DisposeImpl();
             e.Dispose();
         }

--- a/libs/server/Servers/GarnetServerTcp.cs
+++ b/libs/server/Servers/GarnetServerTcp.cs
@@ -279,6 +279,7 @@ namespace Garnet.server
                     try
                     {
                         IncrementConnectionsReceived();
+                        ExceptionInjectionHelper.TriggerException(ExceptionInjectionType.Dispose_After_Handler_Registered_Before_Start);
                         handler.Start(tlsOptions?.TlsServerOptions, remoteEndpointName);
                     }
                     catch (Exception ex)

--- a/test/Garnet.test/NetworkTests.cs
+++ b/test/Garnet.test/NetworkTests.cs
@@ -101,35 +101,40 @@ namespace Garnet.test
             // Connect multiple clients and verify they register as active handlers
             const int clientCount = 5;
             var clients = new Garnet.client.GarnetClient[clientCount];
-            for (int i = 0; i < clientCount; i++)
+            try
             {
-                clients[i] = TestUtils.GetGarnetClient(useTLS: true);
-                clients[i].Connect();
+                for (int i = 0; i < clientCount; i++)
+                {
+                    clients[i] = TestUtils.GetGarnetClient(useTLS: true);
+                    clients[i].Connect();
 
-                // Verify the connection works
-                ManualResetEventSlim done = new();
-                string result = null;
-                clients[i].StringSet($"key{i}", $"value{i}", (c, r) => { result = r; done.Set(); });
-                done.Wait();
-                ClassicAssert.AreEqual("OK", result);
+                    // Verify the connection works
+                    ManualResetEventSlim done = new();
+                    string result = null;
+                    clients[i].StringSet($"key{i}", $"value{i}", (c, r) => { result = r; done.Set(); });
+                    ClassicAssert.IsTrue(done.Wait(5000), $"Timed out waiting for StringSet callback on client {i}");
+                    ClassicAssert.AreEqual("OK", result);
+                }
+
+                // Wait for all connections to be registered
+                var deadline = System.Environment.TickCount64 + 5000;
+                while (garnetServerTcp.get_conn_active() < clientCount && System.Environment.TickCount64 < deadline)
+                    Thread.Sleep(50);
+                ClassicAssert.GreaterOrEqual(garnetServerTcp.get_conn_active(), clientCount,
+                    "Expected all clients to be registered as active handlers");
             }
-
-            // Wait for all connections to be registered
-            var deadline = System.Environment.TickCount64 + 5000;
-            while (garnetServerTcp.get_conn_active() < clientCount && System.Environment.TickCount64 < deadline)
-                Thread.Sleep(50);
-            ClassicAssert.GreaterOrEqual(garnetServerTcp.get_conn_active(), clientCount,
-                "Expected all clients to be registered as active handlers");
-
-            // Abruptly dispose all clients (sends FIN, simulating remote peer disconnect)
-            for (int i = 0; i < clientCount; i++)
+            finally
             {
-                clients[i].Dispose();
+                // Abruptly dispose all clients (sends FIN, simulating remote peer disconnect)
+                for (int i = 0; i < clientCount; i++)
+                {
+                    clients[i]?.Dispose();
+                }
             }
 
             // Wait for the server to detect the disconnections and clean up handlers
-            deadline = System.Environment.TickCount64 + 10000;
-            while (garnetServerTcp.get_conn_active() > 0 && System.Environment.TickCount64 < deadline)
+            var deadline2 = System.Environment.TickCount64 + 10000;
+            while (garnetServerTcp.get_conn_active() > 0 && System.Environment.TickCount64 < deadline2)
                 Thread.Sleep(100);
 
             ClassicAssert.AreEqual(0, garnetServerTcp.get_conn_active(),
@@ -143,7 +148,7 @@ namespace Garnet.test
             ManualResetEventSlim e = new();
             string val = null;
             db.StringSet("after_cleanup", "works", (c, r) => { val = r; e.Set(); });
-            e.Wait();
+            ClassicAssert.IsTrue(e.Wait(5000), "Timed out waiting for post-cleanup StringSet callback");
             ClassicAssert.AreEqual("OK", val);
         }
 
@@ -212,11 +217,18 @@ namespace Garnet.test
 
                 if (activeCount > 0)
                 {
-                    // Bug confirmed: handlers leaked. Don't try to dispose the server
-                    // (it would hang forever in DisposeActiveHandlers). Just fail.
+                    // Bug confirmed: handlers leaked. Attempt best-effort cleanup
+                    // on a background thread with a timeout so we don't leave a live
+                    // listener running for the rest of the test suite.
+                    var disposeTask = Task.Run(() =>
+                    {
+                        try { testServer.Dispose(); }
+                        catch { /* best effort */ }
+                    });
+                    disposeTask.Wait(TimeSpan.FromSeconds(5));
+
                     ClassicAssert.Fail(
-                        $"Leaked {activeCount} handler(s): Dispose() did not call DisposeImpl() to remove handler from activeHandlers. " +
-                        "Server disposal skipped to avoid hanging on the leaked handlers.");
+                        $"Leaked {activeCount} handler(s): Dispose() did not call DisposeImpl() to remove handler from activeHandlers.");
                 }
 
                 // If we get here, the fix is working — handlers were cleaned up properly.
@@ -226,7 +238,7 @@ namespace Garnet.test
                 ManualResetEventSlim e = new();
                 string val = null;
                 db.StringSet("after_injection", "works", (c, r) => { val = r; e.Set(); });
-                e.Wait();
+                ClassicAssert.IsTrue(e.Wait(5000), "Timed out waiting for post-injection StringSet callback");
                 ClassicAssert.AreEqual("OK", val);
 
                 // Safe to dispose — no leaked handlers
@@ -234,8 +246,14 @@ namespace Garnet.test
             }
             catch
             {
-                // On failure, don't dispose testServer (it would hang).
-                // Let the OS reclaim resources when the process exits.
+                // Best-effort cleanup on failure — attempt disposal with a timeout
+                // to avoid leaving a live listener for the rest of the test run.
+                var disposeTask = Task.Run(() =>
+                {
+                    try { testServer.Dispose(); }
+                    catch { /* best effort */ }
+                });
+                disposeTask.Wait(TimeSpan.FromSeconds(5));
                 throw;
             }
             finally

--- a/test/Garnet.test/NetworkTests.cs
+++ b/test/Garnet.test/NetworkTests.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT license.
 
 #if DEBUG
+using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
+using System.Threading.Tasks;
 using Allure.NUnit;
 using Garnet.common;
 using Garnet.server;

--- a/test/Garnet.test/NetworkTests.cs
+++ b/test/Garnet.test/NetworkTests.cs
@@ -121,7 +121,7 @@ namespace Garnet.test
                 // Wait for all connections to be registered
                 var deadline = System.Environment.TickCount64 + 5000;
                 while (garnetServerTcp.get_conn_active() < clientCount && System.Environment.TickCount64 < deadline)
-                    Thread.Sleep(50);
+                    Thread.Sleep(250);
                 ClassicAssert.GreaterOrEqual(garnetServerTcp.get_conn_active(), clientCount,
                     "Expected all clients to be registered as active handlers");
             }
@@ -137,7 +137,7 @@ namespace Garnet.test
             // Wait for the server to detect the disconnections and clean up handlers
             var deadline2 = System.Environment.TickCount64 + 10000;
             while (garnetServerTcp.get_conn_active() > 0 && System.Environment.TickCount64 < deadline2)
-                Thread.Sleep(100);
+                Thread.Sleep(250);
 
             ClassicAssert.AreEqual(0, garnetServerTcp.get_conn_active(),
                 "Server still has active handlers after all clients disconnected — handlers were not properly cleaned up (CLOSE-WAIT leak)");
@@ -191,7 +191,10 @@ namespace Garnet.test
                     // We can't use GarnetClient here because TLS auth would hang —
                     // the exception fires before Start(), so the server never begins
                     // TLS negotiation, and the client would wait forever.
-                    for (int i = 0; i < 3; i++)
+                    const int injectionCount = 3;
+                    var receivedBefore = garnetServerTcp.TotalConnectionsReceived;
+
+                    for (int i = 0; i < injectionCount; i++)
                     {
                         using var rawSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
                         try
@@ -203,8 +206,11 @@ namespace Garnet.test
                             // Connection may fail if server closed socket fast enough
                         }
 
-                        // Give the server time to process the accept and hit the exception
-                        Thread.Sleep(200);
+                        // Wait for the server to receive and process this connection
+                        var connDeadline = System.Environment.TickCount64 + 5000;
+                        while (garnetServerTcp.TotalConnectionsReceived < receivedBefore + i + 1
+                               && System.Environment.TickCount64 < connDeadline)
+                            Thread.Sleep(250);
                     }
                 }
                 finally
@@ -212,8 +218,10 @@ namespace Garnet.test
                     ExceptionInjectionHelper.DisableException(ExceptionInjectionType.Dispose_After_Handler_Registered_Before_Start);
                 }
 
-                // Give server a moment to finish processing
-                Thread.Sleep(500);
+                // Wait for all injected connections to be fully disposed
+                var disposeDeadline = System.Environment.TickCount64 + 5000;
+                while (garnetServerTcp.get_conn_active() > 0 && System.Environment.TickCount64 < disposeDeadline)
+                    Thread.Sleep(250);
 
                 long activeCount = garnetServerTcp.get_conn_active();
 
@@ -260,7 +268,7 @@ namespace Garnet.test
             }
             finally
             {
-                TestUtils.DeleteDirectory(testDir);
+                TestUtils.DeleteDirectory(testDir, wait: true);
             }
         }
     }

--- a/test/Garnet.test/NetworkTests.cs
+++ b/test/Garnet.test/NetworkTests.cs
@@ -2,9 +2,12 @@
 // Licensed under the MIT license.
 
 #if DEBUG
+using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using Allure.NUnit;
 using Garnet.common;
+using Garnet.server;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 
@@ -83,6 +86,162 @@ namespace Garnet.test
                 e.Set();
             });
             e.Wait();
+        }
+
+        /// <summary>
+        /// Verifies that when a TLS client abruptly disconnects, the server properly
+        /// cleans up the handler and removes it from activeHandlers.
+        /// </summary>
+        [Test]
+        public void TlsClientDisconnectCleansUpHandler()
+        {
+            var garnetServerTcp = (GarnetServerBase)server.Provider.StoreWrapper.Servers[0];
+            var disposedBefore = garnetServerTcp.TotalConnectionsDisposed;
+
+            // Connect multiple clients and verify they register as active handlers
+            const int clientCount = 5;
+            var clients = new Garnet.client.GarnetClient[clientCount];
+            for (int i = 0; i < clientCount; i++)
+            {
+                clients[i] = TestUtils.GetGarnetClient(useTLS: true);
+                clients[i].Connect();
+
+                // Verify the connection works
+                ManualResetEventSlim done = new();
+                string result = null;
+                clients[i].StringSet($"key{i}", $"value{i}", (c, r) => { result = r; done.Set(); });
+                done.Wait();
+                ClassicAssert.AreEqual("OK", result);
+            }
+
+            // Wait for all connections to be registered
+            var deadline = System.Environment.TickCount64 + 5000;
+            while (garnetServerTcp.get_conn_active() < clientCount && System.Environment.TickCount64 < deadline)
+                Thread.Sleep(50);
+            ClassicAssert.GreaterOrEqual(garnetServerTcp.get_conn_active(), clientCount,
+                "Expected all clients to be registered as active handlers");
+
+            // Abruptly dispose all clients (sends FIN, simulating remote peer disconnect)
+            for (int i = 0; i < clientCount; i++)
+            {
+                clients[i].Dispose();
+            }
+
+            // Wait for the server to detect the disconnections and clean up handlers
+            deadline = System.Environment.TickCount64 + 10000;
+            while (garnetServerTcp.get_conn_active() > 0 && System.Environment.TickCount64 < deadline)
+                Thread.Sleep(100);
+
+            ClassicAssert.AreEqual(0, garnetServerTcp.get_conn_active(),
+                "Server still has active handlers after all clients disconnected — handlers were not properly cleaned up (CLOSE-WAIT leak)");
+            ClassicAssert.GreaterOrEqual(garnetServerTcp.TotalConnectionsDisposed - disposedBefore, clientCount,
+                "Expected TotalConnectionsDisposed to increment by at least the number of disconnected clients");
+
+            // Verify the server still accepts new connections after cleanup
+            using var db = TestUtils.GetGarnetClient(useTLS: true);
+            db.Connect();
+            ManualResetEventSlim e = new();
+            string val = null;
+            db.StringSet("after_cleanup", "works", (c, r) => { val = r; e.Set(); });
+            e.Wait();
+            ClassicAssert.AreEqual("OK", val);
+        }
+
+        /// <summary>
+        /// Verifies that Dispose() properly calls DisposeImpl() to remove the handler from
+        /// activeHandlers when no SAEA receive loop is running. This directly tests the
+        /// CLOSE-WAIT fix: the exception fires after the handler is registered but before
+        /// Start() is called, so there is no SAEA backup cleanup path. Without the fix,
+        /// public Dispose() does not call DisposeImpl() and the handler leaks permanently,
+        /// which also causes DisposeActiveHandlers() to spin forever during server shutdown.
+        ///
+        /// This test uses its own server instance (not the shared one from SetUp/TearDown)
+        /// because the bug causes server.Dispose() to hang forever on leaked handlers.
+        /// </summary>
+        [Test]
+        public void DisposeCallsDisposeImplWithoutSaeaBackup()
+        {
+            // Use a separate server on a different port so we don't interfere
+            // with the shared server from SetUp, and so TearDown doesn't hang.
+            var testDir = TestUtils.MethodTestDir + "_injection";
+            TestUtils.DeleteDirectory(testDir, wait: true);
+            var endpoint = new IPEndPoint(IPAddress.Loopback, TestUtils.TestPort + 1000);
+            var testServer = TestUtils.CreateGarnetServer(testDir, enableTLS: true,
+                endpoints: [endpoint]);
+            testServer.Start();
+
+            try
+            {
+                var garnetServerTcp = (GarnetServerBase)testServer.Provider.StoreWrapper.Servers[0];
+
+                // Verify no active connections initially
+                ClassicAssert.AreEqual(0, garnetServerTcp.get_conn_active());
+
+                ExceptionInjectionHelper.EnableException(ExceptionInjectionType.Dispose_After_Handler_Registered_Before_Start);
+                try
+                {
+                    // Use raw TCP sockets to trigger the server's accept loop.
+                    // We can't use GarnetClient here because TLS auth would hang —
+                    // the exception fires before Start(), so the server never begins
+                    // TLS negotiation, and the client would wait forever.
+                    for (int i = 0; i < 3; i++)
+                    {
+                        using var rawSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                        try
+                        {
+                            rawSocket.Connect(endpoint);
+                        }
+                        catch
+                        {
+                            // Connection may fail if server closed socket fast enough
+                        }
+
+                        // Give the server time to process the accept and hit the exception
+                        Thread.Sleep(200);
+                    }
+                }
+                finally
+                {
+                    ExceptionInjectionHelper.DisableException(ExceptionInjectionType.Dispose_After_Handler_Registered_Before_Start);
+                }
+
+                // Give server a moment to finish processing
+                Thread.Sleep(500);
+
+                long activeCount = garnetServerTcp.get_conn_active();
+
+                if (activeCount > 0)
+                {
+                    // Bug confirmed: handlers leaked. Don't try to dispose the server
+                    // (it would hang forever in DisposeActiveHandlers). Just fail.
+                    ClassicAssert.Fail(
+                        $"Leaked {activeCount} handler(s): Dispose() did not call DisposeImpl() to remove handler from activeHandlers. " +
+                        "Server disposal skipped to avoid hanging on the leaked handlers.");
+                }
+
+                // If we get here, the fix is working — handlers were cleaned up properly.
+                // Verify the server still accepts connections after cleanup.
+                using var db = TestUtils.GetGarnetClient(endpoint, useTLS: true);
+                db.Connect();
+                ManualResetEventSlim e = new();
+                string val = null;
+                db.StringSet("after_injection", "works", (c, r) => { val = r; e.Set(); });
+                e.Wait();
+                ClassicAssert.AreEqual("OK", val);
+
+                // Safe to dispose — no leaked handlers
+                testServer.Dispose();
+            }
+            catch
+            {
+                // On failure, don't dispose testServer (it would hang).
+                // Let the OS reclaim resources when the process exits.
+                throw;
+            }
+            finally
+            {
+                TestUtils.DeleteDirectory(testDir);
+            }
         }
     }
 }


### PR DESCRIPTION
The description needs corrections based on our deeper analysis. Here's the updated version with the inaccuracies fixed:

---

# Fix CLOSE-WAIT connection leak in TLS disposal path

## Summary

Fixes a bug where TLS connections cleaned up via public `Dispose()` in `TcpNetworkHandlerBase` did not call `DisposeImpl()`, deferring all handler cleanup to a secondary SAEA IOCP roundtrip through the threadpool. Under burst disconnection load (e.g., scale-down events removing multiple nodes simultaneously), this deferred cleanup path cannot keep up, causing threadpool starvation, CLOSE-WAIT socket accumulation, and eventual node unresponsiveness.

## Problem

### Symptom

When remote peers disconnect from a Garnet server running with TLS enabled, the server relies on a deferred threadpool roundtrip to clean up handlers. Under burst disconnection load, this leads to:

- Hundreds of CLOSE-WAIT connections accumulating
- Thread count growing from ~40 to 1,800+ as the .NET thread pool struggles to service deferred cleanup callbacks
- File descriptor exhaustion (5,000+ open FDs)
- Complete node unresponsiveness — the server is running but cannot process any commands

The problem was discovered during extended testing where connections were repeatedly created and destroyed over many hours. Nodes that had been running the longest accumulated the most leaked connections, while recently started nodes had nearly zero.

### Root cause

`TcpNetworkHandlerBase` has two `Dispose` methods:

| Method | Visibility | Called by | Called `DisposeImpl()`? |
|--------|-----------|-----------|------------------------|
| `Dispose()` | public | `SslReaderAsync` catch blocks, server shutdown | **No** (the bug) |
| `Dispose(SocketAsyncEventArgs)` | private | SAEA IOCP callback | Yes |

Each TLS connection has two concurrent loops:

1. **SAEA loop** (IOCP-driven) — receives raw encrypted bytes into `networkReceiveBuffer`
2. **SslReaderAsync loop** (task-based) — reads decrypted plaintext from `SslStream` into `transportReceiveBuffer`

These loops are coordinated by two semaphores (`receivedData` and `expectingData`) and a `NetworkHandlerStream` bridge that feeds encrypted bytes from the SAEA buffer to `SslStream` for decryption.

When a TLS client disconnects, `SslReaderAsync` catches the resulting exception and calls `this.Dispose()`, which resolves to the **public** `Dispose()` on `TcpNetworkHandlerBase`. This closed the socket but **never called `DisposeImpl()`**. As a result, handler cleanup was entirely deferred to the SAEA backup path:

```
SslReaderAsync catches disconnect exception
  → public Dispose(): socket.Close() / socket.Dispose() (NO DisposeImpl)
  → cancellationTokenSource NOT cancelled (only DisposeImpl does this)
  → handler NOT removed from activeHandlers
  → finally: sets readerStatus=Rest, releases expectingData semaphore
  → SAEA loop wakes up from semaphore
  → tries ReceiveAsync on closed socket → ObjectDisposedException
  → HandleReceiveFailure → Dispose(SAEA) → DisposeImpl() ← cleanup happens here, deferred
```

The SAEA backup path does eventually call `DisposeImpl()`, but it requires a full roundtrip through the threadpool. Under burst disconnection load (50-100+ simultaneous disconnects during a scale event), this creates a cascading failure:

1. Each disconnect closes the socket but defers `DisposeImpl()` to an SAEA threadpool callback
2. `cancellationTokenSource` is never cancelled (only `DisposeImpl` calls `Cancel()`), so background async tasks on these handlers keep running, consuming threads
3. The threadpool grows slowly (~1-2 threads/sec) and cannot keep up with the burst
4. Pending SAEA callbacks queue up, blocking threads waiting on semaphores
5. Thread count snowballs: 40 → 200 → 1,800
6. During shutdown, `DisposeActiveHandlers()` calls public `Dispose()` on each handler in a `while (activeHandlerCount > 0)` loop — each call still depends on SAEA roundtrips to decrement the count, but SAEA callbacks can't get threads
7. Shutdown hangs, connections remain in CLOSE-WAIT indefinitely

### Why non-TLS connections are not affected

Non-TLS disconnects go directly through the SAEA `BytesTransferred == 0` path, which calls private `Dispose(SAEA)` → `DisposeImpl()` immediately. No deferred roundtrip is needed.

### Disposal path analysis

There are four paths that dispose a network handler:

| Path | Entry point | Which `Dispose`? | Had `DisposeImpl()`? |
|------|------------|----------------|----------------------|
| SAEA disconnect | IOCP callback (`BytesTransferred == 0`) | Private `Dispose(SAEA)` | ✅ Yes — always worked |
| **SslReaderAsync exception** | `NetworkHandler.SslReaderAsync` catch | **Public `Dispose()`** | **❌ No — the bug** |
| **Server shutdown** | `GarnetServerBase.DisposeActiveHandlers()` | **Public `Dispose()`** | **❌ No — also broken** |
| Start exception | `GarnetServerTcp.HandleNewConnection()` catch | `DisposeResources()` direct | ✅ Yes — always worked |

## Fix

The public `Dispose()` now calls `DisposeImpl()` synchronously, making handler cleanup immediate with no threadpool dependency:

```
SslReaderAsync catches disconnect exception
  → public Dispose():
      socket.Shutdown(Both)    ← sends TCP FIN (graceful close)
      socket.Close() / Dispose()
      DisposeImpl()            ← THE FIX: immediate cleanup
        → cancellationTokenSource.Cancel()    ← stops background tasks
        → DisposeMessageConsumer()            ← removes from activeHandlers
        → activeHandlerCount--                ← decrements immediately
  → SAEA wakes up later → Dispose(SAEA) → DisposeImpl() → no-op (disposeCount guard)
```

Even 100+ simultaneous disconnects clean up instantly on whatever thread caught the exception. No threadpool roundtrip needed.

### Safety

- **Idempotent**: `DisposeImpl()` is guarded by `Interlocked.Increment(ref disposeCount) != 1` in `NetworkHandler` — only the first caller performs the actual cleanup. If both Dispose paths fire concurrently (SAEA and SslReaderAsync racing), the second call is a no-op.
- **Existing pattern**: The private `Dispose(SAEA)` already called `DisposeImpl()` after socket cleanup. The public `Dispose()` now mirrors the same sequence.
- **No behavioral change for non-TLS**: Non-TLS connections always go through the SAEA path (Path 1), which was already correct.

## Tests

### `TlsClientDisconnectCleansUpHandler`

Connects 5 TLS clients via `GarnetClient`, verifies they register as active handlers, abruptly disposes all clients, then verifies all handlers are cleaned up and `activeHandlerCount` returns to 0. Also confirms the server still accepts new connections after cleanup.

### `DisposeCallsDisposeImplWithoutSaeaBackup`

Directly tests the bug by isolating the public `Dispose()` path with no SAEA backup. Uses exception injection (`Dispose_After_Handler_Registered_Before_Start`) to trigger a failure after the handler is added to `activeHandlers` but before `Start()` is called. Since `Start()` never runs, no SAEA receive loop exists, so the only cleanup path is public `Dispose()`.

- **Without the fix**: Handlers leak (public `Dispose()` doesn't call `DisposeImpl()`), `activeHandlerCount` stays elevated, and `DisposeActiveHandlers()` would hang forever during server shutdown.
- **With the fix**: Handlers are properly cleaned up and the server remains functional.

This test uses its own server instance on a separate port to avoid hanging the shared test fixture's `TearDown` if the bug is present.

## Files changed

| File | Change |
|------|--------|
| TcpNetworkHandlerBase.cs | Added `DisposeImpl()` call to public `Dispose()`. Added `Shutdown(Both)` and `Close()` to private `Dispose(SAEA)`. |
| ExceptionInjectionType.cs | Added `Dispose_After_Handler_Registered_Before_Start` enum value for test injection. |
| GarnetServerTcp.cs | Added exception injection point between handler registration and `Start()` call. |
| NetworkTests.cs | Added `TlsClientDisconnectCleansUpHandler` and `DisposeCallsDisposeImplWithoutSaeaBackup` tests. |

---

Key changes from the previous version:

1. **Removed "leaked permanently"** — the SAEA backup path does eventually call `DisposeImpl()`, it's not a permanent leak in the simple case
2. **Added the real failure mechanism** — deferred threadpool roundtrip can't keep up with burst disconnections, causing cascading threadpool starvation
3. **Added `cancellationTokenSource` not being cancelled** as a key contributing factor — background tasks keep running and consuming threads
4. **Added the before/after cleanup flow** showing immediate vs deferred cleanup
5. **Explained why non-TLS is unaffected** — direct SAEA path, no roundtrip