### PR TITLE
Fix scan iterator [dev]

### DIFF
--- a/libs/storage/Tsavorite/cs/src/core/Allocator/ScanIteratorBase.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/ScanIteratorBase.cs
@@ -208,8 +208,14 @@ namespace Tsavorite.core
 
                         void DoReadPage(int frameIndex)
                         {
+                            // The drain callback may execute after the iterator has been disposed (loadCompletionEvents set to null),
+                            // because the callback is deferred via BumpCurrentEpoch and only runs when SafeToReclaimEpoch advances.
+                            // This can happen for read-ahead pages (frameIndex > 0) when the scan completes before the callback runs.
+                            var events = loadCompletionEvents;
+                            if (events is null)
+                                return;
                             AsyncReadPageFromDeviceToFrame(readBuffer, readPage: frameIndex + GetPageOfAddress(currentIterationAddress, logPageSizeBits), untilAddress: endIterationAddress,
-                                context: Empty.Default, out loadCompletionEvents[nextFrame], devicePageOffset: 0, device: null, objectLogDevice: null, loadCTSs[nextFrame]);
+                                context: Empty.Default, out events[nextFrame], devicePageOffset: 0, device: null, objectLogDevice: null, loadCTSs[nextFrame]);
                             loadedPages[nextFrame] = pageEndAddress;
                         }
                     }


### PR DESCRIPTION
### Fix deferred DoReadPage drain callback accessing disposed ScanIteratorBase

BufferAndLoad registers DoReadPage as a deferred drain callback via BumpCurrentEpoch. This callback captures instance state including loadCompletionEvents. When the callback is for a read-ahead page and SafeToReclaimEpoch hasn't advanced yet, the callback remains in the drain list. If the scan completes and the iterator is disposed before the callback executes, loadCompletionEvents is set to null. When the callback later runs (during another thread's Drain), it accesses the null array, throwing NullReferenceException.

This exception from a drain callback leaves the epoch in a held state (SuspendDrain's Resume/Release is not exception-safe), causing the cascading 'Trying to acquire protected epoch' assertion failure seen in ObjectIterationPushLockTest(4,4,Iterate,False).

Fix: capture loadCompletionEvents into a local before accessing it in DoReadPage, and return early if the iterator has been disposed.