### PR TITLE
Fix NullReferenceException in AutoCheckpointTask when AOF is disabled with AofSizeLimit configured

### DIFF
--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -831,6 +831,12 @@ namespace Garnet
                     throw new Exception("SlowLogThreshold must be at least 100 microseconds.");
             }
 
+            if (!EnableAOF.GetValueOrDefault())
+            {
+                if (!string.IsNullOrEmpty(AofSizeLimit))
+                    throw new GarnetException("AofSizeLimit cannot be enforced with disabled AOF!");
+            }
+
             Func<INamedDeviceFactoryCreator> azureFactoryCreator = () =>
             {
                 if (!string.IsNullOrEmpty(AzureStorageConnectionString))

--- a/test/Garnet.test/GarnetServerConfigTests.cs
+++ b/test/Garnet.test/GarnetServerConfigTests.cs
@@ -1312,5 +1312,24 @@ namespace Garnet.test
                 Assert.Throws<Exception>(() => options.GetServerOptions(), $"Should throw for args: {string.Join(" ", args)}");
             }
         }
+
+        [Test]
+        public void AofSizeLimitWithoutAofEnabled()
+        {
+            // Setting --aof-size-limit without --aof should throw
+            var args = new[] { "--aof-size-limit", "64m" };
+            var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+            ClassicAssert.IsTrue(parseSuccessful);
+            ClassicAssert.AreEqual(0, invalidOptions.Count);
+            var ex = Assert.Throws<GarnetException>(() => options.GetServerOptions());
+            ClassicAssert.IsTrue(ex.Message.Contains("AofSizeLimit"));
+
+            // Setting --aof-size-limit with --aof enabled should succeed
+            args = ["--aof", "--aof-size-limit", "64m"];
+            parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out options, out invalidOptions, out _, out _, silentMode: true);
+            ClassicAssert.IsTrue(parseSuccessful);
+            ClassicAssert.AreEqual(0, invalidOptions.Count);
+            Assert.DoesNotThrow(() => options.GetServerOptions());
+        }
     }
 }


### PR DESCRIPTION
## Summary
Reject invalid configuration at startup where `AofSizeLimit` is set but AOF is disabled (`EnableAOF = false`). This prevents a `NullReferenceException` in `AutoCheckpointTask` that occurs because AOF-related objects are never initialized when AOF is off.

## Changes
- **libs/host/Configuration/Options.cs** – Added a validation check that throws a `GarnetException` when `AofSizeLimit` is specified without enabling AOF.
- **test/Garnet.test/GarnetServerConfigTests.cs** – Added test `AofSizeLimitWithoutAofEnabled` to verify the new validation rejects the invalid config and accepts the valid one.

Fixes #1696