### PR TITLE
Vector Set Migration Reliability Fixes

### DIFF
--- a/libs/cluster/Server/Migration/MigrateOperation.cs
+++ b/libs/cluster/Server/Migration/MigrateOperation.cs
@@ -249,7 +249,11 @@ namespace Garnet.cluster
                     migrateOperation.session.WaitForConfigPropagation();
 
                     // Transmit all keys gathered
-                    migrateOperation.TransmitSlots(StoreType.Main);
+                    if (!migrateOperation.TransmitSlots(StoreType.Main))
+                    {
+                        logger?.LogWarning("TransmitSlots failed for {cursor} to {current} (with {count} keys)", cursor, current, migrateOperation.sketch.argSliceVector.Count);
+                        return false;
+                    }
 
                     // Transition EPSM to DELETING
                     migrateOperation.sketch.SetStatus(SketchStatus.DELETING);

--- a/libs/cluster/Server/Migration/MigrateSessionSlots.cs
+++ b/libs/cluster/Server/Migration/MigrateSessionSlots.cs
@@ -100,7 +100,7 @@ namespace Garnet.cluster
             async Task<bool> CreateAndRunMigrateTasks(StoreType storeType, long beginAddress, long tailAddress, int pageSize)
             {
                 logger?.LogTrace("{method} > [{storeType}] Scan in range ({BeginAddress},{TailAddress})", nameof(CreateAndRunMigrateTasks), storeType, beginAddress, tailAddress);
-                var migrateOperationRunners = new Task[clusterProvider.serverOptions.ParallelMigrateTaskCount];
+                var migrateOperationRunners = new Task<bool>[clusterProvider.serverOptions.ParallelMigrateTaskCount];
                 var i = 0;
                 while (i < migrateOperationRunners.Length)
                 {
@@ -111,7 +111,12 @@ namespace Garnet.cluster
 
                 try
                 {
-                    await Task.WhenAll(migrateOperationRunners).WaitAsync(_timeout, _cts.Token).ConfigureAwait(false);
+                    var scanResults = await Task.WhenAll(migrateOperationRunners).WaitAsync(_timeout, _cts.Token).ConfigureAwait(false);
+                    if (!scanResults.All(static x => x))
+                    {
+                        logger?.LogWarning("Aborting migration due to ScanStoreTask failure");
+                        return false;
+                    }
 
                     // Handle migration of discovered Vector Set keys now that they're namespaces have been moved
                     if (storeType == StoreType.Main)
@@ -209,7 +214,11 @@ namespace Garnet.cluster
                     WaitForConfigPropagation();
 
                     // Transmit all keys gathered
-                    migrateOperation.TransmitSlots(storeType);
+                    if (!migrateOperation.TransmitSlots(storeType))
+                    {
+                        logger?.LogWarning("[{taskId}> TransmitSlots failed for {cursor} to {current} (with {count} keys)", taskId, cursor, current, migrateOperation.sketch.argSliceVector.Count);
+                        return Task.FromResult(false);
+                    }
 
                     // Transition EPSM to DELETING
                     migrateOperation.sketch.SetStatus(SketchStatus.DELETING);

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -482,12 +482,13 @@ namespace Garnet
             for (var i = 0; i < servers.Length; i++)
                 servers[i]?.Close();
 
-            // Phase 2: Dispose the provider (storage engine shutdown — may take time).
-            Provider?.Dispose();
-
-            // Phase 3: Drain active handlers and clean up remaining resources.
+            // Phase 2: Drain active handlers and clean up remaining resources.
             for (var i = 0; i < servers.Length; i++)
                 servers[i]?.Dispose();
+
+            // Phase 3: Dispose the provider (storage engine shutdown — may take time).
+            Provider?.Dispose();
+                        
             subscribeBroker?.Dispose();
             storeEpoch?.Dispose();
             aofEpoch?.Dispose();

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -488,7 +488,7 @@ namespace Garnet
 
             // Phase 3: Dispose the provider (storage engine shutdown — may take time).
             Provider?.Dispose();
-                        
+
             subscribeBroker?.Dispose();
             storeEpoch?.Dispose();
             aofEpoch?.Dispose();

--- a/libs/server/InputHeader.cs
+++ b/libs/server/InputHeader.cs
@@ -319,7 +319,7 @@ namespace Garnet.server
             var len = parseState.DeserializeFrom(curr);
             curr += len;
 
-            return (int)(src - curr);
+            return (int)(curr - src);
         }
     }
 

--- a/libs/server/Resp/Parser/SessionParseState.cs
+++ b/libs/server/Resp/Parser/SessionParseState.cs
@@ -298,7 +298,7 @@ namespace Garnet.server
                 curr += sbParam.TotalSize;
             }
 
-            return (int)(dest - curr);
+            return (int)(curr - dest);
         }
 
         /// <summary>
@@ -322,7 +322,7 @@ namespace Garnet.server
                 curr += sbArgument.TotalSize;
             }
 
-            return (int)(src - curr);
+            return (int)(curr - src);
         }
 
         /// <summary>

--- a/libs/server/Resp/Vector/VectorManager.Locking.cs
+++ b/libs/server/Resp/Vector/VectorManager.Locking.cs
@@ -108,7 +108,6 @@ namespace Garnet.server
             ActiveThreadSession = storageSession;
             try
             {
-
                 var keyHash = storageSession.basicContext.GetKeyHash(ref key);
 
                 var indexConfig = SpanByteAndMemory.FromPinnedSpan(indexSpan);
@@ -265,7 +264,6 @@ namespace Garnet.server
             ActiveThreadSession = storageSession;
             try
             {
-
                 var keyHash = storageSession.basicContext.GetKeyHash(ref key);
 
                 var indexConfig = SpanByteAndMemory.FromPinnedSpan(indexSpan);

--- a/libs/server/Resp/Vector/VectorManager.Locking.cs
+++ b/libs/server/Resp/Vector/VectorManager.Locking.cs
@@ -106,131 +106,143 @@ namespace Garnet.server
 
             Debug.Assert(ActiveThreadSession == null, "Shouldn't enter context when already in one");
             ActiveThreadSession = storageSession;
-
-            var keyHash = storageSession.basicContext.GetKeyHash(ref key);
-
-            var indexConfig = SpanByteAndMemory.FromPinnedSpan(indexSpan);
-
-            var readCmd = input.header.cmd;
-
-            while (true)
+            try
             {
-                input.header.cmd = readCmd;
-                input.arg1 = 0;
 
-                vectorSetLocks.AcquireSharedLock(keyHash, out var sharedLockToken);
+                var keyHash = storageSession.basicContext.GetKeyHash(ref key);
 
-                GarnetStatus readRes;
-                try
+                var indexConfig = SpanByteAndMemory.FromPinnedSpan(indexSpan);
+
+                var readCmd = input.header.cmd;
+
+                while (true)
                 {
-                    readRes = storageSession.Read_MainStore(ref key, ref input, ref indexConfig, ref storageSession.basicContext);
-                    Debug.Assert(indexConfig.IsSpanByte, "Should never need to move index onto the heap");
-                }
-                catch
-                {
-                    vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+                    input.header.cmd = readCmd;
+                    input.arg1 = 0;
 
-                    throw;
-                }
+                    vectorSetLocks.AcquireSharedLock(keyHash, out var sharedLockToken);
 
-                bool needsRecreate;
-                if (readRes == GarnetStatus.OK)
-                {
-                    if (PartiallyDeleted(indexConfig.AsReadOnlySpan()))
-                    {
-                        status = GarnetStatus.BADSTATE;
-
-                        vectorSetLocks.ReleaseSharedLock(sharedLockToken);
-                        return default;
-                    }
-
-                    needsRecreate = NeedsRecreate(indexConfig.AsReadOnlySpan());
-                }
-                else
-                {
-                    needsRecreate = false;
-                }
-
-                if (needsRecreate)
-                {
-                    if (!vectorSetLocks.TryPromoteSharedLock(keyHash, sharedLockToken, out var exclusiveLockToken))
-                    {
-                        // Release the SHARED lock if we can't promote and try again
-                        vectorSetLocks.ReleaseSharedLock(sharedLockToken);
-
-                        continue;
-                    }
-
-                    ReadIndex(indexSpan, out var indexContext, out var dims, out var reduceDims, out var quantType, out var buildExplorationFactor, out var numLinks, out var distanceMetric, out _, out _);
-
-                    input.arg1 = RecreateIndexArg;
-
-                    nint newlyAllocatedIndex;
-                    unsafe
-                    {
-                        newlyAllocatedIndex = Service.RecreateIndex(indexContext, dims, reduceDims, quantType, buildExplorationFactor, numLinks, distanceMetric, ReadCallbackPtr, WriteCallbackPtr, DeleteCallbackPtr, ReadModifyWriteCallbackPtr);
-                    }
-
-                    input.header.cmd = RespCommand.VADD;
-                    input.arg1 = RecreateIndexArg;
-
-                    input.parseState.EnsureCapacity(12);
-
-                    // Save off for recreation
-                    input.parseState.SetArgument(10, ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<ulong, byte>(MemoryMarshal.CreateSpan(ref indexContext, 1)))); // Strictly we don't _need_ this, but it keeps everything else aligned nicely
-                    input.parseState.SetArgument(11, ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<nint, byte>(MemoryMarshal.CreateSpan(ref newlyAllocatedIndex, 1))));
-
-                    GarnetStatus writeRes;
+                    GarnetStatus readRes;
                     try
                     {
-                        try
-                        {
-                            writeRes = storageSession.RMW_MainStore(ref key, ref input, ref indexConfig, ref storageSession.basicContext);
-
-                            if (writeRes != GarnetStatus.OK)
-                            {
-                                // If we didn't write, drop index so we don't leak it
-                                Service.DropIndex(indexContext, newlyAllocatedIndex);
-                            }
-                        }
-                        catch
-                        {
-                            // Drop to avoid leak on error
-                            Service.DropIndex(indexContext, newlyAllocatedIndex);
-                            throw;
-                        }
+                        readRes = storageSession.Read_MainStore(ref key, ref input, ref indexConfig, ref storageSession.basicContext);
+                        Debug.Assert(indexConfig.IsSpanByte, "Should never need to move index onto the heap");
                     }
                     catch
                     {
-                        vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+                        vectorSetLocks.ReleaseSharedLock(sharedLockToken);
 
                         throw;
                     }
 
-                    if (writeRes == GarnetStatus.OK)
+                    bool needsRecreate;
+                    if (readRes == GarnetStatus.OK)
                     {
-                        // Try again so we don't hold an exclusive lock while performing a search
-                        vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
-                        continue;
+                        if (PartiallyDeleted(indexConfig.AsReadOnlySpan()))
+                        {
+                            status = GarnetStatus.BADSTATE;
+
+                            vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+                            return default;
+                        }
+
+                        needsRecreate = NeedsRecreate(indexConfig.AsReadOnlySpan());
                     }
                     else
                     {
-                        status = writeRes;
-                        vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+                        needsRecreate = false;
+                    }
+
+                    if (needsRecreate)
+                    {
+                        if (!vectorSetLocks.TryPromoteSharedLock(keyHash, sharedLockToken, out var exclusiveLockToken))
+                        {
+                            // Release the SHARED lock if we can't promote and try again
+                            vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+
+                            continue;
+                        }
+
+                        ReadIndex(indexSpan, out var indexContext, out var dims, out var reduceDims, out var quantType, out var buildExplorationFactor, out var numLinks, out var distanceMetric, out _, out _);
+
+                        input.arg1 = RecreateIndexArg;
+
+                        nint newlyAllocatedIndex;
+                        unsafe
+                        {
+                            newlyAllocatedIndex = Service.RecreateIndex(indexContext, dims, reduceDims, quantType, buildExplorationFactor, numLinks, distanceMetric, ReadCallbackPtr, WriteCallbackPtr, DeleteCallbackPtr, ReadModifyWriteCallbackPtr);
+                        }
+
+                        input.header.cmd = RespCommand.VADD;
+                        input.arg1 = RecreateIndexArg;
+
+                        input.parseState.EnsureCapacity(12);
+
+                        // Save off for recreation
+                        input.parseState.SetArgument(10, ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<ulong, byte>(MemoryMarshal.CreateSpan(ref indexContext, 1)))); // Strictly we don't _need_ this, but it keeps everything else aligned nicely
+                        input.parseState.SetArgument(11, ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<nint, byte>(MemoryMarshal.CreateSpan(ref newlyAllocatedIndex, 1))));
+
+                        GarnetStatus writeRes;
+                        try
+                        {
+                            try
+                            {
+                                writeRes = storageSession.RMW_MainStore(ref key, ref input, ref indexConfig, ref storageSession.basicContext);
+
+                                if (writeRes != GarnetStatus.OK)
+                                {
+                                    // If we didn't write, drop index so we don't leak it
+                                    Service.DropIndex(indexContext, newlyAllocatedIndex);
+                                }
+                            }
+                            catch
+                            {
+                                // Drop to avoid leak on error
+                                Service.DropIndex(indexContext, newlyAllocatedIndex);
+                                throw;
+                            }
+                        }
+                        catch
+                        {
+                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+
+                            throw;
+                        }
+
+                        if (writeRes == GarnetStatus.OK)
+                        {
+                            // Try again so we don't hold an exclusive lock while performing a search
+                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+                            continue;
+                        }
+                        else
+                        {
+                            status = writeRes;
+                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+
+                            return default;
+                        }
+                    }
+                    else if (readRes != GarnetStatus.OK)
+                    {
+                        status = readRes;
+                        vectorSetLocks.ReleaseSharedLock(sharedLockToken);
 
                         return default;
                     }
-                }
-                else if (readRes != GarnetStatus.OK)
-                {
-                    status = readRes;
-                    vectorSetLocks.ReleaseSharedLock(sharedLockToken);
 
-                    return default;
+                    status = GarnetStatus.OK;
+                    return new(in vectorSetLocks, sharedLockToken);
                 }
+            }
+            catch
+            {
+                // If we exit without returning a lock, we'll leave ActiveThreadSession set, this clears it and rethrows
+                //
+                // In the normal exit case, disposing ReadVectorLock will clear ActiveThreadSession
+                ActiveThreadSession = null;
 
-                status = GarnetStatus.OK;
-                return new(in vectorSetLocks, sharedLockToken);
+                throw;
             }
         }
 
@@ -251,182 +263,194 @@ namespace Garnet.server
 
             Debug.Assert(ActiveThreadSession == null, "Shouldn't enter context when already in one");
             ActiveThreadSession = storageSession;
-
-            var keyHash = storageSession.basicContext.GetKeyHash(ref key);
-
-            var indexConfig = SpanByteAndMemory.FromPinnedSpan(indexSpan);
-
-            while (true)
+            try
             {
-                input.arg1 = 0;
 
-                vectorSetLocks.AcquireSharedLock(keyHash, out var sharedLockToken);
+                var keyHash = storageSession.basicContext.GetKeyHash(ref key);
 
-                GarnetStatus readRes;
-                try
+                var indexConfig = SpanByteAndMemory.FromPinnedSpan(indexSpan);
+
+                while (true)
                 {
-                    readRes = storageSession.Read_MainStore(ref key, ref input, ref indexConfig, ref storageSession.basicContext);
-                    Debug.Assert(indexConfig.IsSpanByte, "Should never need to move index onto the heap");
-                }
-                catch
-                {
-                    vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+                    input.arg1 = 0;
 
-                    throw;
-                }
+                    vectorSetLocks.AcquireSharedLock(keyHash, out var sharedLockToken);
 
-                bool needsRecreate;
-                if (readRes == GarnetStatus.OK)
-                {
-                    if (PartiallyDeleted(indexConfig.AsReadOnlySpan()))
-                    {
-                        status = GarnetStatus.BADSTATE;
-
-                        vectorSetLocks.ReleaseSharedLock(sharedLockToken);
-                        return default;
-                    }
-
-                    needsRecreate = NeedsRecreate(indexConfig.AsReadOnlySpan());
-                }
-                else
-                {
-                    needsRecreate = false;
-                }
-
-                if (readRes == GarnetStatus.NOTFOUND || needsRecreate)
-                {
-                    if (!vectorSetLocks.TryPromoteSharedLock(keyHash, sharedLockToken, out var exclusiveLockToken))
-                    {
-                        // Release the SHARED lock if we can't promote and try again
-                        vectorSetLocks.ReleaseSharedLock(sharedLockToken);
-
-                        continue;
-                    }
-
-                    ulong indexContext;
-                    nint newlyAllocatedIndex;
-                    if (needsRecreate)
-                    {
-                        ReadIndex(indexSpan, out indexContext, out var dims, out var reduceDims, out var quantType, out var buildExplorationFactor, out var numLinks, out var distanceMetric, out _, out _);
-
-                        input.arg1 = RecreateIndexArg;
-
-                        unsafe
-                        {
-                            newlyAllocatedIndex = Service.RecreateIndex(indexContext, dims, reduceDims, quantType, buildExplorationFactor, numLinks, distanceMetric, ReadCallbackPtr, WriteCallbackPtr, DeleteCallbackPtr, ReadModifyWriteCallbackPtr);
-                        }
-
-                        input.parseState.EnsureCapacity(12);
-
-                        // Save off for recreation
-                        input.parseState.SetArgument(10, ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<ulong, byte>(MemoryMarshal.CreateSpan(ref indexContext, 1)))); // Strictly we don't _need_ this, but it keeps everything else aligned nicely
-                        input.parseState.SetArgument(11, ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<nint, byte>(MemoryMarshal.CreateSpan(ref newlyAllocatedIndex, 1))));
-                    }
-                    else
-                    {
-                        // Create a new index, grab a new context
-
-                        // We must associate the index with a hash slot at creation time to enable future migrations
-                        // TODO: RENAME and friends need to also update this data
-                        var slot = HashSlotUtils.HashSlot(ref key);
-
-                        indexContext = NextVectorSetContext(slot);
-
-                        var dims = MemoryMarshal.Read<uint>(input.parseState.GetArgSliceByRef(0).Span);
-                        var reduceDims = MemoryMarshal.Read<uint>(input.parseState.GetArgSliceByRef(1).Span);
-                        // ValueType is here, skipping during index creation
-                        // Values is here, skipping during index creation
-                        // Element is here, skipping during index creation
-                        var quantizer = MemoryMarshal.Read<VectorQuantType>(input.parseState.GetArgSliceByRef(5).Span);
-                        var buildExplorationFactor = MemoryMarshal.Read<uint>(input.parseState.GetArgSliceByRef(6).Span);
-                        // Attributes is here, skipping during index creation
-                        var numLinks = MemoryMarshal.Read<uint>(input.parseState.GetArgSliceByRef(8).Span);
-                        var distanceMetric = MemoryMarshal.Read<VectorDistanceMetricType>(input.parseState.GetArgSliceByRef(9).Span);
-
-                        unsafe
-                        {
-                            newlyAllocatedIndex = Service.CreateIndex(indexContext, dims, reduceDims, quantizer, buildExplorationFactor, numLinks, distanceMetric, ReadCallbackPtr, WriteCallbackPtr, DeleteCallbackPtr, ReadModifyWriteCallbackPtr);
-                        }
-
-                        input.parseState.EnsureCapacity(12);
-
-                        // Save off for insertion
-                        input.parseState.SetArgument(10, ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<ulong, byte>(MemoryMarshal.CreateSpan(ref indexContext, 1))));
-                        input.parseState.SetArgument(11, ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<nint, byte>(MemoryMarshal.CreateSpan(ref newlyAllocatedIndex, 1))));
-                    }
-
-                    GarnetStatus writeRes;
+                    GarnetStatus readRes;
                     try
                     {
-                        try
-                        {
-                            writeRes = storageSession.RMW_MainStore(ref key, ref input, ref indexConfig, ref storageSession.basicContext);
-
-                            if (writeRes != GarnetStatus.OK)
-                            {
-                                // Insertion failed, drop index
-                                Service.DropIndex(indexContext, newlyAllocatedIndex);
-
-                                // If the failure was for a brand new index, free up the context too
-                                if (!needsRecreate)
-                                {
-                                    CleanupDroppedIndex(ref ActiveThreadSession.vectorContext, indexContext);
-                                }
-                            }
-                        }
-                        catch
-                        {
-                            if (newlyAllocatedIndex != 0)
-                            {
-                                // Drop to avoid a leak on error
-                                Service.DropIndex(indexContext, newlyAllocatedIndex);
-
-                                // If the failure was for a brand new index, free up the context too
-                                if (!needsRecreate)
-                                {
-                                    CleanupDroppedIndex(ref ActiveThreadSession.vectorContext, indexContext);
-                                }
-                            }
-
-                            throw;
-                        }
-
-                        if (!needsRecreate)
-                        {
-                            UpdateContextMetadata(ref storageSession.vectorContext);
-                        }
+                        readRes = storageSession.Read_MainStore(ref key, ref input, ref indexConfig, ref storageSession.basicContext);
+                        Debug.Assert(indexConfig.IsSpanByte, "Should never need to move index onto the heap");
                     }
                     catch
                     {
-                        vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+                        vectorSetLocks.ReleaseSharedLock(sharedLockToken);
 
                         throw;
                     }
 
-                    if (writeRes == GarnetStatus.OK)
+                    bool needsRecreate;
+                    if (readRes == GarnetStatus.OK)
                     {
-                        // Try again so we don't hold an exclusive lock while adding a vector (which might be time consuming)
-                        vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
-                        continue;
+                        if (PartiallyDeleted(indexConfig.AsReadOnlySpan()))
+                        {
+                            status = GarnetStatus.BADSTATE;
+
+                            vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+                            return default;
+                        }
+
+                        needsRecreate = NeedsRecreate(indexConfig.AsReadOnlySpan());
                     }
                     else
                     {
-                        status = writeRes;
-                        vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+                        needsRecreate = false;
+                    }
 
+                    if (readRes == GarnetStatus.NOTFOUND || needsRecreate)
+                    {
+                        if (!vectorSetLocks.TryPromoteSharedLock(keyHash, sharedLockToken, out var exclusiveLockToken))
+                        {
+                            // Release the SHARED lock if we can't promote and try again
+                            vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+
+                            continue;
+                        }
+
+                        ulong indexContext;
+                        nint newlyAllocatedIndex;
+                        if (needsRecreate)
+                        {
+                            ReadIndex(indexSpan, out indexContext, out var dims, out var reduceDims, out var quantType, out var buildExplorationFactor, out var numLinks, out var distanceMetric, out _, out _);
+
+                            input.arg1 = RecreateIndexArg;
+
+                            unsafe
+                            {
+                                newlyAllocatedIndex = Service.RecreateIndex(indexContext, dims, reduceDims, quantType, buildExplorationFactor, numLinks, distanceMetric, ReadCallbackPtr, WriteCallbackPtr, DeleteCallbackPtr, ReadModifyWriteCallbackPtr);
+                            }
+
+                            input.parseState.EnsureCapacity(12);
+
+                            // Save off for recreation
+                            input.parseState.SetArgument(10, ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<ulong, byte>(MemoryMarshal.CreateSpan(ref indexContext, 1)))); // Strictly we don't _need_ this, but it keeps everything else aligned nicely
+                            input.parseState.SetArgument(11, ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<nint, byte>(MemoryMarshal.CreateSpan(ref newlyAllocatedIndex, 1))));
+                        }
+                        else
+                        {
+                            // Create a new index, grab a new context
+
+                            // We must associate the index with a hash slot at creation time to enable future migrations
+                            // TODO: RENAME and friends need to also update this data
+                            var slot = HashSlotUtils.HashSlot(ref key);
+
+                            indexContext = NextVectorSetContext(slot);
+
+                            var dims = MemoryMarshal.Read<uint>(input.parseState.GetArgSliceByRef(0).Span);
+                            var reduceDims = MemoryMarshal.Read<uint>(input.parseState.GetArgSliceByRef(1).Span);
+                            // ValueType is here, skipping during index creation
+                            // Values is here, skipping during index creation
+                            // Element is here, skipping during index creation
+                            var quantizer = MemoryMarshal.Read<VectorQuantType>(input.parseState.GetArgSliceByRef(5).Span);
+                            var buildExplorationFactor = MemoryMarshal.Read<uint>(input.parseState.GetArgSliceByRef(6).Span);
+                            // Attributes is here, skipping during index creation
+                            var numLinks = MemoryMarshal.Read<uint>(input.parseState.GetArgSliceByRef(8).Span);
+                            var distanceMetric = MemoryMarshal.Read<VectorDistanceMetricType>(input.parseState.GetArgSliceByRef(9).Span);
+
+                            unsafe
+                            {
+                                newlyAllocatedIndex = Service.CreateIndex(indexContext, dims, reduceDims, quantizer, buildExplorationFactor, numLinks, distanceMetric, ReadCallbackPtr, WriteCallbackPtr, DeleteCallbackPtr, ReadModifyWriteCallbackPtr);
+                            }
+
+                            input.parseState.EnsureCapacity(12);
+
+                            // Save off for insertion
+                            input.parseState.SetArgument(10, ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<ulong, byte>(MemoryMarshal.CreateSpan(ref indexContext, 1))));
+                            input.parseState.SetArgument(11, ArgSlice.FromPinnedSpan(MemoryMarshal.Cast<nint, byte>(MemoryMarshal.CreateSpan(ref newlyAllocatedIndex, 1))));
+                        }
+
+                        GarnetStatus writeRes;
+                        try
+                        {
+                            try
+                            {
+                                writeRes = storageSession.RMW_MainStore(ref key, ref input, ref indexConfig, ref storageSession.basicContext);
+
+                                if (writeRes != GarnetStatus.OK)
+                                {
+                                    // Insertion failed, drop index
+                                    Service.DropIndex(indexContext, newlyAllocatedIndex);
+
+                                    // If the failure was for a brand new index, free up the context too
+                                    if (!needsRecreate)
+                                    {
+                                        CleanupDroppedIndex(ref ActiveThreadSession.vectorContext, indexContext);
+                                    }
+                                }
+                            }
+                            catch
+                            {
+                                if (newlyAllocatedIndex != 0)
+                                {
+                                    // Drop to avoid a leak on error
+                                    Service.DropIndex(indexContext, newlyAllocatedIndex);
+
+                                    // If the failure was for a brand new index, free up the context too
+                                    if (!needsRecreate)
+                                    {
+                                        CleanupDroppedIndex(ref ActiveThreadSession.vectorContext, indexContext);
+                                    }
+                                }
+
+                                throw;
+                            }
+
+                            if (!needsRecreate)
+                            {
+                                UpdateContextMetadata(ref storageSession.vectorContext);
+                            }
+                        }
+                        catch
+                        {
+                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+
+                            throw;
+                        }
+
+                        if (writeRes == GarnetStatus.OK)
+                        {
+                            // Try again so we don't hold an exclusive lock while adding a vector (which might be time consuming)
+                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+                            continue;
+                        }
+                        else
+                        {
+                            status = writeRes;
+                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+
+                            return default;
+                        }
+                    }
+                    else if (readRes != GarnetStatus.OK)
+                    {
+                        vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+
+                        status = readRes;
                         return default;
                     }
-                }
-                else if (readRes != GarnetStatus.OK)
-                {
-                    vectorSetLocks.ReleaseSharedLock(sharedLockToken);
 
-                    status = readRes;
-                    return default;
+                    status = GarnetStatus.OK;
+                    return new(in vectorSetLocks, sharedLockToken);
                 }
+            }
+            catch
+            {
+                // If we exit without returning a lock, we'll leave ActiveThreadSession set, this clears it and rethrows
+                //
+                // In the normal exit case, disposing ReadVectorLock will clear ActiveThreadSession
+                ActiveThreadSession = null;
 
-                status = GarnetStatus.OK;
-                return new(in vectorSetLocks, sharedLockToken);
+                throw;
             }
         }
 

--- a/test/Garnet.test.cluster/ClusterTestContext.cs
+++ b/test/Garnet.test.cluster/ClusterTestContext.cs
@@ -293,7 +293,8 @@ namespace Garnet.test.cluster
             int replicaSyncTimeout = 60,
             int expiredObjectCollectionFrequencySecs = 0,
             ClusterPreferredEndpointType clusterPreferredEndpointType = ClusterPreferredEndpointType.Ip,
-            bool useClusterAnnounceHostname = false)
+            bool useClusterAnnounceHostname = false,
+            int threadPoolMinIOCompletionThreads = 0)
         {
             var ipAddress = IPAddress.Loopback;
             TestUtils.EndPoint = new IPEndPoint(ipAddress, 7000);
@@ -350,7 +351,8 @@ namespace Garnet.test.cluster
                 replicaSyncTimeout: replicaSyncTimeout,
                 expiredObjectCollectionFrequencySecs: expiredObjectCollectionFrequencySecs,
                 clusterPreferredEndpointType: clusterPreferredEndpointType,
-                clusterAnnounceHostname: useClusterAnnounceHostname ? "localhost" : null);
+                clusterAnnounceHostname: useClusterAnnounceHostname ? "localhost" : null,
+                threadPoolMinIOCompletionThreads: threadPoolMinIOCompletionThreads);
 
             foreach (var node in nodes)
                 node.Start();

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -1611,7 +1611,7 @@ namespace Garnet.test.cluster
 
             try
             {
-                _ = SimpleSetupCluster(DefaultMultiPrimaryShards, primaryCount: DefaultMultiPrimaryShards / 2, replicaCount: 1);
+                _ = SimpleSetupCluster(DefaultMultiPrimaryShards, primaryCount: DefaultMultiPrimaryShards / 2, replicaCount: 1, useTLS: false);
 
                 var primary0 = (IPEndPoint)context.endpoints[Primary0Index];
                 var primary1 = (IPEndPoint)context.endpoints[Primary1Index];
@@ -2097,10 +2097,10 @@ namespace Garnet.test.cluster
             ClassicAssert.IsTrue(vsimRes.Length > 0);
         }
 
-        private (List<ShardInfo> Shards, List<ushort> Slots) SimpleSetupCluster(int shardCount, int primaryCount, int replicaCount, bool onDemandCheckpoint = false, bool enableIncrementalSnapshots = false)
+        private (List<ShardInfo> Shards, List<ushort> Slots) SimpleSetupCluster(int shardCount, int primaryCount, int replicaCount, bool onDemandCheckpoint = false, bool enableIncrementalSnapshots = false, bool useTLS = true)
         {
-            context.CreateInstances(shardCount, useTLS: true, enableAOF: true, AofMemorySize: DefaultAOFMemorySize, OnDemandCheckpoint: onDemandCheckpoint, EnableIncrementalSnapshots: enableIncrementalSnapshots);
-            context.CreateConnection(useTLS: true);
+            context.CreateInstances(shardCount, useTLS: useTLS, enableAOF: true, AofMemorySize: DefaultAOFMemorySize, OnDemandCheckpoint: onDemandCheckpoint, EnableIncrementalSnapshots: enableIncrementalSnapshots);
+            context.CreateConnection(useTLS: useTLS);
             return context.clusterTestUtils.SimpleSetupCluster(primary_count: primaryCount, replica_count: replicaCount);
         }
 

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -94,9 +94,6 @@ namespace Garnet.test.cluster
             context = new ClusterTestContext();
             context.logTextWriter = captureLogWriter;
             context.Setup(MonitorTests);
-
-            // Temporary hackery, force threadpool minimums up
-            _ = ThreadPool.SetMinThreads(512, 512);
         }
 
         [TearDown]
@@ -2102,7 +2099,7 @@ namespace Garnet.test.cluster
 
         private (List<ShardInfo> Shards, List<ushort> Slots) SimpleSetupCluster(int shardCount, int primaryCount, int replicaCount, bool onDemandCheckpoint = false, bool enableIncrementalSnapshots = false, bool useTLS = true)
         {
-            context.CreateInstances(shardCount, useTLS: useTLS, enableAOF: true, AofMemorySize: DefaultAOFMemorySize, OnDemandCheckpoint: onDemandCheckpoint, EnableIncrementalSnapshots: enableIncrementalSnapshots);
+            context.CreateInstances(shardCount, useTLS: useTLS, enableAOF: true, AofMemorySize: DefaultAOFMemorySize, OnDemandCheckpoint: onDemandCheckpoint, EnableIncrementalSnapshots: enableIncrementalSnapshots, threadPoolMinIOCompletionThreads: 512);
             context.CreateConnection(useTLS: useTLS);
             return context.clusterTestUtils.SimpleSetupCluster(primary_count: primaryCount, replica_count: replicaCount);
         }

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -94,6 +94,9 @@ namespace Garnet.test.cluster
             context = new ClusterTestContext();
             context.logTextWriter = captureLogWriter;
             context.Setup(MonitorTests);
+
+            // Temporary hackery, force threadpool minimums up
+            _ = ThreadPool.SetMinThreads(512, 512);
         }
 
         [TearDown]
@@ -1611,7 +1614,7 @@ namespace Garnet.test.cluster
 
             try
             {
-                _ = SimpleSetupCluster(DefaultMultiPrimaryShards, primaryCount: DefaultMultiPrimaryShards / 2, replicaCount: 1, useTLS: false);
+                _ = SimpleSetupCluster(DefaultMultiPrimaryShards, primaryCount: DefaultMultiPrimaryShards / 2, replicaCount: 1);
 
                 var primary0 = (IPEndPoint)context.endpoints[Primary0Index];
                 var primary1 = (IPEndPoint)context.endpoints[Primary1Index];

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -525,7 +525,8 @@ namespace Garnet.test
             int replicaSyncTimeout = 60,
             int expiredObjectCollectionFrequencySecs = 0,
             ClusterPreferredEndpointType clusterPreferredEndpointType = ClusterPreferredEndpointType.Ip,
-            string clusterAnnounceHostname = null)
+            string clusterAnnounceHostname = null,
+            int threadPoolMinIOCompletionThreads = 0)
         {
             if (UseAzureStorage)
                 IgnoreIfNotRunningAzureTests();
@@ -590,7 +591,8 @@ namespace Garnet.test
                     replicaSyncTimeout: replicaSyncTimeout,
                     expiredObjectCollectionFrequencySecs: expiredObjectCollectionFrequencySecs,
                     clusterPreferredEndpointType: clusterPreferredEndpointType,
-                    clusterAnnounceHostname: clusterAnnounceHostname);
+                    clusterAnnounceHostname: clusterAnnounceHostname,
+                    threadPoolMinIOCompletionThreads: threadPoolMinIOCompletionThreads);
 
                 ClassicAssert.IsNotNull(opts);
 
@@ -670,7 +672,8 @@ namespace Garnet.test
             int expiredObjectCollectionFrequencySecs = 0,
             ClusterPreferredEndpointType clusterPreferredEndpointType = ClusterPreferredEndpointType.Ip,
             string clusterAnnounceHostname = null,
-            bool enableVectorSetPreview = true)
+            bool enableVectorSetPreview = true,
+            int threadPoolMinIOCompletionThreads = 0)
         {
             if (useAzureStorage)
                 IgnoreIfNotRunningAzureTests();
@@ -795,7 +798,8 @@ namespace Garnet.test
                 ClusterReplicaResumeWithData = clusterReplicaResumeWithData,
                 ReplicaSyncTimeout = replicaSyncTimeout <= 0 ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(replicaSyncTimeout),
                 EnableVectorSetPreview = enableVectorSetPreview,
-                ExpiredObjectCollectionFrequencySecs = expiredObjectCollectionFrequencySecs
+                ExpiredObjectCollectionFrequencySecs = expiredObjectCollectionFrequencySecs,
+                ThreadPoolMinIOCompletionThreads = threadPoolMinIOCompletionThreads
             };
 
             if (lowMemory)

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -720,7 +720,7 @@ namespace Garnet.test
 
             GarnetServerOptions opts = new(logger)
             {
-                ThreadPoolMinThreads = 100,
+                ThreadPoolMinThreads = 512,
                 SegmentSize = segmentSize,
                 ObjectStoreSegmentSize = segmentSize,
                 EnableStorageTier = useAzureStorage || (!disableStorageTier && logDir != null),


### PR DESCRIPTION
Incorporates a number of separately reported fixes (for `SessionParseState`, `GarnetServer` disposal, `InputHeader` serialization), clearing `ActiveThreadSession` in more error paths, _and_ forces minimum io and worker threadpool threads to 512 in cluster tests.

Each help reliability a bit, but threadpool hackery is a big win.

Additionally adds some extra error checking that, while not impactful for reliability, was helpful for eliminating possibilities while debugging.

`dev` targeting version is #1706