### PR TITLE
Fix #1749: leaked transient X-lock [dev]

### DIFF
--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/ContinuePending.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/ContinuePending.cs
@@ -241,8 +241,14 @@ namespace Tsavorite.core
                 finally
                 {
                     stackCtx.HandleNewRecordOnException(this);
-                    sessionFunctions.PostRMWOperation(pendingContext.requestKey, ref pendingContext.input.Get(), ref rmwInfo, epoch);
-                    EphemeralXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref stackCtx);
+                    try
+                    {
+                        sessionFunctions.PostRMWOperation(pendingContext.requestKey, ref pendingContext.input.Get(), ref rmwInfo, epoch);
+                    }
+                    finally
+                    {
+                        EphemeralXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref stackCtx);
+                    }
                 }
 
                 // Must do this *after* Unlocking.

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/Helpers.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/Helpers.cs
@@ -168,13 +168,6 @@ namespace Tsavorite.core
             return false;
         }
 
-        internal enum LatchOperation : byte
-        {
-            None,
-            Shared,
-            Exclusive
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void SetRecordInvalid(long logicalAddress)
         {

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalDelete.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalDelete.cs
@@ -50,8 +50,6 @@ namespace Tsavorite.core
 #endif
             where TSessionFunctionsWrapper : ISessionFunctionsWrapper<TInput, TOutput, TContext, TStoreFunctions, TAllocator>
         {
-            var latchOperation = LatchOperation.None;
-
             OperationStackContext<TStoreFunctions, TAllocator> stackCtx = new(keyHash);
             pendingContext.keyHash = keyHash;
             pendingContext.logicalAddress = kInvalidAddress;
@@ -70,7 +68,8 @@ namespace Tsavorite.core
                 SessionID = sessionFunctions.Ctx.sessionID
             };
 
-            // We must use try/finally to ensure unlocking even in the presence of exceptions.
+            // We must use try/finally to ensure unlocking even in the presence of exceptions. The inner try/finally ensures
+            // the ephemeral X-lock on the hash bucket is released even if a Post*Operation callback (e.g. AOF append) throws.
             try
             {
                 // Search the entire in-memory region; this lets us find a tombstoned record in the immutable region, avoiding unnecessarily adding one.
@@ -92,11 +91,11 @@ namespace Tsavorite.core
                 // Check for CPR consistency after checking if source is readcache.
                 if (sessionFunctions.Ctx.phase != Phase.REST)
                 {
-                    var latchDestination = CheckCPRConsistencyDelete(sessionFunctions.Ctx.phase, ref stackCtx, ref status, ref latchOperation);
+                    var latchDestination = CheckCPRConsistencyDelete(sessionFunctions.Ctx.phase, ref stackCtx, ref status);
                     switch (latchDestination)
                     {
                         case LatchDestination.Retry:
-                            goto LatchRelease;
+                            goto Done;
                         case LatchDestination.CreateNewRecord:
                             if (stackCtx.recSrc.HasMainLogSrc)
                                 srcLogRecord = stackCtx.recSrc.CreateLogRecord();
@@ -136,13 +135,13 @@ namespace Tsavorite.core
                             HandleRecordElision<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref stackCtx, ref srcLogRecord);
 
                         status = OperationStatusUtils.AdvancedOpCode(OperationStatus.SUCCESS, StatusCode.InPlaceUpdatedRecord);
-                        goto LatchRelease;
+                        goto Done;
                     }
 
                     if (deleteInfo.Action == DeleteAction.CancelOperation)
                     {
                         status = OperationStatus.CANCELED;
-                        goto LatchRelease;
+                        goto Done;
                     }
 
                     // Could not delete in place for some reason - create new record.
@@ -166,36 +165,29 @@ namespace Tsavorite.core
 
                 // We should never return "SUCCESS" for a new record operation: it returns NOTFOUND on success.
                 Debug.Assert(OperationStatusUtils.IsAppend(status) || OperationStatusUtils.BasicOpCode(status) != OperationStatus.SUCCESS);
-                goto LatchRelease;
+                goto Done;
             }
             finally
             {
                 stackCtx.HandleNewRecordOnException(this);
-                sessionFunctions.PostDeleteOperation(key, ref deleteInfo, epoch);
-                EphemeralXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref stackCtx);
-            }
-
-        LatchRelease:
-            {
-                switch (latchOperation)
+                try
                 {
-                    case LatchOperation.Shared:
-                        HashBucket.ReleaseSharedLatch(ref stackCtx.hei);
-                        break;
-                    case LatchOperation.Exclusive:
-                        HashBucket.ReleaseExclusiveLatch(ref stackCtx.hei);
-                        break;
-                    default:
-                        break;
+                    sessionFunctions.PostDeleteOperation(key, ref deleteInfo, epoch);
+                }
+                finally
+                {
+                    EphemeralXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref stackCtx);
                 }
             }
+
+        Done:
             return status;
         }
 
-        private LatchDestination CheckCPRConsistencyDelete(Phase phase, ref OperationStackContext<TStoreFunctions, TAllocator> stackCtx, ref OperationStatus status, ref LatchOperation latchOperation)
+        private LatchDestination CheckCPRConsistencyDelete(Phase phase, ref OperationStackContext<TStoreFunctions, TAllocator> stackCtx, ref OperationStatus status)
         {
             // This is the same logic as Upsert; neither goes pending.
-            return CheckCPRConsistencyUpsert(phase, ref stackCtx, ref status, ref latchOperation);
+            return CheckCPRConsistencyUpsert(phase, ref stackCtx, ref status);
         }
 
         /// <summary>

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalRMW.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalRMW.cs
@@ -57,8 +57,6 @@ namespace Tsavorite.core
 #endif
             where TSessionFunctionsWrapper : ISessionFunctionsWrapper<TInput, TOutput, TContext, TStoreFunctions, TAllocator>
         {
-            var latchOperation = LatchOperation.None;
-
             OperationStackContext<TStoreFunctions, TAllocator> stackCtx = new(keyHash);
             pendingContext.keyHash = keyHash;
             pendingContext.logicalAddress = kInvalidAddress;
@@ -77,7 +75,8 @@ namespace Tsavorite.core
                 SessionID = sessionFunctions.Ctx.sessionID
             };
 
-            // We must use try/finally to ensure unlocking even in the presence of exceptions.
+            // We must use try/finally to ensure unlocking even in the presence of exceptions. The inner try/finally ensures
+            // the ephemeral X-lock on the hash bucket is released even if a Post*Operation callback (e.g. AOF append) throws.
             try
             {
                 // Search the entire in-memory region.
@@ -98,11 +97,11 @@ namespace Tsavorite.core
                 // Check for CPR consistency after checking if source is readcache.
                 if (sessionFunctions.Ctx.phase != Phase.REST)
                 {
-                    var latchDestination = CheckCPRConsistencyRMW(sessionFunctions.Ctx.phase, ref stackCtx, ref status, ref latchOperation);
+                    var latchDestination = CheckCPRConsistencyRMW(sessionFunctions.Ctx.phase, ref stackCtx, ref status);
                     switch (latchDestination)
                     {
                         case LatchDestination.Retry:
-                            goto LatchRelease;
+                            goto Done;
                         case LatchDestination.CreateNewRecord:
                             if (stackCtx.recSrc.HasMainLogSrc)
                                 srcLogRecord = stackCtx.recSrc.CreateLogRecord();
@@ -130,12 +129,12 @@ namespace Tsavorite.core
                             if (!sessionFunctions.NeedInitialUpdate(key, ref input, ref output, ref rmwInfo))
                             {
                                 status = OperationStatus.NOTFOUND;
-                                goto LatchRelease;
+                                goto Done;
                             }
 
                             if (TryRevivifyInChain(ref srcLogRecord, ref input, ref output, ref pendingContext, sessionFunctions, ref stackCtx, ref rmwInfo, out status)
                                     || status != OperationStatus.SUCCESS)
-                                goto LatchRelease;
+                                goto Done;
                         }
                         goto CreateNewRecord;
                     }
@@ -161,7 +160,7 @@ namespace Tsavorite.core
 
                         // status has been set by InPlaceUpdater
                         pendingContext.logicalAddress = stackCtx.recSrc.LogicalAddress;
-                        goto LatchRelease;
+                        goto Done;
                     }
 
                     if (rmwInfo.Action == RMWAction.ExpireAndStop)
@@ -192,7 +191,7 @@ namespace Tsavorite.core
                         if (CanElide<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref stackCtx, srcLogRecord.Info))
                             HandleRecordElision<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref stackCtx, ref srcLogRecord);
 
-                        goto LatchRelease;
+                        goto Done;
                     }
                     else if (rmwInfo.Action == RMWAction.ExpireAndResume)
                     {
@@ -205,11 +204,11 @@ namespace Tsavorite.core
                         // status has been set by InPlaceUpdater, and no modification should have been made to the record.
                         pendingContext.logicalAddress = stackCtx.recSrc.LogicalAddress;
                         status = OperationStatusUtils.AdvancedOpCode(OperationStatus.NOTFOUND, StatusCode.WrongType);
-                        goto LatchRelease;
+                        goto Done;
                     }
 
                     if (OperationStatusUtils.BasicOpCode(status) != OperationStatus.SUCCESS)
-                        goto LatchRelease;
+                        goto Done;
 
                     // InPlaceUpdater failed (e.g. insufficient space, another thread set Tombstone, etc). Use this record as the CopyUpdater source.
                     goto CreateNewRecord;
@@ -218,7 +217,7 @@ namespace Tsavorite.core
                 {
                     // Fuzzy Region: Must retry after epoch refresh, due to lost-update anomaly
                     status = OperationStatus.RETRY_LATER;
-                    goto LatchRelease;
+                    goto Done;
                 }
                 if (stackCtx.recSrc.HasMainLogSrc)
                 {
@@ -234,7 +233,7 @@ namespace Tsavorite.core
                     // Disk Region: Need to issue async io requests. Locking will be checked on pending completion.
                     status = OperationStatus.RECORD_ON_DISK;
                     CreatePendingRMWContext(key, ref input, ref output, userContext, ref pendingContext, sessionFunctions, ref stackCtx);
-                    goto LatchRelease;
+                    goto Done;
                 }
 
                 // No record exists - drop through to create new record.
@@ -247,31 +246,23 @@ namespace Tsavorite.core
                                                 doingCU: stackCtx.recSrc.HasInMemorySrc && !srcLogRecord.Info.Tombstone, ref rmwInfo);
 
                     // OperationStatus.SUCCESS is OK here even if !OperationStatusUtils.IsAppend(status); it means NeedCopyUpdate or NeedInitialUpdate returned false
-                    goto LatchRelease;
+                    goto Done;
                 }
             }
             finally
             {
                 stackCtx.HandleNewRecordOnException(this);
-                sessionFunctions.PostRMWOperation(key, ref input, ref rmwInfo, epoch);
-                EphemeralXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref stackCtx);
-            }
-
-        LatchRelease:
-            if (latchOperation != LatchOperation.None)
-            {
-                switch (latchOperation)
+                try
                 {
-                    case LatchOperation.Shared:
-                        HashBucket.ReleaseSharedLatch(ref stackCtx.hei);
-                        break;
-                    case LatchOperation.Exclusive:
-                        HashBucket.ReleaseExclusiveLatch(ref stackCtx.hei);
-                        break;
-                    default:
-                        break;
+                    sessionFunctions.PostRMWOperation(key, ref input, ref rmwInfo, epoch);
+                }
+                finally
+                {
+                    EphemeralXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref stackCtx);
                 }
             }
+
+        Done:
             return status;
         }
 
@@ -343,7 +334,7 @@ namespace Tsavorite.core
             return false;
         }
 
-        private LatchDestination CheckCPRConsistencyRMW(Phase phase, ref OperationStackContext<TStoreFunctions, TAllocator> stackCtx, ref OperationStatus status, ref LatchOperation latchOperation)
+        private LatchDestination CheckCPRConsistencyRMW(Phase phase, ref OperationStackContext<TStoreFunctions, TAllocator> stackCtx, ref OperationStatus status)
         {
             // The idea of CPR is that if a thread in version V tries to perform an operation and notices a record in V+1, it needs to back off and run CPR_SHIFT_DETECTED.
             // Similarly, a V+1 thread cannot update a V record; it needs to do a read-copy-update (or upsert at tail) instead of an in-place update.

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalUpsert.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/InternalUpsert.cs
@@ -57,8 +57,6 @@ namespace Tsavorite.core
             where TSessionFunctionsWrapper : ISessionFunctionsWrapper<TInput, TOutput, TContext, TStoreFunctions, TAllocator>
             where TSourceLogRecord : ISourceLogRecord
         {
-            var latchOperation = LatchOperation.None;
-
             OperationStackContext<TStoreFunctions, TAllocator> stackCtx = new(keyHash);
             pendingContext.keyHash = keyHash;
             pendingContext.logicalAddress = kInvalidAddress;
@@ -77,7 +75,8 @@ namespace Tsavorite.core
                 SessionID = sessionFunctions.Ctx.sessionID
             };
 
-            // We must use try/finally to ensure unlocking even in the presence of exceptions.
+            // We must use try/finally to ensure unlocking even in the presence of exceptions. The inner try/finally ensures
+            // the ephemeral X-lock on the hash bucket is released even if a Post*Operation callback (e.g. AOF append) throws.
             try
             {
                 // We blindly insert if the key isn't in the mutable region, so only check down to ReadOnlyAddress (minRevivifiableAddress is always >= ReadOnlyAddress).
@@ -96,11 +95,11 @@ namespace Tsavorite.core
                 // Check for CPR consistency after checking if source is readcache.
                 if (sessionFunctions.Ctx.phase != Phase.REST)
                 {
-                    var latchDestination = CheckCPRConsistencyUpsert(sessionFunctions.Ctx.phase, ref stackCtx, ref status, ref latchOperation);
+                    var latchDestination = CheckCPRConsistencyUpsert(sessionFunctions.Ctx.phase, ref stackCtx, ref status);
                     switch (latchDestination)
                     {
                         case LatchDestination.Retry:
-                            goto LatchRelease;
+                            goto Done;
                         case LatchDestination.CreateNewRecord:
                             if (stackCtx.recSrc.HasMainLogSrc)
                                 srcLogRecord = stackCtx.recSrc.CreateLogRecord();
@@ -128,7 +127,7 @@ namespace Tsavorite.core
                             if (TryRevivifyInChain<TValueSelector, TInput, TOutput, TContext, TSessionFunctionsWrapper, TSourceLogRecord>(
                                         ref srcLogRecord, ref input, srcStringValue, srcObjectValue, in inputLogRecord, ref output, ref pendingContext, sessionFunctions, ref stackCtx, ref upsertInfo, out status)
                                     || status != OperationStatus.SUCCESS)
-                                goto LatchRelease;
+                                goto Done;
                         }
                         goto CreateNewRecord;
                     }
@@ -155,17 +154,17 @@ namespace Tsavorite.core
                         pendingContext.logicalAddress = stackCtx.recSrc.LogicalAddress;
 
                         status = OperationStatusUtils.AdvancedOpCode(OperationStatus.SUCCESS, StatusCode.InPlaceUpdatedRecord);
-                        goto LatchRelease;
+                        goto Done;
                     }
                     if (upsertInfo.Action == UpsertAction.CancelOperation)
                     {
                         status = OperationStatus.CANCELED;
-                        goto LatchRelease;
+                        goto Done;
                     }
                     if (upsertInfo.Action == UpsertAction.WrongType)
                     {
                         status = OperationStatus.WRONG_TYPE;
-                        goto LatchRelease;
+                        goto Done;
                     }
 
                     // InPlaceWriter failed (e.g. insufficient space, another thread set Tombstone, etc). Write a new record, but track that we have to seal and unlock this one.
@@ -186,31 +185,23 @@ namespace Tsavorite.core
                         key, ref srcLogRecord, ref input, srcStringValue, srcObjectValue, in inputLogRecord, ref output, ref pendingContext, sessionFunctions, ref stackCtx, ref upsertInfo);
                 // We should never return "SUCCESS" for a new record operation: it returns NOTFOUND on success.
                 Debug.Assert(OperationStatusUtils.IsAppend(status) || OperationStatusUtils.BasicOpCode(status) != OperationStatus.SUCCESS);
-                goto LatchRelease;
+                goto Done;
             }
             finally
             {
                 stackCtx.HandleNewRecordOnException(this);
-                TValueSelector.PostUpsertOperation<TKey, TSourceLogRecord, TInput, TOutput, TContext, TSessionFunctionsWrapper, LightEpoch>(key, ref input,
-                    srcStringValue, srcObjectValue, in inputLogRecord, ref upsertInfo, sessionFunctions, epoch);
-                EphemeralXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref stackCtx);
-            }
-
-        LatchRelease:
-            if (latchOperation != LatchOperation.None)
-            {
-                switch (latchOperation)
+                try
                 {
-                    case LatchOperation.Shared:
-                        HashBucket.ReleaseSharedLatch(ref stackCtx.hei);
-                        break;
-                    case LatchOperation.Exclusive:
-                        HashBucket.ReleaseExclusiveLatch(ref stackCtx.hei);
-                        break;
-                    default:
-                        break;
+                    TValueSelector.PostUpsertOperation<TKey, TSourceLogRecord, TInput, TOutput, TContext, TSessionFunctionsWrapper, LightEpoch>(key, ref input,
+                        srcStringValue, srcObjectValue, in inputLogRecord, ref upsertInfo, sessionFunctions, epoch);
+                }
+                finally
+                {
+                    EphemeralXUnlock<TInput, TOutput, TContext, TSessionFunctionsWrapper>(sessionFunctions, ref stackCtx);
                 }
             }
+
+        Done:
             return status;
         }
 
@@ -273,7 +264,7 @@ namespace Tsavorite.core
             return false;
         }
 
-        private LatchDestination CheckCPRConsistencyUpsert(Phase phase, ref OperationStackContext<TStoreFunctions, TAllocator> stackCtx, ref OperationStatus status, ref LatchOperation latchOperation)
+        private LatchDestination CheckCPRConsistencyUpsert(Phase phase, ref OperationStackContext<TStoreFunctions, TAllocator> stackCtx, ref OperationStatus status)
         {
             // See explanatory comments in CheckCPRConsistencyRMW.
 

--- a/test/Garnet.test/RespAofTests.cs
+++ b/test/Garnet.test/RespAofTests.cs
@@ -1080,6 +1080,52 @@ namespace Garnet.test
             }
         }
 
+        // Regression test for https://github.com/microsoft/garnet/issues/1749
+        // A SET / RMW / DEL whose AOF entry exceeds AofPageSize used to leave the per-bucket ephemeral X-lock
+        // held forever (the AOF Enqueue threw "Entry does not fit on page" before EphemeralXUnlock could run),
+        // pinning subsequent ops on the same key in an infinite RETRY_LATER loop and burning 100% CPU.
+        // The server is rebuilt with a small AofPageSize to trigger the oversize path with small payloads.
+        [Test]
+        public void OversizedAofEntryDoesNotHangServer()
+        {
+            const string key = "oversized-aof-key";
+
+            server.Dispose(false);
+            // 4 KB AOF page so we can trigger the oversize path with a small payload.
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableAOF: true, aofPageSize: "4k");
+            server.Start();
+
+            // 1) SET with a value larger than the AOF page. The AOF Enqueue throws and StackExchange.Redis
+            //    will see the connection drop. Use a tight syncTimeout so a buggy server hang is detected.
+            var oversizedValue = new string('A', 8 * 1024);
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig() + ",syncTimeout=3000,abortConnect=false"))
+            {
+                var db = redis.GetDatabase(0);
+                Assert.Throws<RedisConnectionException>(() => db.StringSet(key, oversizedValue));
+            }
+
+            // 2) From a fresh connection issue several operations on the same key. Before the fix these would
+            //    spin forever inside Tsavorite waiting on the leaked ephemeral X-lock. With the fix they return
+            //    promptly. We don't care what GET returns, only that the server does not hang.
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig() + ",syncTimeout=3000"))
+            {
+                var db = redis.GetDatabase(0);
+
+                // Reads use an ephemeral S-lock on the same hash bucket, so they block on a leaked X-lock.
+                Assert.DoesNotThrow(() => _ = db.StringGet(key));
+
+                // RMW operations (e.g. APPEND) use the same EphemeralX path as SET; verify they don't hang either.
+                Assert.DoesNotThrow(() => _ = db.StringAppend(key, "x"));
+
+                // Delete also takes the ephemeral X-lock; verify it can complete.
+                Assert.DoesNotThrow(() => _ = db.KeyDelete(key));
+
+                // A small SET on the same key after recovery must succeed end-to-end.
+                Assert.DoesNotThrow(() => _ = db.StringSet(key, "ok"));
+                ClassicAssert.AreEqual("ok", (string)db.StringGet(key));
+            }
+        }
+
         private static void ExpectedEtagTest(IDatabase db, string key, string expectedValue, long expected)
         {
             RedisResult res = db.Execute("GETWITHETAG", key);

--- a/test/Garnet.test/TestUtils.cs
+++ b/test/Garnet.test/TestUtils.cs
@@ -278,7 +278,8 @@ namespace Garnet.test
             bool useLogNullDevice = false,
             bool enableVectorSetPreview = true,
             bool enableRangeIndexPreview = false,
-            string aofMemorySize = "64m"
+            string aofMemorySize = "64m",
+            string aofPageSize = null
             )
         {
             if (useAzureStorage)
@@ -387,6 +388,9 @@ namespace Garnet.test
 
             if (indexMaxSize != default)
                 opts.IndexMaxMemorySize = indexMaxSize;
+
+            if (!string.IsNullOrEmpty(aofPageSize))
+                opts.AofPageSize = aofPageSize;
 
             if (lowMemory)
             {


### PR DESCRIPTION
When a SET / RMW / DELETE produces an AOF entry larger than AofPageSize, TsavoriteLog.ValidateAllocatedLength throws TsavoriteException("Entry does not fit on page") from inside the PostUpsertOperation / PostRMWOperation / PostDeleteOperation callback. The exception unwinds the finally block in InternalUpsert / InternalRMW / InternalDelete (and ContinuePendingRMW) before EphemeralXUnlock can run, leaving the hash bucket's ephemeral exclusive lock held forever. Any subsequent op on the same bucket then spins indefinitely in a RETRY_LATER loop, pinning the server CPU at 100% until restart.

Wrap the Post*Operation call in a nested try/finally so EphemeralXUnlock always runs even on exception. The original TsavoriteException continues to propagate, preserving the observed behaviour for the user (connection closed) while leaving the server responsive.

While here, drop the dead 'latchOperation' / 'LatchRelease' machinery from InternalUpsert / InternalRMW / InternalDelete (the LatchOperation enum and the ref parameter on CheckCPRConsistency*): the CheckCPRConsistency* helpers never wrote to the ref parameter ("Now we no longer need to do the bucket latching" comment confirms it), so the switch in the LatchRelease block was unreachable. Renamed the empty LatchRelease label to Done for clarity.

Adds a regression test (OversizedAofEntryDoesNotHangServer) plus an aofPageSize parameter on TestUtils.CreateGarnetServer so the test can trigger the oversize path with a 4 KB AOF page.