### PR TITLE
Fix #1749: leaked transient X-lock [main]

### DIFF
--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/ContinuePending.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/ContinuePending.cs
@@ -242,8 +242,14 @@ namespace Tsavorite.core
                 finally
                 {
                     stackCtx.HandleNewRecordOnException(this);
-                    sessionFunctions.PostRMWOperation(ref key, ref pendingContext.input.Get(), ref rmwInfo, epoch);
-                    TransientXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref key, ref stackCtx);
+                    try
+                    {
+                        sessionFunctions.PostRMWOperation(ref key, ref pendingContext.input.Get(), ref rmwInfo, epoch);
+                    }
+                    finally
+                    {
+                        TransientXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref key, ref stackCtx);
+                    }
                 }
 
                 // Must do this *after* Unlocking.

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/Helpers.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/Helpers.cs
@@ -137,13 +137,6 @@ namespace Tsavorite.core
             return RevivificationManager.TryAdd(stackCtx.recSrc.LogicalAddress, recordLengths.fullRecordLength, ref sessionFunctions.Ctx.RevivificationStats);
         }
 
-        internal enum LatchOperation : byte
-        {
-            None,
-            Shared,
-            Exclusive
-        }
-
         internal void SetRecordInvalid(long logicalAddress)
         {
             // This is called on exception recovery for a newly-inserted record.

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalDelete.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalDelete.cs
@@ -44,8 +44,6 @@ namespace Tsavorite.core
                             ref PendingContext<TInput, TOutput, TContext> pendingContext, TSessionFunctionsWrapper sessionFunctions)
             where TSessionFunctionsWrapper : ISessionFunctionsWrapper<TKey, TValue, TInput, TOutput, TContext, TStoreFunctions, TAllocator>
         {
-            var latchOperation = LatchOperation.None;
-
             OperationStackContext<TKey, TValue, TStoreFunctions, TAllocator> stackCtx = new(keyHash);
             pendingContext.keyHash = keyHash;
 
@@ -64,7 +62,8 @@ namespace Tsavorite.core
                 SessionID = sessionFunctions.Ctx.sessionID
             };
 
-            // We must use try/finally to ensure unlocking even in the presence of exceptions.
+            // We must use try/finally to ensure unlocking even in the presence of exceptions. The inner try/finally ensures
+            // the transient X-lock on the hash bucket is released even if a Post*Operation callback (e.g. AOF append) throws.
             try
             {
                 // Search the entire in-memory region; this lets us find a tombstoned record in the immutable region, avoiding unnecessarily adding one.
@@ -86,11 +85,11 @@ namespace Tsavorite.core
                 // Check for CPR consistency after checking if source is readcache.
                 if (sessionFunctions.Ctx.phase != Phase.REST)
                 {
-                    var latchDestination = CheckCPRConsistencyDelete(sessionFunctions.Ctx.phase, ref stackCtx, ref status, ref latchOperation);
+                    var latchDestination = CheckCPRConsistencyDelete(sessionFunctions.Ctx.phase, ref stackCtx, ref status);
                     switch (latchDestination)
                     {
                         case LatchDestination.Retry:
-                            goto LatchRelease;
+                            goto Done;
                         case LatchDestination.CreateNewRecord:
                             if (stackCtx.recSrc.HasMainLogSrc)
                                 srcRecordInfo = ref stackCtx.recSrc.GetInfo();
@@ -127,12 +126,12 @@ namespace Tsavorite.core
                         }
 
                         status = OperationStatusUtils.AdvancedOpCode(OperationStatus.SUCCESS, StatusCode.InPlaceUpdatedRecord);
-                        goto LatchRelease;
+                        goto Done;
                     }
                     if (deleteInfo.Action == DeleteAction.CancelOperation)
                     {
                         status = OperationStatus.CANCELED;
-                        goto LatchRelease;
+                        goto Done;
                     }
 
                     // Could not delete in place for some reason - create new record.
@@ -164,24 +163,17 @@ namespace Tsavorite.core
             finally
             {
                 stackCtx.HandleNewRecordOnException(this);
-                sessionFunctions.PostDeleteOperation(ref key, ref deleteInfo, epoch);
-                TransientXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref key, ref stackCtx);
-            }
-
-        LatchRelease:
-            {
-                switch (latchOperation)
+                try
                 {
-                    case LatchOperation.Shared:
-                        HashBucket.ReleaseSharedLatch(ref stackCtx.hei);
-                        break;
-                    case LatchOperation.Exclusive:
-                        HashBucket.ReleaseExclusiveLatch(ref stackCtx.hei);
-                        break;
-                    default:
-                        break;
+                    sessionFunctions.PostDeleteOperation(ref key, ref deleteInfo, epoch);
+                }
+                finally
+                {
+                    TransientXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref key, ref stackCtx);
                 }
             }
+
+        Done:
             return status;
         }
 
@@ -197,10 +189,10 @@ namespace Tsavorite.core
             pendingContext.logicalAddress = stackCtx.recSrc.LogicalAddress;
         }
 
-        private LatchDestination CheckCPRConsistencyDelete(Phase phase, ref OperationStackContext<TKey, TValue, TStoreFunctions, TAllocator> stackCtx, ref OperationStatus status, ref LatchOperation latchOperation)
+        private LatchDestination CheckCPRConsistencyDelete(Phase phase, ref OperationStackContext<TKey, TValue, TStoreFunctions, TAllocator> stackCtx, ref OperationStatus status)
         {
             // This is the same logic as Upsert; neither goes pending.
-            return CheckCPRConsistencyUpsert(phase, ref stackCtx, ref status, ref latchOperation);
+            return CheckCPRConsistencyUpsert(phase, ref stackCtx, ref status);
         }
 
         /// <summary>

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalRMW.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalRMW.cs
@@ -51,8 +51,6 @@ namespace Tsavorite.core
                                     ref PendingContext<TInput, TOutput, TContext> pendingContext, TSessionFunctionsWrapper sessionFunctions)
             where TSessionFunctionsWrapper : ISessionFunctionsWrapper<TKey, TValue, TInput, TOutput, TContext, TStoreFunctions, TAllocator>
         {
-            var latchOperation = LatchOperation.None;
-
             OperationStackContext<TKey, TValue, TStoreFunctions, TAllocator> stackCtx = new(keyHash);
             pendingContext.keyHash = keyHash;
 
@@ -71,7 +69,8 @@ namespace Tsavorite.core
                 SessionID = sessionFunctions.Ctx.sessionID
             };
 
-            // We must use try/finally to ensure unlocking even in the presence of exceptions.
+            // We must use try/finally to ensure unlocking even in the presence of exceptions. The inner try/finally ensures
+            // the transient X-lock on the hash bucket is released even if a Post*Operation callback (e.g. AOF append) throws.
             try
             {
                 // Search the entire in-memory region.
@@ -92,11 +91,11 @@ namespace Tsavorite.core
                 // Check for CPR consistency after checking if source is readcache.
                 if (sessionFunctions.Ctx.phase != Phase.REST)
                 {
-                    var latchDestination = CheckCPRConsistencyRMW(sessionFunctions.Ctx.phase, ref stackCtx, ref status, ref latchOperation);
+                    var latchDestination = CheckCPRConsistencyRMW(sessionFunctions.Ctx.phase, ref stackCtx, ref status);
                     switch (latchDestination)
                     {
                         case LatchDestination.Retry:
-                            goto LatchRelease;
+                            goto Done;
                         case LatchDestination.CreateNewRecord:
                             if (stackCtx.recSrc.HasMainLogSrc)
                                 srcRecordInfo = ref stackCtx.recSrc.GetInfo();
@@ -127,12 +126,12 @@ namespace Tsavorite.core
                             if (!sessionFunctions.NeedInitialUpdate(ref key, ref input, ref output, ref rmwInfo))
                             {
                                 status = OperationStatus.NOTFOUND;
-                                goto LatchRelease;
+                                goto Done;
                             }
 
                             if (TryRevivifyInChain(ref key, ref input, ref output, ref pendingContext, sessionFunctions, ref stackCtx, ref srcRecordInfo, ref rmwInfo, out status, ref recordValue)
                                     || status != OperationStatus.SUCCESS)
-                                goto LatchRelease;
+                                goto Done;
                         }
                         goto CreateNewRecord;
                     }
@@ -145,7 +144,7 @@ namespace Tsavorite.core
                         pendingContext.recordInfo = srcRecordInfo;
                         pendingContext.logicalAddress = stackCtx.recSrc.LogicalAddress;
                         // status has been set by InPlaceUpdater
-                        goto LatchRelease;
+                        goto Done;
                     }
 
                     if (rmwInfo.Action == RMWAction.ExpireAndStop)
@@ -166,11 +165,11 @@ namespace Tsavorite.core
 
                         pendingContext.recordInfo = srcRecordInfo;
                         pendingContext.logicalAddress = stackCtx.recSrc.LogicalAddress;
-                        goto LatchRelease;
+                        goto Done;
                     }
 
                     if (OperationStatusUtils.BasicOpCode(status) != OperationStatus.SUCCESS)
-                        goto LatchRelease;
+                        goto Done;
 
                     // InPlaceUpdater failed (e.g. insufficient space, another thread set Tombstone, etc). Use this record as the CopyUpdater source.
                     goto CreateNewRecord;
@@ -179,7 +178,7 @@ namespace Tsavorite.core
                 {
                     // Fuzzy Region: Must retry after epoch refresh, due to lost-update anomaly
                     status = OperationStatus.RETRY_LATER;
-                    goto LatchRelease;
+                    goto Done;
                 }
                 if (stackCtx.recSrc.HasMainLogSrc)
                 {
@@ -195,7 +194,7 @@ namespace Tsavorite.core
                     // Disk Region: Need to issue async io requests. Locking will be checked on pending completion.
                     status = OperationStatus.RECORD_ON_DISK;
                     CreatePendingRMWContext(ref key, ref input, output, userContext, ref pendingContext, sessionFunctions, ref stackCtx);
-                    goto LatchRelease;
+                    goto Done;
                 }
 
                 // No record exists - drop through to create new record.
@@ -214,31 +213,23 @@ namespace Tsavorite.core
                         if (status == OperationStatus.ALLOCATE_FAILED && pendingContext.IsAsync || status == OperationStatus.RECORD_ON_DISK)
                             CreatePendingRMWContext(ref key, ref input, output, userContext, ref pendingContext, sessionFunctions, ref stackCtx);
                     }
-                    goto LatchRelease;
+                    goto Done;
                 }
             }
             finally
             {
                 stackCtx.HandleNewRecordOnException(this);
-                sessionFunctions.PostRMWOperation(ref key, ref input, ref rmwInfo, epoch);
-                TransientXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref key, ref stackCtx);
-            }
-
-        LatchRelease:
-            if (latchOperation != LatchOperation.None)
-            {
-                switch (latchOperation)
+                try
                 {
-                    case LatchOperation.Shared:
-                        HashBucket.ReleaseSharedLatch(ref stackCtx.hei);
-                        break;
-                    case LatchOperation.Exclusive:
-                        HashBucket.ReleaseExclusiveLatch(ref stackCtx.hei);
-                        break;
-                    default:
-                        break;
+                    sessionFunctions.PostRMWOperation(ref key, ref input, ref rmwInfo, epoch);
+                }
+                finally
+                {
+                    TransientXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref key, ref stackCtx);
                 }
             }
+
+        Done:
             return status;
         }
 
@@ -322,7 +313,7 @@ namespace Tsavorite.core
             return false;
         }
 
-        private LatchDestination CheckCPRConsistencyRMW(Phase phase, ref OperationStackContext<TKey, TValue, TStoreFunctions, TAllocator> stackCtx, ref OperationStatus status, ref LatchOperation latchOperation)
+        private LatchDestination CheckCPRConsistencyRMW(Phase phase, ref OperationStackContext<TKey, TValue, TStoreFunctions, TAllocator> stackCtx, ref OperationStatus status)
         {
             // The idea of CPR is that if a thread in version V tries to perform an operation and notices a record in V+1, it needs to back off and run CPR_SHIFT_DETECTED.
             // Similarly, a V+1 thread cannot update a V record; it needs to do a read-copy-update (or upsert at tail) instead of an in-place update.

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalUpsert.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalUpsert.cs
@@ -47,8 +47,6 @@ namespace Tsavorite.core
                             ref TContext userContext, ref PendingContext<TInput, TOutput, TContext> pendingContext, TSessionFunctionsWrapper sessionFunctions)
             where TSessionFunctionsWrapper : ISessionFunctionsWrapper<TKey, TValue, TInput, TOutput, TContext, TStoreFunctions, TAllocator>
         {
-            var latchOperation = LatchOperation.None;
-
             OperationStackContext<TKey, TValue, TStoreFunctions, TAllocator> stackCtx = new(keyHash);
             pendingContext.keyHash = keyHash;
 
@@ -67,7 +65,8 @@ namespace Tsavorite.core
                 SessionID = sessionFunctions.Ctx.sessionID
             };
 
-            // We must use try/finally to ensure unlocking even in the presence of exceptions.
+            // We must use try/finally to ensure unlocking even in the presence of exceptions. The inner try/finally ensures
+            // the transient X-lock on the hash bucket is released even if a Post*Operation callback (e.g. AOF append) throws.
             try
             {
                 // We blindly insert if the key isn't in the mutable region, so only check down to ReadOnlyAddress (minRevivifiableAddress is always >= ReadOnlyAddress).
@@ -86,11 +85,11 @@ namespace Tsavorite.core
                 // Check for CPR consistency after checking if source is readcache.
                 if (sessionFunctions.Ctx.phase != Phase.REST)
                 {
-                    var latchDestination = CheckCPRConsistencyUpsert(sessionFunctions.Ctx.phase, ref stackCtx, ref status, ref latchOperation);
+                    var latchDestination = CheckCPRConsistencyUpsert(sessionFunctions.Ctx.phase, ref stackCtx, ref status);
                     switch (latchDestination)
                     {
                         case LatchDestination.Retry:
-                            goto LatchRelease;
+                            goto Done;
                         case LatchDestination.CreateNewRecord:
                             if (stackCtx.recSrc.HasMainLogSrc)
                                 srcRecordInfo = ref stackCtx.recSrc.GetInfo();
@@ -119,7 +118,7 @@ namespace Tsavorite.core
                         {
                             if (TryRevivifyInChain(ref key, ref input, ref value, ref output, ref pendingContext, sessionFunctions, ref stackCtx, ref srcRecordInfo, ref upsertInfo, out status, ref recordValue)
                                     || status != OperationStatus.SUCCESS)
-                                goto LatchRelease;
+                                goto Done;
                         }
                         goto CreateNewRecord;
                     }
@@ -131,12 +130,12 @@ namespace Tsavorite.core
                         pendingContext.recordInfo = srcRecordInfo;
                         pendingContext.logicalAddress = stackCtx.recSrc.LogicalAddress;
                         status = OperationStatusUtils.AdvancedOpCode(OperationStatus.SUCCESS, StatusCode.InPlaceUpdatedRecord);
-                        goto LatchRelease;
+                        goto Done;
                     }
                     if (upsertInfo.Action == UpsertAction.CancelOperation)
                     {
                         status = OperationStatus.CANCELED;
-                        goto LatchRelease;
+                        goto Done;
                     }
 
                     // ConcurrentWriter failed (e.g. insufficient space, another thread set Tombstone, etc). Write a new record, but track that we have to seal and unlock this one.
@@ -161,30 +160,22 @@ namespace Tsavorite.core
                     if (status == OperationStatus.ALLOCATE_FAILED && pendingContext.IsAsync)
                         CreatePendingUpsertContext(ref key, ref input, ref value, output, userContext, ref pendingContext, sessionFunctions, ref stackCtx);
                 }
-                goto LatchRelease;
+                goto Done;
             }
             finally
             {
                 stackCtx.HandleNewRecordOnException(this);
-                sessionFunctions.PostUpsertOperation(ref key, ref input, ref value, ref upsertInfo, epoch);
-                TransientXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref key, ref stackCtx);
-            }
-
-        LatchRelease:
-            if (latchOperation != LatchOperation.None)
-            {
-                switch (latchOperation)
+                try
                 {
-                    case LatchOperation.Shared:
-                        HashBucket.ReleaseSharedLatch(ref stackCtx.hei);
-                        break;
-                    case LatchOperation.Exclusive:
-                        HashBucket.ReleaseExclusiveLatch(ref stackCtx.hei);
-                        break;
-                    default:
-                        break;
+                    sessionFunctions.PostUpsertOperation(ref key, ref input, ref value, ref upsertInfo, epoch);
+                }
+                finally
+                {
+                    TransientXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref key, ref stackCtx);
                 }
             }
+
+        Done:
             return status;
         }
 
@@ -271,7 +262,7 @@ namespace Tsavorite.core
             return false;
         }
 
-        private LatchDestination CheckCPRConsistencyUpsert(Phase phase, ref OperationStackContext<TKey, TValue, TStoreFunctions, TAllocator> stackCtx, ref OperationStatus status, ref LatchOperation latchOperation)
+        private LatchDestination CheckCPRConsistencyUpsert(Phase phase, ref OperationStackContext<TKey, TValue, TStoreFunctions, TAllocator> stackCtx, ref OperationStatus status)
         {
             // See explanatory comments in CheckCPRConsistencyRMW.
 

--- a/test/Garnet.test/RespAofTests.cs
+++ b/test/Garnet.test/RespAofTests.cs
@@ -1062,6 +1062,52 @@ namespace Garnet.test
             }
         }
 
+        // Regression test for https://github.com/microsoft/garnet/issues/1749
+        // A SET / RMW / DEL whose AOF entry exceeds AofPageSize used to leave the per-bucket transient X-lock
+        // held forever (the AOF Enqueue threw "Entry does not fit on page" before TransientXUnlock could run),
+        // pinning subsequent ops on the same key in an infinite RETRY_LATER loop and burning 100% CPU.
+        // The server is rebuilt with a small AofPageSize to trigger the oversize path with small payloads.
+        [Test]
+        public void OversizedAofEntryDoesNotHangServer()
+        {
+            const string key = "oversized-aof-key";
+
+            server.Dispose(false);
+            // 4 KB AOF page so we can trigger the oversize path with a small payload.
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableAOF: true, aofPageSize: "4k");
+            server.Start();
+
+            // 1) SET with a value larger than the AOF page. The AOF Enqueue throws and StackExchange.Redis
+            //    will see the connection drop. Use a tight syncTimeout so a buggy server hang is detected.
+            var oversizedValue = new string('A', 8 * 1024);
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig() + ",syncTimeout=3000,abortConnect=false"))
+            {
+                var db = redis.GetDatabase(0);
+                Assert.Throws<RedisConnectionException>(() => db.StringSet(key, oversizedValue));
+            }
+
+            // 2) From a fresh connection issue several operations on the same key. Before the fix these would
+            //    spin forever inside Tsavorite waiting on the leaked transient X-lock. With the fix they return
+            //    promptly. We don't care what GET returns, only that the server does not hang.
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig() + ",syncTimeout=3000"))
+            {
+                var db = redis.GetDatabase(0);
+
+                // Reads use a transient S-lock on the same hash bucket, so they block on a leaked X-lock.
+                Assert.DoesNotThrow(() => _ = db.StringGet(key));
+
+                // RMW operations (e.g. APPEND) use the same TransientX path as SET; verify they don't hang either.
+                Assert.DoesNotThrow(() => _ = db.StringAppend(key, "x"));
+
+                // Delete also takes the transient X-lock; verify it can complete.
+                Assert.DoesNotThrow(() => _ = db.KeyDelete(key));
+
+                // A small SET on the same key after recovery must succeed end-to-end.
+                Assert.DoesNotThrow(() => _ = db.StringSet(key, "ok"));
+                ClassicAssert.AreEqual("ok", (string)db.StringGet(key));
+            }
+        }
+
         private static void ExpectedEtagTest(IDatabase db, string key, string expectedValue, long expected)
         {
             RedisResult res = db.Execute("GETWITHETAG", key);

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -279,7 +279,8 @@ namespace Garnet.test
             bool useInChainRevivOnly = false,
             bool useLogNullDevice = false,
             bool enableVectorSetPreview = true,
-            string aofMemorySize = "64m"
+            string aofMemorySize = "64m",
+            string aofPageSize = null
         )
         {
             if (useAzureStorage)
@@ -395,6 +396,9 @@ namespace Garnet.test
 
             if (indexMaxSize != default) opts.IndexMaxSize = indexMaxSize;
             if (objectStoreIndexMaxSize != default) opts.ObjectStoreIndexMaxSize = objectStoreIndexMaxSize;
+
+            if (!string.IsNullOrEmpty(aofPageSize))
+                opts.AofPageSize = aofPageSize;
 
             if (lowMemory)
             {


### PR DESCRIPTION
When a SET / RMW / DELETE produces an AOF entry larger than AofPageSize, TsavoriteLog.ValidateAllocatedLength throws TsavoriteException("Entry does not fit on page") from inside the PostUpsertOperation / PostRMWOperation / PostDeleteOperation callback. The exception unwinds the finally block in InternalUpsert / InternalRMW / InternalDelete (and ContinuePendingRMW) before TransientXUnlock can run, leaving the hash bucket's transient exclusive lock held forever. Any subsequent op on the same bucket then spins indefinitely in a RETRY_LATER loop, pinning the server CPU at 100% until restart.

Wrap the Post*Operation call in a nested try/finally so TransientXUnlock always runs even on exception. The original TsavoriteException continues to propagate, preserving the observed behaviour for the user (connection closed) while leaving the server responsive.

While here, drop the dead 'latchOperation' / 'LatchRelease' machinery from InternalUpsert / InternalRMW / InternalDelete (the LatchOperation enum and the ref parameter on CheckCPRConsistency*): the CheckCPRConsistency* helpers never wrote to the ref parameter ("Now we no longer need to do the bucket latching" comment confirms it), so the switch in the LatchRelease block was unreachable. Renamed the empty LatchRelease label to Done for clarity.

Adds a regression test (OversizedAofEntryDoesNotHangServer) plus an aofPageSize parameter on TestUtils.CreateGarnetServer so the test can trigger the oversize path with a 4 KB AOF page.