### PR TITLE
Block on TLS auth in NetworkHandler

### DIFF
--- a/benchmark/BDN.benchmark/Embedded/GarnetServerEmbedded.cs
+++ b/benchmark/BDN.benchmark/Embedded/GarnetServerEmbedded.cs
@@ -72,17 +72,6 @@ namespace Embedded.server
                     {
                         IncrementConnectionsReceived();
                         handler.Start(tlsOptions, remoteEndpointName);
-
-                        // Spin until auth finishes
-                        while (!handler.IsAuthenticated(out var fault))
-                        {
-                            if (fault != null)
-                            {
-                                throw new Exception("Authentication failed", fault);
-                            }
-
-                            Thread.Sleep(1);
-                        }
                     }
                     catch (Exception ex)
                     {

--- a/libs/client/ClientSession/GarnetClientSession.cs
+++ b/libs/client/ClientSession/GarnetClientSession.cs
@@ -148,20 +148,6 @@ namespace Garnet.client
                 networkSendThrottleMax: networkSendThrottleMax,
                 logger: logger);
             networkHandler.Start(sslOptions, EndPoint.ToString(), token);
-
-            // Spin until auth finishes or cancellation occurs
-            while (!networkHandler.IsAuthenticated(out var fault))
-            {
-                if (fault != null)
-                {
-                    throw new Exception("Authentication failed", fault);
-                }
-
-                token.ThrowIfCancellationRequested();
-
-                Thread.Sleep(1);
-            }
-
             networkSender = networkHandler.GetNetworkSender();
             networkSender.GetResponseObject();
             offset = networkSender.GetResponseObjectHead();

--- a/libs/client/GarnetClient.cs
+++ b/libs/client/GarnetClient.cs
@@ -201,19 +201,6 @@ namespace Garnet.client
             networkWriter = new NetworkWriter(this, socket, bufferSize, sslOptions, out networkHandler, sendPageSize, networkSendThrottleMax, epoch, logger);
             networkHandler.Start(sslOptions, EndPoint.ToString(), token);
 
-            // Spin until auth finishes or cancellation occurs
-            while (!networkHandler.IsAuthenticated(out var fault))
-            {
-                if (fault != null)
-                {
-                    throw new Exception("Authentication failed", fault);
-                }
-
-                token.ThrowIfCancellationRequested();
-
-                Thread.Sleep(1);
-            }
-
             if (timeoutMilliseconds > 0)
             {
                 Task.Run(TimeoutChecker);

--- a/libs/common/LightClient.cs
+++ b/libs/common/LightClient.cs
@@ -114,18 +114,6 @@ namespace Garnet.common
             socket = ConnectSendSocket();
             networkHandler = new LightClientTcpNetworkHandler(this, socket, networkBufferSettings, networkPool, sslOptions != null, this);
             networkHandler.Start(sslOptions, endpoint.ToString());
-
-            // Spin until auth finishes or cancellation occurs
-            while (!networkHandler.IsAuthenticated(out var fault))
-            {
-                if (fault != null)
-                {
-                    throw new Exception("Authentication failed", fault);
-                }
-
-                Thread.Sleep(1);
-            }
-
             networkSender = networkHandler.GetNetworkSender();
             networkSender.GetResponseObject();
         }

--- a/libs/common/Networking/NetworkHandler.cs
+++ b/libs/common/Networking/NetworkHandler.cs
@@ -142,7 +142,7 @@ namespace Garnet.networking
         /// <summary>
         /// Begin (background) network handler.
         /// 
-        /// 
+        /// Blocks until auth completes.
         /// </summary>
         public virtual void Start(SslServerAuthenticationOptions tlsOptions = null, string remoteEndpointName = null, CancellationToken token = default)
         {
@@ -158,8 +158,6 @@ namespace Garnet.networking
 
         /// <summary>
         /// Begin async network handler.
-        /// 
-        /// Blocks until auth completes.
         /// </summary>
         public virtual async Task StartAsync(SslServerAuthenticationOptions tlsOptions = null, string remoteEndpointName = null, CancellationToken token = default)
         {

--- a/libs/common/Networking/NetworkHandler.cs
+++ b/libs/common/Networking/NetworkHandler.cs
@@ -91,7 +91,6 @@ namespace Garnet.networking
         readonly SslStream sslStream;
         readonly SemaphoreSlim receivedData, expectingData;
         protected readonly CancellationTokenSource cancellationTokenSource;
-        Exception authFault;
 
         // Stream reader status: Rest = 0, Active = 1, Waiting = 2
         volatile TlsReaderStatus readerStatus;
@@ -141,8 +140,9 @@ namespace Garnet.networking
         }
 
         /// <summary>
-        /// Begin (background) network handler (including auth). Make sure you do not send data
-        /// until authentication completes.
+        /// Begin (background) network handler.
+        /// 
+        /// 
         /// </summary>
         public virtual void Start(SslServerAuthenticationOptions tlsOptions = null, string remoteEndpointName = null, CancellationToken token = default)
         {
@@ -152,11 +152,14 @@ namespace Garnet.networking
                 throw new Exception("Cannot provide SslServerAuthenticationOptions when TLS is disabled");
             if (tlsOptions == null && sslStream == null) return;
 
-            _ = AuthenticateAsServerAsync(tlsOptions, remoteEndpointName, token);
+            // Can't use SslStream's sync methods for auth, so we must block
+            AsyncUtils.BlockingWait(AuthenticateAsServerAsync(tlsOptions, remoteEndpointName, token));
         }
 
         /// <summary>
-        /// Begin async network handler (including auth)
+        /// Begin async network handler.
+        /// 
+        /// Blocks until auth completes.
         /// </summary>
         public virtual async Task StartAsync(SslServerAuthenticationOptions tlsOptions = null, string remoteEndpointName = null, CancellationToken token = default)
         {
@@ -196,8 +199,6 @@ namespace Garnet.networking
             }
             catch (Exception ex)
             {
-                authFault = ex;
-
                 logger?.LogWarning(ex, "An error has occurred");
                 readerStatus = TlsReaderStatus.Rest;
                 if (expectingData.CurrentCount == 0) expectingData.Release();
@@ -207,9 +208,9 @@ namespace Garnet.networking
         }
 
         /// <summary>
-        /// Begin (background) network handler (including auth).
+        /// Begin (background) network handler.
         /// 
-        /// Make sure you do not send data until authentication completes - use <see cref="IsAuthenticated"/> to check this.
+        /// Blocks until auth completes.
         /// </summary>
         public virtual void Start(SslClientAuthenticationOptions tlsOptions, string remoteEndpointName = null, CancellationToken token = default)
         {
@@ -219,7 +220,8 @@ namespace Garnet.networking
                 throw new Exception("Cannot provide SslClientAuthenticationOptions when TLS is disabled");
             if (tlsOptions == null && sslStream == null) return;
 
-            _ = AuthenticateAsClientAsync(tlsOptions, remoteEndpointName, token);
+            // Can't use SslStream's sync methods for auth, so we must block
+            AsyncUtils.BlockingWait(AuthenticateAsClientAsync(tlsOptions, remoteEndpointName, token));
         }
 
         /// <summary>
@@ -261,34 +263,12 @@ namespace Garnet.networking
             }
             catch (Exception ex)
             {
-                authFault = ex;
-
                 logger?.LogWarning(ex, "An error has occurred");
                 readerStatus = TlsReaderStatus.Rest;
                 if (expectingData.CurrentCount == 0) expectingData.Release();
                 Dispose();
                 throw;
             }
-        }
-
-
-        /// <summary>
-        /// Returns true if handler has completed authentication or doesn't require authentication in the first place.
-        /// 
-        /// If a fault occurred during authentication it will be set when false is returned.
-        /// 
-        /// Use in conjunction with <see cref="Start(SslClientAuthenticationOptions, string, CancellationToken)"/> or <see cref="Start(SslServerAuthenticationOptions, string, CancellationToken)"/>.
-        /// </summary>
-        public bool IsAuthenticated(out Exception fault)
-        {
-            if (sslStream == null)
-            {
-                fault = null;
-                return true;
-            }
-
-            fault = authFault;
-            return sslStream?.IsAuthenticated ?? true;
         }
 
         public unsafe void OnNetworkReceiveWithoutTLS(int bytesTransferred)


### PR DESCRIPTION
Follow up on #1714 - block in `NetworkHandler.Start()` methods on TLS auth.

TODO:
 - [x] `dev` targeting version (https://github.com/microsoft/garnet/pull/1750)