### PR TITLE
Eliminate synthetic RMW for RI.SET/RI.DEL AOF logging

### DIFF
--- a/libs/server/Resp/RangeIndex/RangeIndexManager.cs
+++ b/libs/server/Resp/RangeIndex/RangeIndexManager.cs
@@ -43,19 +43,6 @@ namespace Garnet.server
         /// <summary>Size of the RangeIndex stub in bytes.</summary>
         internal const int IndexSizeBytes = RangeIndexStub.Size;
 
-        /// <summary>
-        /// Sentinel value for <see cref="StringInput.arg1"/> on synthetic RI.SET RMW writes.
-        /// IPU detects this sentinel and skips the no-op RMW body — the RMW exists solely
-        /// to create an AOF log entry that can be replayed on recovery.
-        /// </summary>
-        internal const long RISETAppendLogArg = -100;
-
-        /// <summary>
-        /// Sentinel value for <see cref="StringInput.arg1"/> on synthetic RI.DEL RMW writes.
-        /// Same pattern as <see cref="RISETAppendLogArg"/>.
-        /// </summary>
-        internal const long RIDELAppendLogArg = -101;
-
         /// <summary>Whether range index commands are enabled.</summary>
         public bool IsEnabled { get; }
 
@@ -460,41 +447,39 @@ namespace Garnet.server
         }
 
         /// <summary>
-        /// Inject a synthetic RMW for RI.SET to trigger AOF logging.
-        /// The RMW is a no-op in IPU (detected via <see cref="RISETAppendLogArg"/> sentinel) —
-        /// it exists solely to create an AOF entry that can be replayed on recovery.
+        /// Log RI.SET to AOF via direct enqueue (no synthetic RMW).
+        /// Skipped when <paramref name="storedProcMode"/> is true (stored procedure logs as a unit).
         /// </summary>
-        /// <param name="key">The Garnet key of the RangeIndex.</param>
-        /// <param name="field">The field (BfTree key) being set.</param>
-        /// <param name="value">The value being set.</param>
-        /// <param name="context">The string basic context for the RMW operation.</param>
-        internal void ReplicateRangeIndexSet(PinnedSpanByte key, PinnedSpanByte field, PinnedSpanByte value, ref StringBasicContext context)
+        internal void ReplicateRangeIndexSet(PinnedSpanByte key, PinnedSpanByte field, PinnedSpanByte value,
+            TsavoriteLog appendOnlyFile, long version, int sessionId, bool storedProcMode)
         {
+            if (appendOnlyFile == null || storedProcMode) return;
+
             var replicateParseState = new SessionParseState();
             replicateParseState.InitializeWithArguments(field, value);
-            var input = new StringInput(RespCommand.RISET, ref replicateParseState, arg1: RISETAppendLogArg);
-            var output = new StringOutput();
-            var status = context.RMW((FixedSpanByteKey)key, ref input, ref output);
-            if (status.IsPending)
-                StorageSession.CompletePendingForSession(ref status, ref output, ref context);
+            var input = new StringInput(RespCommand.RISET, ref replicateParseState);
+            input.header.flags |= RespInputFlags.Deterministic;
+            appendOnlyFile.Enqueue(
+                new AofHeader { opType = AofEntryType.StoreRMW, storeVersion = version, sessionID = sessionId },
+                key.ReadOnlySpan, ref input, out _);
         }
 
         /// <summary>
-        /// Inject a synthetic RMW for RI.DEL to trigger AOF logging.
-        /// Same pattern as <see cref="ReplicateRangeIndexSet"/>: no-op in IPU, logged to AOF.
+        /// Log RI.DEL to AOF via direct enqueue (no synthetic RMW).
+        /// Skipped when <paramref name="storedProcMode"/> is true (stored procedure logs as a unit).
         /// </summary>
-        /// <param name="key">The Garnet key of the RangeIndex.</param>
-        /// <param name="field">The field (BfTree key) being deleted.</param>
-        /// <param name="context">The string basic context for the RMW operation.</param>
-        internal void ReplicateRangeIndexDel(PinnedSpanByte key, PinnedSpanByte field, ref StringBasicContext context)
+        internal void ReplicateRangeIndexDel(PinnedSpanByte key, PinnedSpanByte field,
+            TsavoriteLog appendOnlyFile, long version, int sessionId, bool storedProcMode)
         {
+            if (appendOnlyFile == null || storedProcMode) return;
+
             var replicateParseState = new SessionParseState();
             replicateParseState.InitializeWithArgument(field);
-            var input = new StringInput(RespCommand.RIDEL, ref replicateParseState, arg1: RIDELAppendLogArg);
-            var output = new StringOutput();
-            var status = context.RMW((FixedSpanByteKey)key, ref input, ref output);
-            if (status.IsPending)
-                StorageSession.CompletePendingForSession(ref status, ref output, ref context);
+            var input = new StringInput(RespCommand.RIDEL, ref replicateParseState);
+            input.header.flags |= RespInputFlags.Deterministic;
+            appendOnlyFile.Enqueue(
+                new AofHeader { opType = AofEntryType.StoreRMW, storeVersion = version, sessionID = sessionId },
+                key.ReadOnlySpan, ref input, out _);
         }
 
         /// <summary>

--- a/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
@@ -771,13 +771,6 @@ namespace Garnet.server
                 return;
             }
 
-            // Skip logging for normal RISET/RIDEL (they use the native BfTree directly, not RMW).
-            // Only log the synthetic replication writes (marked with AppendLogArg).
-            if (input.header.cmd == RespCommand.RISET && input.arg1 != RangeIndexManager.RISETAppendLogArg)
-                return;
-            if (input.header.cmd == RespCommand.RIDEL && input.arg1 != RangeIndexManager.RIDELAppendLogArg)
-                return;
-
             input.header.flags |= RespInputFlags.Deterministic;
 
             functionsState.appendOnlyFile.Enqueue(

--- a/libs/server/Storage/Functions/MainStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/RMWMethods.cs
@@ -51,10 +51,6 @@ namespace Garnet.server
                     return false; // Key must already exist; don't create new
                 case RespCommand.RIRESTORE:
                     return false; // Key must already exist
-                case RespCommand.RISET:
-                    return false; // Tree must exist for SET
-                case RespCommand.RIDEL:
-                    return false; // Tree must exist for DEL
                 default:
                     if (input.header.cmd > RespCommandExtensions.LastValidCommand)
                     {
@@ -1103,25 +1099,16 @@ namespace Garnet.server
                     ETagState.ResetState(ref functionsState.etagState);
                     return IPUResult.NotUpdated;
                 case RespCommand.RIPROMOTE:
-                    // Record is in mutable region — it should never have the flushed flag set
-                    // because OnFlushRecord only runs when pages move to read-only.
+                    // Record is in mutable region — no-op. Not logged to AOF (internal maintenance).
                     Debug.Assert(!RangeIndexManager.ReadIndex(logRecord.ValueSpan).IsFlushed,
                         "Mutable record should never have Flushed flag set");
                     ETagState.ResetState(ref functionsState.etagState);
-                    return IPUResult.Succeeded;
+                    return IPUResult.NotUpdated;
                 case RespCommand.RIRESTORE:
-                    // Set the TreeHandle from the restored BfTree pointer (passed via input.arg1).
+                    // Set the TreeHandle from the restored BfTree pointer. Not logged to AOF (transient pointer).
                     RangeIndexManager.RecreateIndex((nint)input.arg1, logRecord.ValueSpan);
                     ETagState.ResetState(ref functionsState.etagState);
-                    return IPUResult.Succeeded;
-                case RespCommand.RISET:
-                    // Synthetic write for AOF logging — the actual insert was done via native BfTree
-                    ETagState.ResetState(ref functionsState.etagState);
-                    return IPUResult.Succeeded;
-                case RespCommand.RIDEL:
-                    // Synthetic write for AOF logging — the actual delete was done via native BfTree
-                    ETagState.ResetState(ref functionsState.etagState);
-                    return IPUResult.Succeeded;
+                    return IPUResult.NotUpdated;
             }
 
             // increment the Etag transparently if in place update happened
@@ -1243,10 +1230,6 @@ namespace Garnet.server
                     return true;
                 case RespCommand.RIRESTORE:
                     // Copy to tail if needed, then IPU will set TreeHandle
-                    return true;
-                case RespCommand.RISET:
-                case RespCommand.RIDEL:
-                    // Copy to tail so synthetic AOF write can be logged
                     return true;
                 default:
                     if (input.header.cmd > RespCommandExtensions.LastValidCommand)
@@ -1786,19 +1769,6 @@ namespace Garnet.server
                         dataHeader.RecordType = RangeIndexManager.RangeIndexRecordType;
                     }
                     break;
-                case RespCommand.RISET:
-                case RespCommand.RIDEL:
-                    {
-                        // Synthetic write for AOF logging — just copy the stub bytes unchanged
-                        var srcValue = srcLogRecord.ValueSpan;
-                        if (!dstLogRecord.TrySetContentLengths(RangeIndexManager.IndexSizeBytes, in sizeInfo))
-                            return false;
-                        srcValue.CopyTo(dstLogRecord.ValueSpan);
-
-                        var dataHeader = dstLogRecord.RecordDataHeader;
-                        dataHeader.RecordType = RangeIndexManager.RangeIndexRecordType;
-                    }
-                    break;
             }
 
 
@@ -1824,14 +1794,18 @@ namespace Garnet.server
             where TSourceLogRecord : ISourceLogRecord
         {
             functionsState.watchVersionMap.IncrementVersion(rmwInfo.KeyHash);
-            if (functionsState.appendOnlyFile != null)
-                rmwInfo.UserData |= NeedAofLog; // Mark that we need to write to AOF
+
+            var cmd = input.header.cmd;
+
+            // RIPROMOTE/RIRESTORE are internal store-maintenance ops — skip AOF.
+            if (cmd != RespCommand.RIPROMOTE && cmd != RespCommand.RIRESTORE)
+            {
+                if (functionsState.appendOnlyFile != null)
+                    rmwInfo.UserData |= NeedAofLog;
+            }
 
             // Clear source TreeHandle after CAS success for RIPROMOTE.
-            // This prevents eviction of the old record from freeing the BfTree
-            // that the new record now owns. Done here (not in CopyUpdater) so
-            // CAS failure doesn't orphan the tree.
-            if (input.header.cmd == RespCommand.RIPROMOTE)
+            if (cmd == RespCommand.RIPROMOTE)
                 RangeIndexManager.ClearTreeHandle(srcLogRecord.ValueSpan);
 
             return true;

--- a/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/VarLenInputMethods.cs
@@ -185,8 +185,6 @@ namespace Garnet.server
                 case RespCommand.RICREATE:
                 case RespCommand.RIPROMOTE:
                 case RespCommand.RIRESTORE:
-                case RespCommand.RISET:
-                case RespCommand.RIDEL:
                     fieldInfo.ValueSize = RangeIndexManager.IndexSizeBytes;
                     return fieldInfo;
 
@@ -351,8 +349,6 @@ namespace Garnet.server
                     case RespCommand.RICREATE:
                     case RespCommand.RIPROMOTE:
                     case RespCommand.RIRESTORE:
-                    case RespCommand.RISET:
-                    case RespCommand.RIDEL:
                         fieldInfo.ValueSize = RangeIndexManager.IndexSizeBytes;
                         return fieldInfo;
 

--- a/libs/server/Storage/Session/MainStore/RangeIndexOps.cs
+++ b/libs/server/Storage/Session/MainStore/RangeIndexOps.cs
@@ -233,8 +233,10 @@ namespace Garnet.server
 
                 result = RangeIndexResult.OK;
 
-                // Inject synthetic RMW for AOF logging
-                functionsState.rangeIndexManager.ReplicateRangeIndexSet(key, field, value, ref stringBasicContext);
+                functionsState.rangeIndexManager.ReplicateRangeIndexSet(
+                    key, field, value, functionsState.appendOnlyFile,
+                    stringBasicContext.Session.Version, stringBasicContext.Session.ID,
+                    functionsState.StoredProcMode);
 
                 return GarnetStatus.OK;
             }
@@ -413,8 +415,10 @@ namespace Garnet.server
                 BfTreeService.DeleteByPtr(treePtr, field);
                 result = RangeIndexResult.OK;
 
-                // Inject synthetic RMW for AOF logging
-                functionsState.rangeIndexManager.ReplicateRangeIndexDel(key, field, ref stringBasicContext);
+                functionsState.rangeIndexManager.ReplicateRangeIndexDel(
+                    key, field, functionsState.appendOnlyFile,
+                    stringBasicContext.Session.Version, stringBasicContext.Session.ID,
+                    functionsState.StoredProcMode);
 
                 return GarnetStatus.OK;
             }

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -1030,12 +1030,40 @@ namespace Tsavorite.core
         }
 
         /// <summary>
-        /// Append a user-defined blittable struct header and three <see cref="ReadOnlySpan{_byte_}"/> entries entries atomically to the log.
+        /// Append a user-defined blittable struct header, one <see cref="ReadOnlySpan{_byte_}"/> entry, and one <see cref="IStoreInput"/> atomically to the log.
         /// </summary>
-        /// <param name="userHeader"></param>
-        /// <param name="item1"></param>
-        /// <param name="input"></param>
-        /// <param name="logicalAddress">Logical address of added entry</param>
+        public unsafe void Enqueue<THeader, TInput>(THeader userHeader, ReadOnlySpan<byte> item1, ref TInput input, out long logicalAddress)
+            where THeader : unmanaged where TInput : IStoreInput
+        {
+            logicalAddress = 0;
+            var length = sizeof(THeader) + item1.TotalSize() + input.SerializedLength;
+            var allocatedLength = headerSize + Align(length);
+            ValidateAllocatedLength(allocatedLength);
+
+            epoch.Resume();
+            try
+            {
+                logicalAddress = AllocateBlock(allocatedLength);
+                var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
+                *(THeader*)(physicalAddress + headerSize) = userHeader;
+                var offset = headerSize + sizeof(THeader);
+                item1.SerializeTo(new Span<byte>(physicalAddress + offset, allocatedLength - offset));
+                offset += item1.TotalSize();
+                _ = input.CopyTo(physicalAddress + offset, input.SerializedLength);
+                SetHeader(length, physicalAddress);
+                safeTailRefreshEntryEnqueued?.Signal();
+            }
+            finally
+            {
+                epoch.Suspend();
+            }
+            if (autoCommit)
+                Commit();
+        }
+
+        /// <summary>
+        /// Append a user-defined blittable struct header, one <see cref="ReadOnlySpan{_byte_}"/> entry, and one <see cref="IStoreInput"/> atomically to the log.
+        /// </summary>
         public unsafe void Enqueue<THeader, TInput, TEpochAccessor>(THeader userHeader, ReadOnlySpan<byte> item1, ref TInput input, TEpochAccessor epochAccessor, out long logicalAddress)
             where THeader : unmanaged where TInput : IStoreInput
             where TEpochAccessor : IEpochAccessor

--- a/test/Garnet.test/RespRangeIndexTests.cs
+++ b/test/Garnet.test/RespRangeIndexTests.cs
@@ -359,8 +359,7 @@ namespace Garnet.test
                 db.Execute("RI.SET", "aoftest", "key3", "val3");
 
                 // Checkpoint to establish base state
-                db.Execute("BGSAVE");
-                Thread.Sleep(500);
+                db.Execute("SAVE");
 
                 // Post-checkpoint mutations — these are only in the AOF
                 db.Execute("RI.SET", "aoftest", "key4", "val4");
@@ -1071,8 +1070,7 @@ namespace Garnet.test
                 ClassicAssert.AreEqual("value-alpha", (string)val);
 
                 // Take checkpoint via BGSAVE
-                db.Execute("BGSAVE");
-                Thread.Sleep(500); // Wait for checkpoint to complete
+                db.Execute("SAVE");
             }
 
             // Dispose and recover
@@ -1152,8 +1150,7 @@ namespace Garnet.test
                 ClassicAssert.AreEqual("val-ccc", (string)val, "Post-promote insert should survive eviction");
 
                 // Take checkpoint
-                db.Execute("BGSAVE");
-                Thread.Sleep(500);
+                db.Execute("SAVE");
             }
 
             // Recover
@@ -1258,8 +1255,7 @@ namespace Garnet.test
                 }
 
                 // Checkpoint
-                db.Execute("BGSAVE");
-                Thread.Sleep(500);
+                db.Execute("SAVE");
             }
 
             // Recover
@@ -1326,8 +1322,7 @@ namespace Garnet.test
                 db.Execute("RI.SET", "fpcp", "before-flush", "updated");
 
                 // Checkpoint should capture the mutated state
-                db.Execute("BGSAVE");
-                Thread.Sleep(500);
+                db.Execute("SAVE");
             }
 
             // Recover
@@ -1427,8 +1422,7 @@ namespace Garnet.test
                 db.Execute("RI.SET", "dblflush", "round3", "value-r3");
 
                 // Checkpoint
-                db.Execute("BGSAVE");
-                Thread.Sleep(500);
+                db.Execute("SAVE");
             }
 
             // Recover
@@ -1489,8 +1483,7 @@ namespace Garnet.test
                 db.Execute("RI.SET", "evictcp", "post-restore", "added");
 
                 // Checkpoint
-                db.Execute("BGSAVE");
-                Thread.Sleep(500);
+                db.Execute("SAVE");
             }
 
             // Recover
@@ -1533,16 +1526,14 @@ namespace Garnet.test
                 db.Execute("RI.SET", "twockpt", "key-bravo", "val-bravo");
 
                 // Checkpoint 1
-                db.Execute("BGSAVE");
-                Thread.Sleep(500);
+                db.Execute("SAVE");
 
                 // Phase 2: insert additional data + update existing
                 db.Execute("RI.SET", "twockpt", "key-charlie", "val-charlie");
                 db.Execute("RI.SET", "twockpt", "key-alpha", "val-alpha-v2");
 
                 // Checkpoint 2
-                db.Execute("BGSAVE");
-                Thread.Sleep(500);
+                db.Execute("SAVE");
             }
 
             // Recover — should get latest checkpoint (checkpoint 2)
@@ -1595,8 +1586,7 @@ namespace Garnet.test
                 db.Execute("RI.SET", "earlyck", "key-B", "val-B");
 
                 // Checkpoint
-                db.Execute("BGSAVE");
-                Thread.Sleep(500);
+                db.Execute("SAVE");
 
                 // Phase 2: add more data AFTER checkpoint (logged to AOF)
                 db.Execute("RI.SET", "earlyck", "key-A", "val-A-updated");
@@ -1648,8 +1638,7 @@ namespace Garnet.test
                 db.Execute("RI.SET", "delafter", "key1", "val1");
                 ClassicAssert.AreEqual(1, rangeIndexManager.LiveIndexCount);
 
-                db.Execute("BGSAVE");
-                Thread.Sleep(500);
+                db.Execute("SAVE");
             }
 
             // Recover


### PR DESCRIPTION
Replace the synthetic no-op RMW path (RangeIndexManager.ReplicateRangeIndexSet/Del) with direct appendOnlyFile.Enqueue at the call site in RangeIndexOps. This avoids the overhead of a full Tsavorite RMW (hash lookup, epoch acquire, IPU/CopyUpdater, PostRMW) just to create an AOF entry.

The AOF entry format is unchanged (AofHeader + key + StringInput with RISET/RIDEL command), so replay via AofProcessor.HandleRangeIndexSetReplay/DelReplay works without modification.

Added a non-epoch Enqueue<THeader, TInput> overload to TsavoriteLog that uses the log's internal epoch (same as other non-epoch Enqueue overloads).

Removed:
- ReplicateRangeIndexSet/Del methods from RangeIndexManager
- RISETAppendLogArg/RIDELAppendLogArg sentinel constants
- RISET/RIDEL cases from NeedInitialUpdate, NeedCopyUpdate, InPlaceUpdater, CopyUpdater, VarLenInputMethods (all dead code now)
- RISET/RIDEL exclusion from WriteLogRMW (no longer goes through RMW)

Also skip AOF for RIPROMOTE/RIRESTORE (internal store-maintenance ops).