### PR TITLE
Reduce AofAddress struct copy overhead on hot paths

### DIFF
--- a/libs/cluster/Server/ClusterProvider.cs
+++ b/libs/cluster/Server/ClusterProvider.cs
@@ -172,7 +172,7 @@ namespace Garnet.cluster
         }
 
         /// <inheritdoc />
-        public void SafeTruncateAOF(AofAddress truncateUntil)
+        public void SafeTruncateAOF(in AofAddress truncateUntil)
         {
             if (clusterManager.CurrentConfig.LocalNodeRole == NodeRole.PRIMARY)
                 replicationManager.AofSyncDriverStore.SafeTruncateAof(truncateUntil);

--- a/libs/cluster/Server/Gossip/GarnetServerNode.cs
+++ b/libs/cluster/Server/Gossip/GarnetServerNode.cs
@@ -165,7 +165,7 @@ namespace Garnet.cluster
                 if (clusterProvider.replicationManager != null)
                     // NOTE: We update replication offset for sublog-0 because this info is used in CLUSTER NODES
                     // and we cannot have multiple replication offsets without changing the expected CLUSTER NODES response
-                    lastConfig.LazyUpdateLocalReplicationOffset(clusterProvider.replicationManager.ReplicationOffset[0]);
+                    lastConfig.LazyUpdateLocalReplicationOffset(clusterProvider.replicationManager.GetReplicationOffset(0));
                 byteArray = lastConfig.ToByteArray();
             }
             else

--- a/libs/cluster/Server/Replication/PrimaryOps/AofOperations/AofSyncDriver.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/AofOperations/AofSyncDriver.cs
@@ -69,6 +69,20 @@ namespace Garnet.cluster
         }
 
         /// <summary>
+        /// Return previous address for a specific sublog without allocating an AofAddress struct
+        /// </summary>
+        /// <param name="physicalSublogIdx">Index of the physical sublog.</param>
+        /// <returns>The previous address of the specified sublog's sync task.</returns>
+        public long GetPreviousAddress(int physicalSublogIdx) => aofSyncTasks[physicalSublogIdx].PreviousAddress;
+
+        /// <summary>
+        /// Return start address for a specific sublog without allocating an AofAddress struct
+        /// </summary>
+        /// <param name="physicalSublogIdx">Index of the physical sublog.</param>
+        /// <returns>The start address of the specified sublog's sync task.</returns>
+        public long GetStartAddress(int physicalSublogIdx) => aofSyncTasks[physicalSublogIdx].StartAddress;
+
+        /// <summary>
         /// Replica endpoint
         /// </summary>
         readonly IPEndPoint endPoint;

--- a/libs/cluster/Server/Replication/PrimaryOps/AofOperations/AofSyncDriver.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/AofOperations/AofSyncDriver.cs
@@ -69,14 +69,14 @@ namespace Garnet.cluster
         }
 
         /// <summary>
-        /// Return previous address for a specific sublog without allocating an AofAddress struct
+        /// Return previous address for a specific sublog without copying the full AofAddress struct
         /// </summary>
         /// <param name="physicalSublogIdx">Index of the physical sublog.</param>
         /// <returns>The previous address of the specified sublog's sync task.</returns>
         public long GetPreviousAddress(int physicalSublogIdx) => aofSyncTasks[physicalSublogIdx].PreviousAddress;
 
         /// <summary>
-        /// Return start address for a specific sublog without allocating an AofAddress struct
+        /// Return start address for a specific sublog without copying the full AofAddress struct
         /// </summary>
         /// <param name="physicalSublogIdx">Index of the physical sublog.</param>
         /// <returns>The start address of the specified sublog's sync task.</returns>

--- a/libs/cluster/Server/Replication/PrimaryOps/AofOperations/AofSyncDriverStore.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/AofOperations/AofSyncDriverStore.cs
@@ -96,8 +96,9 @@ namespace Garnet.cluster
                 for (var i = 0; i < numDrivers; i++)
                 {
                     Debug.Assert(syncDrivers[i] != null, $"syncDriver cannot be null at {nameof(SafeTruncateAof)}");
-                    if (syncDrivers[i].PreviousAddress[physicalSublogIdx] < TruncatedUntil)
-                        TruncatedUntil = syncDrivers[i].PreviousAddress[physicalSublogIdx];
+                    var prevAddress = syncDrivers[i].GetPreviousAddress(physicalSublogIdx);
+                    if (prevAddress < TruncatedUntil)
+                        TruncatedUntil = prevAddress;
                 }
 
                 // Inform that we have logically truncatedUntil

--- a/libs/cluster/Server/Replication/PrimaryOps/AofOperations/AofSyncDriverStore.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/AofOperations/AofSyncDriverStore.cs
@@ -126,7 +126,7 @@ namespace Garnet.cluster
         /// Safely truncate AOF until provided address by checking against active AofSyncDrivers
         /// </summary>
         /// <param name="truncateUntil"></param>
-        public void SafeTruncateAof(AofAddress truncateUntil)
+        public void SafeTruncateAof(in AofAddress truncateUntil)
         {
             _lock.WriteLock();
 
@@ -175,7 +175,7 @@ namespace Garnet.cluster
         /// </summary>
         /// <param name="PrimaryReplicationOffset"></param>
         /// <returns></returns>
-        public List<RoleInfo> GetReplicaInfo(AofAddress PrimaryReplicationOffset)
+        public List<RoleInfo> GetReplicaInfo(in AofAddress PrimaryReplicationOffset)
         {
             // secondary0: ip=127.0.0.1,port=7001,state=online,offset=56,lag=0
             List<RoleInfo> replicaInfo = new(numDrivers);

--- a/libs/cluster/Server/Replication/ReplicaOps/AOFReplay/ReplicaReplayDriver.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/AOFReplay/ReplicaReplayDriver.cs
@@ -197,7 +197,7 @@ namespace Garnet.cluster
 
             if (replicationManager.GetSublogReplicationOffset(physicalSublogIdx) != nextAddress)
             {
-                logger?.LogError("ReplicaReplayTask.Consume NextAddress Mismatch sublogIdx: {sublogIdx}; recordLength:{recordLength}; currentAddress:{currentAddress}; nextAddress:{nextAddress}; replicationOffset:{ReplicationOffset}", physicalSublogIdx, recordLength, currentAddress, nextAddress, replicationManager.ReplicationOffset[physicalSublogIdx]);
+                logger?.LogError("ReplicaReplayTask.Consume NextAddress Mismatch sublogIdx: {sublogIdx}; recordLength:{recordLength}; currentAddress:{currentAddress}; nextAddress:{nextAddress}; replicationOffset:{ReplicationOffset}", physicalSublogIdx, recordLength, currentAddress, nextAddress, replicationManager.GetReplicationOffset(physicalSublogIdx));
                 throw new GarnetException("Failed validating integrity of replay", LogLevel.Warning, clientResponse: false);
             }
         }
@@ -269,7 +269,7 @@ namespace Garnet.cluster
 
             if (replicationOffset != nextAddress)
             {
-                logger?.LogError("ReplicaReplayTask.Consume NextAddress Mismatch sublogIdx: {sublogIdx}; recordLength:{recordLength}; currentAddress:{currentAddress}; nextAddress:{nextAddress}; replicationOffset:{ReplicationOffset}", physicalSublogIdx, recordLength, currentAddress, nextAddress, replicationManager.ReplicationOffset[physicalSublogIdx]);
+                logger?.LogError("ReplicaReplayTask.Consume NextAddress Mismatch sublogIdx: {sublogIdx}; recordLength:{recordLength}; currentAddress:{currentAddress}; nextAddress:{nextAddress}; replicationOffset:{ReplicationOffset}", physicalSublogIdx, recordLength, currentAddress, nextAddress, replicationManager.GetReplicationOffset(physicalSublogIdx));
                 throw new GarnetException("Failed validating integrity of replay", LogLevel.Warning, clientResponse: false);
             }
         }

--- a/libs/cluster/Server/Replication/ReplicaOps/AOFReplay/ReplicaReplayDriver.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/AOFReplay/ReplicaReplayDriver.cs
@@ -329,7 +329,7 @@ namespace Garnet.cluster
         public void ThrottlePrimary()
         {
             while (serverOptions.ReplicationOffsetMaxLag != -1 && replayIterator != null &&
-                appendOnlyFile.Log.TailAddress.AggregateDiff(replicationManager.ReplicationOffset) > serverOptions.ReplicationOffsetMaxLag)
+                appendOnlyFile.Log.GetTailAddress(physicalSublogIdx) - replicationManager.GetReplicationOffset(physicalSublogIdx) > serverOptions.ReplicationOffsetMaxLag)
             {
                 cts.Token.ThrowIfCancellationRequested();
                 Thread.Yield();

--- a/libs/cluster/Server/Replication/ReplicaOps/AOFReplay/ReplicaReplaySession.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/AOFReplay/ReplicaReplaySession.cs
@@ -92,8 +92,8 @@ namespace Garnet.cluster
                 if (clusterProvider.storeWrapper.serverOptions.ReplicationOffsetMaxLag == 0 && clusterProvider.replicationManager.GetSublogReplicationOffset(physicalSublogIdx) != tail)
                 {
                     logger?.LogInformation("Processing {recordLength} bytes; previousAddress {previousAddress}, currentAddress {currentAddress}, nextAddress {nextAddress}, current AOF tail {tail}", recordLength, previousAddress, currentAddress, nextAddress, tail);
-                    logger?.LogError("Before ProcessPrimaryStream: Replication offset mismatch: ReplicaReplicationOffset {ReplicaReplicationOffset}, aof.TailAddress {tailAddress}", clusterProvider.replicationManager.ReplicationOffset, tail);
-                    throw new GarnetException($"Before ProcessPrimaryStream: Replication offset mismatch: ReplicaReplicationOffset {clusterProvider.replicationManager.ReplicationOffset}, aof.TailAddress {tail}", LogLevel.Warning, clientResponse: false);
+                    logger?.LogError("Before ProcessPrimaryStream: Replication offset mismatch: ReplicaReplicationOffset {ReplicaReplicationOffset}, aof.TailAddress {tailAddress}", clusterProvider.replicationManager.GetSublogReplicationOffset(physicalSublogIdx), tail);
+                    throw new GarnetException($"Before ProcessPrimaryStream: Replication offset mismatch: ReplicaReplicationOffset {clusterProvider.replicationManager.GetSublogReplicationOffset(physicalSublogIdx)}, aof.TailAddress {tail}", LogLevel.Warning, clientResponse: false);
                 }
 
                 // Initialize sublog ref if first time

--- a/libs/cluster/Server/Replication/ReplicaOps/AOFReplay/ReplicaReplaySession.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/AOFReplay/ReplicaReplaySession.cs
@@ -75,21 +75,21 @@ namespace Garnet.cluster
                 // Injection for a "something went wrong with THIS Replica's AOF file"
                 ExceptionInjectionHelper.TriggerException(ExceptionInjectionType.Divergent_AOF_Stream);
 
-                var tail = clusterProvider.storeWrapper.appendOnlyFile.Log.TailAddress;
-                var nextPageBeginAddress = ((tail[physicalSublogIdx] >> clusterProvider.replicationManager.PageSizeBits) + 1) << clusterProvider.replicationManager.PageSizeBits;
+                var tail = clusterProvider.storeWrapper.appendOnlyFile.Log.GetTailAddress(physicalSublogIdx);
+                var nextPageBeginAddress = ((tail >> clusterProvider.replicationManager.PageSizeBits) + 1) << clusterProvider.replicationManager.PageSizeBits;
                 // Check to ensure:
                 // 1. if record fits in current page tailAddress of this local node (replica) should be equal to the incoming currentAddress (address of chunk send from primary node)
                 // 2. if record does not fit in current page start address of the next page matches incoming currentAddress (address of chunk send from primary node)
                 // otherwise fail and break the connection
-                if ((tail[physicalSublogIdx] + recordLength <= nextPageBeginAddress && tail[physicalSublogIdx] != currentAddress) ||
-                    (tail[physicalSublogIdx] + recordLength > nextPageBeginAddress && nextPageBeginAddress != currentAddress))
+                if ((tail + recordLength <= nextPageBeginAddress && tail != currentAddress) ||
+                    (tail + recordLength > nextPageBeginAddress && nextPageBeginAddress != currentAddress))
                 {
                     logger?.LogError("Divergent AOF Stream recordLength:{recordLength}; previousAddress:{previousAddress}; currentAddress:{currentAddress}; nextAddress:{nextAddress}; tailAddress:{tail}", recordLength, previousAddress, currentAddress, nextAddress, tail);
                     throw new GarnetException($"Divergent AOF Stream recordLength:{recordLength}; previousAddress:{previousAddress}; currentAddress:{currentAddress}; nextAddress:{nextAddress}; tailAddress:{tail}", LogLevel.Warning, clientResponse: false);
                 }
 
                 // Address check only if synchronous replication is enabled
-                if (clusterProvider.storeWrapper.serverOptions.ReplicationOffsetMaxLag == 0 && clusterProvider.replicationManager.GetSublogReplicationOffset(physicalSublogIdx) != tail[physicalSublogIdx])
+                if (clusterProvider.storeWrapper.serverOptions.ReplicationOffsetMaxLag == 0 && clusterProvider.replicationManager.GetSublogReplicationOffset(physicalSublogIdx) != tail)
                 {
                     logger?.LogInformation("Processing {recordLength} bytes; previousAddress {previousAddress}, currentAddress {currentAddress}, nextAddress {nextAddress}, current AOF tail {tail}", recordLength, previousAddress, currentAddress, nextAddress, tail);
                     logger?.LogError("Before ProcessPrimaryStream: Replication offset mismatch: ReplicaReplicationOffset {ReplicaReplicationOffset}, aof.TailAddress {tailAddress}", clusterProvider.replicationManager.ReplicationOffset, tail);

--- a/libs/cluster/Server/Replication/ReplicationManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationManager.cs
@@ -67,6 +67,22 @@ namespace Garnet.cluster
             }
         }
 
+        /// <summary>
+        /// Return the replication offset for a specific sublog without copying the full AofAddress struct.
+        /// </summary>
+        /// <param name="sublogIdx">Index of the physical sublog.</param>
+        /// <returns>The replication offset of the specified sublog.</returns>
+        public long GetReplicationOffset(int sublogIdx)
+        {
+            if (!storeWrapper.serverOptions.EnableAOF)
+                return replicationOffset[sublogIdx];
+
+            var role = clusterProvider.clusterManager.CurrentConfig.LocalNodeRole;
+            if (role == NodeRole.PRIMARY)
+                return storeWrapper.appendOnlyFile.Log.GetTailAddress(sublogIdx);
+            return replicationOffset[sublogIdx];
+        }
+
         public void SetSublogReplicationOffset(int sublogIdx, long offset)
             => replicationOffset[sublogIdx] = offset;
         public long GetSublogReplicationOffset(int sublogIdx)

--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -200,7 +200,7 @@ namespace Garnet
         [Option("aof-page-size", Required = false, HelpText = "Size of each AOF page in bytes(rounds down to power of 2)")]
         public string AofPageSize { get; set; }
 
-        [IntRangeValidation(1, 64, isRequired: false)]
+        [IntRangeValidation(1, AofAddress.MaxSublogCount, isRequired: false)]
         [Option("aof-physical-sublog-count", Required = false, HelpText = "Number of AOF physical sublogs (i.e. TsavoriteLog instances) used (=1 equivalent to the legacy single log implementation >1: sharded log implementation.")]
         public int AofPhysicalSublogCount { get; set; }
 

--- a/libs/server/AOF/AofAddress.cs
+++ b/libs/server/AOF/AofAddress.cs
@@ -48,7 +48,7 @@ namespace Garnet.server
         /// <returns></returns>
         public long this[int i]
         {
-            get
+            readonly get
             {
                 return addresses[i];
             }

--- a/libs/server/AOF/AofAddress.cs
+++ b/libs/server/AOF/AofAddress.cs
@@ -8,6 +8,10 @@ using System.Text;
 
 namespace Garnet.server
 {
+    /// <summary>
+    /// Represents a fixed-size collection of addresses used for append-only file (AOF) operations, supporting efficient
+    /// serialization, comparison, and manipulation of address sequences.
+    /// </summary>
     public unsafe struct AofAddress
     {
         readonly byte length;
@@ -16,7 +20,7 @@ namespace Garnet.server
         /// <summary>
         /// Maximum number of sublogs supported
         /// </summary>
-        public const int MaxSublogCount = 64;
+        public const int MaxSublogCount = 4;
 
         /// <summary>
         /// AofAddress length

--- a/libs/server/AOF/AofAddress.cs
+++ b/libs/server/AOF/AofAddress.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 
@@ -63,11 +62,11 @@ namespace Garnet.server
         /// and must have the same length as the current instance.</param>
         /// <returns><see langword="true"/> if the specified <see cref="AofAddress"/> is equal to the current instance;
         /// otherwise, <see langword="false"/>.</returns>
-        public bool Equals([NotNullWhen(true)] AofAddress other)
+        public bool Equals(in AofAddress other)
         {
             Debug.Assert(other.Length == Length);
             for (var i = 0; i < Length; i++)
-                if (addresses[i] != other.addresses[i]) return false;
+                if (addresses[i] != other[i]) return false;
             return true;
         }
 
@@ -229,7 +228,7 @@ namespace Garnet.server
         /// </summary>
         /// <param name="value"></param>
         /// <param name="comparand"></param>
-        public void SetValueIf(AofAddress value, long comparand)
+        public void SetValueIf(in AofAddress value, long comparand)
         {
             for (var i = 0; i < Length; i++)
             {
@@ -297,7 +296,7 @@ namespace Garnet.server
             _ = Tsavorite.core.Utility.MonotonicUpdate(ref addresses[physicalSublogIdx], update, out _);
         }
 
-        public void MinExchange(AofAddress address)
+        public void MinExchange(in AofAddress address)
         {
             for (var i = 0; i < Length; i++)
                 addresses[i] = Math.Min(addresses[i], address[i]);
@@ -309,14 +308,14 @@ namespace Garnet.server
                 addresses[i] = Math.Max(addresses[i], address);
         }
 
-        public bool AnyLesser(AofAddress address)
+        public bool AnyLesser(in AofAddress address)
         {
             for (var i = 0; i < Length; i++)
                 if (addresses[i] < address[i]) return true;
             return false;
         }
 
-        public bool AnyGreater(AofAddress address)
+        public bool AnyGreater(in AofAddress address)
         {
             for (var i = 0; i < Length; i++)
                 if (addresses[i] > address[i]) return true;
@@ -330,16 +329,16 @@ namespace Garnet.server
             return true;
         }
 
-        public AofAddress Diff(AofAddress other)
+        public AofAddress Diff(in AofAddress other)
         {
             Debug.Assert(other.Length == Length);
             var aofAddress = new AofAddress(other.Length);
             for (var i = 0; i < other.Length; i++)
-                aofAddress[i] = this.addresses[i] - other.addresses[i];
+                aofAddress[i] = this.addresses[i] - other[i];
             return aofAddress;
         }
 
-        public long AggregateDiff(AofAddress aofAddress)
+        public long AggregateDiff(in AofAddress aofAddress)
         {
             var diff = 0L;
             for (var i = 0; i < Length; i++)
@@ -355,7 +354,7 @@ namespace Garnet.server
             return diff;
         }
 
-        public bool EqualsAll(AofAddress input)
+        public bool EqualsAll(in AofAddress input)
         {
             for (var i = 0; i < Length; i++)
                 if (addresses[i] != input[i])
@@ -363,7 +362,7 @@ namespace Garnet.server
             return true;
         }
 
-        public bool IsOutOfRange(AofAddress begin, AofAddress end)
+        public bool IsOutOfRange(in AofAddress begin, in AofAddress end)
         {
             for (var i = 0; i < Length; i++)
             {

--- a/libs/server/AOF/GarnetLog.cs
+++ b/libs/server/AOF/GarnetLog.cs
@@ -266,6 +266,46 @@ namespace Garnet.server
         }
 
         /// <summary>
+        /// Gets the tail address for a specific sublog without copying the entire AofAddress struct.
+        /// </summary>
+        /// <param name="sublogIdx">Index of the physical sublog.</param>
+        /// <returns>The tail address of the specified sublog.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long GetTailAddress(int sublogIdx)
+        {
+            if (singleLog != null)
+            {
+                Debug.Assert(sublogIdx == 0);
+                return singleLog.log.TailAddress;
+            }
+            else
+            {
+                Debug.Assert(sublogIdx < shardedLog.Length);
+                return shardedLog.sublog[sublogIdx].TailAddress;
+            }
+        }
+
+        /// <summary>
+        /// Gets the begin address for a specific sublog without copying the entire AofAddress struct.
+        /// </summary>
+        /// <param name="sublogIdx">Index of the physical sublog.</param>
+        /// <returns>The begin address of the specified sublog.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long GetBeginAddress(int sublogIdx)
+        {
+            if (singleLog != null)
+            {
+                Debug.Assert(sublogIdx == 0);
+                return singleLog.log.BeginAddress;
+            }
+            else
+            {
+                Debug.Assert(sublogIdx < shardedLog.Length);
+                return shardedLog.sublog[sublogIdx].BeginAddress;
+            }
+        }
+
+        /// <summary>
         /// Set log shift tail callbacks
         /// </summary>
         /// <param name="sublogIdx"></param>

--- a/libs/server/Cluster/IClusterProvider.cs
+++ b/libs/server/Cluster/IClusterProvider.cs
@@ -117,7 +117,7 @@ namespace Garnet.server
         /// Safe truncate AOF until address
         /// </summary>
         /// <param name="truncateUntil"></param>
-        void SafeTruncateAOF(AofAddress truncateUntil);
+        void SafeTruncateAOF(in AofAddress truncateUntil);
 
         /// <summary>
         /// Start cluster operations


### PR DESCRIPTION
AofAddress is a 513-byte struct (1 byte + fixed long[64]) that was frequently copied by value on performance-critical paths.

**Changes:**
- Add `in` modifier to all AofAddress instance method parameters (Equals, AnyLesser, AnyGreater, Diff, AggregateDiff, etc.)
- Add `in` modifier to AofSyncDriverStore and IClusterProvider method parameters
- Add scalar accessors (`GetTailAddress(int)`, `GetBeginAddress(int)`, `GetPreviousAddress(int)`, `GetReplicationOffset(int)`) to avoid full struct copies when only one sublog value is needed
- Update hot-path callers (ReplicaReplaySession, SafeTruncateAof, GarnetServerNode, ReplicaReplayDriver) to use scalar accessors