### PR TITLE
[Tsavorite] Replace SafeTailAddress background refresh with per-thread inflight publish protocol

### DIFF
--- a/benchmark/BDN.benchmark/Embedded/EmbeddedRespServer.cs
+++ b/benchmark/BDN.benchmark/Embedded/EmbeddedRespServer.cs
@@ -30,7 +30,6 @@ namespace Embedded.server
                 new SubscribeBroker(
                     null,
                     opts.PubSubPageSizeBytes(),
-                    opts.SubscriberRefreshFrequencyMs,
                     pubSubEpoch,
                     true);
         }

--- a/benchmark/Resp.benchmark/OfflineBench/AOFBench/AofBench.cs
+++ b/benchmark/Resp.benchmark/OfflineBench/AOFBench/AofBench.cs
@@ -30,7 +30,6 @@ namespace Resp.benchmark
                 AofReplayTaskCount = options.AofReplayTaskCount,
                 ReplicationOffsetMaxLag = 0,
                 CheckpointDir = OperatingSystem.IsLinux() ? "/tmp" : null,
-                AofReplicationRefreshFrequencyMs = 100,
             };
             return serverOptions;
         }

--- a/benchmark/Resp.benchmark/OfflineBench/AOFBench/AofGen.cs
+++ b/benchmark/Resp.benchmark/OfflineBench/AOFBench/AofGen.cs
@@ -234,7 +234,6 @@ namespace Resp.benchmark
                 EnableFastCommit = true,
                 CommitFrequencyMs = -1,
                 FastAofTruncate = true,
-                AofReplicationRefreshFrequencyMs = options.AofReplicationRefreshFrequencyMs,
                 EnableCluster = true,
                 ReplicationOffsetMaxLag = 0,
                 AofPhysicalSublogCount = options.AofPhysicalSublogCount

--- a/benchmark/Resp.benchmark/OfflineBench/GarnetServerInstance.cs
+++ b/benchmark/Resp.benchmark/OfflineBench/GarnetServerInstance.cs
@@ -29,7 +29,6 @@ namespace Resp.benchmark
                 AofReplayTaskCount = options.AofReplayTaskCount,
                 ReplicationOffsetMaxLag = 0,
                 CheckpointDir = OperatingSystem.IsLinux() ? "/tmp" : null,
-                AofReplicationRefreshFrequencyMs = 100,
             };
             return serverOptions;
         }

--- a/benchmark/Resp.benchmark/Options.cs
+++ b/benchmark/Resp.benchmark/Options.cs
@@ -152,9 +152,6 @@ namespace Resp.benchmark
         [Option("aof-page-size", Required = false, Default = "4m", HelpText = "Size of each AOF page in bytes(rounds down to power of 2)")]
         public string AofPageSize { get; set; }
 
-        [Option("aof-tail-ref-freq", Required = false, Default = 100, HelpText = "Aof Tail Refresh Frequency.")]
-        public int AofReplicationRefreshFrequencyMs { get; set; }
-
         /// <summary>
         /// Parse size from string specification
         /// </summary>

--- a/libs/cluster/Server/Replication/PrimaryOps/AofOperations/AofSyncDriverStore.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/AofOperations/AofSyncDriverStore.cs
@@ -21,26 +21,18 @@ namespace Garnet.cluster
             readonly int physicalSublogIdx = physicalSublogIdx;
             readonly AofSyncDriverStore store = store;
 
-            internal void SafeTailShiftCallback(long oldTailAddress, long newTailAddress)
+            internal void SafeTailPageShiftCallback(long oldTailAddress, long newTailAddress)
             {
-                var oldPage = oldTailAddress >> store.logPageSizeBits;
-                var newPage = newTailAddress >> store.logPageSizeBits;
-
-                // Call truncate only once per page
-                if (oldPage != newPage)
-                {
-                    // Truncate 2 pages above ReadOnly mark, so that we have sufficient time to shift begin before we flush.
-                    // Make sure this is page-aligned, in case we go to a non-page-aligned ReadOnlyAddress.
-                    var truncateUntilAddress = store.clusterProvider.storeWrapper.appendOnlyFile.Log.UnsafeGetReadOnlyAddressAbove(physicalSublogIdx, newTailAddress, numPagesAbove: 2);
-                    if (truncateUntilAddress > 0)
-                        _ = store.SafeTruncateAof(truncateUntilAddress, physicalSublogIdx);
-                }
+                // Truncate 2 pages above ReadOnly mark, so that we have sufficient time to shift begin before we flush.
+                // Make sure this is page-aligned, in case we go to a non-page-aligned ReadOnlyAddress.
+                var truncateUntilAddress = store.clusterProvider.storeWrapper.appendOnlyFile.Log.UnsafeGetReadOnlyAddressAbove(physicalSublogIdx, newTailAddress, numPagesAbove: 2);
+                if (truncateUntilAddress > 0)
+                    _ = store.SafeTruncateAof(truncateUntilAddress, physicalSublogIdx);
             }
         }
 
         readonly ClusterProvider clusterProvider;
         readonly ILogger logger;
-        readonly int logPageSizeBits, logPageSizeMask;
 
         AofSyncDriver[] syncDrivers;
         int numDrivers;
@@ -58,15 +50,12 @@ namespace Garnet.cluster
             numDrivers = 0;
             if (clusterProvider.storeWrapper.appendOnlyFile != null)
             {
-                logPageSizeBits = clusterProvider.storeWrapper.appendOnlyFile.Log.UnsafeGetLogPageSizeBits();
-                var logPageSize = 1 << logPageSizeBits;
-                logPageSizeMask = logPageSize - 1;
                 if (clusterProvider.serverOptions.FastAofTruncate)
                 {
                     for (var i = 0; i < clusterProvider.serverOptions.AofPhysicalSublogCount; i++)
                     {
                         var logShiftTailCallback = new LogShiftTailCallback(i, this);
-                        clusterProvider.storeWrapper.appendOnlyFile.Log.SetLogShiftTailCallback(i, logShiftTailCallback.SafeTailShiftCallback);
+                        clusterProvider.storeWrapper.appendOnlyFile.Log.SetLogShiftTailCallback(i, logShiftTailCallback.SafeTailPageShiftCallback);
                     }
                 }
             }

--- a/libs/cluster/Server/Replication/ReplicationManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationManager.cs
@@ -689,7 +689,7 @@ namespace Garnet.cluster
                                     else
                                         converged = false;
                                 }
-                                await Task.Delay(storeWrapper.serverOptions.AofReplicationRefreshFrequencyMs, token).ConfigureAwait(false);
+                                await Task.Delay(storeWrapper.serverOptions.AofTailWitnessFreqMs, token).ConfigureAwait(false);
                             }
                         }
                     }

--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -229,10 +229,6 @@ namespace Garnet
         public int AofSizeLimitEnforceFrequencySecs { get; set; }
 
         [IntRangeValidation(0, int.MaxValue)]
-        [Option("aof-refresh-freq", Required = false, HelpText = "AOF replication (safe tail address) refresh frequency in milliseconds. 0 = auto refresh after every enqueue.")]
-        public int AofReplicationRefreshFrequencyMs { get; set; }
-
-        [IntRangeValidation(0, int.MaxValue)]
         [Option("subscriber-refresh-freq", Required = false, HelpText = "Subscriber (safe tail address) refresh frequency in milliseconds (for pub-sub). 0 = auto refresh after every enqueue.")]
         public int SubscriberRefreshFrequencyMs { get; set; }
 
@@ -856,7 +852,6 @@ namespace Garnet
                 AofPhysicalSublogCount = AofPhysicalSublogCount,
                 AofReplayTaskCount = AofReplayTaskCount,
                 AofTailWitnessFreqMs = AofTailWitnessFreqMs,
-                AofReplicationRefreshFrequencyMs = AofReplicationRefreshFrequencyMs,
                 CommitFrequencyMs = CommitFrequencyMs,
                 WaitForCommit = WaitForCommit.GetValueOrDefault(),
                 AofSizeLimit = AofSizeLimit,

--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -229,10 +229,6 @@ namespace Garnet
         public int AofSizeLimitEnforceFrequencySecs { get; set; }
 
         [IntRangeValidation(0, int.MaxValue)]
-        [Option("subscriber-refresh-freq", Required = false, HelpText = "Subscriber (safe tail address) refresh frequency in milliseconds (for pub-sub). 0 = auto refresh after every enqueue.")]
-        public int SubscriberRefreshFrequencyMs { get; set; }
-
-        [IntRangeValidation(0, int.MaxValue)]
         [Option("compaction-freq", Required = false, HelpText = "Background hybrid log compaction frequency in seconds. 0 = disabled (compaction performed before checkpointing instead)")]
         public int CompactionFrequencySecs { get; set; }
 

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -244,7 +244,7 @@ namespace Garnet
                 CreateDatabase(dbId, opts, clusterFactory, customCommandManager);
 
             if (!opts.DisablePubSub)
-                subscribeBroker = new SubscribeBroker(null, opts.PubSubPageSizeBytes(), opts.SubscriberRefreshFrequencyMs, pubSubEpoch, startFresh: true, logger);
+                subscribeBroker = new SubscribeBroker(null, opts.PubSubPageSizeBytes(), pubSubEpoch, startFresh: true, logger);
 
             logger?.LogTrace("TLS is {tlsEnabled}", opts.TlsOptions == null ? "disabled" : "enabled");
 

--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -141,9 +141,6 @@
 	/* Polling frequency of the background task responsible for moving time ahead for all physical sublogs (Used only with physical sublog value >1). */
 	"AofTailWitnessFreqMs": 10,
 
-	/* Subscriber (safe tail address) refresh frequency in milliseconds (for pub-sub). 0 = auto refresh after every enqueue. */
-	"SubscriberRefreshFrequencyMs": 0,
-
 	/* Write ahead logging (append-only file) commit issue frequency in milliseconds. 0 = issue an immediate commit per operation, -1 = manually issue commits using COMMITAOF command */
 	"CommitFrequencyMs" : 0,
 

--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -132,9 +132,6 @@
 	/* Size of each AOF page in bytes(rounds down to power of 2) */
 	"AofPageSize" : "4m",
 
-	/* AOF replication (safe tail address) refresh frequency in milliseconds. 0 = auto refresh after every enqueue. */
-	"AofReplicationRefreshFrequencyMs": 10,
-
 	/* Number of AOF physical sublogs (i.e. TsavoriteLog instances) used (=1 equivalent to the legacy single log implementation >1: sharded log implementation. */
 	"AofPhysicalSublogCount": 1,
 

--- a/libs/server/AOF/GarnetLog.cs
+++ b/libs/server/AOF/GarnetLog.cs
@@ -309,7 +309,7 @@ namespace Garnet.server
         /// Set log shift tail callbacks
         /// </summary>
         /// <param name="sublogIdx"></param>
-        /// <param name="SafeTailShiftCallback"></param>
+        /// <param name="safeTailPageShiftCallback"></param>
         public void SetLogShiftTailCallback(int sublogIdx, Action<long, long> safeTailPageShiftCallback)
         {
             if (singleLog != null)

--- a/libs/server/AOF/GarnetLog.cs
+++ b/libs/server/AOF/GarnetLog.cs
@@ -310,15 +310,15 @@ namespace Garnet.server
         /// </summary>
         /// <param name="sublogIdx"></param>
         /// <param name="SafeTailShiftCallback"></param>
-        public void SetLogShiftTailCallback(int sublogIdx, Action<long, long> SafeTailShiftCallback)
+        public void SetLogShiftTailCallback(int sublogIdx, Action<long, long> safeTailPageShiftCallback)
         {
             if (singleLog != null)
             {
-                singleLog.log.SafeTailShiftCallback = SafeTailShiftCallback;
+                singleLog.log.SafeTailPageShiftCallback = safeTailPageShiftCallback;
             }
             else
             {
-                shardedLog.sublog[sublogIdx].SafeTailShiftCallback = SafeTailShiftCallback;
+                shardedLog.sublog[sublogIdx].SafeTailPageShiftCallback = safeTailPageShiftCallback;
             }
         }
 

--- a/libs/server/PubSub/SubscribeBroker.cs
+++ b/libs/server/PubSub/SubscribeBroker.cs
@@ -40,9 +40,10 @@ namespace Garnet.server
         /// <param name="startFresh">start the log from scratch, do not continue</param>
         public SubscribeBroker(string logDir, long pageSize, int subscriberRefreshFrequencyMs, LightEpoch epoch, bool startFresh = true, ILogger logger = null)
         {
+            _ = subscriberRefreshFrequencyMs; // retained for API compatibility; SafeTailAddress is now tracked per-enqueue with no refresh frequency.
             device = logDir == null ? new NullDevice() : Devices.CreateLogDevice(logDir + "/pubsubkv", preallocateFile: false);
             device.Initialize((long)(1 << 30) * 64);
-            aof = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSize = pageSize, MemorySize = pageSize * 4, SafeTailRefreshFrequencyMs = subscriberRefreshFrequencyMs, Epoch = epoch });
+            aof = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSize = pageSize, MemorySize = pageSize * 4, Epoch = epoch });
             pageSizeBits = aof.UnsafeGetLogPageSizeBits();
             if (startFresh)
                 aof.TruncateUntil(aof.CommittedUntilAddress);

--- a/libs/server/PubSub/SubscribeBroker.cs
+++ b/libs/server/PubSub/SubscribeBroker.cs
@@ -36,11 +36,9 @@ namespace Garnet.server
         /// </summary>
         /// <param name="logDir">Directory where the log will be stored</param>
         /// <param name="pageSize">Page size of log used for pub/sub</param>
-        /// <param name="subscriberRefreshFrequencyMs">Subscriber log refresh frequency</param>
         /// <param name="startFresh">start the log from scratch, do not continue</param>
-        public SubscribeBroker(string logDir, long pageSize, int subscriberRefreshFrequencyMs, LightEpoch epoch, bool startFresh = true, ILogger logger = null)
+        public SubscribeBroker(string logDir, long pageSize, LightEpoch epoch, bool startFresh = true, ILogger logger = null)
         {
-            _ = subscriberRefreshFrequencyMs; // retained for API compatibility; SafeTailAddress is now tracked per-enqueue with no refresh frequency.
             device = logDir == null ? new NullDevice() : Devices.CreateLogDevice(logDir + "/pubsubkv", preallocateFile: false);
             device.Initialize((long)(1 << 30) * 64);
             aof = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, PageSize = pageSize, MemorySize = pageSize * 4, Epoch = epoch });

--- a/libs/server/Servers/GarnetServerOptions.cs
+++ b/libs/server/Servers/GarnetServerOptions.cs
@@ -72,11 +72,6 @@ namespace Garnet.server
         public string AofPageSize = "4m";
 
         /// <summary>
-        /// AOF replication (safe tail address) refresh frequency in milliseconds. 0 = auto refresh after every enqueue.
-        /// </summary>
-        public int AofReplicationRefreshFrequencyMs = 10;
-
-        /// <summary>
         /// Number of AOF physical sublogs (i.e. TsavoriteLog instances) used (=1 equivalent to the legacy single log implementation >1: sharded log implementation.
         /// </summary>
         public int AofPhysicalSublogCount = 1;
@@ -809,7 +804,6 @@ namespace Garnet.server
                     PageSizeBits = AofPageSizeBits(),
                     LogDevice = GetAofDevice(dbId, subLogIdx: AofPhysicalSublogCount == 1 ? -1 : i),
                     TryRecoverLatest = false,
-                    SafeTailRefreshFrequencyMs = EnableCluster ? AofReplicationRefreshFrequencyMs : -1,
                     FastCommitMode = EnableFastCommit,
                     AutoCommit = AofAutoCommit && (AofPhysicalSublogCount == 1),
                     MutableFraction = 0.9,

--- a/libs/server/Servers/GarnetServerOptions.cs
+++ b/libs/server/Servers/GarnetServerOptions.cs
@@ -87,11 +87,6 @@ namespace Garnet.server
         public int AofTailWitnessFreqMs = 100;
 
         /// <summary>
-        /// Subscriber (safe tail address) refresh frequency in milliseconds (for pub-sub). 0 = auto refresh after every enqueue.
-        /// </summary>
-        public int SubscriberRefreshFrequencyMs = 0;
-
-        /// <summary>
         /// Write ahead logging (append-only file) commit issue frequency in milliseconds.
         /// 0 = issue an immediate commit per operation
         /// -1 = manually issue commits using COMMITAOF command (no auto-commit)

--- a/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
@@ -161,14 +161,9 @@ namespace Tsavorite.core
         public const int MaxUserWords = 6;
 
         /// <summary>
-        /// Initial value written to each entry's user-word slot on allocation and on entry recycle.
-        /// Indexed by user-word index; only slots whose bit is set in <see cref="userWordMask"/> are valid.
-        /// </summary>
-        readonly long[] userWordInitialValues = new long[MaxUserWords];
-
-        /// <summary>
-        /// Bitmask of claimed user-word slots. Each set bit means that word index is in use by some subsystem
-        /// and must be initialized on entry acquire and reset on entry release.
+        /// Bitmask of claimed user-word slots. Each set bit means that word index is in use by some
+        /// subsystem. Managed exclusively via CAS in <see cref="AllocateUserWord"/> and
+        /// <see cref="ReleaseUserWord"/>. Not read on the epoch Acquire/Release hot path.
         /// </summary>
         int userWordMask;
 
@@ -530,10 +525,6 @@ namespace Tsavorite.core
                 "Trying to acquire protected epoch. Make sure you do not re-enter Tsavorite from callbacks or IDevice implementations. If using tasks, use TaskCreationOptions.RunContinuationsAsynchronously.");
             Debug.Assert((*(tableAligned + entry)).threadId > 0, "Epoch table entry missing threadId");
 
-            // Reset any per-thread user-word slots to their configured initial values so that a fresh
-            // thread (or a recycled slot) never observes stale values left by a previous owner.
-            ResetAllocatedUserWords(entry);
-
             // Protect CurrentEpoch by copying it to the instance-specific epoch table
             // so that ComputeNewSafeToReclaimEpoch() will see it.
             (*(tableAligned + entry)).localCurrentEpoch = CurrentEpoch;
@@ -555,11 +546,6 @@ namespace Tsavorite.core
 
             Debug.Assert((*(tableAligned + entry)).localCurrentEpoch != 0,
                 "Trying to release unprotected epoch. Make sure you do not re-enter Tsavorite from callbacks or IDevice implementations. If using tasks, use TaskCreationOptions.RunContinuationsAsynchronously.");
-
-            // Reset any per-thread user-word slots before giving up ownership so the next owner of this
-            // entry starts from a known state. Also ensures that consumers scanning the column via
-            // GetMinUserWord do not observe stale in-flight values after a thread has released the epoch.
-            ResetAllocatedUserWords(entry);
 
             // Clear "ThisInstanceProtected()" (non-static epoch table)
             (*(tableAligned + entry)).localCurrentEpoch = 0;
@@ -748,46 +734,33 @@ namespace Tsavorite.core
         public int EntryCount => kTableSize;
 
         /// <summary>
-        /// Lock used to serialize slot allocation / release. Slot churn is a rare cold-path event
-        /// (one per subsystem construction / Dispose), so a simple lock is the cleanest correctness
-        /// primitive here — it avoids races where two callers claim the same bit and race to
-        /// initialize the column.
-        /// </summary>
-        readonly object userWordSlotLock = new();
-
-        /// <summary>
         /// Claim a per-thread user-word slot. Returns the word index to pass to
         /// <see cref="ThisThreadUserWord(int)"/> and <see cref="GetMinUserWord(int)"/>.
-        /// The column across all entries is initialized to <paramref name="initialValue"/>, and the same
-        /// value will be used to reset the slot on entry recycle (thread exit / new thread acquiring an entry).
-        /// Throws if all <see cref="MaxUserWords"/> slots are already claimed.
+        /// The column across all entries is initialized to <paramref name="initialValue"/>.
+        /// After allocation, the application owns the slot contents — LightEpoch does not
+        /// automatically reset slots on epoch Acquire/Release. Throws if all
+        /// <see cref="MaxUserWords"/> slots are already claimed.
         /// </summary>
-        /// <param name="initialValue">Value written to every entry's slot on allocation and on entry recycle.</param>
+        /// <param name="initialValue">Value written to every entry's slot at allocation time.</param>
         /// <returns>Word index in the range <c>[0, <see cref="MaxUserWords"/>)</c>.</returns>
         public int AllocateUserWord(long initialValue)
         {
-            lock (userWordSlotLock)
+            while (true)
             {
-                var mask = userWordMask;
-                int idx = -1;
-                for (int i = 0; i < MaxUserWords; i++)
-                {
-                    if ((mask & (1 << i)) == 0)
-                    {
-                        idx = i;
-                        break;
-                    }
-                }
-                if (idx < 0)
+                var mask = Volatile.Read(ref userWordMask);
+                int idx = BitOperations.TrailingZeroCount(~mask);
+                if (idx >= MaxUserWords)
                     throw new InvalidOperationException($"All {MaxUserWords} LightEpoch user-word slots are claimed.");
 
-                // Initialize the column, then publish the mask bit so concurrent scanners that observe
-                // the bit set are guaranteed to observe an initialized column.
-                userWordInitialValues[idx] = initialValue;
+                // CAS to claim the slot. Only the winner proceeds to initialize.
+                var newMask = mask | (1 << idx);
+                if (Interlocked.CompareExchange(ref userWordMask, newMask, mask) != mask)
+                    continue; // another thread modified the mask; retry
+
+                // We exclusively own this slot — initialize the column across all entries.
                 for (int i = 1; i <= kTableSize; i++)
                     Volatile.Write(ref UserWordRef(i, idx), initialValue);
 
-                Volatile.Write(ref userWordMask, mask | (1 << idx));
                 return idx;
             }
         }
@@ -795,17 +768,18 @@ namespace Tsavorite.core
         /// <summary>
         /// Release a previously claimed user-word slot. Caller is responsible for ensuring that no
         /// producer thread still holds or can still issue writes to the slot (e.g., by calling this
-        /// only after subsystem quiescence / Dispose). The slot is not "generation-tagged" — a
-        /// straggler write after release followed by a re-allocation would corrupt the new owner's
-        /// column.
+        /// only after subsystem quiescence / Dispose).
         /// </summary>
         public void ReleaseUserWord(int wordIndex)
         {
             if ((uint)wordIndex >= MaxUserWords)
                 throw new ArgumentOutOfRangeException(nameof(wordIndex));
-            lock (userWordSlotLock)
+            while (true)
             {
-                userWordMask &= ~(1 << wordIndex);
+                var mask = Volatile.Read(ref userWordMask);
+                var newMask = mask & ~(1 << wordIndex);
+                if (Interlocked.CompareExchange(ref userWordMask, newMask, mask) == mask)
+                    return;
             }
         }
 
@@ -856,25 +830,6 @@ namespace Tsavorite.core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         ref long UserWordRef(int entryIndex, int wordIndex)
             => ref Unsafe.Add(ref (*(tableAligned + entryIndex)).userWord0, wordIndex);
-
-        /// <summary>
-        /// Reset every currently-allocated user word in the given entry to its configured initial value.
-        /// Called on both entry acquisition and release to ensure a fresh thread never observes stale
-        /// values left by a previous owner of the slot.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        void ResetAllocatedUserWords(int entryIndex)
-        {
-            var mask = userWordMask;
-            if (mask == 0)
-                return;
-            while (mask != 0)
-            {
-                int i = BitOperations.TrailingZeroCount(mask);
-                mask &= mask - 1;
-                Volatile.Write(ref UserWordRef(entryIndex, i), userWordInitialValues[i]);
-            }
-        }
 
         #endregion
 

--- a/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
@@ -857,6 +857,35 @@ namespace Tsavorite.core
         }
 
         /// <summary>
+        /// Compute the minimum value of the user-word at <paramref name="wordIndex"/> across all epoch
+        /// table entries, using a direct unsafe pointer walk. This avoids the overhead of the generic
+        /// visitor pattern (<see cref="ForEachUserWord{TVisitor}"/>) and gives the JIT the best chance
+        /// to emit a tight loop with no interface dispatch.
+        /// </summary>
+        /// <param name="wordIndex">User-word slot index (0-based).</param>
+        /// <returns>The minimum value observed across all entries.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long GetMinUserWord(int wordIndex)
+        {
+            Debug.Assert((uint)wordIndex < MaxUserWords, "Invalid user-word index");
+
+            // tableAligned is a pinned Entry* with stride = kCacheLineBytes (64).
+            // Entries occupy indices 1..kTableSize (index 0 is kInvalidIndex, unused).
+            // Compute the byte offset of userWord0 within Entry, then add wordIndex * 8.
+            long min = long.MaxValue;
+            byte* basePtr = (byte*)(tableAligned + 1) + 16 + wordIndex * 8; // +1 skips entry 0, +16 reaches userWord0
+            int stride = kCacheLineBytes;
+            int count = kTableSize;
+
+            for (int i = 0; i < count; i++)
+            {
+                long v = Volatile.Read(ref Unsafe.AsRef<long>(basePtr + (long)i * stride));
+                if (v < min) min = v;
+            }
+            return min;
+        }
+
+        /// <summary>
         /// Get a ref to the user word at <paramref name="wordIndex"/> for entry <paramref name="entryIndex"/>.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
@@ -808,11 +808,11 @@ namespace Tsavorite.core
         {
             Debug.Assert((uint)wordIndex < MaxUserWords, "Invalid user-word index");
 
-            // tableAligned is a pinned Entry* with stride = kCacheLineBytes (64).
-            // Entries occupy indices 1..kTableSize (index 0 is kInvalidIndex, unused).
-            // Compute the byte offset of userWord0 within Entry, then add wordIndex * 8.
+            // Derive the base address from the actual Entry field layout via UserWordRef,
+            // rather than hardcoding byte offsets. Entries occupy indices 1..kTableSize
+            // (index 0 is kInvalidIndex and unused). Stride between entries is kCacheLineBytes.
             long min = long.MaxValue;
-            byte* basePtr = (byte*)(tableAligned + 1) + 16 + wordIndex * 8; // +1 skips entry 0, +16 reaches userWord0
+            byte* basePtr = (byte*)Unsafe.AsPointer(ref UserWordRef(1, wordIndex));
             int stride = kCacheLineBytes;
             int count = kTableSize;
 

--- a/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
@@ -761,6 +761,14 @@ namespace Tsavorite.core
         public int EntryCount => kTableSize;
 
         /// <summary>
+        /// Lock used to serialize slot allocation / release. Slot churn is a rare cold-path event
+        /// (one per subsystem construction / Dispose), so a simple lock is the cleanest correctness
+        /// primitive here — it avoids races where two callers claim the same bit and race to
+        /// initialize the column.
+        /// </summary>
+        readonly object userWordSlotLock = new();
+
+        /// <summary>
         /// Claim a per-thread user-word slot. Returns the word index to pass to
         /// <see cref="ThisThreadUserWord(int)"/> and <see cref="ForEachUserWord{TVisitor}(int, ref TVisitor)"/>.
         /// The column across all entries is initialized to <paramref name="initialValue"/>, and the same
@@ -771,9 +779,9 @@ namespace Tsavorite.core
         /// <returns>Word index in the range <c>[0, <see cref="MaxUserWords"/>)</c>.</returns>
         public int AllocateUserWord(long initialValue)
         {
-            while (true)
+            lock (userWordSlotLock)
             {
-                var mask = Volatile.Read(ref userWordMask);
+                var mask = userWordMask;
                 int idx = -1;
                 for (int i = 0; i < MaxUserWords; i++)
                 {
@@ -786,32 +794,31 @@ namespace Tsavorite.core
                 if (idx < 0)
                     throw new InvalidOperationException($"All {MaxUserWords} LightEpoch user-word slots are claimed.");
 
-                // Write the initial value before publishing the mask bit so concurrent readers
-                // that observe the bit set also observe the initialized column.
+                // Initialize the column, then publish the mask bit so concurrent scanners that observe
+                // the bit set are guaranteed to observe an initialized column.
                 userWordInitialValues[idx] = initialValue;
                 for (int i = 1; i <= kTableSize; i++)
                     Volatile.Write(ref UserWordRef(i, idx), initialValue);
 
-                var newMask = mask | (1 << idx);
-                if (Interlocked.CompareExchange(ref userWordMask, newMask, mask) == mask)
-                    return idx;
-                // Someone else modified the mask; retry.
+                Volatile.Write(ref userWordMask, mask | (1 << idx));
+                return idx;
             }
         }
 
         /// <summary>
-        /// Release a previously claimed user-word slot.
+        /// Release a previously claimed user-word slot. Caller is responsible for ensuring that no
+        /// producer thread still holds or can still issue writes to the slot (e.g., by calling this
+        /// only after subsystem quiescence / Dispose). The slot is not "generation-tagged" — a
+        /// straggler write after release followed by a re-allocation would corrupt the new owner's
+        /// column.
         /// </summary>
         public void ReleaseUserWord(int wordIndex)
         {
             if ((uint)wordIndex >= MaxUserWords)
                 throw new ArgumentOutOfRangeException(nameof(wordIndex));
-            while (true)
+            lock (userWordSlotLock)
             {
-                var mask = Volatile.Read(ref userWordMask);
-                var newMask = mask & ~(1 << wordIndex);
-                if (Interlocked.CompareExchange(ref userWordMask, newMask, mask) == mask)
-                    return;
+                userWordMask &= ~(1 << wordIndex);
             }
         }
 

--- a/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
@@ -558,7 +558,7 @@ namespace Tsavorite.core
 
             // Reset any per-thread user-word slots before giving up ownership so the next owner of this
             // entry starts from a known state. Also ensures that consumers scanning the column via
-            // ForEachUserWord do not observe stale in-flight values after a thread has released the epoch.
+            // GetMinUserWord do not observe stale in-flight values after a thread has released the epoch.
             ResetAllocatedUserWords(entry);
 
             // Clear "ThisInstanceProtected()" (non-static epoch table)
@@ -743,19 +743,6 @@ namespace Tsavorite.core
         #region User-word API
 
         /// <summary>
-        /// Visitor interface for <see cref="ForEachUserWord{TVisitor}"/>. Implementations should be
-        /// <c>struct</c>s to enable JIT specialization so that <see cref="Visit"/> inlines into the scan loop.
-        /// </summary>
-        public interface ILightEpochUserWordVisitor
-        {
-            /// <summary>
-            /// Invoked once per epoch table entry with the current value of the selected user word.
-            /// </summary>
-            /// <param name="value">Value read via acquire semantics from the entry's user word.</param>
-            void Visit(long value);
-        }
-
-        /// <summary>
         /// Number of entries in the epoch table.
         /// </summary>
         public int EntryCount => kTableSize;
@@ -770,7 +757,7 @@ namespace Tsavorite.core
 
         /// <summary>
         /// Claim a per-thread user-word slot. Returns the word index to pass to
-        /// <see cref="ThisThreadUserWord(int)"/> and <see cref="ForEachUserWord{TVisitor}(int, ref TVisitor)"/>.
+        /// <see cref="ThisThreadUserWord(int)"/> and <see cref="GetMinUserWord(int)"/>.
         /// The column across all entries is initialized to <paramref name="initialValue"/>, and the same
         /// value will be used to reset the slot on entry recycle (thread exit / new thread acquiring an entry).
         /// Throws if all <see cref="MaxUserWords"/> slots are already claimed.
@@ -837,30 +824,8 @@ namespace Tsavorite.core
         }
 
         /// <summary>
-        /// Iterate the user-word column across all epoch table entries, invoking
-        /// <see cref="ILightEpochUserWordVisitor.Visit(long)"/> once per entry. Entries belonging to
-        /// threads not currently registered will carry the slot's configured initial value (e.g.,
-        /// <see cref="long.MaxValue"/> for a <c>min</c> fold), so they contribute neutrally to folds
-        /// without the caller needing to filter on <c>threadId</c>.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void ForEachUserWord<TVisitor>(int wordIndex, ref TVisitor visitor)
-            where TVisitor : struct, ILightEpochUserWordVisitor
-        {
-            Debug.Assert((uint)wordIndex < MaxUserWords, "Invalid user-word index");
-            // Entries are 1..kTableSize; index 0 is kInvalidIndex and unused.
-            for (int i = 1; i <= kTableSize; i++)
-            {
-                long v = Volatile.Read(ref UserWordRef(i, wordIndex));
-                visitor.Visit(v);
-            }
-        }
-
-        /// <summary>
         /// Compute the minimum value of the user-word at <paramref name="wordIndex"/> across all epoch
-        /// table entries, using a direct unsafe pointer walk. This avoids the overhead of the generic
-        /// visitor pattern (<see cref="ForEachUserWord{TVisitor}"/>) and gives the JIT the best chance
-        /// to emit a tight loop with no interface dispatch.
+        /// table entries, using a direct unsafe pointer walk.
         /// </summary>
         /// <param name="wordIndex">User-word slot index (0-based).</param>
         /// <returns>The minimum value observed across all entries.</returns>

--- a/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -151,6 +152,25 @@ namespace Tsavorite.core
         /// ID of this LightEpoch instance
         /// </summary>
         readonly int instanceId;
+
+        /// <summary>
+        /// Maximum number of general-purpose per-thread <see cref="long"/> user-word slots that subsystems
+        /// can claim via <see cref="AllocateUserWord(long)"/>. Bounded by the free space in <see cref="Entry"/>'s
+        /// cache line (48 bytes = 6 longs).
+        /// </summary>
+        public const int MaxUserWords = 6;
+
+        /// <summary>
+        /// Initial value written to each entry's user-word slot on allocation and on entry recycle.
+        /// Indexed by user-word index; only slots whose bit is set in <see cref="userWordMask"/> are valid.
+        /// </summary>
+        readonly long[] userWordInitialValues = new long[MaxUserWords];
+
+        /// <summary>
+        /// Bitmask of claimed user-word slots. Each set bit means that word index is in use by some subsystem
+        /// and must be initialized on entry acquire and reset on entry release.
+        /// </summary>
+        int userWordMask;
 
         /// <summary>
         /// This is the LightEpoch-level static buffer (array) of available instance slots.
@@ -510,6 +530,10 @@ namespace Tsavorite.core
                 "Trying to acquire protected epoch. Make sure you do not re-enter Tsavorite from callbacks or IDevice implementations. If using tasks, use TaskCreationOptions.RunContinuationsAsynchronously.");
             Debug.Assert((*(tableAligned + entry)).threadId > 0, "Epoch table entry missing threadId");
 
+            // Reset any per-thread user-word slots to their configured initial values so that a fresh
+            // thread (or a recycled slot) never observes stale values left by a previous owner.
+            ResetAllocatedUserWords(entry);
+
             // Protect CurrentEpoch by copying it to the instance-specific epoch table
             // so that ComputeNewSafeToReclaimEpoch() will see it.
             (*(tableAligned + entry)).localCurrentEpoch = CurrentEpoch;
@@ -531,6 +555,11 @@ namespace Tsavorite.core
 
             Debug.Assert((*(tableAligned + entry)).localCurrentEpoch != 0,
                 "Trying to release unprotected epoch. Make sure you do not re-enter Tsavorite from callbacks or IDevice implementations. If using tasks, use TaskCreationOptions.RunContinuationsAsynchronously.");
+
+            // Reset any per-thread user-word slots before giving up ownership so the next owner of this
+            // entry starts from a known state. Also ensures that consumers scanning the column via
+            // ForEachUserWord do not observe stale in-flight values after a thread has released the epoch.
+            ResetAllocatedUserWords(entry);
 
             // Clear "ThisInstanceProtected()" (non-static epoch table)
             (*(tableAligned + entry)).localCurrentEpoch = 0;
@@ -711,8 +740,150 @@ namespace Tsavorite.core
             return sb.ToString();
         }
 
+        #region User-word API
+
+        /// <summary>
+        /// Visitor interface for <see cref="ForEachUserWord{TVisitor}"/>. Implementations should be
+        /// <c>struct</c>s to enable JIT specialization so that <see cref="Visit"/> inlines into the scan loop.
+        /// </summary>
+        public interface ILightEpochUserWordVisitor
+        {
+            /// <summary>
+            /// Invoked once per epoch table entry with the current value of the selected user word.
+            /// </summary>
+            /// <param name="value">Value read via acquire semantics from the entry's user word.</param>
+            void Visit(long value);
+        }
+
+        /// <summary>
+        /// Number of entries in the epoch table.
+        /// </summary>
+        public int EntryCount => kTableSize;
+
+        /// <summary>
+        /// Claim a per-thread user-word slot. Returns the word index to pass to
+        /// <see cref="ThisThreadUserWord(int)"/> and <see cref="ForEachUserWord{TVisitor}(int, ref TVisitor)"/>.
+        /// The column across all entries is initialized to <paramref name="initialValue"/>, and the same
+        /// value will be used to reset the slot on entry recycle (thread exit / new thread acquiring an entry).
+        /// Throws if all <see cref="MaxUserWords"/> slots are already claimed.
+        /// </summary>
+        /// <param name="initialValue">Value written to every entry's slot on allocation and on entry recycle.</param>
+        /// <returns>Word index in the range <c>[0, <see cref="MaxUserWords"/>)</c>.</returns>
+        public int AllocateUserWord(long initialValue)
+        {
+            while (true)
+            {
+                var mask = Volatile.Read(ref userWordMask);
+                int idx = -1;
+                for (int i = 0; i < MaxUserWords; i++)
+                {
+                    if ((mask & (1 << i)) == 0)
+                    {
+                        idx = i;
+                        break;
+                    }
+                }
+                if (idx < 0)
+                    throw new InvalidOperationException($"All {MaxUserWords} LightEpoch user-word slots are claimed.");
+
+                // Write the initial value before publishing the mask bit so concurrent readers
+                // that observe the bit set also observe the initialized column.
+                userWordInitialValues[idx] = initialValue;
+                for (int i = 1; i <= kTableSize; i++)
+                    Volatile.Write(ref UserWordRef(i, idx), initialValue);
+
+                var newMask = mask | (1 << idx);
+                if (Interlocked.CompareExchange(ref userWordMask, newMask, mask) == mask)
+                    return idx;
+                // Someone else modified the mask; retry.
+            }
+        }
+
+        /// <summary>
+        /// Release a previously claimed user-word slot.
+        /// </summary>
+        public void ReleaseUserWord(int wordIndex)
+        {
+            if ((uint)wordIndex >= MaxUserWords)
+                throw new ArgumentOutOfRangeException(nameof(wordIndex));
+            while (true)
+            {
+                var mask = Volatile.Read(ref userWordMask);
+                var newMask = mask & ~(1 << wordIndex);
+                if (Interlocked.CompareExchange(ref userWordMask, newMask, mask) == mask)
+                    return;
+            }
+        }
+
+        /// <summary>
+        /// Get a ref to the current thread's user-word slot. Caller MUST be inside epoch protection
+        /// (<see cref="Resume"/> / before <see cref="Suspend"/>). Returns the same cache line that is
+        /// already hot due to epoch Resume, so writes are essentially free.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ref long ThisThreadUserWord(int wordIndex)
+        {
+            Debug.Assert((uint)wordIndex < MaxUserWords, "Invalid user-word index");
+            Debug.Assert(ThisInstanceProtected(), "ThisThreadUserWord must be called while epoch is protected");
+            int entryIndex = Metadata.Entries.GetRef(instanceId);
+            return ref UserWordRef(entryIndex, wordIndex);
+        }
+
+        /// <summary>
+        /// Iterate the user-word column across all epoch table entries, invoking
+        /// <see cref="ILightEpochUserWordVisitor.Visit(long)"/> once per entry. Entries belonging to
+        /// threads not currently registered will carry the slot's configured initial value (e.g.,
+        /// <see cref="long.MaxValue"/> for a <c>min</c> fold), so they contribute neutrally to folds
+        /// without the caller needing to filter on <c>threadId</c>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ForEachUserWord<TVisitor>(int wordIndex, ref TVisitor visitor)
+            where TVisitor : struct, ILightEpochUserWordVisitor
+        {
+            Debug.Assert((uint)wordIndex < MaxUserWords, "Invalid user-word index");
+            // Entries are 1..kTableSize; index 0 is kInvalidIndex and unused.
+            for (int i = 1; i <= kTableSize; i++)
+            {
+                long v = Volatile.Read(ref UserWordRef(i, wordIndex));
+                visitor.Visit(v);
+            }
+        }
+
+        /// <summary>
+        /// Get a ref to the user word at <paramref name="wordIndex"/> for entry <paramref name="entryIndex"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        ref long UserWordRef(int entryIndex, int wordIndex)
+            => ref Unsafe.Add(ref (*(tableAligned + entryIndex)).userWord0, wordIndex);
+
+        /// <summary>
+        /// Reset every currently-allocated user word in the given entry to its configured initial value.
+        /// Called on both entry acquisition and release to ensure a fresh thread never observes stale
+        /// values left by a previous owner of the slot.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void ResetAllocatedUserWords(int entryIndex)
+        {
+            var mask = userWordMask;
+            if (mask == 0)
+                return;
+            while (mask != 0)
+            {
+                int i = BitOperations.TrailingZeroCount(mask);
+                mask &= mask - 1;
+                Volatile.Write(ref UserWordRef(entryIndex, i), userWordInitialValues[i]);
+            }
+        }
+
+        #endregion
+
         /// <summary>
         /// Epoch table entry (cache line size).
+        /// Existing epoch fields occupy the first 16 bytes (localCurrentEpoch + threadId + 4 bytes padding).
+        /// The remaining 48 bytes host <see cref="MaxUserWords"/> general-purpose per-thread <see cref="long"/> slots that
+        /// subsystems can claim via <see cref="AllocateUserWord(long)"/>. This reuses the cache line that is already
+        /// hot from epoch Resume/Suspend, so user-word access is essentially free compared to touching a separate
+        /// data structure.
         /// </summary>
         [StructLayout(LayoutKind.Explicit, Size = kCacheLineBytes)]
         struct Entry
@@ -728,6 +899,28 @@ namespace Tsavorite.core
             /// </summary>
             [FieldOffset(8)]
             public int threadId;
+
+            /// <summary>
+            /// First user-word slot. Remaining <see cref="MaxUserWords"/> - 1 slots are contiguous after this
+            /// field at 8-byte stride. Access via <c>Unsafe.Add(ref userWord0, wordIndex)</c>.
+            /// </summary>
+            [FieldOffset(16)]
+            public long userWord0;
+
+            [FieldOffset(24)]
+            public long userWord1;
+
+            [FieldOffset(32)]
+            public long userWord2;
+
+            [FieldOffset(40)]
+            public long userWord3;
+
+            [FieldOffset(48)]
+            public long userWord4;
+
+            [FieldOffset(56)]
+            public long userWord5;
 
             public override string ToString() => $"lce = {localCurrentEpoch}, tid = {threadId}";
         }

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -338,14 +338,19 @@ namespace Tsavorite.core
 
         /// <summary>
         /// Wake any iterators parked in <see cref="WaitUncommittedAsync"/> or as single-iterators.
-        /// When more than one single iterator is registered, pre-refreshes <see cref="SafeTailAddress"/>
-        /// so that all woken iterators see the fresh cache and skip their own redundant scans (O(1)
-        /// scan total instead of O(N_iterators)). With a single iterator, the scan is deferred to the
-        /// iterator's <see cref="TsavoriteLogScanSingleIterator.SlowWaitUncommittedAsync"/> path.
-        /// Cheap in the common case (no waiters): two null-check loads.
+        /// Fast path (no waiters): two null-check loads. When waiters exist, defers to the slow path.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         void NotifyParkedWaiters()
+        {
+            // Fast path: both references are null when no iterators/waiters exist (NoCons scenario).
+            // The JIT can inline these two loads and the branch without hitting IL size limits.
+            if (refreshUncommittedTcs != null || activeSingleIterators != null)
+                NotifyParkedWaitersSlow();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void NotifyParkedWaitersSlow()
         {
             var tcs = refreshUncommittedTcs;
             var asi = activeSingleIterators;

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -445,11 +445,17 @@ namespace Tsavorite.core
             // Invoke callback outside epoch protection. Producer drive and direct RefreshSafeTailAddress
             // callers may hold the epoch; suspend it so the callback can re-enter log APIs without
             // tripping nested-epoch asserts or corrupting epoch bookkeeping.
+            // Exceptions are caught and logged — the callback is best-effort (e.g., AOF truncation)
+            // and must not propagate into EndInflightEnqueue / producer cleanup paths.
             var isProtected = epoch.ThisInstanceProtected();
             if (isProtected) epoch.Suspend();
             try
             {
                 cb(oldSafe, newSafe);
+            }
+            catch (Exception e)
+            {
+                logger?.LogError(e, "SafeTailPageShiftCallback failed");
             }
             finally
             {
@@ -1005,10 +1011,10 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-
-            logicalAddress = AllocateBlock(allocatedLength);
+            BeginInflightEnqueue();
             try
             {
+                logicalAddress = AllocateBlock(allocatedLength);
                 var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
                 *(THeader*)(physicalAddress + headerSize) = userHeader;
                 SetHeader(length, physicalAddress);
@@ -1036,10 +1042,10 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-
-            logicalAddress = AllocateBlock(allocatedLength);
+            BeginInflightEnqueue();
             try
             {
+                logicalAddress = AllocateBlock(allocatedLength);
                 var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
                 *(THeader*)(physicalAddress + headerSize) = userHeader;
                 var offset = headerSize + sizeof(THeader);
@@ -1071,10 +1077,10 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
+            BeginInflightEnqueue();
             try
             {
                 logicalAddress = AllocateBlock(allocatedLength, epochAccessor);
-
                 var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
                 *(THeader*)(physicalAddress + headerSize) = userHeader;
                 var offset = headerSize + sizeof(THeader);
@@ -1082,10 +1088,10 @@ namespace Tsavorite.core
                 offset += item1.TotalSize();
                 item2.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
                 SetHeader(length, physicalAddress);
-                EndInflightEnqueue();
             }
             finally
             {
+                EndInflightEnqueue();
                 epoch.Suspend();
             }
             if (autoCommit)
@@ -1105,10 +1111,10 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-
-            logicalAddress = AllocateBlock(allocatedLength);
+            BeginInflightEnqueue();
             try
             {
+                logicalAddress = AllocateBlock(allocatedLength);
                 var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
                 var offset = headerSize;
                 item1.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
@@ -1141,10 +1147,10 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-
-            logicalAddress = AllocateBlock(allocatedLength);
+            BeginInflightEnqueue();
             try
             {
+                logicalAddress = AllocateBlock(allocatedLength);
                 var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
                 *(THeader*)(physicalAddress + headerSize) = userHeader;
                 var offset = headerSize + sizeof(THeader);
@@ -1178,10 +1184,10 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-
-            logicalAddress = AllocateBlock(allocatedLength);
+            BeginInflightEnqueue();
             try
             {
+                logicalAddress = AllocateBlock(allocatedLength);
                 var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
                 *(THeader*)(physicalAddress + headerSize) = userHeader;
                 _ = input.CopyTo(physicalAddress + headerSize + sizeof(THeader), input.SerializedLength);
@@ -1207,6 +1213,7 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
+            BeginInflightEnqueue();
             try
             {
                 logicalAddress = AllocateBlock(allocatedLength);
@@ -1217,10 +1224,10 @@ namespace Tsavorite.core
                 offset += item1.TotalSize();
                 _ = input.CopyTo(physicalAddress + offset, input.SerializedLength);
                 SetHeader(length, physicalAddress);
-                EndInflightEnqueue();
             }
             finally
             {
+                EndInflightEnqueue();
                 epoch.Suspend();
             }
             if (autoCommit)
@@ -1240,6 +1247,7 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
+            BeginInflightEnqueue();
             try
             {
                 logicalAddress = AllocateBlock(allocatedLength, epochAccessor);
@@ -1250,10 +1258,10 @@ namespace Tsavorite.core
                 offset += item1.TotalSize();
                 _ = input.CopyTo(physicalAddress + offset, input.SerializedLength);
                 SetHeader(length, physicalAddress);
-                EndInflightEnqueue();
             }
             finally
             {
+                EndInflightEnqueue();
                 epoch.Suspend();
             }
             if (autoCommit)
@@ -1278,6 +1286,7 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
+            BeginInflightEnqueue();
             try
             {
                 logicalAddress = AllocateBlock(allocatedLength, epochAccessor);
@@ -1290,10 +1299,10 @@ namespace Tsavorite.core
                 offset += item2.TotalSize();
                 _ = input.CopyTo(physicalAddress + offset, input.SerializedLength);
                 SetHeader(length, physicalAddress);
-                EndInflightEnqueue();
             }
             finally
             {
+                EndInflightEnqueue();
                 epoch.Suspend();
             }
             if (autoCommit)
@@ -1314,10 +1323,10 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-
-            logicalAddress = AllocateBlock(allocatedLength);
+            BeginInflightEnqueue();
             try
             {
+                logicalAddress = AllocateBlock(allocatedLength);
                 var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
                 *physicalAddress = userHeader;
                 var offset = sizeof(byte);
@@ -1338,19 +1347,13 @@ namespace Tsavorite.core
             while (true)
             {
                 var flushEvent = allocator.flushEvent;
-                BeginInflightEnqueue();
                 if (allocator.TryAllocateRetryNow(recordSize, out var logicalAddress))
-                {
                     return logicalAddress;
-                }
 
                 // logicalAddress less than 0 (RETRY_NOW) should already have been handled. We expect flushEvent to be signaled.
                 Debug.Assert(logicalAddress == 0);
 
-                // Clear our in-flight slot before suspending — LightEpoch does not auto-reset user
-                // words on Release. Without this, the stale low publish would pin min(inflight) and
-                // prevent SafeTailAddress from advancing. NotifyParkedWaiters wakes any readers that
-                // were held back by our Begin publish.
+                // Clear in-flight slot before suspending, re-publish after resuming
                 EndInflightEnqueue();
                 epoch.Suspend();
                 if (cannedException != null)
@@ -1362,6 +1365,7 @@ namespace Tsavorite.core
                 finally
                 {
                     epoch.Resume();
+                    BeginInflightEnqueue();
                 }
             }
         }
@@ -1373,23 +1377,15 @@ namespace Tsavorite.core
             while (true)
             {
                 var flushEvent = allocator.flushEvent;
-                BeginInflightEnqueue();
                 allocator.TryAllocateRetryNow(recordSize, out var logicalAddress);
                 if (logicalAddress > 0)
-                {
                     return logicalAddress;
-                }
 
                 // logicalAddress less than 0 (RETRY_NOW) should already have been handled
                 Debug.Assert(logicalAddress == 0);
 
-                // Clear our in-flight slot before suspending — LightEpoch does not auto-reset user
-                // words on Release. Without this, the stale low publish would pin min(inflight) and
-                // prevent SafeTailAddress from advancing.
+                // Clear in-flight slot before suspending, re-publish after resuming
                 EndInflightEnqueue();
-
-                // We are holding the TsavoriteLog's epoch; release and then reacquire it. And if the caller's epoch is
-                // also held, suspend and reacquire it as well.
                 epoch.Suspend();
                 var suspended = epochAccessor.TrySuspend();
                 try
@@ -1403,6 +1399,7 @@ namespace Tsavorite.core
                     if (suspended)
                         epochAccessor.Resume();
                     epoch.Resume();
+                    BeginInflightEnqueue();
                 }
             }
         }

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -73,9 +73,21 @@ namespace Tsavorite.core
         public long FlushedUntilAddress => allocator.FlushedUntilAddress;
 
         /// <summary>
-        /// Log safe read-only address
+        /// Log safe read-only address.
+        /// This is the largest address below which every byte has been fully written and is safe to
+        /// read by uncommitted iterators / replication streams. Computed lazily via a <c>min</c> fold
+        /// over per-thread in-flight slot publishes in the <see cref="LightEpoch"/> user-word column,
+        /// clamped by <see cref="TailAddress"/> above and by commit/recovery/reset floors below.
+        /// Reads are O(1) (return the monotonically-advanced cache); call
+        /// <see cref="RefreshSafeTailAddress"/> to force recomputation from the current in-flight state.
         /// </summary>
-        public long SafeTailAddress;
+        public long SafeTailAddress => Volatile.Read(ref cachedSafeTailAddress);
+
+        /// <summary>
+        /// Monotonically-advanced cache of the safe tail address. Advanced by
+        /// <see cref="RefreshSafeTailAddress"/> and by commit/recovery/reset paths.
+        /// </summary>
+        long cachedSafeTailAddress;
 
         /// <summary>
         /// Log committed until address
@@ -121,34 +133,20 @@ namespace Tsavorite.core
         readonly ILogger logger;
 
         /// <summary>
-        /// SafeTailAddress refresh frequency in milliseconds. -1 => disabled; 0 => immediate refresh after every enqueue, >1 => refresh period in milliseconds.
+        /// Index of the <see cref="LightEpoch"/> user-word slot used by this log to track in-flight enqueue
+        /// slot start addresses (or <see cref="long.MaxValue"/> when the thread is not currently enqueueing).
+        /// The minimum value across the column, clamped above by <see cref="TailAddress"/>, yields
+        /// <see cref="SafeTailAddress"/> — the largest address below which every byte has been fully written.
+        /// See the "SafeTail via per-thread in-flight publish" region below for the protocol.
         /// </summary>
-        readonly int safeTailRefreshFrequencyMs;
+        readonly int inflightWord;
 
         /// <summary>
-        /// CTS to allow cancellation of the safe tail refresh background task, called during Dispose
+        /// Sentinel written to the in-flight slot when the thread has no enqueue in progress. Chosen as
+        /// <see cref="long.MaxValue"/> so that idle threads contribute neutrally to the <c>min</c> fold
+        /// that computes SafeTailAddress.
         /// </summary>
-        readonly CancellationTokenSource safeTailRefreshTaskCts;
-
-        /// <summary>
-        /// Last captured safe tail address before epoch bump
-        /// </summary>
-        long safeTailRefreshLastTailAddress = 0;
-
-        /// <summary>
-        /// Events to control callback execution
-        /// </summary>
-        readonly SingleWaiterAutoResetEvent safeTailRefreshCallbackCompleted, safeTailRefreshEntryEnqueued;
-
-        /// <summary>
-        /// Task corresponding to safe tail refresh
-        /// </summary>
-        readonly Task safeTailRefreshTask;
-
-        /// <summary>
-        /// Action for bump epoch to refresh safe tail
-        /// </summary>
-        readonly Action periodicRefreshSafeTailAddressBumpCallbackAction;
+        const long InflightInactive = long.MaxValue;
 
         /// <summary>
         /// Callback when safe tail shifts
@@ -212,7 +210,7 @@ namespace Tsavorite.core
 
             CommittedUntilAddress = FirstValidAddress;
             CommittedBeginAddress = FirstValidAddress;
-            SafeTailAddress = FirstValidAddress;
+            cachedSafeTailAddress = FirstValidAddress;
             commitQueue = new WorkQueueLIFO<CommitInfo>(SerialCommitCallbackWorker);
             allocator = new(new AllocatorSettings(logSettings.GetLogSettings(), epoch, logger) { flushCallback = CommitCallback });
             allocator.Initialize();
@@ -242,121 +240,137 @@ namespace Tsavorite.core
                 catch { }
             }
 
-            // Set up safe tail refresh
-            safeTailRefreshFrequencyMs = logSettings.SafeTailRefreshFrequencyMs;
-            if (safeTailRefreshFrequencyMs >= 0)
-            {
-                safeTailRefreshCallbackCompleted = new()
-                {
-                    RunContinuationsAsynchronously = true
-                };
-                if (safeTailRefreshFrequencyMs == 0)
-                {
-                    safeTailRefreshEntryEnqueued = new()
-                    {
-                        RunContinuationsAsynchronously = true
-                    };
-                }
-                safeTailRefreshTaskCts = new();
-                periodicRefreshSafeTailAddressBumpCallbackAction = PeriodicRefreshSafeTailAddressBumpCallback;
-                safeTailRefreshTask = Task.Run(SafeTailRefreshWorker);
-            }
+            // Claim a LightEpoch user-word slot for our in-flight enqueue publish protocol.
+            // Idle threads carry the InflightInactive sentinel (long.MaxValue) so they contribute
+            // neutrally to the min fold that produces SafeTailAddress.
+            inflightWord = epoch.AllocateUserWord(InflightInactive);
         }
 
-        async Task SafeTailRefreshWorker()
+        #region SafeTail via per-thread in-flight publish
+        //
+        // Each enqueue publishes its in-flight slot start address into a per-thread LightEpoch user-word,
+        // cleared when the payload write completes. SafeTailAddress = min(TailAddress, min over threads
+        // of inflightStart). This replaces the background-worker + epoch-bump design that previously
+        // maintained SafeTailAddress, eliminating the refresh-frequency tuning knob entirely.
+        //
+        // Producer protocol (must run inside epoch.Resume / before epoch.Suspend):
+        //   1. BeginInflightEnqueue()   — publish a lower bound ≤ eventual slot start
+        //   2. TryAllocateRetryNow(...) — FAA advances TailAddress and returns our slot start
+        //   3. CommitInflightEnqueue(start) — tighten publish to exact slot start
+        //   4. (payload write)
+        //   5. EndInflightEnqueue()     — publish InflightInactive, wake parked iterators
+        // On allocation failure, call EndInflightEnqueue() to clear the lower bound before Suspend.
+        //
+        // The Step 1 pre-reserve is required because otherwise a reader could observe TailAddress
+        // advanced past our slot while our in-flight slot still reads InflightInactive, erroneously
+        // concluding that region is safe. By publishing a lower bound before the FAA, any reader that
+        // sees TailAddress ≥ X is guaranteed (via release/acquire ordering) to also observe our slot at
+        // some value ≤ X.
+
+        /// <summary>
+        /// Publish a conservative lower bound into this thread's in-flight slot before the allocator's
+        /// FAA. The value is <c>≤</c> our eventual slot start because <see cref="TailAddress"/> is
+        /// monotonic and the FAA can only increase it.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void BeginInflightEnqueue()
         {
-            try
-            {
-                var token = safeTailRefreshTaskCts.Token;
-
-                // Outer loop makes the worker wake up every so often (either delay or enqueue-signal)
-                // and try to move SafeTailAddress towards TailAddress
-                while (!token.IsCancellationRequested)
-                {
-                    // Inner loop keeps moving SafeTailAddress towards TailAddress until we have
-                    // caught up and there is no more movement necessary.
-                    while (!token.IsCancellationRequested)
-                    {
-                        try
-                        {
-                            // Resume epoch protection
-                            epoch.Resume();
-
-                            // Capture the tail address before epoch refresh, so that the bump action
-                            // knows what the new SafeTailAddress should be set to.
-                            safeTailRefreshLastTailAddress = TailAddress;
-
-                            // Break out of inner loop if there is no more work to do
-                            if (safeTailRefreshLastTailAddress <= SafeTailAddress)
-                                break;
-
-                            // Bump epoch with an action to update SafeTailAddress to the captured safeTailRefreshLastTailAddress
-                            epoch.BumpCurrentEpoch(periodicRefreshSafeTailAddressBumpCallbackAction);
-                        }
-                        finally
-                        {
-                            // Suspend epoch protection
-                            epoch.Suspend();
-                        }
-                        // Wait for the bump epoch action to finish executing, so we can re-check
-                        await safeTailRefreshCallbackCompleted.WaitAsync().ConfigureAwait(false);
-                    }
-                    // Work is done, wait for the next iteration of the worker loop
-                    if (safeTailRefreshFrequencyMs > 0)
-                        await Task.Delay(safeTailRefreshFrequencyMs, token).ConfigureAwait(false);
-                    else
-                        await safeTailRefreshEntryEnqueued.WaitAsync().ConfigureAwait(false);
-                }
-            }
-            catch (TaskCanceledException) when (safeTailRefreshTaskCts.Token.IsCancellationRequested)
-            {
-                // Suppress the exception if the task was cancelled due to TsavoriteLog disposal or refresh task cancellation
-            }
-            catch (Exception e)
-            {
-                logger?.LogError(e, "Exception encountered during PeriodicSafeTailRefreshRunner");
-            }
+            Volatile.Write(ref epoch.ThisThreadUserWord(inflightWord), allocator.GetTailAddress());
         }
 
-        void PeriodicRefreshSafeTailAddressBumpCallback()
+        /// <summary>
+        /// Tighten this thread's in-flight publish to the exact slot start returned by the allocator.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void CommitInflightEnqueue(long logicalAddress)
         {
-            try
+            Volatile.Write(ref epoch.ThisThreadUserWord(inflightWord), logicalAddress);
+        }
+
+        /// <summary>
+        /// Clear this thread's in-flight publish (mark not-in-flight) and wake any parked iterators /
+        /// <see cref="WaitUncommittedAsync"/> awaiters. Safe to call unconditionally at the end of an
+        /// enqueue (success or failure).
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void EndInflightEnqueue()
+        {
+            Volatile.Write(ref epoch.ThisThreadUserWord(inflightWord), InflightInactive);
+            NotifyParkedWaiters();
+        }
+
+        /// <summary>
+        /// Wake any iterators parked in <see cref="WaitUncommittedAsync"/> or as single-iterators.
+        /// Cheap in the common case: both references null-check to no-op.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void NotifyParkedWaiters()
+        {
+            var tcs = refreshUncommittedTcs;
+            if (tcs != null && Interlocked.CompareExchange(ref refreshUncommittedTcs, null, tcs) == tcs)
+                tcs.TrySetResult(Empty.Default);
+            var asi = activeSingleIterators;
+            if (asi != null)
             {
-                if (Utility.MonotonicUpdate(ref SafeTailAddress, safeTailRefreshLastTailAddress, out var oldSafeTailAddress))
-                {
-                    var tcs = refreshUncommittedTcs;
-                    if (tcs != null && Interlocked.CompareExchange(ref refreshUncommittedTcs, null, tcs) == tcs)
-                        tcs.SetResult(Empty.Default);
-                    var _callback = SafeTailShiftCallback;
-                    if (_callback != null || activeSingleIterators != null)
-                    {
-                        // We invoke callback outside epoch protection
-                        var isProtected = epoch.ThisInstanceProtected();
-                        if (isProtected) epoch.Suspend();
-                        try
-                        {
-                            // Notify waiting single iterators, if any
-                            var _asi = activeSingleIterators;
-                            if (_asi != null)
-                            {
-                                foreach (var iter in _asi)
-                                    iter.Signal();
-                            }
-                            // Invoke callback, if any
-                            _callback?.Invoke(oldSafeTailAddress, safeTailRefreshLastTailAddress);
-                        }
-                        finally
-                        {
-                            if (isProtected) epoch.Resume();
-                        }
-                    }
-                }
-            }
-            finally
-            {
-                safeTailRefreshCallbackCompleted.Signal();
+                foreach (var iter in asi)
+                    iter.Signal();
             }
         }
+
+        /// <summary>
+        /// Visitor that computes the minimum value across the user-word column.
+        /// </summary>
+        struct MinVisitor : LightEpoch.ILightEpochUserWordVisitor
+        {
+            public long Min;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Visit(long value)
+            {
+                if (value < Min) Min = value;
+            }
+        }
+
+        /// <summary>
+        /// Recompute <see cref="SafeTailAddress"/> from the current in-flight state, advance the
+        /// monotonic cache, and invoke <see cref="SafeTailShiftCallback"/> if it shifted. Also notifies
+        /// any parked iterators of the new value. Consumers needing up-to-the-moment progress call this;
+        /// iterator hot loops can read <see cref="SafeTailAddress"/> directly (O(1) cached read).
+        /// </summary>
+        public long RefreshSafeTailAddress()
+        {
+            var visitor = new MinVisitor { Min = InflightInactive };
+            epoch.ForEachUserWord(inflightWord, ref visitor);
+            long tail = allocator.GetTailAddress();
+            long computed = visitor.Min < tail ? visitor.Min : tail;
+
+            long oldSafe;
+            if (Utility.MonotonicUpdate(ref cachedSafeTailAddress, computed, out oldSafe))
+            {
+                NotifyParkedWaiters();
+                // Invoke callback inline — it is safe to call from protected or unprotected contexts.
+                // The old bump-drain design fired this callback from a drain action on an arbitrary thread;
+                // this is equivalent but without the Suspend/Resume dance that risked aborting an
+                // in-progress iterator frame.
+                SafeTailShiftCallback?.Invoke(oldSafe, computed);
+                return computed;
+            }
+            return oldSafe;
+        }
+
+        /// <summary>
+        /// Monotonically advance the cached <see cref="SafeTailAddress"/> to at least
+        /// <paramref name="floor"/>. Used by commit/recovery/reset paths to publish a known-safe address
+        /// (e.g., committed-until, recovered-until) without scanning in-flight slots.
+        /// </summary>
+        void AdvanceSafeTailFloor(long floor)
+        {
+            if (Utility.MonotonicUpdate(ref cachedSafeTailAddress, floor, out var oldSafe))
+            {
+                NotifyParkedWaiters();
+                SafeTailShiftCallback?.Invoke(oldSafe, floor);
+            }
+        }
+        #endregion
 
         /// <summary>
         /// Reset TsavoriteLog to empty state
@@ -368,7 +382,7 @@ namespace Tsavorite.core
             allocator.Reset();
             CommittedUntilAddress = beginAddress;
             CommittedBeginAddress = beginAddress;
-            SafeTailAddress = beginAddress;
+            cachedSafeTailAddress = beginAddress;
 
             commitNum = 0;
             this.beginAddress = beginAddress;
@@ -429,7 +443,7 @@ namespace Tsavorite.core
 
                 CommittedUntilAddress = committedUntilAddress;
                 CommittedBeginAddress = beginAddress;
-                SafeTailAddress = committedUntilAddress;
+                AdvanceSafeTailFloor(committedUntilAddress);
 
                 commitNum = lastCommitNum;
                 this.beginAddress = beginAddress;
@@ -520,9 +534,9 @@ namespace Tsavorite.core
 
         internal void TrueDispose()
         {
-            safeTailRefreshTaskCts?.Cancel();
-            safeTailRefreshCallbackCompleted?.Signal();
-            safeTailRefreshEntryEnqueued?.Signal();
+            // Release our in-flight user-word slot back to the epoch. Iterators no longer parked; the
+            // slot column is no longer referenced.
+            epoch.ReleaseUserWord(inflightWord);
             commitQueue.Dispose();
             _ = commitTcs.TrySetException(new ObjectDisposedException("TsavoriteLog has been disposed"));
             allocator.Dispose();
@@ -678,18 +692,21 @@ namespace Tsavorite.core
 
             if (commitNum == long.MaxValue) throw new TsavoriteException("Attempting to enqueue into a completed log");
 
+            BeginInflightEnqueue();
             if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
             {
+                EndInflightEnqueue();
                 epoch.Suspend();
                 if (cannedException != null)
                     throw cannedException;
                 return false;
             }
+            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             entry.SerializeTo(new Span<byte>((void*)(headerSize + physicalAddress), length));
             SetHeader(length, (byte*)physicalAddress);
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             if (autoCommit) Commit();
             return true;
@@ -718,13 +735,16 @@ namespace Tsavorite.core
             epoch.Resume();
             if (commitNum == long.MaxValue) throw new TsavoriteException("Attempting to enqueue into a completed log");
 
+            BeginInflightEnqueue();
             if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
             {
+                EndInflightEnqueue();
                 epoch.Suspend();
                 if (cannedException != null)
                     throw cannedException;
                 return false;
             }
+            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             foreach (var entry in entries)
@@ -734,7 +754,7 @@ namespace Tsavorite.core
                 SetHeader(length, (byte*)physicalAddress);
                 physicalAddress += Align(length) + headerSize;
             }
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             if (autoCommit) Commit();
             return true;
@@ -759,19 +779,22 @@ namespace Tsavorite.core
             if (commitNum == long.MaxValue)
                 throw new TsavoriteException("Attempting to enqueue into a completed log");
 
+            BeginInflightEnqueue();
             if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
             {
+                EndInflightEnqueue();
                 epoch.Suspend();
                 if (cannedException != null)
                     throw cannedException;
                 return false;
             }
+            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             fixed (byte* bp = entry)
                 Buffer.MemoryCopy(bp, (void*)(headerSize + physicalAddress), length, length);
             SetHeader(length, (byte*)physicalAddress);
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             if (autoCommit) Commit();
             return true;
@@ -799,17 +822,20 @@ namespace Tsavorite.core
 
             if (commitNum == long.MaxValue) throw new TsavoriteException("Attempting to enqueue into a completed log");
 
+            BeginInflightEnqueue();
             if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
             {
+                EndInflightEnqueue();
                 epoch.Suspend();
                 if (cannedException != null)
                     throw cannedException;
                 return false;
             }
+            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             entryBytes.CopyTo(new Span<byte>((byte*)physicalAddress, length));
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             if (autoCommit && !noCommit) Commit();
             return true;
@@ -833,19 +859,22 @@ namespace Tsavorite.core
 
             if (commitNum == long.MaxValue) throw new TsavoriteException("Attempting to enqueue into a completed log");
 
+            BeginInflightEnqueue();
             if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
             {
+                EndInflightEnqueue();
                 epoch.Suspend();
                 if (cannedException != null)
                     throw cannedException;
                 return false;
             }
+            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             fixed (byte* bp = &entry.GetPinnableReference())
                 Buffer.MemoryCopy(bp, (void*)(headerSize + physicalAddress), length, length);
             SetHeader(length, (byte*)physicalAddress);
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             if (autoCommit) Commit();
             return true;
@@ -871,7 +900,7 @@ namespace Tsavorite.core
             var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
             *(THeader*)(physicalAddress + headerSize) = userHeader;
             SetHeader(length, physicalAddress);
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             if (autoCommit) Commit();
         }
@@ -899,7 +928,7 @@ namespace Tsavorite.core
             var offset = headerSize + sizeof(THeader);
             item.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
             SetHeader(length, physicalAddress);
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             if (autoCommit) Commit();
         }
@@ -932,7 +961,7 @@ namespace Tsavorite.core
                 offset += item1.TotalSize();
                 item2.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
                 SetHeader(length, physicalAddress);
-                safeTailRefreshEntryEnqueued?.Signal();
+                EndInflightEnqueue();
             }
             finally
             {
@@ -964,7 +993,7 @@ namespace Tsavorite.core
             offset += item1.TotalSize();
             item2.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
             SetHeader(length, physicalAddress);
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             if (autoCommit) Commit();
         }
@@ -998,7 +1027,7 @@ namespace Tsavorite.core
             offset += item2.TotalSize();
             item3.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
             SetHeader(length, physicalAddress);
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             if (autoCommit) Commit();
         }
@@ -1024,7 +1053,7 @@ namespace Tsavorite.core
             *(THeader*)(physicalAddress + headerSize) = userHeader;
             _ = input.CopyTo(physicalAddress + headerSize + sizeof(THeader), input.SerializedLength);
             SetHeader(length, physicalAddress);
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             if (autoCommit) Commit();
         }
@@ -1084,7 +1113,7 @@ namespace Tsavorite.core
                 offset += item1.TotalSize();
                 _ = input.CopyTo(physicalAddress + offset, input.SerializedLength);
                 SetHeader(length, physicalAddress);
-                safeTailRefreshEntryEnqueued?.Signal();
+                EndInflightEnqueue();
             }
             finally
             {
@@ -1124,7 +1153,7 @@ namespace Tsavorite.core
                 offset += item2.TotalSize();
                 _ = input.CopyTo(physicalAddress + offset, input.SerializedLength);
                 SetHeader(length, physicalAddress);
-                safeTailRefreshEntryEnqueued?.Signal();
+                EndInflightEnqueue();
             }
             finally
             {
@@ -1156,7 +1185,7 @@ namespace Tsavorite.core
             var offset = sizeof(byte);
             item.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
             SetHeader(length, physicalAddress);
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             if (autoCommit) Commit();
         }
@@ -1167,8 +1196,12 @@ namespace Tsavorite.core
             while (true)
             {
                 var flushEvent = allocator.flushEvent;
+                BeginInflightEnqueue();
                 if (allocator.TryAllocateRetryNow(recordSize, out var logicalAddress))
+                {
+                    CommitInflightEnqueue(logicalAddress);
                     return logicalAddress;
+                }
 
                 // logicalAddress less than 0 (RETRY_NOW) should already have been handled. We expect flushEvent to be signaled.
                 Debug.Assert(logicalAddress == 0);
@@ -1194,9 +1227,13 @@ namespace Tsavorite.core
             while (true)
             {
                 var flushEvent = allocator.flushEvent;
+                BeginInflightEnqueue();
                 allocator.TryAllocateRetryNow(recordSize, out var logicalAddress);
                 if (logicalAddress > 0)
+                {
+                    CommitInflightEnqueue(logicalAddress);
                     return logicalAddress;
+                }
 
                 // logicalAddress less than 0 (RETRY_NOW) should already have been handled
                 Debug.Assert(logicalAddress == 0);
@@ -1242,13 +1279,16 @@ namespace Tsavorite.core
 
             epoch.Resume();
 
+            BeginInflightEnqueue();
             if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
             {
+                EndInflightEnqueue();
                 epoch.Suspend();
                 if (cannedException != null)
                     throw cannedException;
                 return false;
             }
+            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
             *(THeader*)(physicalAddress + headerSize) = userHeader;
@@ -1257,7 +1297,7 @@ namespace Tsavorite.core
             offset += item1.TotalSize();
             item2.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
             SetHeader(length, physicalAddress);
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             if (autoCommit) Commit();
             return true;
@@ -1283,13 +1323,16 @@ namespace Tsavorite.core
 
             epoch.Resume();
 
+            BeginInflightEnqueue();
             if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
             {
+                EndInflightEnqueue();
                 epoch.Suspend();
                 if (cannedException != null)
                     throw cannedException;
                 return false;
             }
+            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
             *(THeader*)(physicalAddress + headerSize) = userHeader;
@@ -1300,7 +1343,7 @@ namespace Tsavorite.core
             offset += item2.TotalSize();
             item3.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
             SetHeader(length, physicalAddress);
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             if (autoCommit) Commit();
             return true;
@@ -1323,20 +1366,23 @@ namespace Tsavorite.core
 
             epoch.Resume();
 
+            BeginInflightEnqueue();
             if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
             {
+                EndInflightEnqueue();
                 epoch.Suspend();
                 if (cannedException != null)
                     throw cannedException;
                 return false;
             }
+            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
             *physicalAddress = userHeader;
             var offset = sizeof(byte);
             item.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
             SetHeader(length, physicalAddress);
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             if (autoCommit) Commit();
             return true;
@@ -1588,8 +1634,13 @@ namespace Tsavorite.core
         /// <returns>true if there's more data available to be read; false if there will never be more data (log has been shutdown)</returns>
         public async ValueTask<bool> WaitUncommittedAsync(long nextAddress, CancellationToken token = default)
         {
-            Debug.Assert(safeTailRefreshFrequencyMs >= 0);
+            // Fast path — cache already past nextAddress.
             if (nextAddress < SafeTailAddress)
+                return true;
+
+            // Refresh once in case in-flight enqueues have already completed but haven't triggered a
+            // recompute yet (e.g., single-producer, no other reader has forced RefreshSafeTailAddress).
+            if (nextAddress < RefreshSafeTailAddress())
                 return true;
 
             while (true)
@@ -1606,7 +1657,7 @@ namespace Tsavorite.core
                     tcs ??= newTcs; // successful CAS so update the local var
                 }
 
-                if (nextAddress < SafeTailAddress)
+                if (nextAddress < SafeTailAddress || nextAddress < RefreshSafeTailAddress())
                     return true;
 
                 // Ignore refresh-uncommitted exceptions, except when the token is signaled
@@ -2199,9 +2250,6 @@ namespace Tsavorite.core
                     throw new TsavoriteException("Cannot use scanUncommitted with read-only TsavoriteLog");
             }
 
-            if (scanUncommitted && safeTailRefreshFrequencyMs < 0)
-                throw new TsavoriteException("Cannot use scanUncommitted without setting SafeTailRefreshFrequencyMs to a non-negative value in TsavoriteLog settings");
-
             var iter = new TsavoriteLogScanIterator(this, allocator, beginAddress, endAddress, getMemory, scanBufferingMode, epoch, headerSize, scanUncommitted, logger: logger);
 
             if (Interlocked.Increment(ref logRefCount) == 1)
@@ -2240,9 +2288,6 @@ namespace Tsavorite.core
                 if (scanUncommitted)
                     throw new TsavoriteException("Cannot use scanUncommitted with read-only TsavoriteLog");
             }
-
-            if (scanUncommitted && safeTailRefreshFrequencyMs < 0)
-                throw new TsavoriteException("Cannot use scanUncommitted without setting SafeTailRefreshFrequencyMs to a non-negative value in TsavoriteLog settings");
 
             var iter = new TsavoriteLogScanSingleIterator(this, allocator, beginAddress, endAddress, getMemory, scanBufferingMode, epoch, headerSize, scanUncommitted, logger: logger);
 
@@ -2347,14 +2392,6 @@ namespace Tsavorite.core
             return GetRecordLengthAndFree(ctx.record);
         }
 
-        /// <summary>
-        /// Trigger refresh of safe tail address
-        /// </summary>
-        private void DoAutoRefreshSafeTailAddress()
-        {
-            safeTailRefreshEntryEnqueued?.Signal();
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int Align(int length)
         {
@@ -2380,11 +2417,14 @@ namespace Tsavorite.core
 
             epoch.Resume();
 
+            BeginInflightEnqueue();
             if (!allocator.TryAllocateRetryNow(allocatedLength, out var logicalAddress))
             {
+                EndInflightEnqueue();
                 epoch.Suspend();
                 return false;
             }
+            CommitInflightEnqueue(logicalAddress);
 
             // Finish filling in all fields
             info.BeginAddress = BeginAddress;
@@ -2396,7 +2436,7 @@ namespace Tsavorite.core
             fixed (byte* bp = entryBody)
                 Buffer.MemoryCopy(bp, (void*)(headerSize + physicalAddress), entryBody.Length, entryBody.Length);
             SetCommitRecordHeader(entryBody.Length, (byte*)physicalAddress);
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             // Return the commit tail
             return true;
@@ -2826,7 +2866,7 @@ namespace Tsavorite.core
         {
             CommittedUntilAddress = info.UntilAddress;
             CommittedBeginAddress = info.BeginAddress;
-            SafeTailAddress = info.UntilAddress;
+            AdvanceSafeTailFloor(info.UntilAddress);
         }
 
         /// <summary>
@@ -2851,13 +2891,16 @@ namespace Tsavorite.core
             epoch.Resume();
             if (commitNum == long.MaxValue) throw new TsavoriteException("Attempting to enqueue into a completed log");
 
+            BeginInflightEnqueue();
             if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
             {
+                EndInflightEnqueue();
                 epoch.Suspend();
                 if (cannedException != null)
                     throw cannedException;
                 return false;
             }
+            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             for (var i = 0; i < totalEntries; i++)
@@ -2869,7 +2912,7 @@ namespace Tsavorite.core
                 SetHeader(entryLength, (byte*)physicalAddress);
                 physicalAddress += Align(entryLength) + headerSize;
             }
-            safeTailRefreshEntryEnqueued?.Signal();
+            EndInflightEnqueue();
             epoch.Suspend();
             if (autoCommit) Commit();
             return true;

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -1300,11 +1300,12 @@ namespace Tsavorite.core
                 // logicalAddress less than 0 (RETRY_NOW) should already have been handled. We expect flushEvent to be signaled.
                 Debug.Assert(logicalAddress == 0);
 
-                // epoch.Suspend releases this thread's LightEpoch entry, which via ResetAllocatedUserWords
-                // clears our in-flight slot back to InflightInactive. That may raise min(inflight), so wake
-                // any parked waiters that were being held back by our Begin publish.
+                // Clear our in-flight slot before suspending — LightEpoch does not auto-reset user
+                // words on Release. Without this, the stale low publish would pin min(inflight) and
+                // prevent SafeTailAddress from advancing. NotifyParkedWaiters wakes any readers that
+                // were held back by our Begin publish.
+                EndInflightEnqueue();
                 epoch.Suspend();
-                NotifyParkedWaiters();
                 if (cannedException != null)
                     throw cannedException;
                 try
@@ -1335,11 +1336,14 @@ namespace Tsavorite.core
                 // logicalAddress less than 0 (RETRY_NOW) should already have been handled
                 Debug.Assert(logicalAddress == 0);
 
+                // Clear our in-flight slot before suspending — LightEpoch does not auto-reset user
+                // words on Release. Without this, the stale low publish would pin min(inflight) and
+                // prevent SafeTailAddress from advancing.
+                EndInflightEnqueue();
+
                 // We are holding the TsavoriteLog's epoch; release and then reacquire it. And if the caller's epoch is
-                // also held, suspend and reacquire it as well. Suspend clears our in-flight slot via
-                // ResetAllocatedUserWords; wake parked waiters that our Begin publish may have been holding back.
+                // also held, suspend and reacquire it as well.
                 epoch.Suspend();
-                NotifyParkedWaiters();
                 var suspended = epochAccessor.TrySuspend();
                 try
                 {

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -1356,10 +1356,10 @@ namespace Tsavorite.core
                 // Clear in-flight slot before suspending, re-publish after resuming
                 EndInflightEnqueue();
                 epoch.Suspend();
-                if (cannedException != null)
-                    throw cannedException;
                 try
                 {
+                    if (cannedException != null)
+                        throw cannedException;
                     flushEvent.Wait();
                 }
                 finally

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -376,6 +376,14 @@ namespace Tsavorite.core
         /// </summary>
         public long RefreshSafeTailAddress()
         {
+            // Fast path: if TailAddress hasn't moved beyond the cached SafeTailAddress, no new
+            // records have been allocated and scanning the inflight column cannot yield a higher
+            // value. Skip the expensive epoch-table scan entirely.
+            long tail = allocator.GetTailAddress();
+            long cached = Volatile.Read(ref cachedSafeTailAddress);
+            if (tail <= cached)
+                return cached;
+
             // Ordering is critical: read the tail *before* the inflight column, with a full fence in
             // between. Producers publish their inflight slot via a release store and then advance the
             // tail via an interlocked FAA. If we read inflight first and tail second, a reader could
@@ -384,7 +392,6 @@ namespace Tsavorite.core
             // range up to the new tail is safe even though the producer has not written its payload.
             // Reading tail first + memory barrier guarantees that if we observed the FAA we will
             // also observe the preceding BeginInflightEnqueue store.
-            long tail = allocator.GetTailAddress();
             Interlocked.MemoryBarrier();
             long minInflight = epoch.GetMinUserWord(inflightWord);
             long computed = minInflight < tail ? minInflight : tail;

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -2355,11 +2355,22 @@ namespace Tsavorite.core
             return iter;
         }
 
+        /// <summary>
+        /// Registered single-waiter iterators (one per replica / pub-sub subscriber). Non-null when at
+        /// least one <see cref="TsavoriteLogScanSingleIterator"/> is active. Replaced atomically under
+        /// <c>lock(this)</c> on iterator add/remove — read without lock on the hot path
+        /// (<see cref="NotifyParkedWaiters"/>).
+        /// </summary>
         List<TsavoriteLogScanSingleIterator> activeSingleIterators;
 
-        /// <summary>Number of registered single iterators. Used by <see cref="NotifyParkedWaiters"/>
-        /// to decide whether to pre-refresh the cache before signaling (avoids redundant scans when
-        /// multiple iterators wake concurrently).</summary>
+        /// <summary>
+        /// Count of registered single iterators, mirroring <c>activeSingleIterators.Count</c>.
+        /// Read via <c>Volatile.Read</c> by <see cref="NotifyParkedWaiters"/> to
+        /// decide whether to pre-refresh <see cref="SafeTailAddress"/> before signaling iterators.
+        /// When <c>&gt; 1</c>, a single scan at the producer side prevents N redundant scans in the
+        /// N woken iterators. Stale reads are benign — see <see cref="NotifyParkedWaiters"/> comments.
+        /// Written under <c>lock(this)</c> alongside <see cref="activeSingleIterators"/>.
+        /// </summary>
         int activeSingleIteratorCount;
 
         public void RemoveIterator(TsavoriteLogScanSingleIterator iterator)
@@ -2378,6 +2389,7 @@ namespace Tsavorite.core
                         }
                     }
                     activeSingleIterators = newList;
+                    // Keep the count in sync; read without lock by NotifyParkedWaiters as a hint.
                     activeSingleIteratorCount = newList?.Count ?? 0;
                 }
             }
@@ -2399,6 +2411,7 @@ namespace Tsavorite.core
             {
                 List<TsavoriteLogScanSingleIterator> newList = activeSingleIterators == null ? new() { iter } : new(activeSingleIterators) { iter };
                 activeSingleIterators = newList;
+                // Keep the count in sync; read without lock by NotifyParkedWaiters as a hint.
                 activeSingleIteratorCount = newList.Count;
             }
 

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -342,15 +342,28 @@ namespace Tsavorite.core
 
         /// <summary>
         /// Wake any iterators parked in <see cref="WaitUncommittedAsync"/> or as single-iterators.
-        /// Cheap in the common case: both references null-check to no-op.
+        /// When more than one single iterator is registered, pre-refreshes <see cref="SafeTailAddress"/>
+        /// so that all woken iterators see the fresh cache and skip their own redundant scans (O(1)
+        /// scan total instead of O(N_iterators)). With a single iterator, the scan is deferred to the
+        /// iterator's <see cref="TsavoriteLogScanSingleIterator.SlowWaitUncommittedAsync"/> path.
+        /// Cheap in the common case (no waiters): two null-check loads.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         void NotifyParkedWaiters()
         {
             var tcs = refreshUncommittedTcs;
+            var asi = activeSingleIterators;
+
+            // When multiple iterators exist, refresh before signaling so they all see
+            // the fresh cache and skip their own RefreshSafeTailAddress scan.
+            // The count is a stale-tolerant hint: if we read an old value of 1 when it's actually 2,
+            // the extra iterator simply does its own scan (correct, just redundant). If we read 2 when
+            // it's actually 1, we do one extra scan (harmless).
+            if (asi != null && Volatile.Read(ref activeSingleIteratorCount) > 1)
+                _ = RefreshSafeTailAddress();
+
             if (tcs != null && Interlocked.CompareExchange(ref refreshUncommittedTcs, null, tcs) == tcs)
                 tcs.TrySetResult(Empty.Default);
-            var asi = activeSingleIterators;
             if (asi != null)
             {
                 foreach (var iter in asi)
@@ -2344,6 +2357,11 @@ namespace Tsavorite.core
 
         List<TsavoriteLogScanSingleIterator> activeSingleIterators;
 
+        /// <summary>Number of registered single iterators. Used by <see cref="NotifyParkedWaiters"/>
+        /// to decide whether to pre-refresh the cache before signaling (avoids redundant scans when
+        /// multiple iterators wake concurrently).</summary>
+        int activeSingleIteratorCount;
+
         public void RemoveIterator(TsavoriteLogScanSingleIterator iterator)
         {
             lock (this)
@@ -2360,6 +2378,7 @@ namespace Tsavorite.core
                         }
                     }
                     activeSingleIterators = newList;
+                    activeSingleIteratorCount = newList?.Count ?? 0;
                 }
             }
         }
@@ -2380,6 +2399,7 @@ namespace Tsavorite.core
             {
                 List<TsavoriteLogScanSingleIterator> newList = activeSingleIterators == null ? new() { iter } : new(activeSingleIterators) { iter };
                 activeSingleIterators = newList;
+                activeSingleIteratorCount = newList.Count;
             }
 
             if (Interlocked.Increment(ref logRefCount) == 1)

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -338,9 +338,18 @@ namespace Tsavorite.core
         /// </summary>
         public long RefreshSafeTailAddress()
         {
+            // Ordering is critical: read the tail *before* the inflight column, with a full fence in
+            // between. Producers publish their inflight slot via a release store and then advance the
+            // tail via an interlocked FAA. If we read inflight first and tail second, a reader could
+            // observe a fresh tail value (post-FAA) while still seeing the producer's slot as
+            // InflightInactive (pre-BeginInflightEnqueue), incorrectly concluding that the entire
+            // range up to the new tail is safe even though the producer has not written its payload.
+            // Reading tail first + memory barrier guarantees that if we observed the FAA we will
+            // also observe the preceding BeginInflightEnqueue store.
+            long tail = allocator.GetTailAddress();
+            Interlocked.MemoryBarrier();
             var visitor = new MinVisitor { Min = InflightInactive };
             epoch.ForEachUserWord(inflightWord, ref visitor);
-            long tail = allocator.GetTailAddress();
             long computed = visitor.Min < tail ? visitor.Min : tail;
 
             long oldSafe;

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -359,19 +359,6 @@ namespace Tsavorite.core
         }
 
         /// <summary>
-        /// Visitor that computes the minimum value across the user-word column.
-        /// </summary>
-        struct MinVisitor : LightEpoch.ILightEpochUserWordVisitor
-        {
-            public long Min;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public void Visit(long value)
-            {
-                if (value < Min) Min = value;
-            }
-        }
-
-        /// <summary>
         /// Recompute <see cref="SafeTailAddress"/> from the current in-flight state, advance the
         /// monotonic cache, and invoke <see cref="SafeTailPageShiftCallback"/> if the new SafeTail
         /// crossed a page boundary. Also notifies any parked iterators of the new value. Consumers
@@ -390,9 +377,8 @@ namespace Tsavorite.core
             // also observe the preceding BeginInflightEnqueue store.
             long tail = allocator.GetTailAddress();
             Interlocked.MemoryBarrier();
-            var visitor = new MinVisitor { Min = InflightInactive };
-            epoch.ForEachUserWord(inflightWord, ref visitor);
-            long computed = visitor.Min < tail ? visitor.Min : tail;
+            long minInflight = epoch.GetMinUserWord(inflightWord);
+            long computed = minInflight < tail ? minInflight : tail;
 
             long oldSafe;
             if (Utility.MonotonicUpdate(ref cachedSafeTailAddress, computed, out oldSafe))

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -1175,7 +1175,7 @@ namespace Tsavorite.core
                 offset += item1.TotalSize();
                 _ = input.CopyTo(physicalAddress + offset, input.SerializedLength);
                 SetHeader(length, physicalAddress);
-                safeTailRefreshEntryEnqueued?.Signal();
+                EndInflightEnqueue();
             }
             finally
             {

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -268,16 +268,21 @@ namespace Tsavorite.core
         // Producer protocol (must run inside epoch.Resume / before epoch.Suspend):
         //   1. BeginInflightEnqueue()   — publish a lower bound ≤ eventual slot start
         //   2. TryAllocateRetryNow(...) — FAA advances TailAddress and returns our slot start
-        //   3. CommitInflightEnqueue(start) — tighten publish to exact slot start
-        //   4. (payload write)
-        //   5. EndInflightEnqueue()     — publish InflightInactive, wake parked iterators
+        //   3. (payload write)
+        //   4. EndInflightEnqueue()     — publish InflightInactive, wake parked iterators
         // On allocation failure, call EndInflightEnqueue() to clear the lower bound before Suspend.
         //
-        // The Step 1 pre-reserve is required because otherwise a reader could observe TailAddress
+        // The Begin pre-publish is required because otherwise a reader could observe TailAddress
         // advanced past our slot while our in-flight slot still reads InflightInactive, erroneously
         // concluding that region is safe. By publishing a lower bound before the FAA, any reader that
         // sees TailAddress ≥ X is guaranteed (via release/acquire ordering) to also observe our slot at
         // some value ≤ X.
+        //
+        // The published lower bound may be slightly below our actual slot start (by the amount other
+        // threads allocated between our GetTailAddress read and our FAA). This makes SafeTailAddress
+        // lag by at most O(N_threads × entry_size) bytes — negligible compared to page-level
+        // granularity of downstream consumers. We tolerate this in exchange for removing one
+        // Volatile.Write per enqueue from the hot path.
 
         /// <summary>
         /// Publish a conservative lower bound into this thread's in-flight slot before the allocator's
@@ -288,15 +293,6 @@ namespace Tsavorite.core
         void BeginInflightEnqueue()
         {
             Volatile.Write(ref epoch.ThisThreadUserWord(inflightWord), allocator.GetTailAddress());
-        }
-
-        /// <summary>
-        /// Tighten this thread's in-flight publish to the exact slot start returned by the allocator.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        void CommitInflightEnqueue(long logicalAddress)
-        {
-            Volatile.Write(ref epoch.ThisThreadUserWord(inflightWord), logicalAddress);
         }
 
         /// <summary>
@@ -793,7 +789,6 @@ namespace Tsavorite.core
                     throw cannedException;
                 return false;
             }
-            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             entry.SerializeTo(new Span<byte>((void*)(headerSize + physicalAddress), length));
@@ -836,7 +831,6 @@ namespace Tsavorite.core
                     throw cannedException;
                 return false;
             }
-            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             foreach (var entry in entries)
@@ -880,7 +874,6 @@ namespace Tsavorite.core
                     throw cannedException;
                 return false;
             }
-            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             fixed (byte* bp = entry)
@@ -923,7 +916,6 @@ namespace Tsavorite.core
                     throw cannedException;
                 return false;
             }
-            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             entryBytes.CopyTo(new Span<byte>((byte*)physicalAddress, length));
@@ -960,7 +952,6 @@ namespace Tsavorite.core
                     throw cannedException;
                 return false;
             }
-            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             fixed (byte* bp = &entry.GetPinnableReference())
@@ -1291,7 +1282,6 @@ namespace Tsavorite.core
                 BeginInflightEnqueue();
                 if (allocator.TryAllocateRetryNow(recordSize, out var logicalAddress))
                 {
-                    CommitInflightEnqueue(logicalAddress);
                     return logicalAddress;
                 }
 
@@ -1327,7 +1317,6 @@ namespace Tsavorite.core
                 allocator.TryAllocateRetryNow(recordSize, out var logicalAddress);
                 if (logicalAddress > 0)
                 {
-                    CommitInflightEnqueue(logicalAddress);
                     return logicalAddress;
                 }
 
@@ -1386,7 +1375,6 @@ namespace Tsavorite.core
                     throw cannedException;
                 return false;
             }
-            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
             *(THeader*)(physicalAddress + headerSize) = userHeader;
@@ -1430,7 +1418,6 @@ namespace Tsavorite.core
                     throw cannedException;
                 return false;
             }
-            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
             *(THeader*)(physicalAddress + headerSize) = userHeader;
@@ -1473,7 +1460,6 @@ namespace Tsavorite.core
                     throw cannedException;
                 return false;
             }
-            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
             *physicalAddress = userHeader;
@@ -2542,7 +2528,6 @@ namespace Tsavorite.core
                 epoch.Suspend();
                 return false;
             }
-            CommitInflightEnqueue(logicalAddress);
 
             // Finish filling in all fields
             info.BeginAddress = BeginAddress;
@@ -3018,7 +3003,6 @@ namespace Tsavorite.core
                     throw cannedException;
                 return false;
             }
-            CommitInflightEnqueue(logicalAddress);
 
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             for (var i = 0; i < totalEntries; i++)

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -421,7 +421,9 @@ namespace Tsavorite.core
         /// <summary>
         /// Fires <see cref="SafeTailPageShiftCallback"/> only when the new SafeTail is on a different
         /// page than the last call. Uses <see cref="lastPublishedSafeTailPage"/> as a monotonic filter so
-        /// that concurrent callers cannot double-fire for the same page transition.
+        /// that concurrent callers cannot double-fire for the same page transition. The callback is
+        /// always invoked outside epoch protection so it can safely re-enter Tsavorite APIs (matching
+        /// the contract of the previous background-worker design).
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         void MaybeInvokePageShiftCallback(long oldSafe, long newSafe)
@@ -432,7 +434,20 @@ namespace Tsavorite.core
             long prev = Volatile.Read(ref lastPublishedSafeTailPage);
             if (newPage <= prev) return;
             if (Interlocked.CompareExchange(ref lastPublishedSafeTailPage, newPage, prev) != prev) return;
-            cb(oldSafe, newSafe);
+
+            // Invoke callback outside epoch protection. Producer drive and direct RefreshSafeTailAddress
+            // callers may hold the epoch; suspend it so the callback can re-enter log APIs without
+            // tripping nested-epoch asserts or corrupting epoch bookkeeping.
+            var isProtected = epoch.ThisInstanceProtected();
+            if (isProtected) epoch.Suspend();
+            try
+            {
+                cb(oldSafe, newSafe);
+            }
+            finally
+            {
+                if (isProtected) epoch.Resume();
+            }
         }
         #endregion
 
@@ -447,6 +462,12 @@ namespace Tsavorite.core
             CommittedUntilAddress = beginAddress;
             CommittedBeginAddress = beginAddress;
             cachedSafeTailAddress = beginAddress;
+
+            // Reset monotonic page trackers to the new (lower) address so that the first post-reset
+            // enqueue that crosses into a new page re-arms both producer-drive and callback dispatch.
+            var resetPage = beginAddress >> allocator.LogPageSizeBits;
+            Volatile.Write(ref lastPublishedSafeTailPage, resetPage);
+            Volatile.Write(ref lastProducerObservedPage, resetPage);
 
             commitNum = 0;
             this.beginAddress = beginAddress;
@@ -507,6 +528,14 @@ namespace Tsavorite.core
 
                 CommittedUntilAddress = committedUntilAddress;
                 CommittedBeginAddress = beginAddress;
+
+                // Align monotonic page trackers to the restored address so that post-recovery producer
+                // drive and page-shift callbacks re-arm correctly (they only advance beyond the
+                // initial floor).
+                var resetPage = committedUntilAddress >> allocator.LogPageSizeBits;
+                Volatile.Write(ref lastPublishedSafeTailPage, resetPage);
+                Volatile.Write(ref lastProducerObservedPage, resetPage);
+
                 AdvanceSafeTailFloor(committedUntilAddress);
 
                 commitNum = lastCommitNum;
@@ -1270,7 +1299,11 @@ namespace Tsavorite.core
                 // logicalAddress less than 0 (RETRY_NOW) should already have been handled. We expect flushEvent to be signaled.
                 Debug.Assert(logicalAddress == 0);
 
+                // epoch.Suspend releases this thread's LightEpoch entry, which via ResetAllocatedUserWords
+                // clears our in-flight slot back to InflightInactive. That may raise min(inflight), so wake
+                // any parked waiters that were being held back by our Begin publish.
                 epoch.Suspend();
+                NotifyParkedWaiters();
                 if (cannedException != null)
                     throw cannedException;
                 try
@@ -1303,8 +1336,10 @@ namespace Tsavorite.core
                 Debug.Assert(logicalAddress == 0);
 
                 // We are holding the TsavoriteLog's epoch; release and then reacquire it. And if the caller's epoch is
-                // also held, suspend and reacquire it as well.
+                // also held, suspend and reacquire it as well. Suspend clears our in-flight slot via
+                // ResetAllocatedUserWords; wake parked waiters that our Begin publish may have been holding back.
                 epoch.Suspend();
+                NotifyParkedWaiters();
                 var suspended = epochAccessor.TrySuspend();
                 try
                 {

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -149,9 +149,21 @@ namespace Tsavorite.core
         const long InflightInactive = long.MaxValue;
 
         /// <summary>
-        /// Callback when safe tail shifts
+        /// Callback fired when the safe tail crosses a page boundary. Arguments are the old and new
+        /// <see cref="SafeTailAddress"/>. Fires at most once per page — byte-level SafeTail advances that
+        /// do not cross a page boundary are coalesced. Iterators that need byte-level notification should
+        /// use <see cref="WaitUncommittedAsync"/> instead of this callback.
         /// </summary>
-        public Action<long, long> SafeTailShiftCallback;
+        public Action<long, long> SafeTailPageShiftCallback;
+
+        /// <summary>Last published page for <see cref="SafeTailPageShiftCallback"/>. Written only inside
+        /// the callback-dispatch path; read without locks under the monotonic-update invariant.</summary>
+        long lastPublishedSafeTailPage;
+
+        /// <summary>Highest page any producer has observed the tail reaching. Producers CAS this when they
+        /// cross into a new page and the CAS winner drives a <see cref="RefreshSafeTailAddress"/>. Ensures
+        /// the page-shift callback fires even with no active iterators driving scans.</summary>
+        long lastProducerObservedPage;
 
         /// <summary>
         /// Whether we automatically commit as records are inserted
@@ -297,6 +309,35 @@ namespace Tsavorite.core
         {
             Volatile.Write(ref epoch.ThisThreadUserWord(inflightWord), InflightInactive);
             NotifyParkedWaiters();
+            MaybeProducerDriveSafeTail();
+        }
+
+        /// <summary>
+        /// If a <see cref="SafeTailPageShiftCallback"/> is registered and this enqueue crossed into a
+        /// new page, drive a <see cref="RefreshSafeTailAddress"/> from the producer side. This keeps
+        /// the callback progressing even with no active iterators. Cost on the hot path is a cheap
+        /// (unsynchronized) long read + branch; the scan only runs once per page transition, driven by
+        /// exactly one producer (the CAS winner).
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void MaybeProducerDriveSafeTail()
+        {
+            if (SafeTailPageShiftCallback == null) return;
+            long tail = allocator.GetTailAddress();
+            long newPage = tail >> allocator.LogPageSizeBits;
+            // Non-volatile read — stale values only cause a redundant CAS attempt, never missed progress
+            // (some subsequent producer will observe the shift and take the slow path).
+            if (newPage <= lastProducerObservedPage) return;
+            ProducerDriveSafeTailSlow(newPage);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void ProducerDriveSafeTailSlow(long newPage)
+        {
+            long prev = Volatile.Read(ref lastProducerObservedPage);
+            if (newPage <= prev) return;
+            if (Interlocked.CompareExchange(ref lastProducerObservedPage, newPage, prev) != prev) return;
+            _ = RefreshSafeTailAddress();
         }
 
         /// <summary>
@@ -332,9 +373,10 @@ namespace Tsavorite.core
 
         /// <summary>
         /// Recompute <see cref="SafeTailAddress"/> from the current in-flight state, advance the
-        /// monotonic cache, and invoke <see cref="SafeTailShiftCallback"/> if it shifted. Also notifies
-        /// any parked iterators of the new value. Consumers needing up-to-the-moment progress call this;
-        /// iterator hot loops can read <see cref="SafeTailAddress"/> directly (O(1) cached read).
+        /// monotonic cache, and invoke <see cref="SafeTailPageShiftCallback"/> if the new SafeTail
+        /// crossed a page boundary. Also notifies any parked iterators of the new value. Consumers
+        /// needing up-to-the-moment progress call this; iterator hot loops can read
+        /// <see cref="SafeTailAddress"/> directly (O(1) cached read).
         /// </summary>
         public long RefreshSafeTailAddress()
         {
@@ -356,11 +398,7 @@ namespace Tsavorite.core
             if (Utility.MonotonicUpdate(ref cachedSafeTailAddress, computed, out oldSafe))
             {
                 NotifyParkedWaiters();
-                // Invoke callback inline — it is safe to call from protected or unprotected contexts.
-                // The old bump-drain design fired this callback from a drain action on an arbitrary thread;
-                // this is equivalent but without the Suspend/Resume dance that risked aborting an
-                // in-progress iterator frame.
-                SafeTailShiftCallback?.Invoke(oldSafe, computed);
+                MaybeInvokePageShiftCallback(oldSafe, computed);
                 return computed;
             }
             return oldSafe;
@@ -376,8 +414,25 @@ namespace Tsavorite.core
             if (Utility.MonotonicUpdate(ref cachedSafeTailAddress, floor, out var oldSafe))
             {
                 NotifyParkedWaiters();
-                SafeTailShiftCallback?.Invoke(oldSafe, floor);
+                MaybeInvokePageShiftCallback(oldSafe, floor);
             }
+        }
+
+        /// <summary>
+        /// Fires <see cref="SafeTailPageShiftCallback"/> only when the new SafeTail is on a different
+        /// page than the last call. Uses <see cref="lastPublishedSafeTailPage"/> as a monotonic filter so
+        /// that concurrent callers cannot double-fire for the same page transition.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void MaybeInvokePageShiftCallback(long oldSafe, long newSafe)
+        {
+            var cb = SafeTailPageShiftCallback;
+            if (cb == null) return;
+            long newPage = newSafe >> allocator.LogPageSizeBits;
+            long prev = Volatile.Read(ref lastPublishedSafeTailPage);
+            if (newPage <= prev) return;
+            if (Interlocked.CompareExchange(ref lastPublishedSafeTailPage, newPage, prev) != prev) return;
+            cb(oldSafe, newSafe);
         }
         #endregion
 

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -789,24 +789,27 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-
-            if (commitNum == long.MaxValue) throw new TsavoriteException("Attempting to enqueue into a completed log");
-
             BeginInflightEnqueue();
-            if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+            try
+            {
+                if (commitNum == long.MaxValue) throw new TsavoriteException("Attempting to enqueue into a completed log");
+
+                if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+                {
+                    if (cannedException != null)
+                        throw cannedException;
+                    return false;
+                }
+
+                var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
+                entry.SerializeTo(new Span<byte>((void*)(headerSize + physicalAddress), length));
+                SetHeader(length, (byte*)physicalAddress);
+            }
+            finally
             {
                 EndInflightEnqueue();
                 epoch.Suspend();
-                if (cannedException != null)
-                    throw cannedException;
-                return false;
             }
-
-            var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
-            entry.SerializeTo(new Span<byte>((void*)(headerSize + physicalAddress), length));
-            SetHeader(length, (byte*)physicalAddress);
-            EndInflightEnqueue();
-            epoch.Suspend();
             if (autoCommit) Commit();
             return true;
         }
@@ -832,28 +835,32 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-            if (commitNum == long.MaxValue) throw new TsavoriteException("Attempting to enqueue into a completed log");
-
             BeginInflightEnqueue();
-            if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+            try
+            {
+                if (commitNum == long.MaxValue) throw new TsavoriteException("Attempting to enqueue into a completed log");
+
+                if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+                {
+                    if (cannedException != null)
+                        throw cannedException;
+                    return false;
+                }
+
+                var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
+                foreach (var entry in entries)
+                {
+                    var length = entry.SerializedLength;
+                    entry.SerializeTo(new Span<byte>((void*)(headerSize + physicalAddress), length));
+                    SetHeader(length, (byte*)physicalAddress);
+                    physicalAddress += Align(length) + headerSize;
+                }
+            }
+            finally
             {
                 EndInflightEnqueue();
                 epoch.Suspend();
-                if (cannedException != null)
-                    throw cannedException;
-                return false;
             }
-
-            var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
-            foreach (var entry in entries)
-            {
-                var length = entry.SerializedLength;
-                entry.SerializeTo(new Span<byte>((void*)(headerSize + physicalAddress), length));
-                SetHeader(length, (byte*)physicalAddress);
-                physicalAddress += Align(length) + headerSize;
-            }
-            EndInflightEnqueue();
-            epoch.Suspend();
             if (autoCommit) Commit();
             return true;
         }
@@ -873,26 +880,29 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-
-            if (commitNum == long.MaxValue)
-                throw new TsavoriteException("Attempting to enqueue into a completed log");
-
             BeginInflightEnqueue();
-            if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+            try
+            {
+                if (commitNum == long.MaxValue)
+                    throw new TsavoriteException("Attempting to enqueue into a completed log");
+
+                if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+                {
+                    if (cannedException != null)
+                        throw cannedException;
+                    return false;
+                }
+
+                var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
+                fixed (byte* bp = entry)
+                    Buffer.MemoryCopy(bp, (void*)(headerSize + physicalAddress), length, length);
+                SetHeader(length, (byte*)physicalAddress);
+            }
+            finally
             {
                 EndInflightEnqueue();
                 epoch.Suspend();
-                if (cannedException != null)
-                    throw cannedException;
-                return false;
             }
-
-            var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
-            fixed (byte* bp = entry)
-                Buffer.MemoryCopy(bp, (void*)(headerSize + physicalAddress), length, length);
-            SetHeader(length, (byte*)physicalAddress);
-            EndInflightEnqueue();
-            epoch.Suspend();
             if (autoCommit) Commit();
             return true;
         }
@@ -916,23 +926,26 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-
-            if (commitNum == long.MaxValue) throw new TsavoriteException("Attempting to enqueue into a completed log");
-
             BeginInflightEnqueue();
-            if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+            try
+            {
+                if (commitNum == long.MaxValue) throw new TsavoriteException("Attempting to enqueue into a completed log");
+
+                if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+                {
+                    if (cannedException != null)
+                        throw cannedException;
+                    return false;
+                }
+
+                var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
+                entryBytes.CopyTo(new Span<byte>((byte*)physicalAddress, length));
+            }
+            finally
             {
                 EndInflightEnqueue();
                 epoch.Suspend();
-                if (cannedException != null)
-                    throw cannedException;
-                return false;
             }
-
-            var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
-            entryBytes.CopyTo(new Span<byte>((byte*)physicalAddress, length));
-            EndInflightEnqueue();
-            epoch.Suspend();
             if (autoCommit && !noCommit) Commit();
             return true;
         }
@@ -952,25 +965,28 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-
-            if (commitNum == long.MaxValue) throw new TsavoriteException("Attempting to enqueue into a completed log");
-
             BeginInflightEnqueue();
-            if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+            try
+            {
+                if (commitNum == long.MaxValue) throw new TsavoriteException("Attempting to enqueue into a completed log");
+
+                if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+                {
+                    if (cannedException != null)
+                        throw cannedException;
+                    return false;
+                }
+
+                var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
+                fixed (byte* bp = &entry.GetPinnableReference())
+                    Buffer.MemoryCopy(bp, (void*)(headerSize + physicalAddress), length, length);
+                SetHeader(length, (byte*)physicalAddress);
+            }
+            finally
             {
                 EndInflightEnqueue();
                 epoch.Suspend();
-                if (cannedException != null)
-                    throw cannedException;
-                return false;
             }
-
-            var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
-            fixed (byte* bp = &entry.GetPinnableReference())
-                Buffer.MemoryCopy(bp, (void*)(headerSize + physicalAddress), length, length);
-            SetHeader(length, (byte*)physicalAddress);
-            EndInflightEnqueue();
-            epoch.Suspend();
             if (autoCommit) Commit();
             return true;
         }
@@ -991,12 +1007,17 @@ namespace Tsavorite.core
             epoch.Resume();
 
             logicalAddress = AllocateBlock(allocatedLength);
-
-            var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
-            *(THeader*)(physicalAddress + headerSize) = userHeader;
-            SetHeader(length, physicalAddress);
-            EndInflightEnqueue();
-            epoch.Suspend();
+            try
+            {
+                var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
+                *(THeader*)(physicalAddress + headerSize) = userHeader;
+                SetHeader(length, physicalAddress);
+            }
+            finally
+            {
+                EndInflightEnqueue();
+                epoch.Suspend();
+            }
             if (autoCommit) Commit();
         }
 
@@ -1017,14 +1038,19 @@ namespace Tsavorite.core
             epoch.Resume();
 
             logicalAddress = AllocateBlock(allocatedLength);
-
-            var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
-            *(THeader*)(physicalAddress + headerSize) = userHeader;
-            var offset = headerSize + sizeof(THeader);
-            item.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
-            SetHeader(length, physicalAddress);
-            EndInflightEnqueue();
-            epoch.Suspend();
+            try
+            {
+                var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
+                *(THeader*)(physicalAddress + headerSize) = userHeader;
+                var offset = headerSize + sizeof(THeader);
+                item.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
+                SetHeader(length, physicalAddress);
+            }
+            finally
+            {
+                EndInflightEnqueue();
+                epoch.Suspend();
+            }
             if (autoCommit) Commit();
         }
 
@@ -1081,15 +1107,20 @@ namespace Tsavorite.core
             epoch.Resume();
 
             logicalAddress = AllocateBlock(allocatedLength);
-
-            var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
-            var offset = headerSize;
-            item1.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
-            offset += item1.TotalSize();
-            item2.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
-            SetHeader(length, physicalAddress);
-            EndInflightEnqueue();
-            epoch.Suspend();
+            try
+            {
+                var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
+                var offset = headerSize;
+                item1.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
+                offset += item1.TotalSize();
+                item2.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
+                SetHeader(length, physicalAddress);
+            }
+            finally
+            {
+                EndInflightEnqueue();
+                epoch.Suspend();
+            }
             if (autoCommit) Commit();
         }
 
@@ -1112,18 +1143,23 @@ namespace Tsavorite.core
             epoch.Resume();
 
             logicalAddress = AllocateBlock(allocatedLength);
-
-            var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
-            *(THeader*)(physicalAddress + headerSize) = userHeader;
-            var offset = headerSize + sizeof(THeader);
-            item1.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
-            offset += item1.TotalSize();
-            item2.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
-            offset += item2.TotalSize();
-            item3.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
-            SetHeader(length, physicalAddress);
-            EndInflightEnqueue();
-            epoch.Suspend();
+            try
+            {
+                var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
+                *(THeader*)(physicalAddress + headerSize) = userHeader;
+                var offset = headerSize + sizeof(THeader);
+                item1.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
+                offset += item1.TotalSize();
+                item2.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
+                offset += item2.TotalSize();
+                item3.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
+                SetHeader(length, physicalAddress);
+            }
+            finally
+            {
+                EndInflightEnqueue();
+                epoch.Suspend();
+            }
             if (autoCommit) Commit();
         }
 
@@ -1144,12 +1180,18 @@ namespace Tsavorite.core
             epoch.Resume();
 
             logicalAddress = AllocateBlock(allocatedLength);
-            var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
-            *(THeader*)(physicalAddress + headerSize) = userHeader;
-            _ = input.CopyTo(physicalAddress + headerSize + sizeof(THeader), input.SerializedLength);
-            SetHeader(length, physicalAddress);
-            EndInflightEnqueue();
-            epoch.Suspend();
+            try
+            {
+                var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
+                *(THeader*)(physicalAddress + headerSize) = userHeader;
+                _ = input.CopyTo(physicalAddress + headerSize + sizeof(THeader), input.SerializedLength);
+                SetHeader(length, physicalAddress);
+            }
+            finally
+            {
+                EndInflightEnqueue();
+                epoch.Suspend();
+            }
             if (autoCommit) Commit();
         }
 
@@ -1274,14 +1316,19 @@ namespace Tsavorite.core
             epoch.Resume();
 
             logicalAddress = AllocateBlock(allocatedLength);
-
-            var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
-            *physicalAddress = userHeader;
-            var offset = sizeof(byte);
-            item.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
-            SetHeader(length, physicalAddress);
-            EndInflightEnqueue();
-            epoch.Suspend();
+            try
+            {
+                var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
+                *physicalAddress = userHeader;
+                var offset = sizeof(byte);
+                item.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
+                SetHeader(length, physicalAddress);
+            }
+            finally
+            {
+                EndInflightEnqueue();
+                epoch.Suspend();
+            }
             if (autoCommit) Commit();
         }
 
@@ -1381,26 +1428,29 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-
             BeginInflightEnqueue();
-            if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+            try
+            {
+                if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+                {
+                    if (cannedException != null)
+                        throw cannedException;
+                    return false;
+                }
+
+                var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
+                *(THeader*)(physicalAddress + headerSize) = userHeader;
+                var offset = headerSize + sizeof(THeader);
+                item1.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
+                offset += item1.TotalSize();
+                item2.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
+                SetHeader(length, physicalAddress);
+            }
+            finally
             {
                 EndInflightEnqueue();
                 epoch.Suspend();
-                if (cannedException != null)
-                    throw cannedException;
-                return false;
             }
-
-            var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
-            *(THeader*)(physicalAddress + headerSize) = userHeader;
-            var offset = headerSize + sizeof(THeader);
-            item1.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
-            offset += item1.TotalSize();
-            item2.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
-            SetHeader(length, physicalAddress);
-            EndInflightEnqueue();
-            epoch.Suspend();
             if (autoCommit) Commit();
             return true;
         }
@@ -1424,28 +1474,31 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-
             BeginInflightEnqueue();
-            if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+            try
+            {
+                if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+                {
+                    if (cannedException != null)
+                        throw cannedException;
+                    return false;
+                }
+
+                var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
+                *(THeader*)(physicalAddress + headerSize) = userHeader;
+                var offset = headerSize + sizeof(THeader);
+                item1.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
+                offset += item1.TotalSize();
+                item2.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
+                offset += item2.TotalSize();
+                item3.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
+                SetHeader(length, physicalAddress);
+            }
+            finally
             {
                 EndInflightEnqueue();
                 epoch.Suspend();
-                if (cannedException != null)
-                    throw cannedException;
-                return false;
             }
-
-            var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
-            *(THeader*)(physicalAddress + headerSize) = userHeader;
-            var offset = headerSize + sizeof(THeader);
-            item1.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
-            offset += item1.TotalSize();
-            item2.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
-            offset += item2.TotalSize();
-            item3.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
-            SetHeader(length, physicalAddress);
-            EndInflightEnqueue();
-            epoch.Suspend();
             if (autoCommit) Commit();
             return true;
         }
@@ -1466,24 +1519,27 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-
             BeginInflightEnqueue();
-            if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+            try
+            {
+                if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+                {
+                    if (cannedException != null)
+                        throw cannedException;
+                    return false;
+                }
+
+                var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
+                *physicalAddress = userHeader;
+                var offset = sizeof(byte);
+                item.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
+                SetHeader(length, physicalAddress);
+            }
+            finally
             {
                 EndInflightEnqueue();
                 epoch.Suspend();
-                if (cannedException != null)
-                    throw cannedException;
-                return false;
             }
-
-            var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
-            *physicalAddress = userHeader;
-            var offset = sizeof(byte);
-            item.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
-            SetHeader(length, physicalAddress);
-            EndInflightEnqueue();
-            epoch.Suspend();
             if (autoCommit) Commit();
             return true;
         }
@@ -2536,27 +2592,30 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-
             BeginInflightEnqueue();
-            if (!allocator.TryAllocateRetryNow(allocatedLength, out var logicalAddress))
+            try
+            {
+                if (!allocator.TryAllocateRetryNow(allocatedLength, out var logicalAddress))
+                {
+                    return false;
+                }
+
+                // Finish filling in all fields
+                info.BeginAddress = BeginAddress;
+                info.UntilAddress = logicalAddress + allocatedLength;
+
+                var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
+
+                var entryBody = info.ToByteArray();
+                fixed (byte* bp = entryBody)
+                    Buffer.MemoryCopy(bp, (void*)(headerSize + physicalAddress), entryBody.Length, entryBody.Length);
+                SetCommitRecordHeader(entryBody.Length, (byte*)physicalAddress);
+            }
+            finally
             {
                 EndInflightEnqueue();
                 epoch.Suspend();
-                return false;
             }
-
-            // Finish filling in all fields
-            info.BeginAddress = BeginAddress;
-            info.UntilAddress = logicalAddress + allocatedLength;
-
-            var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
-
-            var entryBody = info.ToByteArray();
-            fixed (byte* bp = entryBody)
-                Buffer.MemoryCopy(bp, (void*)(headerSize + physicalAddress), entryBody.Length, entryBody.Length);
-            SetCommitRecordHeader(entryBody.Length, (byte*)physicalAddress);
-            EndInflightEnqueue();
-            epoch.Suspend();
             // Return the commit tail
             return true;
         }
@@ -3008,30 +3067,34 @@ namespace Tsavorite.core
             ValidateAllocatedLength(allocatedLength);
 
             epoch.Resume();
-            if (commitNum == long.MaxValue) throw new TsavoriteException("Attempting to enqueue into a completed log");
-
             BeginInflightEnqueue();
-            if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+            try
+            {
+                if (commitNum == long.MaxValue) throw new TsavoriteException("Attempting to enqueue into a completed log");
+
+                if (!allocator.TryAllocateRetryNow(allocatedLength, out logicalAddress))
+                {
+                    if (cannedException != null)
+                        throw cannedException;
+                    return false;
+                }
+
+                var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
+                for (var i = 0; i < totalEntries; i++)
+                {
+                    var span = readOnlySpanBatch.Get(i);
+                    var entryLength = span.Length;
+                    fixed (byte* bp = &span.GetPinnableReference())
+                        Buffer.MemoryCopy(bp, (void*)(headerSize + physicalAddress), entryLength, entryLength);
+                    SetHeader(entryLength, (byte*)physicalAddress);
+                    physicalAddress += Align(entryLength) + headerSize;
+                }
+            }
+            finally
             {
                 EndInflightEnqueue();
                 epoch.Suspend();
-                if (cannedException != null)
-                    throw cannedException;
-                return false;
             }
-
-            var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
-            for (var i = 0; i < totalEntries; i++)
-            {
-                var span = readOnlySpanBatch.Get(i);
-                var entryLength = span.Length;
-                fixed (byte* bp = &span.GetPinnableReference())
-                    Buffer.MemoryCopy(bp, (void*)(headerSize + physicalAddress), entryLength, entryLength);
-                SetHeader(entryLength, (byte*)physicalAddress);
-                physicalAddress += Align(entryLength) + headerSize;
-            }
-            EndInflightEnqueue();
-            epoch.Suspend();
             if (autoCommit) Commit();
             return true;
         }

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanIterator.cs
@@ -748,7 +748,9 @@ namespace Tsavorite.core
                 if (disposed)
                     return false;
 
-                if ((currentAddress >= endAddress) || (currentAddress >= (scanUncommitted ? tsavoriteLog.RefreshSafeTailAddress() : tsavoriteLog.CommittedUntilAddress)))
+                // Use the cached SafeTailAddress for the hot path. Refresh only happens when the
+                // iterator catches up to the cache, via WaitAsync / SlowWaitUncommittedAsync.
+                if ((currentAddress >= endAddress) || (currentAddress >= (scanUncommitted ? tsavoriteLog.SafeTailAddress : tsavoriteLog.CommittedUntilAddress)))
                     return false;
 
                 if (currentAddress < _headAddress)
@@ -866,7 +868,9 @@ namespace Tsavorite.core
                 if (disposed)
                     return false;
 
-                if ((currentAddress >= endAddress) || (currentAddress >= (scanUncommitted ? tsavoriteLog.RefreshSafeTailAddress() : tsavoriteLog.CommittedUntilAddress)))
+                // Use the cached SafeTailAddress for the hot path. Refresh only happens when the
+                // iterator catches up to the cache, via WaitAsync / SlowWaitUncommittedAsync.
+                if ((currentAddress >= endAddress) || (currentAddress >= (scanUncommitted ? tsavoriteLog.SafeTailAddress : tsavoriteLog.CommittedUntilAddress)))
                     return false;
 
                 if (currentAddress < _headAddress)

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanIterator.cs
@@ -748,20 +748,28 @@ namespace Tsavorite.core
                 if (disposed)
                     return false;
 
-                // For scanUncommitted: check cached SafeTailAddress first (O(1)). If caught up,
-                // spin-wait briefly to let producers advance tail and complete in-flight writes,
-                // then re-check the cache before falling back to the full epoch-table scan.
-                // At 15 Mops, ~150 enqueues complete during the spin, so the next ~150 GetNext
-                // calls use the cache (O(1)) — amortizing the scan cost to ~1ns/record.
-                if (scanUncommitted && currentAddress >= tsavoriteLog.SafeTailAddress)
-                {
-                    Thread.SpinWait(100);
-                    if (currentAddress >= tsavoriteLog.SafeTailAddress
-                        && currentAddress >= tsavoriteLog.RefreshSafeTailAddress())
-                        return false;
-                }
-                else if (currentAddress >= endAddress || currentAddress >= (scanUncommitted ? tsavoriteLog.SafeTailAddress : tsavoriteLog.CommittedUntilAddress))
+                if (currentAddress >= endAddress)
                     return false;
+
+                if (scanUncommitted)
+                {
+                    // Check cached SafeTailAddress first (O(1)). If caught up, spin briefly (~2-4μs /
+                    // 100 PAUSE instructions) to let producers complete in-flight writes, then re-check
+                    // cache (may have been advanced by multi-iterator pre-refresh or page-drive) before
+                    // falling back to the full epoch-table scan. At 15 Mops this batches ~30-60 records
+                    // per scan, amortizing the O(kTableSize) scan cost to ~1-3ns per record.
+                    if (currentAddress >= tsavoriteLog.SafeTailAddress)
+                    {
+                        Thread.SpinWait(100);
+                        if (currentAddress >= tsavoriteLog.SafeTailAddress
+                            && currentAddress >= tsavoriteLog.RefreshSafeTailAddress())
+                            return false;
+                    }
+                }
+                else if (currentAddress >= tsavoriteLog.CommittedUntilAddress)
+                {
+                    return false;
+                }
 
                 if (currentAddress < _headAddress)
                 {
@@ -878,15 +886,24 @@ namespace Tsavorite.core
                 if (disposed)
                     return false;
 
-                if (scanUncommitted && currentAddress >= tsavoriteLog.SafeTailAddress)
-                {
-                    Thread.SpinWait(100);
-                    if (currentAddress >= tsavoriteLog.SafeTailAddress
-                        && currentAddress >= tsavoriteLog.RefreshSafeTailAddress())
-                        return false;
-                }
-                else if (currentAddress >= endAddress || currentAddress >= (scanUncommitted ? tsavoriteLog.SafeTailAddress : tsavoriteLog.CommittedUntilAddress))
+                if (currentAddress >= endAddress)
                     return false;
+
+                if (scanUncommitted)
+                {
+                    // Same spin-wait + scan amortization as the primary GetNext path above.
+                    if (currentAddress >= tsavoriteLog.SafeTailAddress)
+                    {
+                        Thread.SpinWait(100);
+                        if (currentAddress >= tsavoriteLog.SafeTailAddress
+                            && currentAddress >= tsavoriteLog.RefreshSafeTailAddress())
+                            return false;
+                    }
+                }
+                else if (currentAddress >= tsavoriteLog.CommittedUntilAddress)
+                {
+                    return false;
+                }
 
                 if (currentAddress < _headAddress)
                 {

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanIterator.cs
@@ -144,7 +144,10 @@ namespace Tsavorite.core
                 return SlowWaitAsync(this, token);
             }
 
-            if (NextAddress < tsavoriteLog.SafeTailAddress || NextAddress < tsavoriteLog.RefreshSafeTailAddress())
+            // Check the cached SafeTailAddress only (O(1)). The more expensive
+            // RefreshSafeTailAddress scan is deferred to SlowWaitUncommittedAsync where
+            // per-iterator backoff logic can throttle scan frequency.
+            if (NextAddress < tsavoriteLog.SafeTailAddress)
                 return new ValueTask<bool>(true);
             return SlowWaitUncommittedAsync(token);
         }

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanIterator.cs
@@ -144,10 +144,7 @@ namespace Tsavorite.core
                 return SlowWaitAsync(this, token);
             }
 
-            // Check the cached SafeTailAddress only (O(1)). The more expensive
-            // RefreshSafeTailAddress scan is deferred to SlowWaitUncommittedAsync where
-            // per-iterator backoff logic can throttle scan frequency.
-            if (NextAddress < tsavoriteLog.SafeTailAddress)
+            if (NextAddress < tsavoriteLog.SafeTailAddress || NextAddress < tsavoriteLog.RefreshSafeTailAddress())
                 return new ValueTask<bool>(true);
             return SlowWaitUncommittedAsync(token);
         }
@@ -751,9 +748,13 @@ namespace Tsavorite.core
                 if (disposed)
                     return false;
 
-                // Use the cached SafeTailAddress for the hot path. Refresh only happens when the
-                // iterator catches up to the cache, via WaitAsync / SlowWaitUncommittedAsync.
-                if ((currentAddress >= endAddress) || (currentAddress >= (scanUncommitted ? tsavoriteLog.SafeTailAddress : tsavoriteLog.CommittedUntilAddress)))
+                // For scanUncommitted: check cached SafeTailAddress first (O(1)). Only scan the
+                // epoch table via RefreshSafeTailAddress when caught up to the cache, avoiding
+                // the O(kTableSize) scan on every record.
+                var boundary = scanUncommitted
+                    ? (currentAddress < tsavoriteLog.SafeTailAddress ? tsavoriteLog.SafeTailAddress : tsavoriteLog.RefreshSafeTailAddress())
+                    : tsavoriteLog.CommittedUntilAddress;
+                if (currentAddress >= endAddress || currentAddress >= boundary)
                     return false;
 
                 if (currentAddress < _headAddress)
@@ -871,9 +872,12 @@ namespace Tsavorite.core
                 if (disposed)
                     return false;
 
-                // Use the cached SafeTailAddress for the hot path. Refresh only happens when the
-                // iterator catches up to the cache, via WaitAsync / SlowWaitUncommittedAsync.
-                if ((currentAddress >= endAddress) || (currentAddress >= (scanUncommitted ? tsavoriteLog.SafeTailAddress : tsavoriteLog.CommittedUntilAddress)))
+                // For scanUncommitted: check cached SafeTailAddress first (O(1)). Only scan the
+                // epoch table via RefreshSafeTailAddress when caught up to the cache.
+                var boundary2 = scanUncommitted
+                    ? (currentAddress < tsavoriteLog.SafeTailAddress ? tsavoriteLog.SafeTailAddress : tsavoriteLog.RefreshSafeTailAddress())
+                    : tsavoriteLog.CommittedUntilAddress;
+                if (currentAddress >= endAddress || currentAddress >= boundary2)
                     return false;
 
                 if (currentAddress < _headAddress)

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanIterator.cs
@@ -748,13 +748,19 @@ namespace Tsavorite.core
                 if (disposed)
                     return false;
 
-                // For scanUncommitted: check cached SafeTailAddress first (O(1)). Only scan the
-                // epoch table via RefreshSafeTailAddress when caught up to the cache, avoiding
-                // the O(kTableSize) scan on every record.
-                var boundary = scanUncommitted
-                    ? (currentAddress < tsavoriteLog.SafeTailAddress ? tsavoriteLog.SafeTailAddress : tsavoriteLog.RefreshSafeTailAddress())
-                    : tsavoriteLog.CommittedUntilAddress;
-                if (currentAddress >= endAddress || currentAddress >= boundary)
+                // For scanUncommitted: check cached SafeTailAddress first (O(1)). If caught up,
+                // spin-wait briefly to let producers advance tail and complete in-flight writes,
+                // then re-check the cache before falling back to the full epoch-table scan.
+                // At 15 Mops, ~150 enqueues complete during the spin, so the next ~150 GetNext
+                // calls use the cache (O(1)) — amortizing the scan cost to ~1ns/record.
+                if (scanUncommitted && currentAddress >= tsavoriteLog.SafeTailAddress)
+                {
+                    Thread.SpinWait(100);
+                    if (currentAddress >= tsavoriteLog.SafeTailAddress
+                        && currentAddress >= tsavoriteLog.RefreshSafeTailAddress())
+                        return false;
+                }
+                else if (currentAddress >= endAddress || currentAddress >= (scanUncommitted ? tsavoriteLog.SafeTailAddress : tsavoriteLog.CommittedUntilAddress))
                     return false;
 
                 if (currentAddress < _headAddress)
@@ -872,12 +878,14 @@ namespace Tsavorite.core
                 if (disposed)
                     return false;
 
-                // For scanUncommitted: check cached SafeTailAddress first (O(1)). Only scan the
-                // epoch table via RefreshSafeTailAddress when caught up to the cache.
-                var boundary2 = scanUncommitted
-                    ? (currentAddress < tsavoriteLog.SafeTailAddress ? tsavoriteLog.SafeTailAddress : tsavoriteLog.RefreshSafeTailAddress())
-                    : tsavoriteLog.CommittedUntilAddress;
-                if (currentAddress >= endAddress || currentAddress >= boundary2)
+                if (scanUncommitted && currentAddress >= tsavoriteLog.SafeTailAddress)
+                {
+                    Thread.SpinWait(100);
+                    if (currentAddress >= tsavoriteLog.SafeTailAddress
+                        && currentAddress >= tsavoriteLog.RefreshSafeTailAddress())
+                        return false;
+                }
+                else if (currentAddress >= endAddress || currentAddress >= (scanUncommitted ? tsavoriteLog.SafeTailAddress : tsavoriteLog.CommittedUntilAddress))
                     return false;
 
                 if (currentAddress < _headAddress)

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanIterator.cs
@@ -144,7 +144,7 @@ namespace Tsavorite.core
                 return SlowWaitAsync(this, token);
             }
 
-            if (NextAddress < tsavoriteLog.SafeTailAddress)
+            if (NextAddress < tsavoriteLog.SafeTailAddress || NextAddress < tsavoriteLog.RefreshSafeTailAddress())
                 return new ValueTask<bool>(true);
             return SlowWaitUncommittedAsync(token);
         }
@@ -185,7 +185,7 @@ namespace Tsavorite.core
                     tcs ??= newTcs; // successful CAS so update the local var
                 }
 
-                if (NextAddress < tsavoriteLog.SafeTailAddress)
+                if (NextAddress < tsavoriteLog.SafeTailAddress || NextAddress < tsavoriteLog.RefreshSafeTailAddress())
                     return true;
 
                 // Ignore refresh-uncommitted exceptions, except when the token is signaled
@@ -748,7 +748,7 @@ namespace Tsavorite.core
                 if (disposed)
                     return false;
 
-                if ((currentAddress >= endAddress) || (currentAddress >= (scanUncommitted ? tsavoriteLog.SafeTailAddress : tsavoriteLog.CommittedUntilAddress)))
+                if ((currentAddress >= endAddress) || (currentAddress >= (scanUncommitted ? tsavoriteLog.RefreshSafeTailAddress() : tsavoriteLog.CommittedUntilAddress)))
                     return false;
 
                 if (currentAddress < _headAddress)
@@ -866,7 +866,7 @@ namespace Tsavorite.core
                 if (disposed)
                     return false;
 
-                if ((currentAddress >= endAddress) || (currentAddress >= (scanUncommitted ? tsavoriteLog.SafeTailAddress : tsavoriteLog.CommittedUntilAddress)))
+                if ((currentAddress >= endAddress) || (currentAddress >= (scanUncommitted ? tsavoriteLog.RefreshSafeTailAddress() : tsavoriteLog.CommittedUntilAddress)))
                     return false;
 
                 if (currentAddress < _headAddress)

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanSingleIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanSingleIterator.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -17,20 +15,6 @@ namespace Tsavorite.core
     public sealed class TsavoriteLogScanSingleIterator : TsavoriteLogScanIterator
     {
         readonly SingleWaiterAutoResetEvent onEnqueue;
-
-        /// <summary>Maximum backoff interval (in Stopwatch ticks) before re-scanning the epoch table.
-        /// Caps at 10ms to match the old baseline refresh frequency.</summary>
-        static readonly long MaxBackoffTicks = Stopwatch.Frequency / 100; // 10ms
-
-        /// <summary>Current backoff interval in Stopwatch ticks. Doubles on each scan that fails to
-        /// advance SafeTailAddress past NextAddress; resets to
-        /// zero when a scan succeeds or when new records are observed via the cached SafeTailAddress.
-        /// </summary>
-        long scanBackoffTicks;
-
-        /// <summary>Timestamp (via <see cref="Stopwatch.GetTimestamp"/>) at which the backoff expires
-        /// and the next scan is permitted.</summary>
-        long scanBackoffUntil;
 
         internal TsavoriteLogScanSingleIterator(TsavoriteLog TsavoriteLog, TsavoriteLogAllocatorImpl hlog, long beginAddress, long endAddress,
                 GetMemory getMemory, DiskScanBufferingMode scanBufferingMode, LightEpoch epoch, int headerSize, bool scanUncommitted = false, ILogger logger = null)
@@ -61,31 +45,9 @@ namespace Tsavorite.core
                     return false;
                 if (this.Ended) return false;
 
-                // Fast check: cached SafeTailAddress may already be ahead (e.g., another iterator
-                // or the multi-iterator pre-refresh in NotifyParkedWaiters advanced it).
-                if (this.NextAddress < this.tsavoriteLog.SafeTailAddress)
-                {
-                    scanBackoffTicks = 0; // data available — reset backoff
+                if (this.NextAddress < this.tsavoriteLog.SafeTailAddress
+                    || this.NextAddress < this.tsavoriteLog.RefreshSafeTailAddress())
                     return true;
-                }
-
-                // Scan the epoch table only if the backoff interval has elapsed. This limits scan
-                // frequency when the consumer is caught up and the producer is slow, capping at one
-                // scan per 10ms in the worst case (matching the old baseline refresh frequency).
-                if (Stopwatch.GetTimestamp() >= scanBackoffUntil)
-                {
-                    if (this.NextAddress < this.tsavoriteLog.RefreshSafeTailAddress())
-                    {
-                        scanBackoffTicks = 0; // scan advanced past NextAddress — reset backoff
-                        return true;
-                    }
-
-                    // Scan didn't help — double the backoff interval (starting from ~100μs).
-                    scanBackoffTicks = scanBackoffTicks == 0
-                        ? Stopwatch.Frequency / 10_000  // initial: ~100μs
-                        : Math.Min(scanBackoffTicks * 2, MaxBackoffTicks);
-                    scanBackoffUntil = Stopwatch.GetTimestamp() + scanBackoffTicks;
-                }
 
                 // Ignore refresh-uncommitted exceptions, except when the token is signaled
                 await onEnqueue.WaitAsync().ConfigureAwait(false);

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanSingleIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanSingleIterator.cs
@@ -45,7 +45,7 @@ namespace Tsavorite.core
                     return false;
                 if (this.Ended) return false;
 
-                if (this.NextAddress < this.tsavoriteLog.SafeTailAddress)
+                if (this.NextAddress < this.tsavoriteLog.SafeTailAddress || this.NextAddress < this.tsavoriteLog.RefreshSafeTailAddress())
                     return true;
 
                 // Ignore refresh-uncommitted exceptions, except when the token is signaled

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanSingleIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogScanSingleIterator.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -15,6 +17,20 @@ namespace Tsavorite.core
     public sealed class TsavoriteLogScanSingleIterator : TsavoriteLogScanIterator
     {
         readonly SingleWaiterAutoResetEvent onEnqueue;
+
+        /// <summary>Maximum backoff interval (in Stopwatch ticks) before re-scanning the epoch table.
+        /// Caps at 10ms to match the old baseline refresh frequency.</summary>
+        static readonly long MaxBackoffTicks = Stopwatch.Frequency / 100; // 10ms
+
+        /// <summary>Current backoff interval in Stopwatch ticks. Doubles on each scan that fails to
+        /// advance SafeTailAddress past NextAddress; resets to
+        /// zero when a scan succeeds or when new records are observed via the cached SafeTailAddress.
+        /// </summary>
+        long scanBackoffTicks;
+
+        /// <summary>Timestamp (via <see cref="Stopwatch.GetTimestamp"/>) at which the backoff expires
+        /// and the next scan is permitted.</summary>
+        long scanBackoffUntil;
 
         internal TsavoriteLogScanSingleIterator(TsavoriteLog TsavoriteLog, TsavoriteLogAllocatorImpl hlog, long beginAddress, long endAddress,
                 GetMemory getMemory, DiskScanBufferingMode scanBufferingMode, LightEpoch epoch, int headerSize, bool scanUncommitted = false, ILogger logger = null)
@@ -45,8 +61,31 @@ namespace Tsavorite.core
                     return false;
                 if (this.Ended) return false;
 
-                if (this.NextAddress < this.tsavoriteLog.SafeTailAddress || this.NextAddress < this.tsavoriteLog.RefreshSafeTailAddress())
+                // Fast check: cached SafeTailAddress may already be ahead (e.g., another iterator
+                // or the multi-iterator pre-refresh in NotifyParkedWaiters advanced it).
+                if (this.NextAddress < this.tsavoriteLog.SafeTailAddress)
+                {
+                    scanBackoffTicks = 0; // data available — reset backoff
                     return true;
+                }
+
+                // Scan the epoch table only if the backoff interval has elapsed. This limits scan
+                // frequency when the consumer is caught up and the producer is slow, capping at one
+                // scan per 10ms in the worst case (matching the old baseline refresh frequency).
+                if (Stopwatch.GetTimestamp() >= scanBackoffUntil)
+                {
+                    if (this.NextAddress < this.tsavoriteLog.RefreshSafeTailAddress())
+                    {
+                        scanBackoffTicks = 0; // scan advanced past NextAddress — reset backoff
+                        return true;
+                    }
+
+                    // Scan didn't help — double the backoff interval (starting from ~100μs).
+                    scanBackoffTicks = scanBackoffTicks == 0
+                        ? Stopwatch.Frequency / 10_000  // initial: ~100μs
+                        : Math.Min(scanBackoffTicks * 2, MaxBackoffTicks);
+                    scanBackoffUntil = Stopwatch.GetTimestamp() + scanBackoffTicks;
+                }
 
                 // Ignore refresh-uncommitted exceptions, except when the token is signaled
                 await onEnqueue.WaitAsync().ConfigureAwait(false);

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogSettings.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLogSettings.cs
@@ -131,11 +131,6 @@ namespace Tsavorite.core
         public bool TryRecoverLatest = true;
 
         /// <summary>
-        /// SafeTailAddress refresh frequency in milliseconds. -1 => disabled; 0 => immediate refresh after every enqueue, >1 => refresh period in milliseconds.
-        /// </summary>
-        public int SafeTailRefreshFrequencyMs = -1;
-
-        /// <summary>
         /// Whether we automatically commit the log as records are inserted
         /// </summary>
         public bool AutoCommit = false;

--- a/libs/storage/Tsavorite/cs/test/LogScanTests.cs
+++ b/libs/storage/Tsavorite/cs/test/LogScanTests.cs
@@ -101,7 +101,7 @@ namespace Tsavorite.test
             }
 
             // Wait for safe tail to catch up
-            while (logUncommitted.SafeTailAddress < logUncommitted.TailAddress)
+            while (logUncommitted.RefreshSafeTailAddress() < logUncommitted.TailAddress)
                 _ = Thread.Yield();
         }
 
@@ -393,7 +393,7 @@ namespace Tsavorite.test
             // Create log and device here (not in setup) because using DeviceType Enum which can't be used in Setup
             string filename = Path.Join(TestUtils.MethodTestDir, "LogScan" + deviceType.ToString() + ".log");
             device = TestUtils.CreateTestDevice(deviceType, filename);
-            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = TestUtils.MethodTestDir, SafeTailRefreshFrequencyMs = 0 });
+            log = new TsavoriteLog(new TsavoriteLogSettings { LogDevice = device, SegmentSizeBits = 22, LogCommitDir = TestUtils.MethodTestDir });
             PopulateUncommittedLog(log);
 
             // Setting scanUnCommitted to true is actual test here.

--- a/libs/storage/Tsavorite/cs/test/LogTests.cs
+++ b/libs/storage/Tsavorite/cs/test/LogTests.cs
@@ -122,7 +122,7 @@ namespace Tsavorite.test
         {
             AsyncByteVector,
             AsyncMemoryOwner,
-            Sync,
+            Sync
         }
 
         internal static bool IsAsync(IteratorType iterType) =>
@@ -665,8 +665,7 @@ namespace Tsavorite.test
                 PageSizeBits = 14,
                 LogChecksum = logChecksum,
                 LogCommitManager = manager,
-                TryRecoverLatest = false,
-                SafeTailRefreshFrequencyMs = 0
+                TryRecoverLatest = false
             };
             log = IsAsync(iteratorType) ? await TsavoriteLog.CreateAsync(logSettings).ConfigureAwait(false) : new TsavoriteLog(logSettings);
 
@@ -678,7 +677,7 @@ namespace Tsavorite.test
                 _ = log.Enqueue(data1);
 
             // Wait for safe tail to catch up
-            while (log.SafeTailAddress < log.TailAddress)
+            while (log.RefreshSafeTailAddress() < log.TailAddress)
                 await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
 
             ClassicAssert.AreEqual(log.TailAddress, log.SafeTailAddress);
@@ -727,7 +726,7 @@ namespace Tsavorite.test
             _ = log.Enqueue(data1);
 
             // Wait for safe tail to catch up
-            while (log.SafeTailAddress < log.TailAddress)
+            while (log.RefreshSafeTailAddress() < log.TailAddress)
                 await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
 
             await AssertGetNext(asyncByteVectorIter, asyncMemoryOwnerIter, iter, data1, verifyAtEnd: true).ConfigureAwait(false);
@@ -747,8 +746,7 @@ namespace Tsavorite.test
                 MemorySizeBits = 20,
                 PageSizeBits = 14,
                 LogChecksum = logChecksum,
-                LogCommitManager = manager,
-                SafeTailRefreshFrequencyMs = 0
+                LogCommitManager = manager
             });
             byte[] data1 = new byte[1000];
             for (int i = 0; i < 100; i++) data1[i] = (byte)i;
@@ -757,7 +755,7 @@ namespace Tsavorite.test
                 _ = log.Enqueue(data1);
 
             // Wait for safe tail to catch up
-            while (log.SafeTailAddress < log.TailAddress)
+            while (log.RefreshSafeTailAddress() < log.TailAddress)
                 await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
 
             ClassicAssert.AreEqual(log.TailAddress, log.SafeTailAddress);
@@ -806,7 +804,7 @@ namespace Tsavorite.test
                 _ = log.Enqueue(data1);
 
                 // Wait for safe tail to catch up
-                while (log.SafeTailAddress < log.TailAddress)
+                while (log.RefreshSafeTailAddress() < log.TailAddress)
                     await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
 
                 await AssertGetNext(asyncByteVectorIter, asyncMemoryOwnerIter, iter, data1, verifyAtEnd: true).ConfigureAwait(false);
@@ -948,8 +946,7 @@ namespace Tsavorite.test
                 MemorySizeBits = 20,
                 PageSizeBits = 14,
                 LogCommitManager = manager,
-                SegmentSizeBits = 22,
-                SafeTailRefreshFrequencyMs = 0
+                SegmentSizeBits = 22
             });
             byte[] data1 = new byte[1000];
             for (int i = 0; i < 100; i++)
@@ -959,7 +956,7 @@ namespace Tsavorite.test
                 _ = log.Enqueue(data1);
 
             // Wait for safe tail to catch up
-            while (log.SafeTailAddress < log.TailAddress)
+            while (log.RefreshSafeTailAddress() < log.TailAddress)
                 await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
 
             ClassicAssert.AreEqual(log.TailAddress, log.SafeTailAddress);
@@ -1008,7 +1005,7 @@ namespace Tsavorite.test
                 _ = log.Enqueue(data1);
 
                 // Wait for safe tail to catch up
-                while (log.SafeTailAddress < log.TailAddress)
+                while (log.RefreshSafeTailAddress() < log.TailAddress)
                     await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
 
                 await AssertGetNext(asyncByteVectorIter, asyncMemoryOwnerIter, iter, data1, verifyAtEnd: true).ConfigureAwait(false);


### PR DESCRIPTION
### Description of Change

Replaces TsavoriteLog's SafeTailAddress tracking — previously a background worker + epoch-bump design with a `SafeTailRefreshFrequencyMs` tuning knob — with a pull-based per-thread publish protocol using LightEpoch user-word slots. Eliminates the refresh-frequency tuning parameter that was a deployment pain point with multiple AOFs.

**LightEpoch user-word API** (`LightEpoch.cs`):
- Extend Entry (64-byte cache line) with 6 per-thread `long` user-word slots
- `AllocateUserWord(initialValue)` via CAS, `ThisThreadUserWord(idx)` for writes, `GetMinUserWord(idx)` for direct unsafe pointer scan
- Application owns slot lifecycle — no auto-reset on Acquire/Release

**TsavoriteLog inflight publish protocol** (`TsavoriteLog.cs`):
- Each enqueue: `BeginInflightEnqueue()` (publish TailAddress as lower bound) → allocate → payload write → `EndInflightEnqueue()` (write long.MaxValue sentinel, notify waiters)
- All enqueue variants wrapped in try/finally for exception safety
- `SafeTailAddress = min(TailAddress, min over inflight slots)`, computed via `RefreshSafeTailAddress()` with tail-first read + memory barrier + epoch-table scan
- Monotonically cached; fast-path skips scan when `tail <= cached`

**Iterator changes** (`TsavoriteLogScanIterator.cs`, `TsavoriteLogScanSingleIterator.cs`):
- GetNext checks cached SafeTailAddress first (O(1)), falls back to SpinWait + scan only when caught up
- `NotifyParkedWaiters` split into inline fast-path (two null checks) + NoInlining slow path for JIT friendliness
- Pre-refreshes cache when >1 iterator registered (avoids O(N) redundant scans with N replicas)

**Callback** (`SafeTailPageShiftCallback`):
- Renamed from `SafeTailShiftCallback`, page-coalesced (fires at most once per page transition)
- Invoked outside epoch protection; exceptions caught and logged (best-effort)
- Producer-side page-boundary CAS drive ensures callback progress even without active iterators

**Removed**:
- `SafeTailRefreshFrequencyMs` (TsavoriteLogSettings)
- `AofReplicationRefreshFrequencyMs` (GarnetServerOptions, Options, defaults.conf)
- `SubscriberRefreshFrequencyMs` (GarnetServerOptions, Options, defaults.conf, SubscribeBroker)
- Background worker task, Task.Delay allocations, epoch-bump refresh mechanism (~200 allocs/sec at idle)

### Benchmark

NullDevice, 16GB in-memory log, 64B entries, 10s measure, 1 ScanSingle uncommitted iterator (simulates replication):

| Producers | Baseline NoCons | PR NoCons | Baseline WithCons | PR WithCons |
|:---------:|:---:|:---:|:---:|:---:|
| 1 | 15.0 | 15.1 | 8.7 | 6.4 |
| 2 | 2.8 | **6.4** | 2.9 | **4.8** |
| 4 | 3.0 | **4.0** | 3.3 | **5.5** |
| 8 | 4.6 | 4.5 | 4.1 | **7.5** |

- 1T NoCons: equal (inflight protocol has negligible overhead)
- 1T WithCons: ~27% lower (inherent consumer-side scan cost; non-issue in production where consumer does real I/O)
- 2-8T: PR wins decisively — 2x at 2T NoCons, 65-83% better WithCons (no background worker epoch-bump contention)

### Key Technical Details

**Affected types:**
- `LightEpoch` — new user-word API (AllocateUserWord, ReleaseUserWord, ThisThreadUserWord, GetMinUserWord)
- `TsavoriteLog` — inflight publish protocol (Begin/End), RefreshSafeTailAddress, NotifyParkedWaiters, MaybeProducerDriveSafeTail
- `TsavoriteLogScanIterator` — cached SafeTailAddress boundary check with SpinWait amortization
- `TsavoriteLogScanSingleIterator` — simplified SlowWaitUncommittedAsync (signal-based wake)
- `AofSyncDriverStore` — renamed callback to SafeTailPageShiftCallback, removed redundant page-diff filter
- `GarnetLog` — updated SetLogShiftTailCallback to use SafeTailPageShiftCallback

### What NOT to Do (for future agents)

- ❌ **Don't use cached-only SafeTailAddress in GetNext without a scan fallback** — causes replication hangs when cache is stale and no one refreshes it
- ❌ **Don't call RefreshSafeTailAddress() on every GetNext** — O(kTableSize) scan per record consumed; catastrophic at low thread counts
- ❌ **Don't reset user-word slots in LightEpoch Acquire/Release** — adds overhead to every epoch Resume/Suspend; application manages its own slot lifecycle
- ❌ **Don't put complex logic (foreach, Interlocked) in NotifyParkedWaiters inline body** — JIT refuses to inline EndInflightEnqueue, dropping 1T throughput by ~20%
