### PR TITLE
Fix use-after-free in GetAllocationForRetry when page is evicted

### DIFF
--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/BlockAllocate.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/BlockAllocate.cs
@@ -198,8 +198,14 @@ namespace Tsavorite.core
             return true;
 
         Fail:
-            var logRecord = hlog.CreateLogRecord(newLogicalAddress);
-            OnDispose(ref logRecord, DisposeReason.CASAndRetryFailed);
+            // Only dispose if the record is still in memory. If the page was evicted (address < HeadAddress),
+            // the record's heap fields were already cleared by OnDispose before SaveAllocationForRetry, and
+            // the page memory may have been recycled — accessing it would crash or corrupt live records.
+            if (newLogicalAddress >= hlogBase.HeadAddress)
+            {
+                var logRecord = hlog.CreateLogRecord(newLogicalAddress);
+                OnDispose(ref logRecord, DisposeReason.CASAndRetryFailed);
+            }
             newPhysicalAddress = 0;
             return false;
         }

--- a/test/Garnet.test/RespListTests.cs
+++ b/test/Garnet.test/RespListTests.cs
@@ -1110,14 +1110,27 @@ namespace Garnet.test
                         var value = await db.ListRightPopAsync(key).ConfigureAwait(false);
                         while (value.IsNull)
                         {
-                            await Task.Delay(1).ConfigureAwait(false);
+                            // Use Thread.Sleep instead of Task.Delay to avoid threadpool scheduling
+                            // pressure — Task.Delay(1) in a tight retry loop across many tasks can
+                            // cause threadpool starvation on small CI runners.
+                            Thread.Sleep(1);
                             value = await db.ListRightPopAsync(key).ConfigureAwait(false);
                         }
                         ClassicAssert.IsTrue((int)value >= 0 && (int)value < ppCount, "Pop value inconsistency");
                     }
                 });
             }
-            await Task.WhenAll(tasks);
+
+            // Use LongRunning to get a dedicated thread for the timeout — Task.Delay can't
+            // fire under threadpool starvation since its timer callback needs a pool thread.
+            var timeoutTask = Task.Factory.StartNew(
+                () => Thread.Sleep(TimeSpan.FromMinutes(5)),
+                TaskCreationOptions.LongRunning);
+
+            var allDone = Task.WhenAll(tasks);
+            if (await Task.WhenAny(allDone, timeoutTask) != allDone)
+                ClassicAssert.Fail("ListPushPopStressTest timed out after 5 minutes — possible threadpool starvation or lost values");
+            await allDone;
 
             foreach (var key in keyArray)
             {


### PR DESCRIPTION
When a retry record's page is evicted between SaveAllocationForRetry and GetAllocationForRetry, the Fail block unconditionally created a LogRecord from the stale address and called OnDispose/ClearHeapFields. This accessed freed or recycled memory, causing either:
- Crashes in GetFillerLength (accessing invalid memory)
- Corruption of live records on recycled pages (e.g. clearing ValueIsObject bit, leading to WRONGTYPE errors on concurrent object operations)

The fix guards the OnDispose call with a HeadAddress check. When the record is below HeadAddress, its heap fields were already cleared by OnDispose before SaveAllocationForRetry (in CAS failure paths) or were never written (in pre-write paths), so no cleanup is needed.