### PR TITLE
[dev][RangeIndex] Fix FlagRecovered never cleared on RangeIndex stub after restore

### DIFF
--- a/libs/server/Resp/RangeIndex/RangeIndexManager.Index.cs
+++ b/libs/server/Resp/RangeIndex/RangeIndexManager.Index.cs
@@ -138,6 +138,10 @@ namespace Garnet.server
         {
             ref var stub = ref Unsafe.As<byte, RangeIndexStub>(ref MemoryMarshal.GetReference(valueSpan));
             stub.TreeHandle = newTreeHandle;
+
+            // Clear FlagRecovered so that future eviction cycles use the flush snapshot
+            // (which reflects post-recovery writes) instead of the stale checkpoint snapshot.
+            stub.Flags &= unchecked((byte)~RangeIndexStub.FlagRecovered);
         }
 
         /// <summary>

--- a/test/Garnet.test/RespRangeIndexTests.cs
+++ b/test/Garnet.test/RespRangeIndexTests.cs
@@ -1955,6 +1955,59 @@ namespace Garnet.test
         }
 
         /// <summary>
+        /// After checkpoint recovery, <c>FlagRecovered</c> must be cleared when the tree
+        /// is first restored. Otherwise, a second eviction cycle causes
+        /// RestoreTreeFromFlush to pick the stale checkpoint snapshot instead of the
+        /// fresh <c>flush.bftree</c>, losing post-recovery writes.
+        /// </summary>
+        [Test]
+        public void RIRecoverThenSecondEvictionUsesFlushSnapshotTest()
+        {
+            server.Dispose();
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableRangeIndexPreview: true, lowMemory: true, enableAOF: true);
+            server.Start();
+
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true)))
+            {
+                var db = redis.GetDatabase(0);
+
+                db.Execute("RI.CREATE", "stalecp", "DISK", "CACHESIZE", "65536", "MINRECORD", "8");
+                db.Execute("RI.SET", "stalecp", "pre-checkpoint", "original");
+                db.Execute("SAVE");
+            }
+
+            server.Dispose();
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableRangeIndexPreview: true, lowMemory: true, enableAOF: true, tryRecover: true);
+            server.Start();
+
+            var rangeIndexManager = server.Provider.StoreWrapper.rangeIndexManager;
+
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true)))
+            {
+                var db = redis.GetDatabase(0);
+
+                var val = db.Execute("RI.GET", "stalecp", "pre-checkpoint");
+                ClassicAssert.AreEqual("original", (string)val, "Checkpoint data should be restored");
+
+                db.Execute("RI.SET", "stalecp", "post-recovery", "new-value");
+
+                // Fill log to trigger flush (writes flush.bftree) then eviction (frees tree)
+                for (int i = 0; i < 200; i++)
+                    db.StringSet($"fill{i:D4}", $"data{i:D4}");
+
+                ClassicAssert.AreEqual(0, rangeIndexManager.LiveIndexCount, "Tree should be evicted");
+
+                val = db.Execute("RI.GET", "stalecp", "pre-checkpoint");
+                ClassicAssert.AreEqual("original", (string)val, "Pre-checkpoint data should survive");
+
+                val = db.Execute("RI.GET", "stalecp", "post-recovery");
+                ClassicAssert.AreEqual("new-value", (string)val,
+                    "Post-recovery data must survive eviction (flush.bftree, not stale checkpoint)");
+            }
+        }
+
+        /// <summary>
         /// Verifies pure AOF-only recovery (no checkpoint). RI.CREATE is replayed to
         /// recreate the BfTree, then RI.SET/RI.DEL operations rebuild the data.
         /// </summary>

--- a/website/docs/dev/range-index-resp-api.md
+++ b/website/docs/dev/range-index-resp-api.md
@@ -65,8 +65,12 @@ When `ReadRangeIndex` detects `TreeHandle == 0`:
 3. Re-read stub — if another thread already restored, return
 4. Determine snapshot path: `FlagRecovered` → checkpoint file, else → `flush.bftree`
 5. Copy snapshot to `data.bftree` (working path), open via `RecoverFromSnapshot`
-6. Register in `liveIndexes`, issue `RIRESTORE` RMW to set new `TreeHandle`
+6. Register in `liveIndexes`, issue `RIRESTORE` RMW to set new `TreeHandle` and clear `FlagRecovered`
 7. Release exclusive lock, retry
+
+> **Note:** `RecreateIndex()` clears `FlagRecovered` when setting the new `TreeHandle`.
+> This ensures that subsequent eviction cycles restore from `flush.bftree` (which
+> reflects post-recovery writes) rather than the stale checkpoint snapshot.
 
 ### Checkpoint Consistency
 


### PR DESCRIPTION
## Summary

After checkpoint recovery, FlagRecovered is set on RangeIndex stubs but never cleared. On a second eviction cycle, RestoreTreeFromFlush picks the stale checkpoint snapshot instead of the fresh flush.bftree, losing post-recovery writes.

## Root Cause

RecreateIndex() only sets TreeHandle — it does not clear FlagRecovered. No other code path clears the flag either.

**Scenario:**
1. Create disk-backed RI key, insert data, checkpoint
2. Recover from checkpoint — FlagRecovered set on stub
3. First access restores from checkpoint snapshot (correct)
4. Write new data (tree diverges from checkpoint)
5. Eviction triggers flush (writes flush.bftree with current state) then frees tree
6. Next access — RestoreTreeFromFlush sees FlagRecovered still set — picks stale checkpoint snapshot
7. Post-recovery writes are lost

## Fix

Clear FlagRecovered in RecreateIndex() after setting the new TreeHandle. This is safe because Tsavorite always calls OnFlush (which writes a fresh flush.bftree) before eviction, so any post-restore eviction will have the correct flush snapshot available.

## Testing

- Added RIRecoverThenSecondEvictionUsesFlushSnapshotTest
- Without fix: test fails (Expected: "new-value" But was: null)
- With fix: test passes
- All 56 existing RI tests pass (no regressions)
