### PR TITLE
Fix misc memory bugs [dev]

### DIFF
--- a/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
@@ -210,15 +210,15 @@ namespace Garnet.server
                     break;
 
                 case RespCommand.BITOP:
-                    var outPtr = output.SpanByteAndMemory.SpanByte.ToPointer();
-
-                    if (srcLogRecord.IsPinnedValue)
-                        *(long*)outPtr = ((IntPtr)srcLogRecord.PinnedValuePointer).ToInt64();
-                    else
-                        fixed (byte* valuePtr = value)
-                            *(long*)outPtr = ((IntPtr)valuePtr).ToInt64();
-
-                    *(int*)(outPtr + sizeof(long)) = value.Length;
+                    // Expose the value as a SpanByteAndMemory: inline values point directly at log memory
+                    // (stable under the unsafe context); overflow values come back as a no-copy borrowed
+                    // Memory<byte> that the caller pins for the duration of BITOP execution. For values
+                    // sourced from a DiskLogRecord (pending completion of a disk read), the inline
+                    // SectorAlignedMemory recordBuffer would be returned to the pool when the
+                    // DiskLogRecord is disposed; the getter handles that by copying inline values into a
+                    // pooled IMemoryOwner before returning, so the SpanByteAndMemory returned here is
+                    // always safe to use beyond this callback.
+                    output.SpanByteAndMemory = srcLogRecord.ValueSpanByteAndMemory;
                     return;
 
                 case RespCommand.BITFIELD:
@@ -253,36 +253,43 @@ namespace Garnet.server
 
                 case RespCommand.PFCOUNT:
                 case RespCommand.PFMERGE:
+                    // Caller (HyperLogLogOps) provides a sector-aligned destination buffer sized to
+                    // HyperLogLog.DefaultHLL.DenseBytes. Validate signature AND size before the copy
+                    // so a corrupted/oversized value cannot overflow the destination.
+                    var pfDstPtr = output.SpanByteAndMemory.SpanByte.ToPointer();
+                    var pfDstCapacity = output.SpanByteAndMemory.SpanByte.Length;
+
                     bool isValid;
                     if (srcLogRecord.IsPinnedValue)
                     {
                         isValid = HyperLogLog.DefaultHLL.IsValidHYLL(srcLogRecord.PinnedValuePointer, value.Length);
-                        if (isValid)
-                            Buffer.MemoryCopy(srcLogRecord.PinnedValuePointer, output.SpanByteAndMemory.SpanByte.ToPointer(), value.Length, value.Length);
                     }
                     else
                     {
                         fixed (byte* valuePtr = value)
-                        {
                             isValid = HyperLogLog.DefaultHLL.IsValidHYLL(valuePtr, value.Length);
-                            if (isValid)
-                                Buffer.MemoryCopy(valuePtr, output.SpanByteAndMemory.SpanByte.ToPointer(), value.Length, value.Length);
-                        }
                     }
 
-                    if (!isValid)
+                    // Surface invalid OR oversized as the -1 sentinel; the caller already checks for it.
+                    if (!isValid || value.Length > pfDstCapacity)
                     {
-                        *(long*)output.SpanByteAndMemory.SpanByte.ToPointer() = -1;
+                        *(long*)pfDstPtr = -1;
                         return;
                     }
 
-                    if (value.Length <= output.SpanByteAndMemory.Length)
+                    // Pass the actual destination capacity to MemoryCopy so the bounds check is meaningful.
+                    if (srcLogRecord.IsPinnedValue)
                     {
-                        output.SpanByteAndMemory.SpanByte.Length = value.Length;
-                        return;
+                        Buffer.MemoryCopy(srcLogRecord.PinnedValuePointer, pfDstPtr, pfDstCapacity, value.Length);
+                    }
+                    else
+                    {
+                        fixed (byte* valuePtr = value)
+                            Buffer.MemoryCopy(valuePtr, pfDstPtr, pfDstCapacity, value.Length);
                     }
 
-                    throw new GarnetException($"Not enough space in {input.header.cmd} buffer");
+                    output.SpanByteAndMemory.SpanByte.Length = value.Length;
+                    return;
 
                 case RespCommand.TTL:
                     var ttlValue = ConvertUtils.SecondsFromDiffUtcNowTicks(srcLogRecord.Info.HasExpiration ? srcLogRecord.Expiration : -1);

--- a/libs/server/Storage/Session/MainStore/BitmapOps.cs
+++ b/libs/server/Storage/Session/MainStore/BitmapOps.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
@@ -74,11 +75,15 @@ namespace Garnet.server
             var keys = input.parseState.Parameters;
             var keyCount = keys.Length;
 
-            // 8 byte start pointer
-            // 4 byte int length
-            Span<byte> output = stackalloc byte[12];
             var srcBitmapPtrs = stackalloc byte*[keyCount - 1];
             var srcBitmapEndPtrs = stackalloc byte*[keyCount - 1];
+
+            // Tracks heap-allocated source value buffers (used when the value is stored as overflow byte[]
+            // outside the log) and the pin handle held over them for the duration of BITOP execution.
+            // Allocated lazily and disposed in the finally block.
+            IMemoryOwner<byte>[] overflowOwners = null;
+            MemoryHandle[] overflowHandles = null;
+            var overflowCount = 0;
 
             var createTransaction = false;
             if (txnManager.state != TxnState.Running)
@@ -99,15 +104,24 @@ namespace Garnet.server
             {
                 uc.BeginUnsafe();
             readFromScratch:
-                var localHeadAddress = HeadAddress;
+                // Reset all per-attempt state and release any pin handles / heap buffers accumulated by the
+                // previous attempt before re-reading sources from scratch.
+                ReleaseOverflowBuffers(overflowOwners, overflowHandles, ref overflowCount);
+                maxBitmapLen = int.MinValue;
+                minBitmapLen = int.MaxValue;
+
+                var localHeadAddress = uc.Session.HeadAddress;
+                var localReadCacheHeadAddress = uc.Session.ReadCacheHeadAddress;
                 var keysFound = 0;
 
                 for (var i = 1; i < keys.Length; i++)
                 {
                     var srcKey = keys[i];
-                    //Read srcKey
-                    var outputBitmap = StringOutput.FromPinnedSpan(output);
-                    status = ReadWithUnsafeContext(srcKey, ref input, ref outputBitmap, localHeadAddress, out bool epochChanged, ref uc);
+                    // Read srcKey. The backend populates either SpanByteAndMemory.SpanByte (inline values
+                    // already pinned in log memory) or SpanByteAndMemory.Memory (overflow values copied to
+                    // a heap-rented buffer that we must pin here for BITOP execution).
+                    var outputBitmap = new StringOutput();
+                    status = ReadWithUnsafeContext(srcKey, ref input, ref outputBitmap, localHeadAddress, localReadCacheHeadAddress, out bool epochChanged, ref uc);
                     if (epochChanged)
                     {
                         goto readFromScratch;
@@ -117,9 +131,31 @@ namespace Garnet.server
                     if (status == GarnetStatus.NOTFOUND)
                         continue;
 
-                    var outputBitmapPtr = outputBitmap.SpanByteAndMemory.SpanByte.ToPointer();
-                    var localBitmapPtr = (byte*)(nuint)(*(ulong*)outputBitmapPtr);
-                    var localBitmapLength = *(int*)(outputBitmapPtr + 8);
+                    byte* localBitmapPtr;
+                    int localBitmapLength;
+
+                    if (outputBitmap.SpanByteAndMemory.IsSpanByte)
+                    {
+                        // Inline value: SpanByte points directly into the log buffer.
+                        localBitmapPtr = outputBitmap.SpanByteAndMemory.SpanByte.ToPointer();
+                        localBitmapLength = outputBitmap.SpanByteAndMemory.SpanByte.Length;
+                    }
+                    else
+                    {
+                        // Overflow value: data was copied into a heap buffer. Pin it so that GC compaction
+                        // cannot relocate the underlying array between now and the BITOP execution below.
+                        var owner = outputBitmap.SpanByteAndMemory.Memory;
+                        localBitmapLength = outputBitmap.SpanByteAndMemory.Length;
+                        var memHandle = owner.Memory.Pin();
+
+                        overflowOwners ??= new IMemoryOwner<byte>[keys.Length - 1];
+                        overflowHandles ??= new MemoryHandle[keys.Length - 1];
+                        overflowOwners[overflowCount] = owner;
+                        overflowHandles[overflowCount] = memHandle;
+                        overflowCount++;
+
+                        localBitmapPtr = (byte*)memHandle.Pointer;
+                    }
 
                     // Keep track of pointers returned from ISessionFunctions
                     srcBitmapPtrs[keysFound] = localBitmapPtr;
@@ -163,11 +199,23 @@ namespace Garnet.server
             {
                 // Suspend Thread
                 uc.EndUnsafe();
+                // Release any overflow pin handles and heap buffers regardless of whether BITOP succeeded.
+                ReleaseOverflowBuffers(overflowOwners, overflowHandles, ref overflowCount);
                 if (createTransaction)
                     txnManager.Commit(true);
             }
             result = maxBitmapLen;
             return status;
+
+            static void ReleaseOverflowBuffers(IMemoryOwner<byte>[] owners, MemoryHandle[] handles, ref int count)
+            {
+                for (var h = 0; h < count; h++)
+                {
+                    handles[h].Dispose();
+                    owners[h].Dispose();
+                }
+                count = 0;
+            }
         }
 
         public GarnetStatus StringBitOperation(BitmapOperation bitOp, PinnedSpanByte destinationKey, PinnedSpanByte[] keys, out long result)

--- a/libs/server/Storage/Session/MainStore/HyperLogLogOps.cs
+++ b/libs/server/Storage/Session/MainStore/HyperLogLogOps.cs
@@ -135,6 +135,10 @@ namespace Garnet.server
                     // Handle case merging source key does not exist
                     if (status == GarnetStatus.NOTFOUND)
                         continue;
+                    // The PFCOUNT/PFMERGE backend is contracted to populate SpanByte (sector-aligned native
+                    // memory we passed in) and never overflow to heap Memory. Assert the contract so any
+                    // future regression is caught immediately rather than silently returning garbage.
+                    Debug.Assert(srcMergeBuffer.SpanByteAndMemory.IsSpanByte, "PFCOUNT backend must populate SpanByte");
                     // Invalid Type
                     if (*(long*)srcReadBuffer == -1)
                     {
@@ -228,6 +232,11 @@ namespace Garnet.server
                     // Handle case merging source key does not exist
                     if (status == GarnetStatus.NOTFOUND)
                         continue;
+
+                    // The PFCOUNT/PFMERGE backend is contracted to populate SpanByte (sector-aligned native
+                    // memory we passed in) and never overflow to heap Memory. Assert the contract so any
+                    // future regression is caught immediately rather than silently returning garbage.
+                    Debug.Assert(mergeBuffer.SpanByteAndMemory.IsSpanByte, "PFMERGE backend must populate SpanByte");
 
                     // Invalid Type
                     if (*(long*)readBuffer == -1)

--- a/libs/server/Storage/Session/MainStore/MainStoreOps.cs
+++ b/libs/server/Storage/Session/MainStore/MainStoreOps.cs
@@ -41,7 +41,7 @@ namespace Garnet.server
             }
         }
 
-        public unsafe GarnetStatus ReadWithUnsafeContext<TStringContext>(PinnedSpanByte key, ref StringInput input, ref StringOutput output, long localHeadAddress, out bool epochChanged, ref TStringContext context)
+        public unsafe GarnetStatus ReadWithUnsafeContext<TStringContext>(PinnedSpanByte key, ref StringInput input, ref StringOutput output, long localHeadAddress, long localReadCacheHeadAddress, out bool epochChanged, ref TStringContext context)
             where TStringContext : ITsavoriteContext<FixedSpanByteKey, StringInput, StringOutput, long, MainSessionFunctions, StoreFunctions, StoreAllocator>, IUnsafeContext
         {
             epochChanged = false;
@@ -54,8 +54,12 @@ namespace Garnet.server
                 CompletePendingForSession(ref status, ref output, ref context);
                 StopPendingMetrics();
                 context.BeginUnsafe();
-                // Start read of pointers from beginning if epoch changed
-                if (HeadAddress == localHeadAddress)
+                // If either the main-log head or the read-cache head advanced while we waited on
+                // pending I/O, any log/read-cache pointers captured by previous reads in this loop
+                // may now reference evicted pages. Tell the caller to re-read all sources from
+                // scratch. (Synchronously-returned reads can have pointers into either log.)
+                if (context.Session.HeadAddress != localHeadAddress
+                    || context.Session.ReadCacheHeadAddress != localReadCacheHeadAddress)
                 {
                     context.EndUnsafe();
                     epochChanged = true;

--- a/libs/server/Storage/Session/ObjectStore/SortedSetGeoOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/SortedSetGeoOps.cs
@@ -201,9 +201,20 @@ namespace Garnet.server
                     }, ref parseState);
 
                     var zAddOutput = new ObjectOutput();
-                    RMWObjectStoreOperation(destination, ref zAddInput, ref geoObjectTransactionalContext, ref zAddOutput);
+                    try
+                    {
+                        RMWObjectStoreOperation(destination, ref zAddInput, ref geoObjectTransactionalContext, ref zAddOutput);
 
-                    writer.WriteInt32(foundItems);
+                        writer.WriteInt32(foundItems);
+                    }
+                    finally
+                    {
+                        // ZADD backend writes its result via RespMemoryWriter, which allocates a
+                        // MemoryPool buffer when the (default) SpanByte cannot hold the response.
+                        // Dispose to avoid leaking that buffer back to the pool.
+                        if (!zAddOutput.SpanByteAndMemory.IsSpanByte)
+                            zAddOutput.SpanByteAndMemory.Memory?.Dispose();
+                    }
                 }
                 finally
                 {

--- a/libs/server/Storage/Session/ObjectStore/SortedSetOps.cs
+++ b/libs/server/Storage/Session/ObjectStore/SortedSetOps.cs
@@ -789,13 +789,27 @@ namespace Garnet.server
                         }, ref parseState);
 
                         var zAddOutput = new ObjectOutput();
-                        RMWObjectStoreOperation(destinationKey, ref zAddInput, ref ssObjectTransactionalContext, ref zAddOutput);
-                        itemBroker?.HandleCollectionUpdate(destinationKey.ToArray());
+                        try
+                        {
+                            RMWObjectStoreOperation(destinationKey, ref zAddInput, ref ssObjectTransactionalContext, ref zAddOutput);
+                            itemBroker?.HandleCollectionUpdate(destinationKey.ToArray());
+                        }
+                        finally
+                        {
+                            // ZADD backend writes its result via RespMemoryWriter, which allocates a
+                            // MemoryPool buffer when the (default) SpanByte cannot hold the response.
+                            // Dispose to avoid leaking that buffer back to the pool.
+                            if (!zAddOutput.SpanByteAndMemory.IsSpanByte)
+                                zAddOutput.SpanByteAndMemory.Memory?.Dispose();
+                        }
                     }
                 }
                 finally
                 {
                     rangeOutputHandler.Dispose();
+                    // SortedSetRange writes via RespMemoryWriter, which (with a default SpanByte) rents
+                    // a MemoryPool buffer and assigns it here. Dispose to release it back to the pool.
+                    rangeOutputMem.Dispose();
                 }
                 return status;
             }

--- a/libs/server/Storage/Session/StorageSession.cs
+++ b/libs/server/Storage/Session/StorageSession.cs
@@ -17,7 +17,6 @@ namespace Garnet.server
     {
         int bitmapBufferSize = 1 << 15;
         SectorAlignedMemory sectorAlignedMemoryBitmap;
-        readonly long HeadAddress;
 
         /// <summary>
         /// Session Contexts for main store
@@ -146,7 +145,6 @@ namespace Garnet.server
             vectorBasicContext = vectorSession.BasicContext;
             vectorTransactionalContext = vectorSession.TransactionalContext;
 
-            HeadAddress = db.Store.Log.HeadAddress;
             ObjectScanCountLimit = storeWrapper.serverOptions.ObjectScanCountLimit;
         }
 

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/DiskLogRecord.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/DiskLogRecord.cs
@@ -192,6 +192,33 @@ namespace Tsavorite.core
         }
 
         /// <inheritdoc/>
+        public readonly SpanByteAndMemory ValueSpanByteAndMemory
+        {
+            get
+            {
+                // For an inline value, the underlying SpanByte points into this DiskLogRecord's
+                // recordBuffer (a SectorAlignedMemory rented from a pool). That buffer is returned
+                // to the pool when this DiskLogRecord is disposed -- typically as part of pending-
+                // completion cleanup, immediately after the read callback returns, or when a scan
+                // iterator advances. To keep the contract uniform with in-memory LogRecord (where
+                // SpanByte is stable for the unsafe context), copy the bytes into a pooled
+                // IMemoryOwner so the returned SpanByteAndMemory remains valid past disposal.
+                if (logRecord.IsPinnedValue)
+                {
+                    var span = logRecord.ValueSpan;
+                    var owner = MemoryPool<byte>.Shared.Rent(span.Length);
+                    span.CopyTo(owner.Memory.Span);
+                    return new SpanByteAndMemory(owner, span.Length);
+                }
+
+                // Overflow values come back as a no-copy BorrowedMemoryOwner around the underlying
+                // GC-managed byte[]. The byte[] stays rooted via the Memory<byte> reference inside
+                // the owner, so it survives DiskLogRecord disposal without an extra copy.
+                return logRecord.ValueSpanByteAndMemory;
+            }
+        }
+
+        /// <inheritdoc/>
         public readonly byte RecordType => logRecord.IsSet ? logRecord.RecordType : default;
 
         /// <inheritdoc/>

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/ISourceLogRecord.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/ISourceLogRecord.cs
@@ -59,6 +59,45 @@ namespace Tsavorite.core
         /// <summary>Get and set the <see cref="OverflowByteArray"/> if this Value is not Overflow; an exception is thrown if it is a pinned pointer (e.g. to a <see cref="SectorAlignedMemory"/>.</summary>
         OverflowByteArray ValueOverflow { get; set; }
 
+        /// <summary>
+        /// Expose the value bytes through the <see cref="SpanByteAndMemory"/> abstraction.
+        /// </summary>
+        /// <remarks>
+        /// <para>The shape and lifetime of the returned <see cref="SpanByteAndMemory"/> depend on
+        /// the source record:
+        /// <list type="bullet">
+        /// <item><description><b>In-memory <see cref="LogRecord"/>, inline value</b> — returns a
+        /// <see cref="SpanByteAndMemory.SpanByte"/> pointing directly at the allocator's main log
+        /// memory (no copy). The pointer is valid <em>only while the enclosing epoch / unsafe
+        /// context is held</em>; once the epoch is released the page may be evicted and the
+        /// pointer becomes invalid.</description></item>
+        /// <item><description><b><see cref="DiskLogRecord"/>, inline value</b> — the bytes are
+        /// copied into a pooled <see cref="System.Buffers.IMemoryOwner{T}"/> returned in
+        /// <see cref="SpanByteAndMemory.Memory"/>. The underlying
+        /// <see cref="SectorAlignedMemory"/> <c>recordBuffer</c> is returned to its pool when the
+        /// <see cref="DiskLogRecord"/> is disposed (e.g. at the end of pending completion or when
+        /// a scan iterator advances), so the inline pointer would otherwise dangle; the copy
+        /// makes the returned <see cref="SpanByteAndMemory.Memory"/> safe beyond the callback /
+        /// iterator scope.</description></item>
+        /// <item><description><b>Overflow value</b> (either record type) — returns a no-copy
+        /// <see cref="BorrowedMemoryOwner"/> wrapping the underlying GC-managed byte[]. The array
+        /// stays rooted via the <see cref="System.Memory{T}"/> reference inside the owner, so the
+        /// contents survive disposal of the source record (and do not require epoch protection).
+        /// </description></item>
+        /// </list>
+        /// </para>
+        /// <para>Consumers that need a stable native pointer (e.g. for SIMD operations) into the
+        /// <see cref="SpanByteAndMemory.Memory"/> path MUST call <see cref="System.Memory{T}.Pin"/>
+        /// on it and hold the resulting <see cref="System.Buffers.MemoryHandle"/> for the duration
+        /// of the operation, otherwise GC compaction may relocate the underlying array.</para>
+        /// <para>The caller owns the returned <see cref="SpanByteAndMemory.Memory"/> (when set)
+        /// and is responsible for disposing it. <see cref="BorrowedMemoryOwner"/>'s
+        /// <see cref="System.IDisposable.Dispose"/> is a no-op; pooled owners returned for the
+        /// inline <see cref="DiskLogRecord"/> path return their buffer to the pool on dispose.</para>
+        /// <para>Throws if the value is an object.</para>
+        /// </remarks>
+        SpanByteAndMemory ValueSpanByteAndMemory { get; }
+
         /// <summary>The ETag of the record, if any (see <see cref="RecordInfo.HasETag"/>; 0 by default.</summary>
         long ETag { get; }
 

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/LogRecord.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/LogRecord.cs
@@ -342,6 +342,22 @@ namespace Tsavorite.core
         }
 
         /// <inheritdoc/>
+        public readonly SpanByteAndMemory ValueSpanByteAndMemory
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                if (Info.ValueIsObject)
+                    ThrowTsavoriteException("ValueSpanByteAndMemory is not valid for Object values");
+                var (length, dataAddress) = new RecordDataHeader((byte*)DataHeaderAddress).GetValueFieldInfo(Info);
+                if (Info.ValueIsInline)
+                    return SpanByteAndMemory.FromPinnedPointer((byte*)dataAddress, (int)length);
+                var overflow = objectIdMap.GetOverflowByteArray(*(int*)dataAddress);
+                return new SpanByteAndMemory(new BorrowedMemoryOwner(overflow.AsMemory()), overflow.Length);
+            }
+        }
+
+        /// <inheritdoc/>
         public readonly long ETag => Info.HasETag ? *(long*)GetETagAddress(GetOptionalStartAddress()) : NoETag;
         /// <inheritdoc/>
         public readonly long Expiration => Info.HasExpiration ? *(long*)GetExpirationAddress(GetETagAddress(GetOptionalStartAddress())) : 0;

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/ObjectScanIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/ObjectScanIterator.cs
@@ -367,6 +367,9 @@ namespace Tsavorite.core
         }
 
         /// <inheritdoc/>
+        public SpanByteAndMemory ValueSpanByteAndMemory => diskLogRecord.ValueSpanByteAndMemory;
+
+        /// <inheritdoc/>
         public long ETag => diskLogRecord.ETag;
 
         /// <inheritdoc/>

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/OverflowByteArray.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/OverflowByteArray.cs
@@ -78,6 +78,17 @@ namespace Tsavorite.core
         /// <summary>Span of all data, including before and after offsets; this is for aligned Read from the device.</summary>
         internal readonly Span<byte> AlignedReadSpan => Array.AsSpan(OverflowHeader.Size);
 
+        /// <summary>
+        /// Get a <see cref="System.Memory{T}"/> view over the value bytes (between <see cref="StartOffset"/> and the end-offset).
+        /// </summary>
+        /// <remarks>
+        /// The returned <see cref="System.Memory{T}"/> aliases the underlying byte[]; consumers that need a stable native pointer
+        /// (e.g. for SIMD operations) should call <see cref="System.Memory{T}.Pin"/> for the duration of the operation, otherwise
+        /// GC compaction may relocate the array.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly Memory<byte> AsMemory() => Array.AsMemory(StartOffset, Length);
+
         /// <summary>Construct an <see cref="OverflowByteArray"/> from a byte[] allocated by <see cref="OverflowByteArray(int, int, int, bool)"/>.</summary>
         internal OverflowByteArray(byte[] data) => Array = data;
 

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/SpanByteScanIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/SpanByteScanIterator.cs
@@ -353,6 +353,9 @@ namespace Tsavorite.core
         }
 
         /// <inheritdoc/>
+        public SpanByteAndMemory ValueSpanByteAndMemory => diskLogRecord.ValueSpanByteAndMemory;
+
+        /// <inheritdoc/>
         public long ETag => diskLogRecord.ETag;
 
         /// <inheritdoc/>

--- a/libs/storage/Tsavorite/cs/src/core/ClientSession/ClientSession.cs
+++ b/libs/storage/Tsavorite/cs/src/core/ClientSession/ClientSession.cs
@@ -128,6 +128,23 @@ namespace Tsavorite.core
         public long Version => ctx.version;
 
         /// <summary>
+        /// The current head address of the underlying store's main log. Reads the live value, so it
+        /// reflects any updates from log eviction or page advancement. Callers that compare snapshots
+        /// (e.g. before vs. after a pending I/O completion) should hold epoch protection so that the
+        /// addresses they read remain meaningful.
+        /// </summary>
+        public long HeadAddress => store.Log.HeadAddress;
+
+        /// <summary>
+        /// The current head address of the underlying store's read cache, or 0 if the read cache is
+        /// not configured. Reads the live value. Callers that capture pointers into records returned
+        /// by <c>Read</c> must check this in addition to <see cref="HeadAddress"/>: a synchronously
+        /// returned pointer can live in the read cache (when the record was cached on a prior disk
+        /// read), and that page can be evicted independently of the main log.
+        /// </summary>
+        public long ReadCacheHeadAddress => store.ReadCache?.HeadAddress ?? 0;
+
+        /// <summary>
         /// Dispose session
         /// </summary>
         public void Dispose()

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/TsavoriteIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/TsavoriteIterator.cs
@@ -311,6 +311,9 @@ namespace Tsavorite.core
         }
 
         /// <inheritdoc/>
+        public SpanByteAndMemory ValueSpanByteAndMemory => CurrentIter.ValueSpanByteAndMemory;
+
+        /// <inheritdoc/>
         public long ETag => CurrentIter.ETag;
 
         /// <inheritdoc/>

--- a/libs/storage/Tsavorite/cs/src/core/VarLen/BorrowedMemoryOwner.cs
+++ b/libs/storage/Tsavorite/cs/src/core/VarLen/BorrowedMemoryOwner.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Buffers;
+
+namespace Tsavorite.core
+{
+    /// <summary>
+    /// Lightweight <see cref="IMemoryOwner{T}"/> wrapper around an externally-owned <see cref="System.Memory{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// Use this when you need to expose a region of memory that lives elsewhere (e.g. inside an
+    /// <see cref="OverflowByteArray"/> or another long-lived allocation) through APIs that require an
+    /// <see cref="IMemoryOwner{T}"/> (e.g. <see cref="SpanByteAndMemory.Memory"/>) without copying.
+    /// <see cref="Dispose"/> is a no-op because this type does not own the underlying allocation.
+    /// </remarks>
+    public sealed class BorrowedMemoryOwner : IMemoryOwner<byte>
+    {
+        /// <inheritdoc/>
+        public Memory<byte> Memory { get; }
+
+        public BorrowedMemoryOwner(Memory<byte> memory)
+        {
+            Memory = memory;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            // No-op: the underlying memory is owned by the producer (e.g. Tsavorite log/overflow allocator).
+        }
+    }
+}

--- a/test/Garnet.test/GarnetBitmapTests.cs
+++ b/test/Garnet.test/GarnetBitmapTests.cs
@@ -976,6 +976,94 @@ namespace Garnet.test
             ClassicAssert.AreEqual(expectedBitmap, actualBitmap);
         }
 
+        // Regression test for a use-after-fixed bug in the BITOP read callback:
+        // for overflow values (byte[] > MaxInlineValueSize, default 4 KB) the callback used to
+        // capture a pointer inside a `fixed` block and dereference it later from the BITOP
+        // execution path; GC compaction between the two could relocate the byte[], causing
+        // BITOP to read garbage. Running BITOP on overflow-sized values while a background
+        // thread periodically triggers compacting GCs must produce stable, correct results.
+        [Test, Order(21)]
+        [Category("BITOP")]
+        public void BitOp_OverflowValues_StableUnderGCCompaction(
+            [Values(Bitwise.And, Bitwise.Or, Bitwise.Xor, Bitwise.Diff)] Bitwise op)
+        {
+            // Pick lengths that exceed the default ObjectAllocator MaxInlineValueSize (4 KB),
+            // which forces values into the overflow (heap byte[]) path inside Tsavorite.
+            const int sharedLength = 4096 + 32 + 3;
+            var additionalLengths = new[] { 0, 7 };
+
+            Func<byte, byte, byte> opFunc = op switch
+            {
+                Bitwise.And => static (a, b) => (byte)(a & b),
+                Bitwise.Or => static (a, b) => (byte)(a | b),
+                Bitwise.Xor => static (a, b) => (byte)(a ^ b),
+                Bitwise.Diff => static (a, b) => (byte)(a & ~b),
+                _ => throw new NotSupportedException()
+            };
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            var srcKeyCount = additionalLengths.Length;
+            var srcKeys = new RedisKey[srcKeyCount];
+            var srcKeyBitmaps = new byte[srcKeyCount][];
+            var srcMaxLength = sharedLength + Enumerable.Max(additionalLengths);
+
+            const string dstKey = "dst";
+            var expectedBitmap = new byte[srcMaxLength];
+
+            for (var i = 0; i < srcKeys.Length; i++)
+            {
+                srcKeyBitmaps[i] = new byte[sharedLength + additionalLengths[i]];
+                rng.NextBytes(srcKeyBitmaps[i]);
+
+                srcKeys[i] = "src" + i;
+                db.StringSet(srcKeys[i], srcKeyBitmaps[i]);
+
+                if (i == 0)
+                    srcKeyBitmaps[i].AsSpan().CopyTo(expectedBitmap);
+                else
+                    ApplyBitop(ref expectedBitmap, srcKeyBitmaps[i], opFunc);
+            }
+
+            // Background thread that periodically forces compacting GCs to maximize the chance
+            // of the GC running between the BITOP read callback's `fixed` block and the
+            // subsequent in-server BITOP execution. Before the fix this exposed a stale-pointer
+            // dereference that produced wrong bytes.
+            using var stop = new System.Threading.CancellationTokenSource();
+            var gcThread = new System.Threading.Thread(() =>
+            {
+                while (!stop.IsCancellationRequested)
+                {
+                    System.Runtime.GCSettings.LargeObjectHeapCompactionMode =
+                        System.Runtime.GCLargeObjectHeapCompactionMode.CompactOnce;
+                    GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
+                    System.Threading.Thread.Sleep(1);
+                }
+            })
+            { IsBackground = true, Name = "BitOpGCStress" };
+            gcThread.Start();
+
+            try
+            {
+                const int iterations = 100;
+                for (var iter = 0; iter < iterations; iter++)
+                {
+                    var size = db.StringBitOperation(op, dstKey, srcKeys);
+                    ClassicAssert.AreEqual(expectedBitmap.Length, size, $"Iteration {iter}: BITOP returned wrong size");
+
+                    byte[] actualBitmap = db.StringGet(dstKey);
+                    ClassicAssert.AreEqual(expectedBitmap.Length, actualBitmap.Length, $"Iteration {iter}: GET returned wrong length");
+                    ClassicAssert.AreEqual(expectedBitmap, actualBitmap, $"Iteration {iter}: BITOP {op} produced incorrect bytes");
+                }
+            }
+            finally
+            {
+                stop.Cancel();
+                gcThread.Join();
+            }
+        }
+
         private static long GetValueFromBitmap(ref byte[] bitmap, long offset, int bitCount, bool signed)
         {
             long startBit = offset;


### PR DESCRIPTION
Three related correctness fixes around SpanByteAndMemory handling.

### BITOP: use-after-fixed for overflow byte[] values (flaky CI failure) 

Root cause of the flaky 'BitOp_Binary_DifferentTails(Diff,4131,[0, 7])' test failure (and similar AccessViolationException crashes seen on Windows Release CI):

The BITOP read callback in PrivateMethods.cs captured the value pointer inside a 'fixed (byte* valuePtr = value)' block, stored it as an integer in the output buffer, then exited the fixed block before the BITOP execution dereferenced it. For values larger than the default ObjectAllocator MaxInlineValueSize (4 KB), the value lives in a GC-managed overflow byte[] that compaction can relocate between the fixed-block exit and the SIMD execution in BitmapManager.InvokeBitOperationUnsafe -- yielding either wrong bytes or a hard crash in Vector512.Load.

Fix: expose value memory through the standard SpanByteAndMemory abstraction via a new ISourceLogRecord.ValueSpanByteAndMemory getter.

  - For inline values, returns SpanByte pointing at log memory (stable under the unsafe context, perf-equivalent to the original code).
  - For overflow values, returns Memory<byte> via a new no-copy BorrowedMemoryOwner wrapper around the existing OverflowByteArray. BitmapOps pins it via Memory.Pin() for the duration of the BITOP and releases the MemoryHandle in 'finally' (and on goto-readFromScratch).

The getter is a regular interface property (not a default interface method) with a single GetValueFieldInfo call, so the JIT devirtualizes through the existing 'where TSourceLogRecord : ISourceLogRecord' generic constraint and the inline-path cost is unchanged.

Includes new BitOp_OverflowValues_StableUnderGCCompaction regression test that reliably crashes the unfixed code with AccessViolationException (verified) and passes after the fix.

### PFCOUNT/PFMERGE backend: latent buffer-overflow in Buffer.MemoryCopy 

PrivateMethods.cs passed value.Length as BOTH the destination-capacity argument AND the source-bytes-to-copy argument, so the safety check trivially passed even when value.Length exceeded the 12 KB sector-aligned destination buffer. The post-copy size check at line 274 was effectively dead code. If a corrupted/oversized HLL value ever passed IsValidHYLL (currently bounded by design but defense-in-depth says guard it), this would silently overflow the buffer.

Fix: capture the buffer's actual capacity before any modification, validate size BEFORE the copy, treat oversized values the same as 'invalid' (-1 sentinel that callers already handle), and pass the true capacity to Buffer.MemoryCopy. Added Debug.Assert in HyperLogLogOps that the backend populated SpanByte (not Memory), documenting the contract so any future regression that converts to heap is caught immediately.

### Sorted-set Memory leaks in GEO*STORE / ZUNIONSTORE / ZINTERSTORE

SortedSetGeoOps.cs and SortedSetOps.cs both had:

    var zAddOutput = new ObjectOutput();
    RMWObjectStoreOperation(destinationKey, ref zAddInput, ..., ref zAddOutput);
    // zAddOutput never disposed

The internal ZADD's backend (SortedSetAdd) writes its reply via RespMemoryWriter. With a default ObjectOutput (SpanByte length 0), the first WriteInt32 triggers ReallocateOutput which rents a MemoryPool<byte> buffer (>=512 bytes) and assigns it to zAddOutput.SpanByteAndMemory.Memory. Neither call site disposed it -- under heavy GEO*STORE / ZUNIONSTORE / ZINTERSTORE traffic this was real MemoryPool churn and GC pressure.

Audit
-----
While in here, audited the rest of the storage layer for the same patterns. No other use-after-fixed pointer escapes (BITOP was the only backend that stored a raw pointer in its output for later use; BITCOUNT/ BITPOS/BITFIELD/HLL all consume the pointer inside the fixed block) and no other Memory leaks (other RMW helpers either consume the output via ProcessResp* helpers / SendAndReset which dispose, or invoke backends that only write result1 and never call RespMemoryWriter).

Files changed
-------------
- libs/server/Storage/Functions/MainStore/PrivateMethods.cs  (BITOP, HLL)
- libs/server/Storage/Session/MainStore/BitmapOps.cs         (BITOP front-end)
- libs/server/Storage/Session/MainStore/HyperLogLogOps.cs    (defensive assert)
- libs/server/Storage/Session/ObjectStore/SortedSetGeoOps.cs (leak)
- libs/server/Storage/Session/ObjectStore/SortedSetOps.cs    (leak)
- libs/storage/Tsavorite/cs/src/core/Allocator/ISourceLogRecord.cs (new getter)
- libs/storage/Tsavorite/cs/src/core/Allocator/LogRecord.cs        (impl)
- libs/storage/Tsavorite/cs/src/core/Allocator/DiskLogRecord.cs    (delegating impl)
- libs/storage/Tsavorite/cs/src/core/Allocator/ObjectScanIterator.cs (delegating impl)
- libs/storage/Tsavorite/cs/src/core/Allocator/SpanByteScanIterator.cs (delegating impl)
- libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/TsavoriteIterator.cs (delegating impl)
- libs/storage/Tsavorite/cs/src/core/Allocator/OverflowByteArray.cs (public AsMemory)
- libs/storage/Tsavorite/cs/src/core/VarLen/BorrowedMemoryOwner.cs  (new)
- test/Garnet.test/GarnetBitmapTests.cs (regression test)

Validation
----------
- All 351 GarnetBitmapTests pass (was 347 + 4 new regression variants); verified the new regression test crashes with AccessViolationException on the unfixed code.
- All 697 sorted-set / geo / bitmap / HLL tests pass.
- Tsavorite test project builds clean.
- 'dotnet format --verify-no-changes' is clean.