### PR TITLE
Fix 5 open Dependabot npm alerts (dompurify, uuid)

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -40,8 +40,10 @@
     "lodash-es": "4.18.1",
     "//minimatch": "CVE-2024-21538, CVE-2023-36326, CVE-2023-34104 (ReDoS)",
     "minimatch": "3.1.5",
-    "//dompurify": "CVE-2025-26791 (XSS)",
-    "dompurify": "3.3.3"
+    "//dompurify": "CVE-2025-26791, CVE-2026-0540, CVE-2026-41238, CVE-2026-41239, CVE-2026-41240 (XSS / prototype pollution)",
+    "dompurify": "3.4.0",
+    "//uuid": "GHSA uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided",
+    "uuid": "14.0.0"
   },
   "browserslist": {
     "production": [

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -5106,10 +5106,10 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@3.3.3, dompurify@^3.3.1:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.3.tgz#680cae8af3e61320ddf3666a3bc843f7b291b2b6"
-  integrity sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==
+dompurify@3.4.0, dompurify@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.0.tgz#b1fc33ebdadb373241621e0a30e4ad81573dfd0b"
+  integrity sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
@@ -9976,15 +9976,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
-  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
-
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@14.0.0, uuid@^11.1.0, uuid@^8.3.2:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 value-equal@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Summary

Fixes all 5 open Dependabot security alerts in the website npm dependencies.

### dompurify 3.3.3 → 3.4.0 (fixes 4 alerts)
- **#82** ADD_TAGS function form bypasses FORBID_TAGS
- **#83** CVE-2026-41238: Prototype Pollution to XSS Bypass via CUSTOM_ELEMENT_HANDLING
- **#84** CVE-2026-41240: FORBID_TAGS bypassed by function-based ADD_TAGS predicate
- **#85** CVE-2026-41239: SAFE_FOR_TEMPLATES bypass in RETURN_DOM mode

### uuid 8.3.2/11.1.0 → 14.0.0 (fixes 1 alert)
- **#86** Missing buffer bounds check in v3/v5/v6 when buf is provided

### Validation
- `yarn install` succeeds
- `yarn build` succeeds — website builds cleanly

### Note on uuid 14.0.0
uuid 14 is ESM-only. The two consumers in the dependency tree are:
- **mermaid** (previously uuid ^11.1.0) — ESM, compatible
- **sockjs** (previously uuid ^8.3.2) — CJS, used only by webpack-dev-server during `docusaurus start` (dev mode). The sockjs code path only calls `uuid.v4()` which is unaffected by the vulnerability (v3/v5/v6 buffer bounds). If dev-server issues arise, the resolution can be scoped to `mermaid/uuid` only.
