### PR TITLE
Remove unused sizeInfo and other performance tweaks

### DIFF
--- a/benchmark/BDN.benchmark/Operations/RawStringOperations.cs
+++ b/benchmark/BDN.benchmark/Operations/RawStringOperations.cs
@@ -18,10 +18,10 @@ namespace BDN.benchmark.Operations
         static ReadOnlySpan<byte> SETEX => "*4\r\n$5\r\nSETEX\r\n$1\r\nd\r\n$1\r\n9\r\n$1\r\nd\r\n"u8;
         Request setex;
 
-        static ReadOnlySpan<byte> SETNX => "*4\r\n$3\r\nSET\r\n$1\r\na\r\n$1\r\na\r\n$2\r\nNX\r\n"u8;
+        static ReadOnlySpan<byte> SETNX => "*4\r\n$3\r\nSET\r\n$1\r\na\r\n$1\r\na\r\n$2\r\nNX\r\n"u8;   // Becomes SETEXNX rather than SETNX
         Request setnx;
 
-        static ReadOnlySpan<byte> SETXX => "*4\r\n$3\r\nSET\r\n$1\r\na\r\n$1\r\na\r\n$2\r\nXX\r\n"u8;
+        static ReadOnlySpan<byte> SETXX => "*4\r\n$3\r\nSET\r\n$1\r\na\r\n$1\r\na\r\n$2\r\nXX\r\n"u8;   // Becomes SETEXXX rather than SETXX
         Request setxx;
 
         static ReadOnlySpan<byte> GETNF => "*2\r\n$3\r\nGET\r\n$1\r\nb\r\n"u8;

--- a/libs/server/InputHeader.cs
+++ b/libs/server/InputHeader.cs
@@ -12,7 +12,7 @@ namespace Garnet.server
 {
     /// <summary>
     /// Flags used by append-only file (AOF/WAL)
-    /// The byte representation only use the last 3 bits of the byte since the lower 5 bits of the field used to store the flag stores other data in the case of Object types.
+    /// The byte representation only use the last 3 bits of the byte since the lower 5 bits of the "union" field that is used to store the flag stores other data (see RespInputHeader.FlagMask).
     /// In the case of a Rawstring, the last 4 bits are used for flags, and the other 4 bits are unused of the byte.
     /// </summary>
     [Flags]

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -642,10 +642,6 @@ namespace Garnet.server
 
                     if (CheckACLPermissions(cmd) && (noScriptPassed = CheckScriptPermissions(cmd)))
                     {
-                        // Reset error flag only when stats tracking is active (read after command execution below)
-                        if (commandStats != null)
-                            commandErrorWritten = false;
-
                         if (txnManager.state != TxnState.None)
                         {
                             if (txnManager.state == TxnState.Running)
@@ -671,7 +667,10 @@ namespace Garnet.server
                         {
                             commandStats.IncrementCalls(cmd);
                             if (commandErrorWritten)
+                            {
                                 commandStats.IncrementFailed(cmd);
+                                commandErrorWritten = false;
+                            }
                         }
                     }
                     else

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -640,11 +640,12 @@ namespace Garnet.server
                 {
                     var noScriptPassed = true;
 
-                    // Reset error flag unconditionally (only read when commandStats != null)
-                    commandErrorWritten = false;
-
                     if (CheckACLPermissions(cmd) && (noScriptPassed = CheckScriptPermissions(cmd)))
                     {
+                        // Reset error flag only when stats tracking is active (read after command execution below)
+                        if (commandStats != null)
+                            commandErrorWritten = false;
+
                         if (txnManager.state != TxnState.None)
                         {
                             if (txnManager.state == TxnState.Running)

--- a/libs/server/Storage/Functions/MainStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/RMWMethods.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Garnet.common;
 using Microsoft.Extensions.Logging;
@@ -382,16 +383,19 @@ namespace Garnet.server
                 return false;
             }
 
-            // RangeIndex type safety – reject non-RI commands on RI keys
-            if (logRecord.RecordType == RangeIndexManager.RangeIndexRecordType && !input.header.cmd.IsLegalOnRangeIndex())
+            // RangeIndex type safety – normal string records have RecordType 0; skip all checks in that common case.
+            if (logRecord.RecordType == RangeIndexManager.RangeIndexRecordType)
             {
-                rmwInfo.Action = RMWAction.WrongType;
-                return false;
-            }
-
-            // Reject RI-specific commands on non-RI keys
-            if (logRecord.RecordType != RangeIndexManager.RangeIndexRecordType && input.header.cmd.IsRangeIndexCommand())
+                // Reject non-RI commands on RI keys
+                if (!input.header.cmd.IsLegalOnRangeIndex())
+                {
+                    rmwInfo.Action = RMWAction.WrongType;
+                    return false;
+                }
+            } 
+            else if (input.header.cmd.IsRangeIndexCommand())
             {
+                // Reject RI-specific commands on non-RI keys
                 rmwInfo.Action = RMWAction.WrongType;
                 return false;
             }
@@ -447,6 +451,7 @@ namespace Garnet.server
                     return IPUResult.NotUpdated;
                 case RespCommand.SET:
                 case RespCommand.SETEXXX:
+                    // Note: SETEXXX may or may not actually have an expiration.
                     // Check if SetGet flag is set
                     if (input.header.CheckSetGetFlag())
                     {
@@ -1426,6 +1431,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void PostRMWOperation<TKey, TEpochAccessor>(TKey key, ref StringInput input, ref RMWInfo rmwInfo, TEpochAccessor epochAccessor)
             where TKey : IKey
 #if NET9_0_OR_GREATER

--- a/libs/server/Storage/Functions/MainStore/RMWMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/RMWMethods.cs
@@ -392,7 +392,7 @@ namespace Garnet.server
                     rmwInfo.Action = RMWAction.WrongType;
                     return false;
                 }
-            } 
+            }
             else if (input.header.cmd.IsRangeIndexCommand())
             {
                 // Reject RI-specific commands on non-RI keys

--- a/libs/server/Storage/Functions/MainStore/ReadMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/ReadMethods.cs
@@ -16,7 +16,19 @@ namespace Garnet.server
         public bool Reader<TSourceLogRecord>(in TSourceLogRecord srcLogRecord, ref StringInput input, ref StringOutput output, ref ReadInfo readInfo)
             where TSourceLogRecord : ISourceLogRecord
         {
-            if (srcLogRecord.Info.ValueIsObject)
+            var info = srcLogRecord.Info;
+
+            // Fast path for simple GET on a normal inline string key with no optional fields.
+            // HasOptionalOrObjectFields is false iff: KeyIsInline, ValueIsInline, !HasETag, !HasExpiration (implies !ValueIsObject).
+            // RecordType 0 means normal string (not VectorSet or RangeIndex).
+            // This avoids expiry checks (no expiration), type-safety checks, ETag handling, and custom command dispatch.
+            if (input.arg1 < 0 && !info.HasOptionalOrObjectFields && srcLogRecord.RecordType == 0)
+            {
+                CopyRespTo(srcLogRecord.ValueSpan, ref output);
+                return true;
+            }
+
+            if (info.ValueIsObject)
             {
                 readInfo.Action = ReadAction.WrongType;
                 return false;

--- a/libs/server/Storage/Functions/MainStore/UpsertMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/UpsertMethods.cs
@@ -67,8 +67,9 @@ namespace Garnet.server
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool InPlaceWriter(ref LogRecord logRecord, ref StringInput input, ReadOnlySpan<byte> srcValue, ref StringOutput output, ref UpsertInfo upsertInfo)
         {
-            // Prevent SET from overwriting VectorSet or RangeIndex stubs
-            if (logRecord.RecordType == VectorManager.RecordType || logRecord.RecordType == RangeIndexManager.RangeIndexRecordType)
+            // Prevent SET from overwriting VectorSet or RangeIndex stubs – normal string records have RecordType 0; skip all checks in that common case.
+            var recordType = logRecord.RecordType;
+            if (recordType != 0 && (recordType == VectorManager.RecordType || recordType == RangeIndexManager.RangeIndexRecordType))
             {
                 upsertInfo.Action = UpsertAction.WrongType;
                 return false;
@@ -103,6 +104,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void PostUpsertOperation<TKey, TEpochAccessor>(TKey key, ref StringInput input, ReadOnlySpan<byte> valueSpan, ref UpsertInfo upsertInfo, TEpochAccessor epochAccessor)
             where TKey : IKey
 #if NET9_0_OR_GREATER
@@ -115,6 +117,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void PostUpsertOperation<TKey, TEpochAccessor>(TKey key, ref StringInput input, IHeapObject valueObject, ref UpsertInfo upsertInfo, TEpochAccessor epochAccessor)
             where TKey : IKey
 #if NET9_0_OR_GREATER

--- a/libs/server/Storage/Functions/SessionFunctionsUtils.cs
+++ b/libs/server/Storage/Functions/SessionFunctionsUtils.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Garnet.common;
 using Microsoft.Extensions.Logging;
 using Tsavorite.core;
@@ -93,13 +94,14 @@ namespace Garnet.server
                 ref SpanByteAndMemory output, ref UpsertInfo upsertInfo, TVariableLengthInput varlenInput, FunctionsState functionsState, long expiration)
             where TVariableLengthInput : IVariableLengthInput<TInput>
         {
-            RecordSizeInfo sizeInfo = new();
+            RecordSizeInfo sizeInfo;
 
             if (logRecord.Info.ValueIsInline && (expiration == 0 || logRecord.Info.HasExpiration))
             {
                 var (valueAddress, valueLength) = logRecord.PinnedValueAddressAndLength;
                 if (!logRecord.TrySetPinnedValueSpan(newValue, valueAddress, ref valueLength))
                     return false;
+                sizeInfo = new();
             }
             else
             {
@@ -159,6 +161,7 @@ namespace Garnet.server
             return true;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void UpdateExpiration(ref LogRecord logRecord, long expiration)
         {
             if (expiration != 0)

--- a/libs/storage/Tsavorite/cs/src/core/ClientSession/SessionFunctionsWrapper.cs
+++ b/libs/storage/Tsavorite/cs/src/core/ClientSession/SessionFunctionsWrapper.cs
@@ -77,7 +77,7 @@ namespace Tsavorite.core
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool InPlaceWriter(ref LogRecord logRecord, in RecordSizeInfo sizeInfo, ref TInput input, ReadOnlySpan<byte> srcValue, ref TOutput output, ref UpsertInfo upsertInfo)
+        public bool InPlaceWriter(ref LogRecord logRecord, ref TInput input, ReadOnlySpan<byte> srcValue, ref TOutput output, ref UpsertInfo upsertInfo)
         {
             if (!_clientSession.functions.InPlaceWriter(ref logRecord, ref input, srcValue, ref output, ref upsertInfo))
                 return false;
@@ -86,7 +86,7 @@ namespace Tsavorite.core
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool InPlaceWriter(ref LogRecord logRecord, in RecordSizeInfo sizeInfo, ref TInput input, IHeapObject srcValue, ref TOutput output, ref UpsertInfo upsertInfo)
+        public bool InPlaceWriter(ref LogRecord logRecord, ref TInput input, IHeapObject srcValue, ref TOutput output, ref UpsertInfo upsertInfo)
         {
             if (!_clientSession.functions.InPlaceWriter(ref logRecord, ref input, srcValue, ref output, ref upsertInfo))
                 return false;
@@ -95,7 +95,7 @@ namespace Tsavorite.core
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool InPlaceWriter<TSourceLogRecord>(ref LogRecord logRecord, in RecordSizeInfo sizeInfo, ref TInput input, in TSourceLogRecord inputLogRecord, ref TOutput output, ref UpsertInfo upsertInfo)
+        public bool InPlaceWriter<TSourceLogRecord>(ref LogRecord logRecord, ref TInput input, in TSourceLogRecord inputLogRecord, ref TOutput output, ref UpsertInfo upsertInfo)
             where TSourceLogRecord : ISourceLogRecord
         {
             if (!_clientSession.functions.InPlaceWriter(ref logRecord, ref input, in inputLogRecord, ref output, ref upsertInfo))
@@ -167,7 +167,7 @@ namespace Tsavorite.core
 
         #region InPlaceUpdater
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool InPlaceUpdater(ref LogRecord logRecord, in RecordSizeInfo sizeInfo, ref TInput input, ref TOutput output, ref RMWInfo rmwInfo, out OperationStatus status)
+        public bool InPlaceUpdater(ref LogRecord logRecord, ref TInput input, ref TOutput output, ref RMWInfo rmwInfo, out OperationStatus status)
         {
             // This wraps the ISessionFunctions call to provide expiration logic.
             if (_clientSession.functions.InPlaceUpdater(ref logRecord, ref input, ref output, ref rmwInfo))

--- a/libs/storage/Tsavorite/cs/src/core/Index/Interfaces/ISessionFunctionsWrapper.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Interfaces/ISessionFunctionsWrapper.cs
@@ -31,9 +31,9 @@ namespace Tsavorite.core
         void PostInitialWriter(ref LogRecord logRecord, in RecordSizeInfo sizeInfo, ref TInput input, IHeapObject srcValue, ref TOutput output, ref UpsertInfo upsertInfo);
         void PostInitialWriter<TSourceLogRecord>(ref LogRecord logRecord, in RecordSizeInfo sizeInfo, ref TInput input, in TSourceLogRecord inputLogRecord, ref TOutput output, ref UpsertInfo upsertInfo)
             where TSourceLogRecord : ISourceLogRecord;
-        bool InPlaceWriter(ref LogRecord logRecord, in RecordSizeInfo sizeInfo, ref TInput input, ReadOnlySpan<byte> srcValue, ref TOutput output, ref UpsertInfo upsertInfo);
-        bool InPlaceWriter(ref LogRecord logRecord, in RecordSizeInfo sizeInfo, ref TInput input, IHeapObject srcValue, ref TOutput output, ref UpsertInfo upsertInfo);
-        bool InPlaceWriter<TSourceLogRecord>(ref LogRecord logRecord, in RecordSizeInfo sizeInfo, ref TInput input, in TSourceLogRecord inputLogRecord, ref TOutput output, ref UpsertInfo upsertInfo)
+        bool InPlaceWriter(ref LogRecord logRecord, ref TInput input, ReadOnlySpan<byte> srcValue, ref TOutput output, ref UpsertInfo upsertInfo);
+        bool InPlaceWriter(ref LogRecord logRecord, ref TInput input, IHeapObject srcValue, ref TOutput output, ref UpsertInfo upsertInfo);
+        bool InPlaceWriter<TSourceLogRecord>(ref LogRecord logRecord, ref TInput input, in TSourceLogRecord inputLogRecord, ref TOutput output, ref UpsertInfo upsertInfo)
             where TSourceLogRecord : ISourceLogRecord;
         void PostUpsertOperation<TKey, TEpochAccessor>(TKey key, ref TInput input, ReadOnlySpan<byte> srcValueSpan, ref UpsertInfo upsertInfo, TEpochAccessor epochAccessor)
              where TKey : IKey
@@ -71,7 +71,7 @@ namespace Tsavorite.core
         #endregion CopyUpdater
 
         #region InPlaceUpdater
-        bool InPlaceUpdater(ref LogRecord logRecord, in RecordSizeInfo sizeInfo, ref TInput input, ref TOutput output, ref RMWInfo rmwInfo, out OperationStatus status);
+        bool InPlaceUpdater(ref LogRecord logRecord, ref TInput input, ref TOutput output, ref RMWInfo rmwInfo, out OperationStatus status);
         #endregion InPlaceUpdater
 
         void PostRMWOperation<TKey, TEpochAccessor>(TKey key, ref TInput input, ref RMWInfo rmwInfo, TEpochAccessor epochAccessor)

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalRMW.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalRMW.cs
@@ -140,22 +140,15 @@ namespace Tsavorite.core
                         goto CreateNewRecord;
                     }
 
-                    var sizeInfo = new RecordSizeInfo(); // TODO temporary for perf work
-
-                    // Track value heap delta across in-place update. Only measure when value is
-                    // heap-allocated (overflow or object); inline values have zero heap cost.
-                    var ipuPreInline = srcLogRecord.Info.ValueIsInline;
-                    var ipuPreHeap = ipuPreInline ? 0L : srcLogRecord.GetValueHeapMemorySize();
-
-                    if (sessionFunctions.InPlaceUpdater(ref srcLogRecord, in sizeInfo, ref input, ref output, ref rmwInfo, out status))
+                    // Track value heap delta across in-place update. HeapMemorySize is zero for inline values but IPU may change the value from inline to object or vice-versa.
+                    var sizeTracker = hlogBase.logSizeTracker;
+                    var ipuPreHeap = sizeTracker is not null ? srcLogRecord.GetValueHeapMemorySize() : 0L;
+                    var ipuResult = sessionFunctions.InPlaceUpdater(ref srcLogRecord, ref input, ref output, ref rmwInfo, out status);
+                    var ipuDelta = sizeTracker is not null ? srcLogRecord.GetValueHeapMemorySize() - ipuPreHeap : 0L;
+                    if (ipuResult)
                     {
-                        if (!ipuPreInline || !srcLogRecord.Info.ValueIsInline)
-                        {
-                            var ipuPostHeap = srcLogRecord.Info.ValueIsInline ? 0L : srcLogRecord.GetValueHeapMemorySize();
-                            var ipuDelta = ipuPostHeap - ipuPreHeap;
-                            if (ipuDelta != 0)
-                                hlogBase.logSizeTracker?.IncrementSize(ipuDelta);
-                        }
+                        if (ipuDelta != 0)
+                            sizeTracker.IncrementSize(ipuDelta);
 
                         MarkPage(stackCtx.recSrc.LogicalAddress, sessionFunctions.Ctx);
 
@@ -166,22 +159,15 @@ namespace Tsavorite.core
 
                     if (rmwInfo.Action == RMWAction.ExpireAndStop)
                     {
-                        // ExpireAndStop: the object was mutated in-place (e.g. last element removed)
-                        // before IPU returned false. Track the delta before OnDispose subtracts the
-                        // remaining empty-collection overhead.
-                        if (!ipuPreInline || !srcLogRecord.Info.ValueIsInline)
-                        {
-                            var ipuPostHeap = srcLogRecord.Info.ValueIsInline ? 0L : srcLogRecord.GetValueHeapMemorySize();
-                            var ipuDelta = ipuPostHeap - ipuPreHeap;
-                            if (ipuDelta != 0)
-                                hlogBase.logSizeTracker?.IncrementSize(ipuDelta);
-                        }
+                        // ExpireAndStop: the object was mutated in-place (e.g. last element removed) before IPU returned false.
+                        // Track the delta before OnDispose subtracts the remaining empty-collection overhead.
+                        if (ipuDelta != 0)
+                            sizeTracker.IncrementSize(ipuDelta);
                         MarkPage(stackCtx.recSrc.LogicalAddress, sessionFunctions.Ctx);
 
                         pendingContext.logicalAddress = stackCtx.recSrc.LogicalAddress;
 
-                        // Dispose resources and decrement value heap BEFORE setting Tombstone,
-                        // so that GetValueHeapMemorySize returns the correct pre-tombstone value.
+                        // Dispose resources and decrement value heap BEFORE setting Tombstone so GetValueHeapMemorySize returns the correct pre-tombstone value.
                         OnDispose(ref srcLogRecord, DisposeReason.Deleted);
 
                         srcLogRecord.InfoRef.SetTombstone();
@@ -196,9 +182,8 @@ namespace Tsavorite.core
                     }
                     else if (rmwInfo.Action == RMWAction.ExpireAndResume)
                     {
-                        // ExpireAndResume: for IPU, ReinitializeExpiredRecord already called
-                        // OnDispose(Deleted). If it failed and we fall through to CreateNewRecord,
-                        // the record is already disposed.
+                        // ExpireAndResume: for IPU, ReinitializeExpiredRecord already called OnDispose(Deleted).
+                        // If it failed and we fall through to CreateNewRecord, the record is already disposed.
                     }
                     else if (rmwInfo.Action == RMWAction.WrongType)
                     {

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalUpsert.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalUpsert.cs
@@ -133,23 +133,16 @@ namespace Tsavorite.core
                         goto CreateNewRecord;
                     }
 
-                    var sizeInfo = new RecordSizeInfo(); // TODO temporary for perf work
-
                     // Track value heap delta across in-place write.
-                    var ipwPreInline = srcLogRecord.Info.ValueIsInline;
-                    var ipwPreHeap = ipwPreInline ? 0L : srcLogRecord.GetValueHeapMemorySize();
-
-                    // Type arg specification is needed because we don't pass TContext
-                    if (TValueSelector.InPlaceWriter<TSourceLogRecord, TInput, TOutput, TContext, TSessionFunctionsWrapper>(
-                        ref srcLogRecord, in sizeInfo, ref input, srcStringValue, srcObjectValue, in inputLogRecord, ref output, ref upsertInfo, sessionFunctions))
+                    var sizeTracker = hlogBase.logSizeTracker;
+                    var ipwPreHeap = sizeTracker is not null ? srcLogRecord.GetValueHeapMemorySize() : 0L;
+                    var ipwResult = TValueSelector.InPlaceWriter<TSourceLogRecord, TInput, TOutput, TContext, TSessionFunctionsWrapper>(
+                        ref srcLogRecord, ref input, srcStringValue, srcObjectValue, in inputLogRecord, ref output, ref upsertInfo, sessionFunctions);
+                    var ipwDelta = sizeTracker is not null ? srcLogRecord.GetValueHeapMemorySize() - ipwPreHeap : 0L;
+                    if (ipwResult)
                     {
-                        if (!ipwPreInline || !srcLogRecord.Info.ValueIsInline)
-                        {
-                            var ipwPostHeap = srcLogRecord.Info.ValueIsInline ? 0L : srcLogRecord.GetValueHeapMemorySize();
-                            var ipwDelta = ipwPostHeap - ipwPreHeap;
-                            if (ipwDelta != 0)
-                                hlogBase.logSizeTracker?.IncrementSize(ipwDelta);
-                        }
+                        if (ipwDelta != 0)
+                            sizeTracker.IncrementSize(ipwDelta);
 
                         MarkPage(stackCtx.recSrc.LogicalAddress, sessionFunctions.Ctx);
                         pendingContext.logicalAddress = stackCtx.recSrc.LogicalAddress;

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/UpsertValueSelector.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/UpsertValueSelector.cs
@@ -32,7 +32,7 @@ namespace Tsavorite.core
                 where TSourceLogRecord : ISourceLogRecord
                 where TSessionFunctionsWrapper : ISessionFunctionsWrapper<TInput, TOutput, TContext, TStoreFunctions, TAllocator>;
 
-            static abstract bool InPlaceWriter<TSourceLogRecord, TInput, TOutput, TContext, TSessionFunctionsWrapper>(ref LogRecord logRecord, in RecordSizeInfo sizeInfo, ref TInput input,
+            static abstract bool InPlaceWriter<TSourceLogRecord, TInput, TOutput, TContext, TSessionFunctionsWrapper>(ref LogRecord logRecord, ref TInput input,
                     ReadOnlySpan<byte> valueSpan, IHeapObject valueObject, in TSourceLogRecord inputLogRecord, ref TOutput output, ref UpsertInfo upsertInfo, TSessionFunctionsWrapper sessionFunctions)
                 where TSourceLogRecord : ISourceLogRecord
                 where TSessionFunctionsWrapper : ISessionFunctionsWrapper<TInput, TOutput, TContext, TStoreFunctions, TAllocator>;
@@ -72,11 +72,11 @@ namespace Tsavorite.core
                 where TSessionFunctionsWrapper : ISessionFunctionsWrapper<TInput, TOutput, TContext, TStoreFunctions, TAllocator>
                 => sessionFunctions.PostInitialWriter(ref logRecord, in sizeInfo, ref input, valueSpan, ref output, ref upsertInfo);
 
-            public static bool InPlaceWriter<TSourceLogRecord, TInput, TOutput, TContext, TSessionFunctionsWrapper>(ref LogRecord logRecord, in RecordSizeInfo sizeInfo, ref TInput input,
+            public static bool InPlaceWriter<TSourceLogRecord, TInput, TOutput, TContext, TSessionFunctionsWrapper>(ref LogRecord logRecord, ref TInput input,
                     ReadOnlySpan<byte> valueSpan, IHeapObject valueObject, in TSourceLogRecord inputLogRecord, ref TOutput output, ref UpsertInfo upsertInfo, TSessionFunctionsWrapper sessionFunctions)
                 where TSourceLogRecord : ISourceLogRecord
                 where TSessionFunctionsWrapper : ISessionFunctionsWrapper<TInput, TOutput, TContext, TStoreFunctions, TAllocator>
-                => sessionFunctions.InPlaceWriter(ref logRecord, in sizeInfo, ref input, valueSpan, ref output, ref upsertInfo);
+                => sessionFunctions.InPlaceWriter(ref logRecord, ref input, valueSpan, ref output, ref upsertInfo);
 
             public static void PostUpsertOperation<TKey, TSourceLogRecord, TInput, TOutput, TContext, TSessionFunctionsWrapper, TEpochAccessor>(TKey key, ref TInput input,
                     ReadOnlySpan<byte> valueSpan, IHeapObject valueObject, in TSourceLogRecord inputLogRecord, ref UpsertInfo upsertInfo, TSessionFunctionsWrapper sessionFunctions, TEpochAccessor epochAccessor)
@@ -114,11 +114,11 @@ namespace Tsavorite.core
                 where TSessionFunctionsWrapper : ISessionFunctionsWrapper<TInput, TOutput, TContext, TStoreFunctions, TAllocator>
                 => sessionFunctions.PostInitialWriter(ref logRecord, in sizeInfo, ref input, valueObject, ref output, ref upsertInfo);
 
-            public static bool InPlaceWriter<TSourceLogRecord, TInput, TOutput, TContext, TSessionFunctionsWrapper>(ref LogRecord logRecord, in RecordSizeInfo sizeInfo, ref TInput input,
+            public static bool InPlaceWriter<TSourceLogRecord, TInput, TOutput, TContext, TSessionFunctionsWrapper>(ref LogRecord logRecord, ref TInput input,
                     ReadOnlySpan<byte> valueSpan, IHeapObject valueObject, in TSourceLogRecord inputLogRecord, ref TOutput output, ref UpsertInfo upsertInfo, TSessionFunctionsWrapper sessionFunctions)
                 where TSourceLogRecord : ISourceLogRecord
                 where TSessionFunctionsWrapper : ISessionFunctionsWrapper<TInput, TOutput, TContext, TStoreFunctions, TAllocator>
-                => sessionFunctions.InPlaceWriter(ref logRecord, in sizeInfo, ref input, valueObject, ref output, ref upsertInfo);
+                => sessionFunctions.InPlaceWriter(ref logRecord, ref input, valueObject, ref output, ref upsertInfo);
 
             public static void PostUpsertOperation<TKey, TSourceLogRecord, TInput, TOutput, TContext, TSessionFunctionsWrapper, TEpochAccessor>(TKey key, ref TInput input,
                     ReadOnlySpan<byte> valueSpan, IHeapObject valueObject, in TSourceLogRecord inputLogRecord, ref UpsertInfo upsertInfo, TSessionFunctionsWrapper sessionFunctions, TEpochAccessor epochAccessor)
@@ -156,11 +156,11 @@ namespace Tsavorite.core
                 where TSessionFunctionsWrapper : ISessionFunctionsWrapper<TInput, TOutput, TContext, TStoreFunctions, TAllocator>
                 => sessionFunctions.PostInitialWriter(ref logRecord, in sizeInfo, ref input, in inputLogRecord, ref output, ref upsertInfo);
 
-            public static bool InPlaceWriter<TSourceLogRecord, TInput, TOutput, TContext, TSessionFunctionsWrapper>(ref LogRecord logRecord, in RecordSizeInfo sizeInfo, ref TInput input,
+            public static bool InPlaceWriter<TSourceLogRecord, TInput, TOutput, TContext, TSessionFunctionsWrapper>(ref LogRecord logRecord, ref TInput input,
                     ReadOnlySpan<byte> valueSpan, IHeapObject valueObject, in TSourceLogRecord inputLogRecord, ref TOutput output, ref UpsertInfo upsertInfo, TSessionFunctionsWrapper sessionFunctions)
                 where TSourceLogRecord : ISourceLogRecord
                 where TSessionFunctionsWrapper : ISessionFunctionsWrapper<TInput, TOutput, TContext, TStoreFunctions, TAllocator>
-                => sessionFunctions.InPlaceWriter(ref logRecord, in sizeInfo, ref input, in inputLogRecord, ref output, ref upsertInfo);
+                => sessionFunctions.InPlaceWriter(ref logRecord, ref input, in inputLogRecord, ref output, ref upsertInfo);
 
             public static void PostUpsertOperation<TKey, TSourceLogRecord, TInput, TOutput, TContext, TSessionFunctionsWrapper, TEpochAccessor>(TKey key, ref TInput input,
                     ReadOnlySpan<byte> valueSpan, IHeapObject valueObject, in TSourceLogRecord inputLogRecord, ref UpsertInfo upsertInfo, TSessionFunctionsWrapper sessionFunctions, TEpochAccessor epochAccessor)


### PR DESCRIPTION
Remove unused sizeInfo from InternalRMW, InternalUpsert, UpsertValueSelector, and SessionFunctionsWrapper.
Make some changes to reduce "if"s and field accesses.
This pull request introduces several improvements and refactorings focused on safety, performance, and maintainability in the string operations and storage engine layers. The main themes are: improved type safety and fast paths for string operations, API simplification in session functions, and more accurate heap memory tracking for in-place updates.

**String Operations and Type Safety:**

* Improved type safety for RangeIndex operations in `RMWMethods.cs`: now, type checks are skipped for normal string records (RecordType 0), and only the relevant checks are performed for RangeIndex and non-RangeIndex keys. This prevents unnecessary checks and improves safety for mixed key types. [[1]](diffhunk://#diff-6cbd87fd835981e3b6c24ab0f1d3d688bb5afa5b3fabcd5cc854f422180e4b43L385-R398) [[2]](diffhunk://#diff-c2463c1b27bd4d763a170369efe1c4de1e1a01dee6684fa01eccb9a1fbcdb384L70-R72)
* Added a fast path for simple GET on normal inline string keys in `ReadMethods.cs`, bypassing unnecessary checks for the most common case, which improves read performance.

**Session Functions API Simplification:**

* Refactored the `ISessionFunctionsWrapper` and related wrappers to remove the unused `RecordSizeInfo` parameter from in-place writer/updater methods, simplifying the API and reducing overhead. [[1]](diffhunk://#diff-34cfff8c1987ea82892eda1e278d07cc9ee7870395f5594494fb3e203536aca8L34-R36) [[2]](diffhunk://#diff-34cfff8c1987ea82892eda1e278d07cc9ee7870395f5594494fb3e203536aca8L74-R74) [[3]](diffhunk://#diff-07106efb13a725a8a65e4c8e2f532110d57ec9fab0c639f89081037d1dbaeb6eL80-R80) [[4]](diffhunk://#diff-07106efb13a725a8a65e4c8e2f532110d57ec9fab0c639f89081037d1dbaeb6eL89-R89) [[5]](diffhunk://#diff-07106efb13a725a8a65e4c8e2f532110d57ec9fab0c639f89081037d1dbaeb6eL98-R98) [[6]](diffhunk://#diff-07106efb13a725a8a65e4c8e2f532110d57ec9fab0c639f89081037d1dbaeb6eL170-R170)

**Performance and Memory Tracking:**

* Improved heap memory tracking in `InternalRMW.cs` by using a `logSizeTracker` to accurately measure and update heap usage before and after in-place updates, including special handling for expired or deleted objects. [[1]](diffhunk://#diff-e849ad4cd2836cd94788ed7d263581d6cbb100ef17df83434868726eb6db2927L143-R151) [[2]](diffhunk://#diff-e849ad4cd2836cd94788ed7d263581d6cbb100ef17df83434868726eb6db2927L169-R170)

**Code Quality and Maintainability:**

* Added `[MethodImpl(MethodImplOptions.AggressiveInlining)]` to several frequently called methods to encourage inlining and improve performance. [[1]](diffhunk://#diff-6cbd87fd835981e3b6c24ab0f1d3d688bb5afa5b3fabcd5cc854f422180e4b43R1434) [[2]](diffhunk://#diff-c2463c1b27bd4d763a170369efe1c4de1e1a01dee6684fa01eccb9a1fbcdb384R107) [[3]](diffhunk://#diff-c2463c1b27bd4d763a170369efe1c4de1e1a01dee6684fa01eccb9a1fbcdb384R120) [[4]](diffhunk://#diff-234e6471caa11f648cd44c617ad54016250f731d14897bf31421d3e5cf42bfccR164)
* Minor documentation and initialization fixes, including clarifying comments and ensuring proper initialization of local variables. [[1]](diffhunk://#diff-fe74096631e636a46832a07504c04c0d0141e52012c14b139695ef2aca4a4146L15-R15) [[2]](diffhunk://#diff-234e6471caa11f648cd44c617ad54016250f731d14897bf31421d3e5cf42bfccL96-R104) [[3]](diffhunk://#diff-6cbd87fd835981e3b6c24ab0f1d3d688bb5afa5b3fabcd5cc854f422180e4b43R6) [[4]](diffhunk://#diff-234e6471caa11f648cd44c617ad54016250f731d14897bf31421d3e5cf42bfccR6)

**Other:**

* Added clarifying comments to the SETNX/SETXX command encodings in `RawStringOperations.cs`.
* Added a note regarding possible expiration on SETEXXX in `RMWMethods.cs`.