### PR TITLE
[dev] Add INFO COMMANDSTATS tracking with per-command success rates

### DIFF
--- a/libs/common/Metrics/InfoMetricsType.cs
+++ b/libs/common/Metrics/InfoMetricsType.cs
@@ -74,6 +74,10 @@ namespace Garnet.common
         /// Scan and return distribution of in-memory portion of hybrid logs
         /// </summary>
         HLOGSCAN,
+        /// <summary>
+        /// Per-command usage statistics (calls, failures, rejections)
+        /// </summary>
+        COMMANDSTATS,
     }
 
     /// <summary>

--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -311,6 +311,10 @@ namespace Garnet
         [Option("latency-monitor", Required = false, HelpText = "Track latency of various events.")]
         public bool? LatencyMonitor { get; set; }
 
+        [OptionValidation]
+        [Option("commandstats-monitor", Required = false, HelpText = "Track per-command usage statistics (calls, failures, rejections). Exposed via INFO COMMANDSTATS.")]
+        public bool? CommandStatsMonitor { get; set; }
+
         [IntRangeValidation(0, int.MaxValue)]
         [Option("slowlog-log-slower-than", Required = false, HelpText = "Threshold (microseconds) for logging command in the slow log. 0 to disable.")]
         public int SlowLogThreshold { get; set; }
@@ -862,6 +866,7 @@ namespace Garnet
                     ServerCertificateRequired.GetValueOrDefault(),
                     logger: logger) : null,
                 LatencyMonitor = LatencyMonitor.GetValueOrDefault(),
+                CommandStatsMonitor = CommandStatsMonitor.GetValueOrDefault(),
                 SlowLogThreshold = SlowLogThreshold,
                 SlowLogMaxEntries = SlowLogMaxEntries,
                 MetricsSamplingFrequency = MetricsSamplingFrequency,

--- a/libs/host/Configuration/Redis/RedisOptions.cs
+++ b/libs/host/Configuration/Redis/RedisOptions.cs
@@ -83,6 +83,9 @@ Specify your subject name via the cert-subject-name command line argument, if ap
         [RedisOption("latency-tracking", nameof(Options.LatencyMonitor))]
         public Option<RedisBoolean> LatencyTracking { get; set; }
 
+        [RedisOption("commandstats-tracking", nameof(Options.CommandStatsMonitor))]
+        public Option<RedisBoolean> CommandStatsTracking { get; set; }
+
         [RedisOption("loglevel", nameof(Options.LogLevel))]
         public Option<RedisLogLevel> LogLevel { get; set; }
 

--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -224,6 +224,9 @@
 	/* Track latency of various events. */
 	"LatencyMonitor" : false,
 
+	/* Track per-command usage statistics (calls, failures, rejections). Exposed via INFO COMMANDSTATS. */
+	"CommandStatsMonitor" : false,
+
 	/* Threshold (microseconds) for logging command in the slow log. 0 to disable. */
 	"SlowLogThreshold": 0,
 

--- a/libs/server/Metrics/CommandStats.cs
+++ b/libs/server/Metrics/CommandStats.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Garnet.server
+{
+    /// <summary>
+    /// Per-command statistics entry tracking calls, failures, and rejections.
+    /// Follows the Redis COMMANDSTATS convention.
+    /// </summary>
+    public struct CommandStatsEntry
+    {
+        /// <summary>
+        /// Total number of times this command was called.
+        /// </summary>
+        public ulong Calls;
+
+        /// <summary>
+        /// Total number of times this command failed (returned an error response).
+        /// </summary>
+        public ulong FailedCalls;
+
+        /// <summary>
+        /// Total number of times this command was rejected before execution (e.g., ACL denied, OOM).
+        /// </summary>
+        public ulong RejectedCalls;
+    }
+
+    /// <summary>
+    /// Tracks per-command usage statistics for built-in commands.
+    /// Array-indexed by RespCommand enum value for O(1) access.
+    /// Each session owns its own instance (single-writer, no locking needed).
+    /// </summary>
+    public class CommandStats
+    {
+        /// <summary>
+        /// Number of entries in the stats array, sized to hold all valid RespCommand values.
+        /// </summary>
+        internal static readonly int EntryCount = (int)RespCommandExtensions.LastValidCommand + 1;
+
+        /// <summary>
+        /// Per-command statistics entries indexed by (int)RespCommand.
+        /// </summary>
+        internal CommandStatsEntry[] entries;
+
+        /// <summary>
+        /// Creates a new CommandStats instance with zeroed entries.
+        /// </summary>
+        public CommandStats()
+        {
+            entries = new CommandStatsEntry[EntryCount];
+        }
+
+        /// <summary>
+        /// Increment the calls counter for the given command.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void IncrementCalls(RespCommand cmd)
+        {
+            ushort idx = (ushort)cmd;
+            if (idx < entries.Length)
+                entries[idx].Calls++;
+        }
+
+        /// <summary>
+        /// Increment the failed calls counter for the given command.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void IncrementFailed(RespCommand cmd)
+        {
+            ushort idx = (ushort)cmd;
+            if (idx < entries.Length)
+                entries[idx].FailedCalls++;
+        }
+
+        /// <summary>
+        /// Increment the rejected calls counter for the given command.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void IncrementRejected(RespCommand cmd)
+        {
+            ushort idx = (ushort)cmd;
+            if (idx < entries.Length)
+                entries[idx].RejectedCalls++;
+        }
+
+        /// <summary>
+        /// Get the stats entry for the given command.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public CommandStatsEntry GetEntry(RespCommand cmd)
+        {
+            ushort idx = (ushort)cmd;
+            if (idx < entries.Length)
+                return entries[idx];
+            return default;
+        }
+
+        /// <summary>
+        /// Add another CommandStats instance into this one (for aggregation).
+        /// </summary>
+        internal void Add(CommandStats other)
+        {
+            if (other?.entries == null)
+                return;
+
+            int len = Math.Min(entries.Length, other.entries.Length);
+            for (int i = 0; i < len; i++)
+            {
+                entries[i].Calls += other.entries[i].Calls;
+                entries[i].FailedCalls += other.entries[i].FailedCalls;
+                entries[i].RejectedCalls += other.entries[i].RejectedCalls;
+            }
+        }
+
+        /// <summary>
+        /// Reset all entries to zero.
+        /// </summary>
+        internal void Reset()
+        {
+            Array.Clear(entries, 0, entries.Length);
+        }
+
+    }
+}

--- a/libs/server/Metrics/GarnetServerMetrics.cs
+++ b/libs/server/Metrics/GarnetServerMetrics.cs
@@ -35,7 +35,17 @@ namespace Garnet.server
         /// </summary>
         public readonly GarnetLatencyMetrics globalLatencyMetrics;
 
-        public GarnetServerMetrics(bool trackStats, bool trackLatency, GarnetServerMonitor monitor)
+        /// <summary>
+        /// Global per-command usage statistics (calls, failures, rejections).
+        /// </summary>
+        public CommandStats globalCommandStats;
+
+        /// <summary>
+        /// History of per-command usage statistics from disposed sessions.
+        /// </summary>
+        public CommandStats historyCommandStats;
+
+        public GarnetServerMetrics(bool trackStats, bool trackLatency, bool trackCommandStats, GarnetServerMonitor monitor)
         {
             total_connections_received = 0;
             total_connections_disposed = 0;
@@ -49,6 +59,9 @@ namespace Garnet.server
             historySessionMetrics = trackStats ? new GarnetSessionMetrics() : null;
 
             globalLatencyMetrics = trackLatency ? new() : null;
+
+            globalCommandStats = trackCommandStats ? new CommandStats() : null;
+            historyCommandStats = trackCommandStats ? new CommandStats() : null;
         }
 
         public void Dispose()

--- a/libs/server/Metrics/GarnetServerMonitor.cs
+++ b/libs/server/Metrics/GarnetServerMonitor.cs
@@ -20,7 +20,7 @@ namespace Garnet.server
     internal sealed class GarnetServerMonitor
     {
         public readonly Dictionary<InfoMetricsType, bool>
-            resetEventFlags = GarnetInfoMetrics.DefaultInfo.ToDictionary(x => x, y => false);
+            resetEventFlags = Enum.GetValues<InfoMetricsType>().ToDictionary(x => x, y => false);
 
         public readonly Dictionary<LatencyMetricsType, bool>
             resetLatencyMetrics = GarnetLatencyMetrics.defaultLatencyTypes.ToDictionary(x => x, y => false);
@@ -33,16 +33,19 @@ namespace Garnet.server
 
         GarnetServerMetrics globalMetrics;
         readonly GarnetSessionMetrics accSessionMetrics;
+        readonly CommandStats accCommandStats;
         private ulong instant_input_net_bytes;
         private ulong instant_output_net_bytes;
         private ulong instant_commands_processed;
 
         readonly CancellationTokenSource cts = new();
-        readonly ManualResetEvent done = new(false);
+        readonly ManualResetEvent done = new(true);
 
         readonly ILogger logger;
 
         public GarnetServerMetrics GlobalMetrics => globalMetrics;
+
+        internal IGarnetServer[] Servers => servers;
 
         SingleWriterMultiReaderLock rwLock = new();
 
@@ -58,9 +61,10 @@ namespace Garnet.server
             instant_input_net_bytes = 0;
             instant_output_net_bytes = 0;
             instant_commands_processed = 0;
-            globalMetrics = new(true, opts.LatencyMonitor, this);
+            globalMetrics = new(true, opts.LatencyMonitor, opts.CommandStatsMonitor, this);
 
             accSessionMetrics = new GarnetSessionMetrics();
+            accCommandStats = opts.CommandStatsMonitor ? new CommandStats() : null;
         }
 
         public void Dispose()
@@ -74,16 +78,23 @@ namespace Garnet.server
 
         public void Start()
         {
-            Task.Run(() => MainMonitorTask(cts.Token));
+            // Only run the periodic sampling task if a sampling frequency is configured.
+            // The monitor may be created solely for command stats history (without periodic sampling).
+            if (monitorSamplingFrequency > TimeSpan.Zero)
+            {
+                done.Reset();
+                Task.Run(() => MainMonitorTask(cts.Token));
+            }
         }
 
-        public void AddMetricsHistorySessionDispose(GarnetSessionMetrics currSessionMetrics, GarnetLatencyMetricsSession currLatencyMetrics)
+        public void AddMetricsHistorySessionDispose(GarnetSessionMetrics currSessionMetrics, GarnetLatencyMetricsSession currLatencyMetrics, CommandStats currCommandStats = null)
         {
             rwLock.WriteLock();
             try
             {
                 if (currSessionMetrics != null) globalMetrics.historySessionMetrics.Add(currSessionMetrics);
                 if (currLatencyMetrics != null) globalMetrics.globalLatencyMetrics.Merge(currLatencyMetrics);
+                if (currCommandStats != null) globalMetrics.historyCommandStats?.Add(currCommandStats);
                 currLatencyMetrics?.Return();
             }
             finally { rwLock.WriteUnlock(); }
@@ -133,6 +144,12 @@ namespace Garnet.server
                 // Accumulate session metrics
                 accSessionMetrics.Add(session.GetSessionMetrics);
 
+                // Accumulate command stats if enabled
+                if (accCommandStats != null)
+                {
+                    accCommandStats.Add(session.GetCommandStats);
+                }
+
                 // Accumulate latency metrics if latency monitor is enabled
                 if (opts.LatencyMonitor)
                 {
@@ -154,6 +171,12 @@ namespace Garnet.server
             // Add accumulated session metrics for this iteration
             globalMetrics.globalSessionMetrics.Add(accSessionMetrics);
 
+            // Reset global command stats and add accumulated for this iteration
+            if (accCommandStats != null)
+            {
+                globalMetrics.globalCommandStats.Reset();
+                globalMetrics.globalCommandStats.Add(accCommandStats);
+            }
         }
 
         private void CleanupGlobalStats()
@@ -188,6 +211,24 @@ namespace Garnet.server
                 storeWrapper.ResetRevivificationStats();
 
                 resetEventFlags[InfoMetricsType.STATS] = false;
+            }
+
+            if (resetEventFlags.TryGetValue(InfoMetricsType.COMMANDSTATS, out bool resetCommandStats) && resetCommandStats)
+            {
+                logger?.LogInformation("Resetting command stats");
+                globalMetrics.globalCommandStats?.Reset();
+                globalMetrics.historyCommandStats?.Reset();
+
+                foreach (var garnetServer in servers.Cast<GarnetServerBase>())
+                {
+                    var sessions = garnetServer.ActiveConsumers();
+                    foreach (var s in sessions)
+                    {
+                        ((RespServerSession)s).GetCommandStats?.Reset();
+                    }
+                }
+
+                resetEventFlags[InfoMetricsType.COMMANDSTATS] = false;
             }
         }
 
@@ -283,6 +324,13 @@ namespace Garnet.server
                 accSessionMetrics.Reset();
                 // Add session metrics history in accumulator
                 accSessionMetrics.Add(globalMetrics.historySessionMetrics);
+
+                // Reset command stats accumulator and add history
+                if (accCommandStats != null)
+                {
+                    accCommandStats.Reset();
+                    accCommandStats.Add(globalMetrics.historyCommandStats);
+                }
             }
 
             void ResetLatencySessionMetrics()

--- a/libs/server/Metrics/Info/GarnetInfoMetrics.cs
+++ b/libs/server/Metrics/Info/GarnetInfoMetrics.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using Garnet.common;
+using Garnet.networking;
 using Garnet.server.Metrics;
 
 namespace Garnet.server
@@ -20,6 +21,7 @@ namespace Garnet.server
                 InfoMetricsType.STOREHASHTABLE => false,
                 InfoMetricsType.STOREREVIV => false,
                 InfoMetricsType.HLOGSCAN => false,
+                InfoMetricsType.COMMANDSTATS => false,
                 _ => true
             })];
 
@@ -42,6 +44,7 @@ namespace Garnet.server
         MetricsItem[] bufferPoolStats = null;
         MetricsItem[] checkpointStats = null;
         MetricsItem[][] hlogScanStats = null;
+        MetricsItem[] commandStatsInfo = null;
 
         private void PopulateServerInfo(StoreWrapper storeWrapper)
         {
@@ -57,6 +60,7 @@ namespace Garnet.server
                 new("monitor_task", storeWrapper.serverOptions.MetricsSamplingFrequency > 0 ? "enabled" : "disabled"),
                 new("monitor_freq", storeWrapper.serverOptions.MetricsSamplingFrequency.ToString()),
                 new("latency_monitor", storeWrapper.serverOptions.LatencyMonitor ? "enabled" : "disabled"),
+                new("commandstats_monitor", storeWrapper.serverOptions.CommandStatsMonitor ? "enabled" : "disabled"),
                 new("run_id", storeWrapper.RunId),
                 new("redis_version", storeWrapper.redisProtocolVersion),
                 new("redis_mode", storeWrapper.serverOptions.EnableCluster ? "cluster" : "standalone"),
@@ -207,6 +211,70 @@ namespace Garnet.server
                 Array.Copy(gossipStats, 0, tmp, statsInfo.Length, gossipStats.Length);
                 statsInfo = tmp;
             }
+        }
+
+        private void PopulateCommandStatsInfo(StoreWrapper storeWrapper)
+        {
+            if (storeWrapper.monitor == null || !storeWrapper.serverOptions.CommandStatsMonitor)
+            {
+                commandStatsInfo = [new("", "Command stats monitoring is disabled. Enable with --commandstats-monitor flag.")];
+                return;
+            }
+
+            // Build an aggregate from history (disposed sessions) + active sessions
+            CommandStats aggregate = new();
+
+            if (storeWrapper.serverOptions.MetricsSamplingFrequency > 0)
+            {
+                // Periodic sampling is running — globalCommandStats already includes
+                // history + active sessions from the last sampling tick.
+                CommandStats globalStats = storeWrapper.monitor.GlobalMetrics.globalCommandStats;
+                if (globalStats != null)
+                    aggregate.Add(globalStats);
+            }
+            else
+            {
+                // No periodic sampling — aggregate history + active sessions on demand
+                CommandStats historyStats = storeWrapper.monitor.GlobalMetrics.historyCommandStats;
+                if (historyStats != null)
+                    aggregate.Add(historyStats);
+
+                foreach (IGarnetServer server in storeWrapper.monitor.Servers)
+                {
+                    foreach (IMessageConsumer consumer in ((GarnetServerBase)server).ActiveConsumers())
+                    {
+                        CommandStats sessionStats = ((RespServerSession)consumer).GetCommandStats;
+                        if (sessionStats != null)
+                            aggregate.Add(sessionStats);
+                    }
+                }
+            }
+
+            var items = new List<MetricsItem>();
+            RespCommand[] allCommands = Enum.GetValues<RespCommand>();
+
+            foreach (RespCommand cmd in allCommands)
+            {
+                if (cmd == RespCommand.NONE || cmd == RespCommand.INVALID)
+                    continue;
+
+                int idx = (int)cmd;
+                if ((uint)idx >= (uint)aggregate.entries.Length)
+                    continue;
+
+                CommandStatsEntry entry = aggregate.entries[idx];
+                if (entry.Calls == 0 && entry.RejectedCalls == 0)
+                    continue;
+
+                string cmdName = RespCommandsInfo.GetRespCommandName(cmd).ToLowerInvariant();
+                if (cmdName == "unknown")
+                    continue;
+
+                items.Add(new($"cmdstat_{cmdName}",
+                    $"calls={entry.Calls},usec=0,usec_per_call=0.00,rejected_calls={entry.RejectedCalls},failed_calls={entry.FailedCalls}"));
+            }
+
+            commandStatsInfo = items.Count > 0 ? [.. items] : null;
         }
 
         private void PopulateStoreStats(StoreWrapper storeWrapper)
@@ -362,6 +430,7 @@ namespace Garnet.server
                 InfoMetricsType.BPSTATS => "BufferPoolStats",
                 InfoMetricsType.CINFO => "CheckpointInfo",
                 InfoMetricsType.HLOGSCAN => $"MainStoreHLogScan_DB_{dbId}",
+                InfoMetricsType.COMMANDSTATS => "Commandstats",
                 _ => "Default",
             };
         }
@@ -452,6 +521,10 @@ namespace Garnet.server
                     PopulateHlogScanInfo(storeWrapper);
                     GetSectionRespInfo(header, hlogScanStats[dbId], sbResponse);
                     return;
+                case InfoMetricsType.COMMANDSTATS:
+                    PopulateCommandStatsInfo(storeWrapper);
+                    GetSectionRespInfo(header, commandStatsInfo, sbResponse);
+                    return;
                 default:
                     return;
             }
@@ -512,6 +585,9 @@ namespace Garnet.server
                     return keyspaceInfo;
                 case InfoMetricsType.MODULES:
                     return null;
+                case InfoMetricsType.COMMANDSTATS:
+                    PopulateCommandStatsInfo(storeWrapper);
+                    return commandStatsInfo;
                 default:
                     return null;
             }

--- a/libs/server/Resp/Objects/ObjectStoreUtils.cs
+++ b/libs/server/Resp/Objects/ObjectStoreUtils.cs
@@ -46,6 +46,7 @@ namespace Garnet.server
         /// <returns>true if the command was completely consumed, false if the input on the receive buffer was incomplete.</returns>
         private bool AbortWithErrorMessage(ReadOnlySpan<byte> errorMessage)
         {
+            commandErrorWritten = true;
             // Print error message to result stream
             while (!RespWriteUtils.TryWriteError(errorMessage, ref dcurr, dend))
                 SendAndReset();

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -29,10 +29,25 @@ namespace Garnet.server
 
         public GarnetLatencyMetricsSession LatencyMetrics { get; }
 
+        readonly CommandStats commandStats;
+
+        /// <summary>
+        /// Flag set when a RESP error response is written during command execution.
+        /// Used by CommandStats to detect failed commands. Note: only covers error paths
+        /// that go through WriteError() or AbortWithErrorMessage(); direct TryWriteError
+        /// calls in some command handlers may not set this flag.
+        /// </summary>
+        bool commandErrorWritten;
+
         /// <summary>
         /// Get a copy of sessionMetrics
         /// </summary>
         public GarnetSessionMetrics GetSessionMetrics => sessionMetrics;
+
+        /// <summary>
+        /// Get the command stats tracker for this session
+        /// </summary>
+        public CommandStats GetCommandStats => commandStats;
 
         /// <summary>
         /// Get a copy of latencyMetrics
@@ -231,6 +246,7 @@ namespace Garnet.server
             this.customCommandManagerSession = new CustomCommandManagerSession(storeWrapper.customCommandManager);
             this.sessionMetrics = storeWrapper.serverOptions.MetricsSamplingFrequency > 0 ? new GarnetSessionMetrics() : null;
             this.LatencyMetrics = storeWrapper.serverOptions.LatencyMonitor ? new GarnetLatencyMetricsSession(storeWrapper.monitor) : null;
+            this.commandStats = storeWrapper.serverOptions.CommandStatsMonitor ? new CommandStats() : null;
             logger = storeWrapper.sessionLogger != null ? new SessionLogger(storeWrapper.sessionLogger, $"[{networkSender?.RemoteEndpointName}] [{GetHashCode():X8}] ") : null;
 
             this.Id = id;
@@ -359,8 +375,8 @@ namespace Garnet.server
             foreach (var dbSession in databaseSessions.Map)
                 dbSession?.Dispose();
 
-            if (storeWrapper.serverOptions.MetricsSamplingFrequency > 0 || storeWrapper.serverOptions.LatencyMonitor)
-                storeWrapper.monitor.AddMetricsHistorySessionDispose(sessionMetrics, LatencyMetrics);
+            if (storeWrapper.monitor != null)
+                storeWrapper.monitor.AddMetricsHistorySessionDispose(sessionMetrics, LatencyMetrics, commandStats);
 
             subscribeBroker?.RemoveSubscription(this);
             storeWrapper.itemBroker?.HandleSessionDisposed(this);
@@ -573,6 +589,9 @@ namespace Garnet.server
                 {
                     var noScriptPassed = true;
 
+                    // Reset error flag unconditionally (only read when commandStats != null)
+                    commandErrorWritten = false;
+
                     if (CheckACLPermissions(cmd) && (noScriptPassed = CheckScriptPermissions(cmd)))
                     {
                         if (txnManager.state != TxnState.None)
@@ -595,6 +614,13 @@ namespace Garnet.server
                             if (clusterSession == null || CanServeSlot(cmd))
                                 _ = ProcessBasicCommands(cmd, ref basicGarnetApi);
                         }
+
+                        if (commandStats != null)
+                        {
+                            commandStats.IncrementCalls(cmd);
+                            if (commandErrorWritten)
+                                commandStats.IncrementFailed(cmd);
+                        }
                     }
                     else
                     {
@@ -608,6 +634,9 @@ namespace Garnet.server
                             while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_NOSCRIPT, ref dcurr, dend))
                                 SendAndReset();
                         }
+
+                        // Track rejected command (ACL or script permission failure)
+                        commandStats?.IncrementRejected(cmd);
                     }
                 }
                 else

--- a/libs/server/Resp/RespServerSessionOutput.cs
+++ b/libs/server/Resp/RespServerSessionOutput.cs
@@ -113,12 +113,14 @@ namespace Garnet.server
 
         private void WriteError(scoped ReadOnlySpan<byte> errorString)
         {
+            commandErrorWritten = true;
             while (!RespWriteUtils.TryWriteError(errorString, ref dcurr, dend))
                 SendAndReset();
         }
 
         private void WriteError(ReadOnlySpan<char> errorString)
         {
+            commandErrorWritten = true;
             while (!RespWriteUtils.TryWriteError(errorString, ref dcurr, dend))
                 SendAndReset();
         }

--- a/libs/server/Servers/GarnetServerOptions.cs
+++ b/libs/server/Servers/GarnetServerOptions.cs
@@ -195,6 +195,12 @@ namespace Garnet.server
         public bool LatencyMonitor = false;
 
         /// <summary>
+        /// Enable per-command usage statistics tracking (calls, failures, rejections).
+        /// Exposed via INFO COMMANDSTATS.
+        /// </summary>
+        public bool CommandStatsMonitor = false;
+
+        /// <summary>
         /// Threshold (microseconds) for logging command in the slow log. 0 to disable
         /// </summary>
         public int SlowLogThreshold = 0;

--- a/libs/server/SessionParseStateExtensions.cs
+++ b/libs/server/SessionParseStateExtensions.cs
@@ -58,6 +58,8 @@ namespace Garnet.server
                 value = InfoMetricsType.CINFO;
             else if (sbArg.EqualsUpperCaseSpanIgnoringCase("HLOGSCAN"u8))
                 value = InfoMetricsType.HLOGSCAN;
+            else if (sbArg.EqualsUpperCaseSpanIgnoringCase("COMMANDSTATS"u8))
+                value = InfoMetricsType.COMMANDSTATS;
             else return false;
 
             return true;

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -187,7 +187,7 @@ namespace Garnet.server
             this.customCommandManager = customCommandManager;
             this.loggerFactory = loggerFactory;
             this.databaseManager = databaseManager ?? DatabaseManagerFactory.CreateDatabaseManager(serverOptions, createDatabaseDelegate, this);
-            this.monitor = serverOptions.MetricsSamplingFrequency > 0
+            this.monitor = serverOptions.MetricsSamplingFrequency > 0 || serverOptions.CommandStatsMonitor || serverOptions.LatencyMonitor
                 ? new GarnetServerMonitor(this, serverOptions, servers,
                     loggerFactory?.CreateLogger("GarnetServerMonitor"))
                 : null;

--- a/test/Garnet.test/RespCommandStatsTests.cs
+++ b/test/Garnet.test/RespCommandStatsTests.cs
@@ -1,0 +1,267 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Linq;
+using System.Threading;
+using Allure.NUnit;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using StackExchange.Redis;
+
+namespace Garnet.test
+{
+    [AllureNUnit]
+    [TestFixture]
+    public class RespCommandStatsTests : AllureTestBase
+    {
+        GarnetServer server;
+
+        private void StartServer(bool commandStatsMonitor = true, int metricsSamplingFreq = 0)
+        {
+            server = TestUtils.CreateGarnetServer(
+                TestUtils.MethodTestDir,
+                metricsSamplingFreq: metricsSamplingFreq,
+                commandStatsMonitor: commandStatsMonitor);
+            server.Start();
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            server = null;
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            server?.Dispose();
+            TestUtils.OnTearDown(waitForDelete: true);
+        }
+
+        [Test]
+        public void CommandStatsDisabledByDefaultTest()
+        {
+            // When CommandStatsMonitor is off, INFO COMMANDSTATS should return a disabled message
+            StartServer(commandStatsMonitor: false);
+
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            IDatabase db = redis.GetDatabase(0);
+
+            db.StringSet("key1", "value1");
+
+            string infoResult = db.Execute("INFO", "COMMANDSTATS").ToString();
+            ClassicAssert.IsTrue(infoResult.Contains("Commandstats"), "Expected Commandstats section header");
+            ClassicAssert.IsFalse(infoResult.Contains("cmdstat_set"), "Expected no cmdstat entries when disabled");
+        }
+
+        [Test]
+        public void CommandStatsCallsTrackingTest()
+        {
+            StartServer();
+
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            IDatabase db = redis.GetDatabase(0);
+
+            int setCount = 10;
+            int getCount = 5;
+
+            for (int i = 0; i < setCount; i++)
+                db.StringSet($"key{i}", $"value{i}");
+
+            for (int i = 0; i < getCount; i++)
+                db.StringGet($"key{i}");
+
+            string infoResult = db.Execute("INFO", "COMMANDSTATS").ToString();
+            string[] lines = infoResult.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+
+            // Find SET command stats
+            string setLine = lines.FirstOrDefault(l => l.StartsWith("cmdstat_set:"));
+            ClassicAssert.IsNotNull(setLine, "Expected cmdstat_set entry");
+            ulong setCalls = ParseCommandStatField(setLine, "calls");
+            ClassicAssert.GreaterOrEqual(setCalls, (ulong)setCount, $"Expected at least {setCount} SET calls");
+
+            // Find GET command stats
+            string getLine = lines.FirstOrDefault(l => l.StartsWith("cmdstat_get:"));
+            ClassicAssert.IsNotNull(getLine, "Expected cmdstat_get entry");
+            ulong getCalls = ParseCommandStatField(getLine, "calls");
+            ClassicAssert.GreaterOrEqual(getCalls, (ulong)getCount, $"Expected at least {getCount} GET calls");
+        }
+
+        [Test]
+        public void CommandStatsFailedCallsTest()
+        {
+            StartServer();
+
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            IDatabase db = redis.GetDatabase(0);
+
+            // SETRANGE with a non-integer offset triggers AbortWithErrorMessage,
+            // which sets commandErrorWritten and is tracked as a failed call.
+            try
+            {
+                db.Execute("SETRANGE", "mykey", "not_a_number", "value");
+            }
+            catch (RedisServerException)
+            {
+                // Expected error: value is not an integer
+            }
+
+            string infoResult = db.Execute("INFO", "COMMANDSTATS").ToString();
+            string[] lines = infoResult.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+
+            // The SETRANGE command should show a failed call
+            string setrangeLine = lines.FirstOrDefault(l => l.StartsWith("cmdstat_setrange:"));
+            ClassicAssert.IsNotNull(setrangeLine, "Expected cmdstat_setrange entry");
+            ulong failedCalls = ParseCommandStatField(setrangeLine, "failed_calls");
+            ClassicAssert.GreaterOrEqual(failedCalls, (ulong)1, "Expected at least 1 failed SETRANGE call");
+        }
+
+        [Test]
+        public void CommandStatsUsecFieldsZeroTest()
+        {
+            StartServer();
+
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            IDatabase db = redis.GetDatabase(0);
+
+            for (int i = 0; i < 100; i++)
+                db.StringSet($"key{i}", $"value{i}");
+
+            string infoResult = db.Execute("INFO", "COMMANDSTATS").ToString();
+            string[] lines = infoResult.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+
+            string setLine = lines.FirstOrDefault(l => l.StartsWith("cmdstat_set:"));
+            ClassicAssert.IsNotNull(setLine, "Expected cmdstat_set entry");
+
+            // usec fields are present for Redis format compatibility but report 0
+            // (per-command latency tracking is not implemented to avoid Stopwatch overhead)
+            ulong usec = ParseCommandStatField(setLine, "usec");
+            ClassicAssert.AreEqual((ulong)0, usec, "Expected usec=0 (latency tracking not implemented)");
+
+            string usecPerCallStr = ParseCommandStatFieldString(setLine, "usec_per_call");
+            ClassicAssert.AreEqual("0.00", usecPerCallStr, "Expected usec_per_call=0.00");
+        }
+
+        [Test]
+        public void CommandStatsMultipleCommandsTest()
+        {
+            StartServer();
+
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            IDatabase db = redis.GetDatabase(0);
+
+            // Execute various commands
+            db.StringSet("k1", "v1");
+            db.StringGet("k1");
+            db.Execute("DEL", "k1");
+            db.Execute("PING");
+
+            string infoResult = db.Execute("INFO", "COMMANDSTATS").ToString();
+            string[] lines = infoResult.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+
+            // Verify multiple commands appear independently
+            ClassicAssert.IsTrue(lines.Any(l => l.StartsWith("cmdstat_set:")), "Expected cmdstat_set");
+            ClassicAssert.IsTrue(lines.Any(l => l.StartsWith("cmdstat_get:")), "Expected cmdstat_get");
+            ClassicAssert.IsTrue(lines.Any(l => l.StartsWith("cmdstat_del:")), "Expected cmdstat_del");
+            ClassicAssert.IsTrue(lines.Any(l => l.StartsWith("cmdstat_ping:")), "Expected cmdstat_ping");
+        }
+
+        [Test]
+        public void CommandStatsSuccessRateTest()
+        {
+            // Use periodic sampling to cover the MetricsSamplingFrequency > 0 aggregation path
+            StartServer(metricsSamplingFreq: 1);
+
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            IDatabase db = redis.GetDatabase(0);
+
+            // Execute 5 successful SETs
+            for (int i = 0; i < 5; i++)
+                db.StringSet($"key{i}", $"value{i}");
+
+            Thread.Sleep(TimeSpan.FromSeconds(1.5));
+
+            string infoResult = db.Execute("INFO", "COMMANDSTATS").ToString();
+            string[] lines = infoResult.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+
+            string setLine = lines.FirstOrDefault(l => l.StartsWith("cmdstat_set:"));
+            ClassicAssert.IsNotNull(setLine, "Expected cmdstat_set entry");
+
+            ulong calls = ParseCommandStatField(setLine, "calls");
+            ulong failedCalls = ParseCommandStatField(setLine, "failed_calls");
+            ulong rejectedCalls = ParseCommandStatField(setLine, "rejected_calls");
+
+            // Success rate should be 100% — no failures or rejections for normal SET
+            double successRate = calls > 0 ? (double)(calls - failedCalls - rejectedCalls) / calls : 0;
+            ClassicAssert.AreEqual(1.0, successRate, 0.001, "Expected 100% success rate for SET commands");
+        }
+
+        [Test]
+        public void CommandStatsInfoServerShowsMonitorStatus()
+        {
+            StartServer();
+
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            IDatabase db = redis.GetDatabase(0);
+
+            string infoResult = db.Execute("INFO", "SERVER").ToString();
+            ClassicAssert.IsTrue(infoResult.Contains("commandstats_monitor:enabled"),
+                "Expected commandstats_monitor:enabled in INFO SERVER");
+        }
+
+        [Test]
+        public void CommandStatsFormatMatchesRedisConvention()
+        {
+            StartServer();
+
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            IDatabase db = redis.GetDatabase(0);
+
+            db.StringSet("k", "v");
+
+            string infoResult = db.Execute("INFO", "COMMANDSTATS").ToString();
+            string[] lines = infoResult.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+
+            string setLine = lines.FirstOrDefault(l => l.StartsWith("cmdstat_set:"));
+            ClassicAssert.IsNotNull(setLine, "Expected cmdstat_set entry");
+
+            // Verify Redis-compatible format: cmdstat_<name>:calls=X,usec=Y,usec_per_call=Z,rejected_calls=R,failed_calls=F
+            ClassicAssert.IsTrue(setLine.Contains("calls="), "Expected calls= field");
+            ClassicAssert.IsTrue(setLine.Contains("usec="), "Expected usec= field");
+            ClassicAssert.IsTrue(setLine.Contains("usec_per_call="), "Expected usec_per_call= field");
+            ClassicAssert.IsTrue(setLine.Contains("rejected_calls="), "Expected rejected_calls= field");
+            ClassicAssert.IsTrue(setLine.Contains("failed_calls="), "Expected failed_calls= field");
+        }
+
+        /// <summary>
+        /// Parse a numeric field value from a Redis commandstats line.
+        /// Format: cmdstat_set:calls=100,usec=500,usec_per_call=5.00,rejected_calls=0,failed_calls=2
+        /// </summary>
+        private static ulong ParseCommandStatField(string line, string fieldName)
+        {
+            string value = ParseCommandStatFieldString(line, fieldName);
+            // Handle floating point values by parsing as double first
+            if (value.Contains('.'))
+                return (ulong)double.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
+            return ulong.Parse(value);
+        }
+
+        /// <summary>
+        /// Parse a string field value from a Redis commandstats line.
+        /// </summary>
+        private static string ParseCommandStatFieldString(string line, string fieldName)
+        {
+            string searchKey = fieldName + "=";
+            int startIdx = line.IndexOf(searchKey, StringComparison.Ordinal);
+            ClassicAssert.IsTrue(startIdx >= 0, $"Field '{fieldName}' not found in: {line}");
+            startIdx += searchKey.Length;
+
+            int endIdx = line.IndexOf(',', startIdx);
+            if (endIdx < 0) endIdx = line.Length;
+
+            return line.Substring(startIdx, endIdx - startIdx);
+        }
+    }
+}

--- a/test/Garnet.test/RespInfoTests.cs
+++ b/test/Garnet.test/RespInfoTests.cs
@@ -105,9 +105,13 @@ namespace Garnet.test
                 ClassicAssert.IsTrue(infoResult.Contains("# Modules"), $"INFO {option} should contain Modules section");
             }
 
-            // All three options are based on DefaultInfo which excludes expensive sections
+            // All three options are based on DefaultInfo which excludes expensive/verbose sections
             ClassicAssert.IsFalse(infoResult.Contains("MainStoreHashTableDistribution"), $"INFO {option} should not contain StoreHashTable section");
+            ClassicAssert.IsFalse(infoResult.Contains("ObjectStoreHashTableDistribution"), $"INFO {option} should not contain ObjectStoreHashTable section");
             ClassicAssert.IsFalse(infoResult.Contains("MainStoreDeletedRecordRevivification"), $"INFO {option} should not contain StoreReviv section");
+            ClassicAssert.IsFalse(infoResult.Contains("ObjectStoreDeletedRecordRevivification"), $"INFO {option} should not contain ObjectStoreReviv section");
+            ClassicAssert.IsFalse(infoResult.Contains("MainStoreHLogScan"), $"INFO {option} should not contain HLogScan section");
+            ClassicAssert.IsFalse(infoResult.Contains("# Commandstats"), $"INFO {option} should not contain Commandstats section");
         }
 
         [Test]

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -237,6 +237,7 @@ namespace Garnet.test
             bool disableObjects = false,
             int metricsSamplingFreq = -1,
             bool latencyMonitor = false,
+            bool commandStatsMonitor = false,
             int commitFrequencyMs = 0,
             bool commitWait = false,
             bool useAzureStorage = false,
@@ -341,6 +342,7 @@ namespace Garnet.test
                 QuietMode = true,
                 MetricsSamplingFrequency = metricsSamplingFreq,
                 LatencyMonitor = latencyMonitor,
+                CommandStatsMonitor = commandStatsMonitor,
                 DeviceFactoryCreator = useAzureStorage ?
                         logger == null ? TestUtils.AzureStorageNamedDeviceFactoryCreator : new AzureStorageNamedDeviceFactoryCreator(AzureEmulatedStorageString, logger)
                         : new LocalStorageNamedDeviceFactoryCreator(logger: logger),


### PR DESCRIPTION
## Why is this change being made?

Garnet lacks Redis-compatible command usage statistics. Users and monitoring tools that rely on `INFO COMMANDSTATS` get no data, making it harder to understand workload composition and identify failing commands. This cherry-picks #1702 (merged to main) onto dev.

## What changed?

- **libs/server/Metrics/CommandStats.cs** — New per-command statistics structure (calls, failed_calls, rejected_calls) array-indexed by RespCommand for O(1) access
- **libs/server/Resp/RespServerSession.cs** — Per-session command stats field, counter increments in ProcessMessages loop, commandErrorWritten flag for error detection, history handoff on dispose
- **libs/server/Resp/RespServerSessionOutput.cs** — WriteError overloads set commandErrorWritten flag
- **libs/server/Resp/Objects/ObjectStoreUtils.cs** — AbortWithErrorMessage sets commandErrorWritten flag
- **libs/server/Metrics/GarnetServerMonitor.cs** — History storage from disposed sessions, on-demand aggregation via Servers property, COMMANDSTATS reset support, dispose fix for when Start() was never called, resetEventFlags uses Enum.GetValues to fix pre-existing KeyNotFoundException
- **libs/server/Metrics/GarnetServerMetrics.cs** — globalCommandStats and historyCommandStats fields
- **libs/server/Metrics/Info/GarnetInfoMetrics.cs** — PopulateCommandStatsInfo with on-demand aggregation, canonical command names via RespCommandsInfo.GetRespCommandName()
- **libs/server/Servers/GarnetServerOptions.cs** — CommandStatsMonitor bool property
- **libs/server/StoreWrapper.cs** — Monitor creation includes CommandStatsMonitor and LatencyMonitor (fixes pre-existing NRE when only --latency-monitor enabled)
- **libs/host/Configuration/Options.cs** — --commandstats-monitor CLI flag
- **libs/host/Configuration/Redis/RedisOptions.cs** — commandstats-tracking Redis config alias
- **libs/host/defaults.conf** — CommandStatsMonitor default entry
- **libs/common/Metrics/InfoMetricsType.cs** — COMMANDSTATS enum value
- **libs/server/SessionParseStateExtensions.cs** — COMMANDSTATS parser case
- **test/Garnet.test/RespCommandStatsTests.cs** — 8 test cases covering disabled state, call tracking, failed calls, usec fields, multiple commands, success rate with periodic sampling, INFO SERVER status, Redis format
- **test/Garnet.test/RespInfoTests.cs** — Extended InfoSectionOptionsTest to validate all 6 excluded sections are absent from bare INFO
- **test/Garnet.test/TestUtils.cs** — commandStatsMonitor parameter for test server setup

## How was this validated?

- [ ] All 12 new/updated tests pass on net8.0 and net10.0 (8 CommandStats + 4 InfoSection tests)
- [ ] BDN benchmarks show acceptable overhead: PING ~7.8%, SET/GET 0-4% (counter increments only, no Stopwatch)
- [ ] Existing test suite unaffected (CI green on #1702)
- [ ] Integration pipeline: [link]