### PR TITLE
Rework SimpleSetupCluster in cluster tests, and longer timeouts for select tests

### DIFF
--- a/libs/cluster/Server/Replication/ReplicationManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationManager.cs
@@ -251,7 +251,7 @@ namespace Garnet.cluster
                     return;
                 }
 
-                logger.LogInformation("Beginning resync to {primaryId} after replication session failed", primaryId);
+                logger?.LogInformation("Beginning resync to {primaryId} after replication session failed", primaryId);
 
                 // At this point we need to hold the lock until this upcoming task completes
                 suppressUnlock = true;
@@ -270,16 +270,16 @@ namespace Garnet.cluster
 
                             if (success)
                             {
-                                logger.LogInformation("Resync to {primaryId} successfully started", primaryId);
+                                logger?.LogInformation("Resync to {primaryId} successfully started", primaryId);
                             }
                             else
                             {
-                                logger.LogWarning("Failed to resync to {primaryId} after replication session failed: {errorMessage}", primaryId, Encoding.UTF8.GetString(errorMessage.Span));
+                                logger?.LogWarning("Failed to resync to {primaryId} after replication session failed: {errorMessage}", primaryId, Encoding.UTF8.GetString(errorMessage.Span));
                             }
                         }
                         catch (Exception ex)
                         {
-                            logger.LogError(ex, "Error encountered on replication recovery background task");
+                            logger?.LogError(ex, "Error encountered on replication recovery background task");
                         }
                         finally
                         {

--- a/libs/cluster/Session/RespClusterBasicCommands.cs
+++ b/libs/cluster/Session/RespClusterBasicCommands.cs
@@ -356,94 +356,85 @@ namespace Garnet.cluster
         /// <returns></returns>
         private bool NetworkClusterGossip(out bool invalidParameters)
         {
-            try
+            invalidParameters = false;
+
+            // Expecting 1 or 2 arguments
+            if (parseState.Count is < 1 or > 2)
             {
-                invalidParameters = false;
+                invalidParameters = true;
+                return true;
+            }
 
-                // Expecting 1 or 2 arguments
-                if (parseState.Count is < 1 or > 2)
+            var gossipWithMeet = false;
+
+            var currTokenIdx = 0;
+            if (parseState.Count > 1)
+            {
+                var withMeetSpan = parseState.GetArgSliceByRef(currTokenIdx++).ReadOnlySpan;
+
+                Debug.Assert(withMeetSpan.EqualsUpperCaseSpanIgnoringCase(CmdStrings.WITHMEET));
+                if (withMeetSpan.EqualsUpperCaseSpanIgnoringCase(CmdStrings.WITHMEET))
                 {
-                    invalidParameters = true;
-                    return true;
+                    gossipWithMeet = true;
                 }
+            }
 
-                var gossipWithMeet = false;
+            var gossipMessage = parseState.GetArgSliceByRef(currTokenIdx).SpanByte.ToByteArray();
 
-                var currTokenIdx = 0;
-                if (parseState.Count > 1)
+            clusterProvider.clusterManager.gossipStats.UpdateGossipBytesRecv(gossipMessage.Length);
+            var current = clusterProvider.clusterManager.CurrentConfig;
+
+            // Try merge if not just a ping message
+            if (gossipMessage.Length > 0)
+            {
+                var other = ClusterConfig.FromByteArray(gossipMessage);
+                // Accept gossip message if it is a gossipWithMeet or node from node that is already known and trusted
+                // GossipWithMeet messages are only send through a call to CLUSTER MEET at the remote node
+                if (gossipWithMeet || current.IsKnown(other.LocalNodeId))
                 {
-                    var withMeetSpan = parseState.GetArgSliceByRef(currTokenIdx++).ReadOnlySpan;
-
-                    Debug.Assert(withMeetSpan.EqualsUpperCaseSpanIgnoringCase(CmdStrings.WITHMEET));
-                    if (withMeetSpan.EqualsUpperCaseSpanIgnoringCase(CmdStrings.WITHMEET))
+                    // NOTE: release the epoch to avoid deadlock with MIGRATE config suspension
+                    ReleaseCurrentEpoch();
+                    try
                     {
-                        gossipWithMeet = true;
+                        _ = clusterProvider.clusterManager.TryMerge(other);
                     }
-                }
-
-                var gossipMessage = parseState.GetArgSliceByRef(currTokenIdx).SpanByte.ToByteArray();
-
-                clusterProvider.clusterManager.gossipStats.UpdateGossipBytesRecv(gossipMessage.Length);
-                var current = clusterProvider.clusterManager.CurrentConfig;
-
-                // Try merge if not just a ping message
-                if (gossipMessage.Length > 0)
-                {
-                    var other = ClusterConfig.FromByteArray(gossipMessage);
-                    // Accept gossip message if it is a gossipWithMeet or node from node that is already known and trusted
-                    // GossipWithMeet messages are only send through a call to CLUSTER MEET at the remote node
-                    if (gossipWithMeet || current.IsKnown(other.LocalNodeId))
+                    finally
                     {
-                        // NOTE: release the epoch to avoid deadlock with MIGRATE config suspension
-                        ReleaseCurrentEpoch();
-                        try
-                        {
-                            _ = clusterProvider.clusterManager.TryMerge(other);
-                        }
-                        finally
-                        {
-                            AcquireCurrentEpoch();
-                        }
-
-                        // Remember that this connection is being used for another cluster node to talk to us
-                        Debug.Assert(RemoteNodeId is null || RemoteNodeId == other.LocalNodeId, "Node Id shouldn't change once set for a connection");
-                        RemoteNodeId = other.LocalNodeId;
+                        AcquireCurrentEpoch();
                     }
-                    else
-                    {
-                        logger?.LogWarning("Received gossip from unknown node: {node-id}", other.LocalNodeId);
-                    }
-                }
 
-                // Respond if configuration has changed or gossipWithMeet option is specified
-                if (lastSentConfig != current || gossipWithMeet)
-                {
-                    var configByteArray = current.ToByteArray();
-                    clusterProvider.clusterManager.gossipStats.UpdateGossipBytesSend(configByteArray.Length);
-                    while (!RespWriteUtils.TryWriteBulkString(configByteArray, ref dcurr, dend))
-                        SendAndReset();
-                    lastSentConfig = current;
+                    // Remember that this connection is being used for another cluster node to talk to us
+                    Debug.Assert(RemoteNodeId is null || RemoteNodeId == other.LocalNodeId, "Node Id shouldn't change once set for a connection");
+                    RemoteNodeId = other.LocalNodeId;
                 }
                 else
                 {
-                    while (!RespWriteUtils.TryWriteBulkString([], ref dcurr, dend))
-                        SendAndReset();
+                    logger?.LogWarning("Received gossip from unknown node: {node-id}", other.LocalNodeId);
                 }
-
-                // After each GOSSIP, ensure cluster connections for replication are in a good state
-                if (Server is GarnetServerBase garnetServer)
-                {
-                    clusterProvider.replicationManager.EnsureReplication(this, garnetServer.ActiveClusterSessions());
-                }
-
-                return true;
             }
-            catch (Exception ex)
+
+            // Respond if configuration has changed or gossipWithMeet option is specified
+            if (lastSentConfig != current || gossipWithMeet)
             {
-                logger?.LogError(ex, "Gossip failure");
-
-                throw;
+                var configByteArray = current.ToByteArray();
+                clusterProvider.clusterManager.gossipStats.UpdateGossipBytesSend(configByteArray.Length);
+                while (!RespWriteUtils.TryWriteBulkString(configByteArray, ref dcurr, dend))
+                    SendAndReset();
+                lastSentConfig = current;
             }
+            else
+            {
+                while (!RespWriteUtils.TryWriteBulkString([], ref dcurr, dend))
+                    SendAndReset();
+            }
+
+            // After each GOSSIP, ensure cluster connections for replication are in a good state
+            if (Server is GarnetServerBase garnetServer)
+            {
+                clusterProvider.replicationManager.EnsureReplication(this, garnetServer.ActiveClusterSessions());
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/libs/cluster/Session/RespClusterBasicCommands.cs
+++ b/libs/cluster/Session/RespClusterBasicCommands.cs
@@ -356,81 +356,94 @@ namespace Garnet.cluster
         /// <returns></returns>
         private bool NetworkClusterGossip(out bool invalidParameters)
         {
-            invalidParameters = false;
-
-            // Expecting 1 or 2 arguments
-            if (parseState.Count is < 1 or > 2)
+            try
             {
-                invalidParameters = true;
-                return true;
-            }
+                invalidParameters = false;
 
-            var gossipWithMeet = false;
-
-            var currTokenIdx = 0;
-            if (parseState.Count > 1)
-            {
-                var withMeetSpan = parseState.GetArgSliceByRef(currTokenIdx++).ReadOnlySpan;
-
-                Debug.Assert(withMeetSpan.EqualsUpperCaseSpanIgnoringCase(CmdStrings.WITHMEET));
-                if (withMeetSpan.EqualsUpperCaseSpanIgnoringCase(CmdStrings.WITHMEET))
-                    gossipWithMeet = true;
-            }
-
-            var gossipMessage = parseState.GetArgSliceByRef(currTokenIdx).SpanByte.ToByteArray();
-
-            clusterProvider.clusterManager.gossipStats.UpdateGossipBytesRecv(gossipMessage.Length);
-            var current = clusterProvider.clusterManager.CurrentConfig;
-
-            // Try merge if not just a ping message
-            if (gossipMessage.Length > 0)
-            {
-                var other = ClusterConfig.FromByteArray(gossipMessage);
-                // Accept gossip message if it is a gossipWithMeet or node from node that is already known and trusted
-                // GossipWithMeet messages are only send through a call to CLUSTER MEET at the remote node
-                if (gossipWithMeet || current.IsKnown(other.LocalNodeId))
+                // Expecting 1 or 2 arguments
+                if (parseState.Count is < 1 or > 2)
                 {
-                    // NOTE: release the epoch to avoid deadlock with MIGRATE config suspension
-                    ReleaseCurrentEpoch();
-                    try
-                    {
-                        _ = clusterProvider.clusterManager.TryMerge(other);
-                    }
-                    finally
-                    {
-                        AcquireCurrentEpoch();
-                    }
+                    invalidParameters = true;
+                    return true;
+                }
 
-                    // Remember that this connection is being used for another cluster node to talk to us
-                    Debug.Assert(RemoteNodeId is null || RemoteNodeId == other.LocalNodeId, "Node Id shouldn't change once set for a connection");
-                    RemoteNodeId = other.LocalNodeId;
+                var gossipWithMeet = false;
+
+                var currTokenIdx = 0;
+                if (parseState.Count > 1)
+                {
+                    var withMeetSpan = parseState.GetArgSliceByRef(currTokenIdx++).ReadOnlySpan;
+
+                    Debug.Assert(withMeetSpan.EqualsUpperCaseSpanIgnoringCase(CmdStrings.WITHMEET));
+                    if (withMeetSpan.EqualsUpperCaseSpanIgnoringCase(CmdStrings.WITHMEET))
+                    {
+                        gossipWithMeet = true;
+                    }
+                }
+
+                var gossipMessage = parseState.GetArgSliceByRef(currTokenIdx).SpanByte.ToByteArray();
+
+                clusterProvider.clusterManager.gossipStats.UpdateGossipBytesRecv(gossipMessage.Length);
+                var current = clusterProvider.clusterManager.CurrentConfig;
+
+                // Try merge if not just a ping message
+                if (gossipMessage.Length > 0)
+                {
+                    var other = ClusterConfig.FromByteArray(gossipMessage);
+                    // Accept gossip message if it is a gossipWithMeet or node from node that is already known and trusted
+                    // GossipWithMeet messages are only send through a call to CLUSTER MEET at the remote node
+                    if (gossipWithMeet || current.IsKnown(other.LocalNodeId))
+                    {
+                        // NOTE: release the epoch to avoid deadlock with MIGRATE config suspension
+                        ReleaseCurrentEpoch();
+                        try
+                        {
+                            _ = clusterProvider.clusterManager.TryMerge(other);
+                        }
+                        finally
+                        {
+                            AcquireCurrentEpoch();
+                        }
+
+                        // Remember that this connection is being used for another cluster node to talk to us
+                        Debug.Assert(RemoteNodeId is null || RemoteNodeId == other.LocalNodeId, "Node Id shouldn't change once set for a connection");
+                        RemoteNodeId = other.LocalNodeId;
+                    }
+                    else
+                    {
+                        logger?.LogWarning("Received gossip from unknown node: {node-id}", other.LocalNodeId);
+                    }
+                }
+
+                // Respond if configuration has changed or gossipWithMeet option is specified
+                if (lastSentConfig != current || gossipWithMeet)
+                {
+                    var configByteArray = current.ToByteArray();
+                    clusterProvider.clusterManager.gossipStats.UpdateGossipBytesSend(configByteArray.Length);
+                    while (!RespWriteUtils.TryWriteBulkString(configByteArray, ref dcurr, dend))
+                        SendAndReset();
+                    lastSentConfig = current;
                 }
                 else
-                    logger?.LogWarning("Received gossip from unknown node: {node-id}", other.LocalNodeId);
-            }
+                {
+                    while (!RespWriteUtils.TryWriteBulkString([], ref dcurr, dend))
+                        SendAndReset();
+                }
 
-            // Respond if configuration has changed or gossipWithMeet option is specified
-            if (lastSentConfig != current || gossipWithMeet)
-            {
-                var configByteArray = current.ToByteArray();
-                clusterProvider.clusterManager.gossipStats.UpdateGossipBytesSend(configByteArray.Length);
-                while (!RespWriteUtils.TryWriteBulkString(configByteArray, ref dcurr, dend))
-                    SendAndReset();
-                lastSentConfig = current;
-            }
-            else
-            {
-                while (!RespWriteUtils.TryWriteBulkString([], ref dcurr, dend))
-                    SendAndReset();
-            }
+                // After each GOSSIP, ensure cluster connections for replication are in a good state
+                if (Server is GarnetServerBase garnetServer)
+                {
+                    clusterProvider.replicationManager.EnsureReplication(this, garnetServer.ActiveClusterSessions());
+                }
 
-            // After each GOSSIP, ensure cluster connections for replication are in a good state
-            if (Server is GarnetServerBase garnetServer)
-            {
-                clusterProvider.replicationManager.EnsureReplication(this, garnetServer.ActiveClusterSessions());
+                return true;
             }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Gossip failure");
 
-            return true;
+                throw;
+            }
         }
 
         /// <summary>

--- a/test/Garnet.test.cluster/ClusterConfigTests.cs
+++ b/test/Garnet.test.cluster/ClusterConfigTests.cs
@@ -63,7 +63,7 @@ namespace Garnet.test.cluster
         }
 
         [Test, Order(2)]
-        [Category("CLUSTER-CONFIG"), CancelAfter(1000)]
+        [Category("CLUSTER-CONFIG")]
         public void ClusterForgetAfterNodeRestartTest()
         {
             int nbInstances = 4;

--- a/test/Garnet.test.cluster/ClusterMigrateTests.cs
+++ b/test/Garnet.test.cluster/ClusterMigrateTests.cs
@@ -1404,7 +1404,7 @@ namespace Garnet.test.cluster
 
         [Test, Order(15)]
         [Category("CLUSTER")]
-        public void ClusterAllowWritesDuringMigrateTest()
+        public async Task ClusterAllowWritesDuringMigrateTestAsync()
         {
             context.logger.LogDebug("0. ClusterSimpleMigrateTestWithReadWrite started");
             var Shards = defaultShards;
@@ -1428,7 +1428,7 @@ namespace Garnet.test.cluster
 
             // Get slot mapping
             var slot = context.clusterTestUtils.ClusterKeySlot(srcNode.EndPoint.ToIPEndPoint(), Encoding.ASCII.GetString(keyExists));
-            var tgtNode = context.clusterTestUtils.GetAnyOtherNode(srcNode.EndPoint.ToIPEndPoint(), logger: context.logger);
+            var tgtNode = await context.clusterTestUtils.GetAnyOtherNodeAsync(srcNode.EndPoint.ToIPEndPoint(), logger: context.logger).ConfigureAwait(false);
 
             // Set slot to IMPORTING state
             var resp = context.clusterTestUtils.SetSlot(tgtNode.EndPoint.ToIPEndPoint(), slot, "IMPORTING", srcNode.NodeId);

--- a/test/Garnet.test.cluster/ClusterNegativeTests.cs
+++ b/test/Garnet.test.cluster/ClusterNegativeTests.cs
@@ -628,7 +628,7 @@ namespace Garnet.test.cluster
         }
         [Test, Order(14), CancelAfter(testTimeout)]
         [Category("REPLICATION")]
-        public void ClusterFailoverSucceedsDuringEnsureReplication(CancellationToken cancellationToken)
+        public async Task ClusterFailoverSucceedsDuringEnsureReplicationAsync(CancellationToken cancellationToken)
         {
             // Verify that EnsureReplication does not block an in-flight failover.
             // EnsureReplication polls for dropped replication sessions and attempts auto-resync.
@@ -653,7 +653,7 @@ namespace Garnet.test.cluster
             var resp = context.clusterTestUtils.ClusterReplicate(replicaNodeIndex: replicaIndex, primaryNodeIndex: primaryIndex, logger: context.logger);
             ClassicAssert.AreEqual("OK", resp);
             context.clusterTestUtils.WaitForReplicaRecovery(replicaIndex, context.logger);
-            context.clusterTestUtils.WaitForConnectedReplicaCount(primaryIndex, 1, context.logger);
+            await context.clusterTestUtils.WaitForConnectedReplicaCountAsync(primaryIndex, 1, context.logger).ConfigureAwait(false);
 
             // Populate primary and wait for sync
             context.kvPairs = [];
@@ -686,7 +686,7 @@ namespace Garnet.test.cluster
 
         [Test, Order(15), CancelAfter(testTimeout)]
         [Category("REPLICATION")]
-        public void ClusterEnsureReplicationWorksAfterFailover(CancellationToken cancellationToken)
+        public async Task ClusterEnsureReplicationWorksAfterFailoverAsync(CancellationToken cancellationToken)
         {
             // Verify that EnsureReplication still functions after a failover completes.
             // The failover guard should only suppress auto-resync during active failover states,
@@ -710,7 +710,7 @@ namespace Garnet.test.cluster
             var resp = context.clusterTestUtils.ClusterReplicate(replicaNodeIndex: replicaIndex, primaryNodeIndex: primaryIndex, logger: context.logger);
             ClassicAssert.AreEqual("OK", resp);
             context.clusterTestUtils.WaitForReplicaRecovery(replicaIndex, context.logger);
-            context.clusterTestUtils.WaitForConnectedReplicaCount(primaryIndex, 1, context.logger);
+            await context.clusterTestUtils.WaitForConnectedReplicaCountAsync(primaryIndex, 1, context.logger).ConfigureAwait(false);
 
             // Populate primary data and sync
             context.kvPairs = [];
@@ -746,7 +746,7 @@ namespace Garnet.test.cluster
 #if DEBUG
         [Test, Order(16), CancelAfter(testTimeout)]
         [Category("REPLICATION")]
-        public void ClusterFailoverResetsPrimaryOnTakeOverFailure(CancellationToken cancellationToken)
+        public async Task ClusterFailoverResetsPrimaryOnTakeOverFailureAsync(CancellationToken cancellationToken)
         {
             // Verify that when TakeOverAsPrimary fails after PauseWritesAndWaitForSync
             // has already sent failstopwrites to the primary, the primary is reset back
@@ -772,7 +772,7 @@ namespace Garnet.test.cluster
             var resp = context.clusterTestUtils.ClusterReplicate(replicaNodeIndex: replicaIndex, primaryNodeIndex: primaryIndex, logger: context.logger);
             ClassicAssert.AreEqual("OK", resp);
             context.clusterTestUtils.WaitForReplicaRecovery(replicaIndex, context.logger);
-            context.clusterTestUtils.WaitForConnectedReplicaCount(primaryIndex, 1, context.logger);
+            await context.clusterTestUtils.WaitForConnectedReplicaCountAsync(primaryIndex, 1, context.logger).ConfigureAwait(false);
 
             // Populate data and sync
             context.kvPairs = [];

--- a/test/Garnet.test.cluster/ClusterTestContext.cs
+++ b/test/Garnet.test.cluster/ClusterTestContext.cs
@@ -46,6 +46,12 @@ namespace Garnet.test.cluster
 
         public void Setup(Dictionary<string, LogLevel> monitorTests, int testTimeoutSeconds = 60)
         {
+            // Pull timeout off [CancelAfter] if its specified, otherwise use default
+            if (TestContext.CurrentContext.Test.Properties.ContainsKey("Timeout"))
+            {
+                testTimeoutSeconds = ((int)TestContext.CurrentContext.Test.Properties["Timeout"].First()) / 1_000;
+            }
+
             cts = new CancellationTokenSource(TimeSpan.FromSeconds(testTimeoutSeconds));
 
             TestFolder = TestUtils.UnitTestWorkingDir() + "\\";

--- a/test/Garnet.test.cluster/ClusterTestContext.cs
+++ b/test/Garnet.test.cluster/ClusterTestContext.cs
@@ -779,7 +779,7 @@ namespace Garnet.test.cluster
             }
         }
 
-        public void AttachAndWaitForSync(int primary_count, int replica_count, bool disableObjects)
+        public async Task AttachAndWaitForSyncAsync(int primary_count, int replica_count, bool disableObjects)
         {
             var primaryId = clusterTestUtils.GetNodeIdFromNode(0, logger);
 
@@ -800,7 +800,7 @@ namespace Garnet.test.cluster
                 clusterTestUtils.WaitForReplicaAofSync(0, i, logger);
             }
 
-            clusterTestUtils.WaitForConnectedReplicaCount(0, replica_count, logger: logger);
+            await clusterTestUtils.WaitForConnectedReplicaCountAsync(0, replica_count, logger: logger).ConfigureAwait(false);
 
             // Validate data on replicas
             for (var i = primary_count; i < replica_count; i++)

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -105,6 +105,9 @@ namespace Garnet.test.cluster
         PRIMARY_FAILOVER_STATE,
         RECOVER_STATUS,
         LAST_FAILOVER_STATE,
+
+        MASTER_HOST,
+        MASTER_PORT,
     }
 
     public enum StoreInfoItem
@@ -162,14 +165,33 @@ namespace Garnet.test.cluster
                 return RedisResult.Create((RedisValue)ex.Message);
             }
         }
+        public Task<RedisResult> ExecuteAsync(IPEndPoint endPoint, string cmd, ICollection<object> args, bool skipLogging = false, ILogger logger = null, CommandFlags flags = CommandFlags.None)
+        {
+            if (!skipLogging)
+                logger?.LogInformation("({address}:{port}) > {cmd} {args}", endPoint.Address, endPoint.Port, cmd, string.Join(' ', args));
+            try
+            {
+                var server = GetServer(endPoint);
+                var resp = server.ExecuteAsync(cmd, args, flags: flags);
+                return resp;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "An error occured {cmd} {msg}", cmd, ex.Message);
+                return Task.FromResult(RedisResult.Create((RedisValue)ex.Message));
+            }
+        }
 
-        public RedisResult NodesV2(IPEndPoint endPoint, ILogger logger = null)
-            => Execute(endPoint, "cluster", ["nodes"], skipLogging: true, logger);
+        public Task<RedisResult> NodesV2Async(IPEndPoint endPoint, ILogger logger = null)
+            => ExecuteAsync(endPoint, "cluster", ["nodes"], skipLogging: true, logger);
 
         public string NodesMyself(IPEndPoint endPoint, ClusterInfoTag tag, ILogger logger)
+            => AsyncUtils.BlockingWait(NodesMyselfAsync(endPoint, tag, logger));
+
+        public async Task<string> NodesMyselfAsync(IPEndPoint endPoint, ClusterInfoTag tag, ILogger logger)
         {
             var nodeConfigInfo = string.Empty;
-            var nodeConfigStr = (string)NodesV2(endPoint, logger);
+            var nodeConfigStr = (string)await NodesV2Async(endPoint, logger).ConfigureAwait(false);
             if (nodeConfigStr != null)
             {
                 var lines = nodeConfigStr.ToString().Split('\n');
@@ -181,12 +203,15 @@ namespace Garnet.test.cluster
         }
 
         public string GetLocalNodeId(int nodeIndex, ILogger logger = null)
-            => ClusterNodes(nodeIndex, logger).Nodes.First().NodeId;
+            => AsyncUtils.BlockingWait(GetLocalNodeIdAsync(nodeIndex, logger));
 
-        public string[] NodesMyself(IPEndPoint endPoint, ClusterInfoTag[] tags)
+        public async Task<string> GetLocalNodeIdAsync(int nodeIndex, ILogger logger = null)
+            => (await ClusterNodesAsync(nodeIndex, logger).ConfigureAwait(false)).Nodes.First().NodeId;
+
+        public async Task<string[]> NodesMyselfAsync(IPEndPoint endPoint, ClusterInfoTag[] tags)
         {
             var nodeConfigInfo = new string[tags.Length];
-            var nodeConfigStr = (string)NodesV2(endPoint);
+            var nodeConfigStr = (string)await NodesV2Async(endPoint).ConfigureAwait(false);
             if (nodeConfigStr != null)
             {
                 var lines = nodeConfigStr.ToString().Split('\n');
@@ -201,10 +226,10 @@ namespace Garnet.test.cluster
             return nodeConfigInfo;
         }
 
-        public List<string[]> NodesAll(IPEndPoint endPoint, ClusterInfoTag[] tags, string nodeid = null)
+        public async Task<List<string[]>> NodesAllAsync(IPEndPoint endPoint, ClusterInfoTag[] tags, string nodeid = null)
         {
             var nodeConfigInfo = new List<string[]>();
-            var nodeConfigStr = (string)NodesV2(endPoint);
+            var nodeConfigStr = (string)await NodesV2Async(endPoint).ConfigureAwait(false);
             if (nodeConfigStr != null)
             {
                 var lines = nodeConfigStr.ToString().Split('\n');
@@ -229,14 +254,14 @@ namespace Garnet.test.cluster
         private async Task<bool> WaitForEpochSync(IPEndPoint endPoint)
         {
             var endpoints = GetEndpointsWithout(endPoint);
-            var configInfo = NodesMyself(endPoint, [ClusterInfoTag.NODEID, ClusterInfoTag.CONFIG_EPOCH]);
+            var configInfo = await NodesMyselfAsync(endPoint, [ClusterInfoTag.NODEID, ClusterInfoTag.CONFIG_EPOCH]).ConfigureAwait(false);
             while (true)
             {
                 await Task.Delay(endpoints.Length * 100).ConfigureAwait(false);
             retry:
                 foreach (var endpoint in endpoints)
                 {
-                    var _configInfo = NodesAll(endpoint, [ClusterInfoTag.NODEID, ClusterInfoTag.CONFIG_EPOCH], configInfo[0]);
+                    var _configInfo = await NodesAllAsync(endpoint, [ClusterInfoTag.NODEID, ClusterInfoTag.CONFIG_EPOCH], configInfo[0]).ConfigureAwait(false);
                     if (_configInfo[0][0] == configInfo[1])
                         ThrowException($"WaitForEpochSync unexpected node id {_configInfo[0][0]} {configInfo[1]}");
 
@@ -287,17 +312,17 @@ namespace Garnet.test.cluster
             return slotRanges;
         }
 
-        private ClientClusterConfig GetClusterConfig(int primary_count, int node_count, List<(int, int)>[] slotRanges, ILogger logger)
+        private async Task<ClientClusterConfig> GetClusterConfigAsync(int primary_count, int node_count, List<(int, int)>[] slotRanges, ILogger logger)
         {
             ClientClusterConfig clusterConfig = new(node_count);
             var endpoints = GetEndpoints();
             int j = 0;
             for (int i = 0; i < node_count; i++)
             {
-                var nodeid = NodesMyself(endpoints[i], ClusterInfoTag.NODEID, logger: logger);
-                var hostname = NodesMyself(endpoints[i], ClusterInfoTag.ADDRESS, logger: logger).Split(',')[1];
+                var nodeid = await NodesMyselfAsync(endpoints[i], ClusterInfoTag.NODEID, logger: logger).ConfigureAwait(false);
+                var hostname = (await NodesMyselfAsync(endpoints[i], ClusterInfoTag.ADDRESS, logger: logger).ConfigureAwait(false)).Split(',')[1];
                 bool isPrimary = i < primary_count;
-                var primaryId = isPrimary ? string.Empty : NodesMyself(endpoints[j], ClusterInfoTag.NODEID, logger: logger);
+                var primaryId = isPrimary ? string.Empty : await NodesMyselfAsync(endpoints[j], ClusterInfoTag.NODEID, logger: logger).ConfigureAwait(false);
                 j = isPrimary ? 0 : (j + 1) % primary_count;
 
                 clusterConfig.AddWorker(nodeid,
@@ -332,7 +357,7 @@ namespace Garnet.test.cluster
             return true;
         }
 
-        private void WaitForSync(ClientClusterConfig clusterConfig)
+        private async Task WaitForSyncAsync(ClientClusterConfig clusterConfig)
         {
             var expectedConfig = clusterConfig.GetConfigInfo();
             while (true)
@@ -342,7 +367,7 @@ namespace Garnet.test.cluster
                 foreach (var server in servers)
                 {
                     int count = expectedConfig.Count;
-                    var nodes = server.ClusterNodes()?.Nodes;
+                    var nodes = (await server.ClusterNodesAsync().ConfigureAwait(false))?.Nodes;
                     if (nodes != null)
                     {
                         foreach (var node in nodes)
@@ -357,7 +382,7 @@ namespace Garnet.test.cluster
 
                     if (count > 0)
                     {
-                        BackOff(cancellationToken: context.cts.Token);
+                        await BackOffAsync(cancellationToken: context.cts.Token).ConfigureAwait(false);
                         goto retry;
                     }
                 }
@@ -366,6 +391,15 @@ namespace Garnet.test.cluster
         }
 
         public (List<ShardInfo>, List<ushort>) SimpleSetupCluster(
+            int primary_count = -1,
+            int replica_count = -1,
+            bool assignSlots = true,
+            List<(int, int)>[] customSlotRanges = null,
+            ILogger logger = null
+        )
+        => AsyncUtils.BlockingWait(SimpleSetupClusterAsync(primary_count, replica_count, assignSlots, customSlotRanges, logger));
+
+        public async Task<(List<ShardInfo>, List<ushort>)> SimpleSetupClusterAsync(
             int primary_count = -1,
             int replica_count = -1,
             bool assignSlots = true,
@@ -379,7 +413,7 @@ namespace Garnet.test.cluster
             ClassicAssert.AreEqual(node_count, primary_count + primary_count * replica_count, $"Error primary per replica misconfig mCount: {primary_count}, rCount:{replica_count}");
 
             var slotRanges = customSlotRanges == null ? GetSlotRanges(primary_count) : customSlotRanges;
-            var clusterConfig = GetClusterConfig(primary_count, node_count, slotRanges, logger);
+            var clusterConfig = await GetClusterConfigAsync(primary_count, node_count, slotRanges, logger).ConfigureAwait(false);
 
             var shards = new List<ShardInfo>();
             var slots = new List<ushort>();
@@ -390,7 +424,17 @@ namespace Garnet.test.cluster
                 foreach (var slotRange in slotRanges[i])
                 {
                     var endpoint = endpoints[i];
-                    AddSlotsRange(endpoint, new List<(int, int)> { slotRange }, logger);
+                    var addRes = await AddSlotsRangeAsync(endpoint, new List<(int, int)> { slotRange }, logger).ConfigureAwait(false);
+                    ClassicAssert.AreEqual("OK", (string)addRes);
+
+                    // Check slot assignment worked
+                    var finalSlots = await GetOwnedSlotsFromNodeAsync(endpoint, logger).ConfigureAwait(false);
+                    ClassicAssert.AreEqual((slotRange.Item2 - slotRange.Item1) + 1, finalSlots.Count, "Incorrect number of slots on node");
+                    for (var slot = slotRange.Item1; slot <= slotRange.Item2; slot++)
+                    {
+                        ClassicAssert.IsTrue(finalSlots.Contains(slot), "Assigned slot is not present after adding slot");
+                    }
+
                     slots.AddRange(Enumerable.Range(slotRange.Item1, slotRange.Item2 - slotRange.Item1 + 1).Select(x => (ushort)x));
                     ShardInfo shardInfo = new()
                     {
@@ -413,41 +457,78 @@ namespace Garnet.test.cluster
                 }
             }
 
-            //Set-config-epoch
+            // Set-config-epoch
             for (int i = 0; i < endpoints.Length; i++)
-                SetConfigEpoch(endpoints[i], i + 1, logger);
+                await SetConfigEpochAsync(endpoints[i], i + 1, logger).ConfigureAwait(false);
 
-            //Initiate meet
-            var _firstEndpoint = endpoints[0];
-            for (int i = 1; i < endpoints.Length; i++)
-                Meet(_firstEndpoint, endpoints[i], logger);
+            // Initiate meets
 
-            //WaitForClusterJoin(clusterConfig);
-            //WaitForSync(clusterConfig);
+            var sendMeetTo = endpoints[0];
+            for (var newNode = 1; newNode < endpoints.Length; newNode++)
+            {
+                var toMeet = endpoints[newNode];
 
-            //Assign replicas
+                await MeetAsync(sendMeetTo, toMeet, logger).ConfigureAwait(false);
+
+                // Wait for new node to know first node
+                while (true)
+                {
+                    var expectedEntry = $" {sendMeetTo.Address}:{sendMeetTo.Port}@";
+
+                    var knownNodes = await NodesAsync(toMeet, logger).ConfigureAwait(false);
+                    if (knownNodes.Any(x => x.Contains(expectedEntry)))
+                    {
+                        break;
+                    }
+
+                    await BackOffAsync(context.cts.Token);
+                }
+
+                // Wait for other nodes to know new node
+                for (var otherNode = 0; otherNode < newNode; otherNode++)
+                {
+                    var otherEndpoint = endpoints[otherNode];
+
+                    while (true)
+                    {
+                        var expectedEntry = $" {toMeet.Address}:{toMeet.Port}@";
+
+                        var knownNodes = await NodesAsync(otherEndpoint, logger).ConfigureAwait(false);
+                        if (knownNodes.Any(x => x.Contains(expectedEntry)))
+                        {
+                            break;
+                        }
+
+                        await BackOffAsync(context.cts.Token);
+                    }
+                }
+            }
+
+            // Assign replicas
             if (replica_count > 0)
             {
-                int j = 0;
-                for (int i = primary_count; i < endpoints.Length; i++)
+                var j = 0;
+                for (var i = primary_count; i < endpoints.Length; i++)
                 {
-                    var primaryId = GetLocalNodeId(j);
-                    var replicaId = GetLocalNodeId(i);
+                    var primaryId = await GetLocalNodeIdAsync(j).ConfigureAwait(false);
+                    var replicaId = await GetLocalNodeIdAsync(i).ConfigureAwait(false);
 
                     // Wait until replica knows primary
-                    WaitUntilNodeIdIsKnown(i, primaryId, logger);
+                    await WaitUntilNodeIdIsKnownAsync(i, primaryId, logger).ConfigureAwait(false);
 
                     // Wait until primary knows this replica in order for
                     // TryConnectToReplica to succeed for AOF sync
-                    WaitUntilNodeIdIsKnown(j, replicaId, logger);
+                    await WaitUntilNodeIdIsKnownAsync(j, replicaId, logger).ConfigureAwait(false);
 
-                    var primaryEndpoint = endpoints[i];
-                    string resp = (string)ClusterReplicate(primaryEndpoint, primaryId, logger: logger);
+                    // Start replication
+                    var primaryEndpoint = endpoints[j];
+                    var replicaEndpoint = endpoints[i];
+                    var resp = (string)await ClusterReplicateAsync(replicaEndpoint, primaryId, logger: logger).ConfigureAwait(false);
                     {
                         var msg = "";
                         for (int k = 0; k < endpoints.Length; k++)
                         {
-                            var ns = ClusterNodes(k, logger).Nodes;
+                            var ns = (await ClusterNodesAsync(k, logger).ConfigureAwait(false)).Nodes;
 
                             var rawStr = $"[{k}]\n";
                             foreach (var n in ns)
@@ -455,10 +536,54 @@ namespace Garnet.test.cluster
                                 rawStr += "\t" + n.Raw + "\n";
                             }
                             rawStr += $"[{k}]\n";
-                            //logger?.LogError(rawStr);
                             msg += rawStr;
                         }
                         ClassicAssert.AreEqual("OK", resp, msg);
+                    }
+
+                    // Wait for replica to see primary
+                    while (true)
+                    {
+                        var role = await GetReplicationRoleAsync(replicaEndpoint, logger).ConfigureAwait(false);
+                        if (role != "slave")
+                        {
+                            await BackOffAsync(context.cts.Token).ConfigureAwait(false);
+                            continue;
+                        }
+
+                        var primaryDetails = await GetReplicationInfoAsync(replicaEndpoint, [ReplicationInfoItem.MASTER_HOST, ReplicationInfoItem.MASTER_PORT], logger).ConfigureAwait(false);
+                        if (primaryDetails.Count != 2)
+                        {
+                            await BackOffAsync(context.cts.Token).ConfigureAwait(false);
+                            continue;
+                        }
+
+                        var expectedPrimaryEndpoint = $"{primaryEndpoint.Address}:{primaryEndpoint.Port}";
+                        var actualPrimaryEndpoint = $"{primaryDetails[0].Item2}:{primaryDetails[1].Item2}";
+                        ClassicAssert.AreEqual(expectedPrimaryEndpoint, actualPrimaryEndpoint);
+
+                        break;
+                    }
+
+                    // Wait for primary to see replica
+                    while (true)
+                    {
+                        var role = await GetReplicationRoleAsync(primaryEndpoint, logger).ConfigureAwait(false);
+                        if (role != "master")
+                        {
+                            await BackOffAsync(context.cts.Token).ConfigureAwait(false);
+                            continue;
+                        }
+
+                        var replicas = await GetClusterReplicasAsync(primaryEndpoint, logger).ConfigureAwait(false);
+
+                        if(!replicas.Any(c => c.StartsWith($"{replicaId} ")))
+                        {
+                            await BackOffAsync(context.cts.Token).ConfigureAwait(false);
+                            continue;
+                        }
+
+                        break;
                     }
 
                     shards[j].nodes.Add(
@@ -480,12 +605,10 @@ namespace Garnet.test.cluster
                 j = 0;
                 for (int i = 0; i < primary_count; i++)
                 {
-                    WaitForConnectedReplicaCount(i, replica_count, logger);
+                    await WaitForConnectedReplicaCountAsync(i, replica_count, logger).ConfigureAwait(false);
                 }
-
-                //WaitForClusterJoin(clusterConfig, true);
             }
-            WaitForSync(clusterConfig);
+            await WaitForSyncAsync(clusterConfig).ConfigureAwait(false);
             return (shards, slots);
         }
 
@@ -562,7 +685,7 @@ namespace Garnet.test.cluster
         }
     }
 
-    public unsafe partial class ClusterTestUtils
+    public partial class ClusterTestUtils
     {
         static readonly TimeSpan backoff = TimeSpan.FromSeconds(0.1);
         static readonly byte[] bresp_OK = Encoding.ASCII.GetBytes("+OK\r\n");
@@ -608,26 +731,43 @@ namespace Garnet.test.cluster
 
         public static void BackOff(TimeSpan timeSpan = default) => Thread.Sleep(timeSpan == default ? backoff : timeSpan);
 
+        public static Task BackOffAsync(TimeSpan timeSpan = default) => BackOffAsync(default, timeSpan);
+
         public static void BackOff(CancellationToken cancellationToken, TimeSpan timeSpan = default, string msg = null)
         {
             if (cancellationToken.IsCancellationRequested)
+            {
                 Assert.Fail(msg ?? "Cancellation Requested");
+            }
 
             Thread.Sleep(timeSpan == default ? backoff : timeSpan);
         }
 
-        public void Connect(bool cluster = true, ILogger logger = null)
+        public static Task BackOffAsync(CancellationToken cancellationToken, TimeSpan timeSpan = default, string msg = null)
         {
-            InitMultiplexer(GetRedisConfig(endpoints), textWriter, logger: logger);
-            if (cluster)
-                this.nodeIds = GetNodeIds(logger: logger);
+            if (cancellationToken.IsCancellationRequested)
+            {
+                Assert.Fail(msg ?? "Cancellation Requested");
+            }
+
+            return Task.Delay(timeSpan == default ? backoff : timeSpan);
         }
 
-        private void InitMultiplexer(ConfigurationOptions redisConfig, TextWriter textWriter, bool failAssert = true, ILogger logger = null)
+        public void Connect(bool cluster = true, ILogger logger = null)
+            => AsyncUtils.BlockingWait(ConnectAsync(cluster, logger));
+
+        public async Task ConnectAsync(bool cluster = true, ILogger logger = null)
+        {
+            await InitMultiplexerAsync(GetRedisConfig(endpoints), textWriter, logger: logger);
+            if (cluster)
+                this.nodeIds = await GetNodeIdsAsync(logger: logger).ConfigureAwait(false);
+        }
+
+        private async Task InitMultiplexerAsync(ConfigurationOptions redisConfig, TextWriter textWriter, bool failAssert = true, ILogger logger = null)
         {
             try
             {
-                redis = ConnectionMultiplexer.Connect(redisConfig, null);
+                redis = await ConnectionMultiplexer.ConnectAsync(redisConfig, null);
             }
             catch (Exception ex)
             {
@@ -651,13 +791,16 @@ namespace Garnet.test.cluster
 
         public void Dispose()
         {
-            CloseConnections();
+            AsyncUtils.BlockingWait(CloseConnectionsAsync());
         }
 
-        public void CloseConnections()
+        public async Task CloseConnectionsAsync()
         {
-            redis?.Close(false);
-            redis?.Dispose();
+            if (redis != null)
+            {
+                await redis.CloseAsync(false);
+                await redis.DisposeAsync();
+            }
 
             if (gcsConnections != null)
             {
@@ -667,27 +810,30 @@ namespace Garnet.test.cluster
         }
 
         public string[] GetNodeIds(List<int> nodes = null, ILogger logger = null)
+             => AsyncUtils.BlockingWait(GetNodeIdsAsync(nodes, logger));
+
+        public async Task<string[]> GetNodeIdsAsync(List<int> nodes = null, ILogger logger = null)
         {
             string[] nodeIds = new string[endpoints.Count];
             if (nodes == null)
             {
                 for (int i = 0; i < nodeIds.Length; i++)
-                    nodeIds[i] = NodesMyself((IPEndPoint)endpoints[i], ClusterInfoTag.NODEID, logger: logger);
+                    nodeIds[i] = await NodesMyselfAsync((IPEndPoint)endpoints[i], ClusterInfoTag.NODEID, logger: logger).ConfigureAwait(false);
             }
             else
             {
                 for (int i = 0; i < nodes.Count; i++)
                 {
                     var j = nodes[i];
-                    nodeIds[j] = NodesMyself((IPEndPoint)endpoints[j], ClusterInfoTag.NODEID, logger: logger);
+                    nodeIds[j] = await NodesMyselfAsync((IPEndPoint)endpoints[j], ClusterInfoTag.NODEID, logger: logger).ConfigureAwait(false);
                 }
             }
             return nodeIds;
         }
 
-        public void Reconnect(List<int> nodes = null, TextWriter textWriter = null, ILogger logger = null)
+        public async Task ReconnectAsync(List<int> nodes = null, TextWriter textWriter = null, ILogger logger = null)
         {
-            CloseConnections();
+            await CloseConnectionsAsync().ConfigureAwait(false);
             EndPointCollection endPoints = endpoints;
             if (nodes != null)
             {
@@ -699,8 +845,8 @@ namespace Garnet.test.cluster
                 }
             }
             var connOpts = GetRedisConfig(endPoints);
-            InitMultiplexer(connOpts, textWriter, logger: logger);
-            nodeIds = GetNodeIds(nodes, logger);
+            await InitMultiplexerAsync(connOpts, textWriter, logger: logger).ConfigureAwait(false);
+            nodeIds = await GetNodeIdsAsync(nodes, logger).ConfigureAwait(false);
         }
 
         public EndPointCollection GetEndPoints() => endpoints;
@@ -838,7 +984,7 @@ namespace Garnet.test.cluster
             return Encoding.ASCII.GetString(data);
         }
 
-        public static ushort HashSlot(byte[] key)
+        public static unsafe ushort HashSlot(byte[] key)
         {
             fixed (byte* ptr = key)
             {
@@ -854,7 +1000,7 @@ namespace Garnet.test.cluster
             return targetNodeIndex;
         }
 
-        public static (int, int) LightReceive(byte* buf, int bytesRead, int opType)
+        public static unsafe (int, int) LightReceive(byte* buf, int bytesRead, int opType)
         {
             string result = null;
             byte* ptr = buf;
@@ -894,7 +1040,7 @@ namespace Garnet.test.cluster
             return (bytesRead, count);
         }
 
-        public static string ParseRespToString(byte[] data, out string[] resultArray)
+        public static unsafe string ParseRespToString(byte[] data, out string[] resultArray)
         {
             resultArray = null;
             string result = null;
@@ -1028,7 +1174,7 @@ namespace Garnet.test.cluster
             return ResponseState.NONE;
         }
 
-        public static LightClientRequest[] CreateLightRequestConnections(int[] Ports)
+        public static unsafe LightClientRequest[] CreateLightRequestConnections(int[] Ports)
         {
             LightClientRequest[] lightClientRequests = new LightClientRequest[Ports.Length];
             for (int i = 0; i < Ports.Length; i++)
@@ -1063,9 +1209,12 @@ namespace Garnet.test.cluster
         }
 
         public string AddSlotsRange(int nodeIndex, List<(int, int)> ranges, ILogger logger)
-            => (string)AddSlotsRange((IPEndPoint)endpoints[nodeIndex], ranges, logger);
+            => AsyncUtils.BlockingWait(AddSlotsRangeAsync(nodeIndex, ranges, logger));
 
-        public RedisResult AddSlotsRange(IPEndPoint endPoint, List<(int, int)> ranges, ILogger logger)
+        public async Task<string> AddSlotsRangeAsync(int nodeIndex, List<(int, int)> ranges, ILogger logger)
+            => (string)await AddSlotsRangeAsync((IPEndPoint)endpoints[nodeIndex], ranges, logger);
+
+        public Task<RedisResult> AddSlotsRangeAsync(IPEndPoint endPoint, List<(int, int)> ranges, ILogger logger)
         {
             ICollection<object> args = new List<object>() { "addslotsrange" };
             foreach (var range in ranges)
@@ -1073,18 +1222,18 @@ namespace Garnet.test.cluster
                 args.Add(range.Item1);
                 args.Add(range.Item2);
             }
-            return Execute(endPoint, "cluster", args, logger: logger);
+            return ExecuteAsync(endPoint, "cluster", args, logger: logger);
         }
 
         public void SetConfigEpoch(int sourceNodeIndex, long epoch, ILogger logger = null)
-            => SetConfigEpoch((IPEndPoint)endpoints[sourceNodeIndex], epoch, logger);
+            => AsyncUtils.BlockingWait(SetConfigEpochAsync((IPEndPoint)endpoints[sourceNodeIndex], epoch, logger));
 
-        public void SetConfigEpoch(IPEndPoint endPoint, long epoch, ILogger logger = null)
+        public async Task SetConfigEpochAsync(IPEndPoint endPoint, long epoch, ILogger logger = null)
         {
             try
             {
                 var server = redis.GetServer(endPoint);
-                var resp = server.Execute("cluster", "set-config-epoch", $"{epoch}");
+                var resp = await server.ExecuteAsync("cluster", "set-config-epoch", $"{epoch}").ConfigureAwait(false);
                 ClassicAssert.AreEqual((string)resp, "OK");
             }
             catch (Exception ex)
@@ -1202,14 +1351,14 @@ namespace Garnet.test.cluster
         }
 
         public void Meet(int sourceNodeIndex, int meetNodeIndex, ILogger logger = null)
-            => Meet((IPEndPoint)endpoints[sourceNodeIndex], (IPEndPoint)endpoints[meetNodeIndex], logger);
+            => AsyncUtils.BlockingWait(MeetAsync((IPEndPoint)endpoints[sourceNodeIndex], (IPEndPoint)endpoints[meetNodeIndex], logger));
 
-        public void Meet(IPEndPoint source, IPEndPoint target, ILogger logger = null)
+        public async Task MeetAsync(IPEndPoint source, IPEndPoint target, ILogger logger = null)
         {
             try
             {
                 var server = redis.GetServer(source);
-                var resp = server.Execute("cluster", "meet", $"{target.Address}", $"{target.Port}");
+                var resp = await server.ExecuteAsync("cluster", "meet", $"{target.Address}", $"{target.Port}").ConfigureAwait(false);
                 ClassicAssert.AreEqual((string)resp, "OK");
             }
             catch (Exception ex)
@@ -1277,11 +1426,14 @@ namespace Garnet.test.cluster
         }
 
         public List<string> Nodes(IPEndPoint endPoint, ILogger logger)
+            => AsyncUtils.BlockingWait(NodesAsync(endPoint, logger));
+
+        public async Task<List<string>> NodesAsync(IPEndPoint endPoint, ILogger logger)
         {
             try
             {
                 var server = redis.GetServer(endPoint);
-                var strResult = (string)server.Execute("cluster", "nodes");
+                var strResult = (string)await server.ExecuteAsync("cluster", "nodes").ConfigureAwait(false);
                 var data = strResult.Split('\n');
                 List<string> nodeConfig = new();
 
@@ -1407,17 +1559,21 @@ namespace Garnet.test.cluster
         }
 
         public void WaitUntilNodeIdIsKnown(int nodeIndex, string nodeId, ILogger logger = null)
+            => AsyncUtils.BlockingWait(WaitUntilNodeIdIsKnownAsync(nodeIndex, nodeId, logger));
+
+        public async Task WaitUntilNodeIdIsKnownAsync(int nodeIndex, string nodeId, ILogger logger = null)
         {
             while (true)
             {
-                var nodes = ClusterNodes(nodeIndex, logger).Nodes;
+                var nodes = (await ClusterNodesAsync(nodeIndex, logger).ConfigureAwait(false)).Nodes;
 
                 var found = false;
                 foreach (var node in nodes)
                     if (node.NodeId.Equals(nodeId))
                         found = true;
                 if (found) break;
-                BackOff(cancellationToken: context.cts.Token);
+
+                await BackOffAsync(cancellationToken: context.cts.Token).ConfigureAwait(false);
             }
         }
 
@@ -1503,8 +1659,11 @@ namespace Garnet.test.cluster
         }
 
         public List<int> GetOwnedSlotsFromNode(IPEndPoint endPoint, ILogger logger)
+             => AsyncUtils.BlockingWait(GetOwnedSlotsFromNodeAsync(endPoint, logger));
+
+        public async Task<List<int>> GetOwnedSlotsFromNodeAsync(IPEndPoint endPoint, ILogger logger)
         {
-            var nodeConfig = Nodes(endPoint, logger);
+            var nodeConfig = await NodesAsync(endPoint, logger).ConfigureAwait(false);
             var nodeInfo = nodeConfig[0].Split(' ');
 
             var slots = new List<int>();
@@ -1993,15 +2152,15 @@ namespace Garnet.test.cluster
         }
 
         public string ClusterReplicate(int sourceNodeIndex, string primaryNodeId, bool async = false, bool failEx = true, ILogger logger = null)
-            => ClusterReplicate((IPEndPoint)endpoints[sourceNodeIndex], primaryNodeId, async: async, failEx: failEx, logger);
+            => AsyncUtils.BlockingWait(ClusterReplicateAsync((IPEndPoint)endpoints[sourceNodeIndex], primaryNodeId, async: async, failEx: failEx, logger));
 
-        public string ClusterReplicate(IPEndPoint endPoint, string primaryNodeId, bool async = false, bool failEx = true, ILogger logger = null)
+        public async Task<string> ClusterReplicateAsync(IPEndPoint endPoint, string primaryNodeId, bool async = false, bool failEx = true, ILogger logger = null)
         {
             try
             {
                 var server = redis.GetServer(endPoint);
                 List<object> args = async ? ["replicate", primaryNodeId, "async"] : ["replicate", primaryNodeId, "sync"];
-                var result = (string)server.Execute("cluster", args);
+                var result = (string)(await server.ExecuteAsync("cluster", args).ConfigureAwait(false));
                 ClassicAssert.AreEqual("OK", result);
                 return result;
             }
@@ -2175,9 +2334,12 @@ namespace Garnet.test.cluster
         }
 
         public ClusterConfiguration ClusterNodes(int nodeIndex, ILogger logger = null)
-            => ClusterNodes((IPEndPoint)endpoints[nodeIndex], logger);
+            => AsyncUtils.BlockingWait(ClusterNodesAsync(nodeIndex, logger));
 
-        public ClusterConfiguration ClusterNodes(IPEndPoint endPoint, ILogger logger = null)
+        public Task<ClusterConfiguration> ClusterNodesAsync(int nodeIndex, ILogger logger = null)
+            => ClusterNodesAsync((IPEndPoint)endpoints[nodeIndex], logger);
+
+        public async Task<ClusterConfiguration> ClusterNodesAsync(IPEndPoint endPoint, ILogger logger = null)
         {
             try
             {
@@ -2739,10 +2901,13 @@ namespace Garnet.test.cluster
             => GetReplicationRole((IPEndPoint)endpoints[nodeIndex], logger);
 
         public string GetReplicationRole(IPEndPoint endPoint, ILogger logger = null)
+            => AsyncUtils.BlockingWait(GetReplicationRoleAsync(endPoint, logger));
+
+        public async Task<string> GetReplicationRoleAsync(IPEndPoint endPoint, ILogger logger = null)
         {
             try
             {
-                return GetReplicationInfo(endPoint, [ReplicationInfoItem.ROLE], logger)[0].Item2;
+                return (await GetReplicationInfoAsync(endPoint, [ReplicationInfoItem.ROLE], logger).ConfigureAwait(false))[0].Item2;
             }
             catch (Exception ex)
             {
@@ -2809,17 +2974,41 @@ namespace Garnet.test.cluster
         public List<(ReplicationInfoItem, string)> GetReplicationInfo(int nodeIndex, ReplicationInfoItem[] infoItems, ILogger logger = null)
             => GetReplicationInfo((IPEndPoint)endpoints[nodeIndex], infoItems, logger);
 
+        public Task<List<(ReplicationInfoItem, string)>> GetReplicationInfoAsync(int nodeIndex, ReplicationInfoItem[] infoItems, ILogger logger = null)
+            => GetReplicationInfoAsync((IPEndPoint)endpoints[nodeIndex], infoItems, logger);
+
         private List<(ReplicationInfoItem, string)> GetReplicationInfo(IPEndPoint endPoint, ReplicationInfoItem[] infoItems, ILogger logger = null)
+            => AsyncUtils.BlockingWait(GetReplicationInfoAsync(endPoint, infoItems, logger));
+
+        private async Task<List<(ReplicationInfoItem, string)>> GetReplicationInfoAsync(IPEndPoint endPoint, ReplicationInfoItem[] infoItems, ILogger logger = null)
         {
             var server = redis.GetServer(endPoint);
             try
             {
-                var result = server.InfoRawAsync("replication").Result;
+                var result = await server.InfoRawAsync("replication").ConfigureAwait(false);
                 return ProcessReplicationInfo(result, infoItems);
             }
             catch (Exception ex)
             {
                 logger?.LogError(ex, "An error has occured; GetReplicationInfo");
+                Assert.Fail(ex.Message);
+            }
+            return null;
+        }
+
+        private async Task<List<string>> GetClusterReplicasAsync(IPEndPoint endpoint, ILogger logger)
+        {
+            var server = redis.GetServer(endpoint);
+            try
+            {
+                var myId = server.ClusterConfiguration.Nodes.Single(n => n.IsMyself).NodeId;
+
+                var result = (string[])await server.ExecuteAsync("CLUSTER", "REPLICAS", myId).ConfigureAwait(false);
+                return result.ToList();
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "An error has occurred; GetClusterReplicas");
                 Assert.Fail(ex.Message);
             }
             return null;
@@ -2937,6 +3126,14 @@ namespace Garnet.test.cluster
                             startsWith = "last_failover_state:";
                             if (item.StartsWith(startsWith)) items.Add((ii, item.Split(startsWith)[1].Trim()));
                             break;
+                        case ReplicationInfoItem.MASTER_HOST:
+                            startsWith = "master_host:";
+                            if (item.StartsWith(startsWith)) items.Add((ii, item.Split(startsWith)[1].Trim()));
+                            break;
+                        case ReplicationInfoItem.MASTER_PORT:
+                            startsWith = "master_port:";
+                            if (item.StartsWith(startsWith)) items.Add((ii, item.Split(startsWith)[1].Trim()));
+                            break;
                         default:
                             Assert.Fail($"type {infoItem} not supported!");
                             return null;
@@ -3031,12 +3228,12 @@ namespace Garnet.test.cluster
             logger?.LogInformation("[{primaryEndpoint}]{primaryReplicationOffset} ?? [{endpoints[secondaryEndpoint}]{secondaryReplicationOffset1}", endpoints[primaryIndex], primaryReplicationOffset, endpoints[secondaryIndex], secondaryReplicationOffset1);
         }
 
-        public void WaitForConnectedReplicaCount(int primaryIndex, long minCount, ILogger logger = null)
+        public async Task WaitForConnectedReplicaCountAsync(int primaryIndex, long minCount, ILogger logger = null)
         {
             while (true)
             {
 
-                var items = GetReplicationInfo(primaryIndex, [ReplicationInfoItem.ROLE, ReplicationInfoItem.CONNECTED_REPLICAS], logger);
+                var items = await GetReplicationInfoAsync(primaryIndex, [ReplicationInfoItem.ROLE, ReplicationInfoItem.CONNECTED_REPLICAS], logger).ConfigureAwait(false);
                 var role = items[0].Item2;
                 ClassicAssert.AreEqual(role, "master");
 
@@ -3051,7 +3248,7 @@ namespace Garnet.test.cluster
                     Assert.Fail(ex.Message);
                 }
 
-                BackOff(cancellationToken: context.cts.Token);
+                await BackOffAsync(cancellationToken: context.cts.Token).ConfigureAwait(false);
             }
         }
 
@@ -3258,9 +3455,9 @@ namespace Garnet.test.cluster
             }
         }
 
-        public ClusterNode GetAnyOtherNode(IPEndPoint endPoint, ILogger logger = null)
+        public async Task<ClusterNode> GetAnyOtherNodeAsync(IPEndPoint endPoint, ILogger logger = null)
         {
-            var config = ClusterNodes(endPoint, logger);
+            var config = await ClusterNodesAsync(endPoint, logger).ConfigureAwait(false);
             foreach (var node in config.Nodes)
             {
                 if (!node.EndPoint.ToIPEndPoint().Equals(endPoint))

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -165,20 +165,21 @@ namespace Garnet.test.cluster
                 return RedisResult.Create((RedisValue)ex.Message);
             }
         }
-        public Task<RedisResult> ExecuteAsync(IPEndPoint endPoint, string cmd, ICollection<object> args, bool skipLogging = false, ILogger logger = null, CommandFlags flags = CommandFlags.None)
+
+        public async Task<RedisResult> ExecuteAsync(IPEndPoint endPoint, string cmd, ICollection<object> args, bool skipLogging = false, ILogger logger = null, CommandFlags flags = CommandFlags.None)
         {
             if (!skipLogging)
                 logger?.LogInformation("({address}:{port}) > {cmd} {args}", endPoint.Address, endPoint.Port, cmd, string.Join(' ', args));
             try
             {
                 var server = GetServer(endPoint);
-                var resp = server.ExecuteAsync(cmd, args, flags: flags);
+                var resp = await server.ExecuteAsync(cmd, args, flags: flags).ConfigureAwait(false);
                 return resp;
             }
             catch (Exception ex)
             {
                 logger?.LogError(ex, "An error occured {cmd} {msg}", cmd, ex.Message);
-                return Task.FromResult(RedisResult.Create((RedisValue)ex.Message));
+                return RedisResult.Create((RedisValue)ex.Message);
             }
         }
 
@@ -429,7 +430,6 @@ namespace Garnet.test.cluster
 
                     // Check slot assignment worked
                     var finalSlots = await GetOwnedSlotsFromNodeAsync(endpoint, logger).ConfigureAwait(false);
-                    ClassicAssert.AreEqual((slotRange.Item2 - slotRange.Item1) + 1, finalSlots.Count, "Incorrect number of slots on node");
                     for (var slot = slotRange.Item1; slot <= slotRange.Item2; slot++)
                     {
                         ClassicAssert.IsTrue(finalSlots.Contains(slot), "Assigned slot is not present after adding slot");

--- a/test/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/Garnet.test.cluster/ClusterTestUtils.cs
@@ -577,7 +577,7 @@ namespace Garnet.test.cluster
 
                         var replicas = await GetClusterReplicasAsync(primaryEndpoint, logger).ConfigureAwait(false);
 
-                        if(!replicas.Any(c => c.StartsWith($"{replicaId} ")))
+                        if (!replicas.Any(c => c.StartsWith($"{replicaId} ")))
                         {
                             await BackOffAsync(context.cts.Token).ConfigureAwait(false);
                             continue;

--- a/test/Garnet.test.cluster/ReplicationTests/ClusterReplicationBaseTests.cs
+++ b/test/Garnet.test.cluster/ReplicationTests/ClusterReplicationBaseTests.cs
@@ -34,10 +34,10 @@ namespace Garnet.test.cluster
                 new(() => ClusterSRNoCheckpointRestartSecondary(false, true), "ClusterSRNoCheckpointRestartSecondary(false, true)"),
                 new(() => ClusterSRNoCheckpointRestartSecondary(true, false), "ClusterSRNoCheckpointRestartSecondary(true, false)"),
                 new(() => ClusterSRNoCheckpointRestartSecondary(true, true), "ClusterSRNoCheckpointRestartSecondary(true, true)"),
-                new(() => ClusterSRPrimaryCheckpoint(false, false), "ClusterSRPrimaryCheckpoint(false, false)"),
-                new(() => ClusterSRPrimaryCheckpoint(false, true), "ClusterSRPrimaryCheckpoint(false, true)"),
-                new(() => ClusterSRPrimaryCheckpoint(true, false), "ClusterSRPrimaryCheckpoint(true, false)"),
-                new(() => ClusterSRPrimaryCheckpoint(true, true), "ClusterSRPrimaryCheckpoint(true, true)"),
+                new(() => AsyncUtils.BlockingWait(ClusterSRPrimaryCheckpointAsync(false, false)), "ClusterSRPrimaryCheckpointAsync(false, false)"),
+                new(() => AsyncUtils.BlockingWait(ClusterSRPrimaryCheckpointAsync(false, true)), "ClusterSRPrimaryCheckpointAsync(false, true)"),
+                new(() => AsyncUtils.BlockingWait(ClusterSRPrimaryCheckpointAsync(true, false)), "ClusterSRPrimaryCheckpointAsync(true, false)"),
+                new(() => AsyncUtils.BlockingWait(ClusterSRPrimaryCheckpointAsync(true, true)), "ClusterSRPrimaryCheckpointAsync(true, true)"),
                 new(() => ClusterSRPrimaryCheckpointRetrieve(false, false, false, false), "ClusterSRPrimaryCheckpointRetrieve(false, false, false, false)"),
                 new(() => ClusterSRPrimaryCheckpointRetrieve(false, false, false, true), "ClusterSRPrimaryCheckpointRetrieve(false, false, false, true)"),
                 new(() => ClusterSRPrimaryCheckpointRetrieve(false, true, false, false), "ClusterSRPrimaryCheckpointRetrieve(false, true, false, false)"),
@@ -216,7 +216,7 @@ namespace Garnet.test.cluster
 
         [Test, Order(3)]
         [Category("REPLICATION")]
-        public void ClusterSRPrimaryCheckpoint([Values] bool performRMW, [Values] bool disableObjects)
+        public async Task ClusterSRPrimaryCheckpointAsync([Values] bool performRMW, [Values] bool disableObjects)
         {
             var replica_count = 1;// Per primary
             var primary_count = 1;
@@ -281,7 +281,7 @@ namespace Garnet.test.cluster
             context.CreateConnection(useTLS: useTLS);
 
             for (int i = 1; i < replica_count; i++) context.clusterTestUtils.WaitForReplicaRecovery(i, context.logger);
-            context.clusterTestUtils.WaitForConnectedReplicaCount(0, replica_count, context.logger);
+            await context.clusterTestUtils.WaitForConnectedReplicaCountAsync(0, replica_count, context.logger).ConfigureAwait(false);
 
             // Validate synchronization was success
             context.clusterTestUtils.WaitForReplicaAofSync(0, 1, context.logger);
@@ -765,7 +765,7 @@ namespace Garnet.test.cluster
             context.kvPairs = [];
             context.kvPairsObj = [];
             context.checkpointTask = Task.Run(() => context.PopulatePrimaryAndTakeCheckpointTask(performRMW, disableObjects, takeCheckpoint: true));
-            var attachReplicaTask = Task.Run(() => context.AttachAndWaitForSync(primary_count, replica_count, disableObjects));
+            var attachReplicaTask = Task.Run(() => context.AttachAndWaitForSyncAsync(primary_count, replica_count, disableObjects));
 
             if (!context.checkpointTask.Wait(TimeSpan.FromSeconds(60)))
                 Assert.Fail("checkpointTask timeout");
@@ -997,7 +997,7 @@ namespace Garnet.test.cluster
 
         [Test, Order(22)]
         [Category("REPLICATION")]
-        public void ClusterReplicationCheckpointAlignmentTest([Values] bool performRMW)
+        public async Task ClusterReplicationCheckpointAlignmentTestAsync([Values] bool performRMW)
         {
             var replica_count = 1;// Per primary
             var primary_count = 1;
@@ -1088,7 +1088,7 @@ namespace Garnet.test.cluster
             var primaryNodeId = context.clusterTestUtils.ClusterMyId(primaryNodeIndex, logger: context.logger);
 
             // Enable replication
-            context.clusterTestUtils.WaitUntilNodeIdIsKnown(replicaNodeIndex, primaryNodeId, logger: context.logger);
+            await context.clusterTestUtils.WaitUntilNodeIdIsKnownAsync(replicaNodeIndex, primaryNodeId, logger: context.logger).ConfigureAwait(false);
             ClassicAssert.AreEqual("OK", context.clusterTestUtils.ClusterReplicate(replicaNodeIndex, primaryNodeIndex, logger: context.logger));
 
             // Both nodes are at version 1 despite replica recovering to version earlier
@@ -1440,7 +1440,7 @@ namespace Garnet.test.cluster
         [Test, Order(27)]
         [Category("CLUSTER")]
         [Category("REPLICATION")]
-        public void ClusterReplicationDivergentHistoryWithoutCheckpoint()
+        public async Task ClusterReplicationDivergentHistoryWithoutCheckpointAsync()
         {
             var replica_count = 1;// Per primary
             var primary_count = 1;
@@ -1482,7 +1482,7 @@ namespace Garnet.test.cluster
                 tryRecover: false,
                 cleanClusterConfig: false);
             context.nodes[primaryNodeIndex].Start();
-            context.clusterTestUtils.Reconnect([primaryNodeIndex]);
+            await context.clusterTestUtils.ReconnectAsync([primaryNodeIndex]).ConfigureAwait(false);
             primaryServer = context.clusterTestUtils.GetServer(primaryNodeIndex);
 
             offset += keyCount;
@@ -1499,7 +1499,7 @@ namespace Garnet.test.cluster
                 tryRecover: true,
                 cleanClusterConfig: false);
             context.nodes[replicaNodeIndex].Start();
-            context.clusterTestUtils.Reconnect([primaryNodeIndex, replicaNodeIndex]);
+            await context.clusterTestUtils.ReconnectAsync([primaryNodeIndex, replicaNodeIndex]).ConfigureAwait(false);
             primaryServer = context.clusterTestUtils.GetServer(primaryNodeIndex);
             replicaServer = context.clusterTestUtils.GetServer(replicaNodeIndex);
 

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -108,7 +108,7 @@ namespace Garnet.test.cluster
         [TestCase("XB8", "NOQUANT")]
         [TestCase("FP32", "XPREQ8")]
         [TestCase("FP32", "NOQUANT")]
-        public void BasicVADDReplicates(string vectorFormat, string quantizer)
+        public async Task BasicVADDReplicatesAsync(string vectorFormat, string quantizer)
         {
             // TODO: also test VALUES format?
 
@@ -118,7 +118,7 @@ namespace Garnet.test.cluster
             ClassicAssert.IsTrue(Enum.TryParse<VectorValueType>(vectorFormat, ignoreCase: true, out var vectorFormatParsed));
             ClassicAssert.IsTrue(Enum.TryParse<VectorQuantType>(quantizer, ignoreCase: true, out var quantTypeParsed));
 
-            _ = SimpleSetupCluster(DefaultShards, primaryCount: 1, replicaCount: 1);
+            _ = await SimpleSetupClusterAsync(DefaultShards, primaryCount: 1, replicaCount: 1).ConfigureAwait(false);
 
             var primary = (IPEndPoint)context.endpoints[PrimaryIndex];
             var secondary = (IPEndPoint)context.endpoints[SecondaryIndex];
@@ -205,7 +205,7 @@ namespace Garnet.test.cluster
             const int Vectors = 2_000;
             const string Key = nameof(ConcurrentVADDReplicatedVSimsAsync);
 
-            _ = SimpleSetupCluster(DefaultShards, primaryCount: 1, replicaCount: 1);
+            _ = await SimpleSetupClusterAsync(DefaultShards, primaryCount: 1, replicaCount: 1).ConfigureAwait(false);
 
             var primary = (IPEndPoint)context.endpoints[PrimaryIndex];
             var secondary = (IPEndPoint)context.endpoints[SecondaryIndex];
@@ -352,12 +352,12 @@ namespace Garnet.test.cluster
         }
 
         [Test]
-        public void RepeatedCreateDelete()
+        public async Task RepeatedCreateDeleteAsync()
         {
             const int PrimaryIndex = 0;
             const int SecondaryIndex = 1;
 
-            _ = SimpleSetupCluster(DefaultShards, primaryCount: 1, replicaCount: 1);
+            _ = await SimpleSetupClusterAsync(DefaultShards, primaryCount: 1, replicaCount: 1).ConfigureAwait(false);
 
             var primary = (IPEndPoint)context.endpoints[PrimaryIndex];
             var secondary = (IPEndPoint)context.endpoints[SecondaryIndex];
@@ -469,7 +469,7 @@ namespace Garnet.test.cluster
             const int Vectors = 2_000;
             const string Key = nameof(MultipleReplicasWithVectorSetsAsync);
 
-            _ = SimpleSetupCluster(HighReplicationShards, primaryCount: 1, replicaCount: 5);
+            _ = await SimpleSetupClusterAsync(HighReplicationShards, primaryCount: 1, replicaCount: 5).ConfigureAwait(false);
 
             var primary = (IPEndPoint)context.endpoints[PrimaryIndex];
             var secondaries = new IPEndPoint[SecondaryEndIndex - SecondaryStartIndex + 1];
@@ -614,7 +614,7 @@ namespace Garnet.test.cluster
             const int Deletes = Vectors / 10;
             const string Key = nameof(MultipleReplicasWithVectorSetsAndDeletesAsync);
 
-            _ = SimpleSetupCluster(HighReplicationShards, primaryCount: 1, replicaCount: 5);
+            _ = await SimpleSetupClusterAsync(HighReplicationShards, primaryCount: 1, replicaCount: 5).ConfigureAwait(false);
 
             var primary = (IPEndPoint)context.endpoints[PrimaryIndex];
             var secondaries = new IPEndPoint[SecondaryEndIndex - SecondaryStartIndex + 1];
@@ -797,7 +797,7 @@ namespace Garnet.test.cluster
         }
 
         [Test]
-        public void VectorSetMigrateSingleBySlot()
+        public async Task VectorSetMigrateSingleBySlotAsync()
         {
             // Test migrating a single slot with a vector set of one element in it
 
@@ -806,7 +806,7 @@ namespace Garnet.test.cluster
             const int Secondary0Index = 2;
             const int Secondary1Index = 3;
 
-            _ = SimpleSetupCluster(DefaultMultiPrimaryShards, primaryCount: DefaultMultiPrimaryShards / 2, replicaCount: 1);
+            _ = await SimpleSetupClusterAsync(DefaultMultiPrimaryShards, primaryCount: DefaultMultiPrimaryShards / 2, replicaCount: 1).ConfigureAwait(false);
 
             var primary0 = (IPEndPoint)context.endpoints[Primary0Index];
             var primary1 = (IPEndPoint)context.endpoints[Primary1Index];
@@ -829,7 +829,7 @@ namespace Garnet.test.cluster
 
                 while (true)
                 {
-                    primary0Key = $"{nameof(VectorSetMigrateSingleBySlot)}_{ix}";
+                    primary0Key = $"{nameof(VectorSetMigrateSingleBySlotAsync)}_{ix}";
                     primary0HashSlot = context.clusterTestUtils.HashSlot(primary0Key);
 
                     if (slots.Any(x => x.nnInfo.Any(y => y.nodeid == primary0Id) && primary0HashSlot >= x.startSlot && primary0HashSlot <= x.endSlot))
@@ -928,14 +928,14 @@ namespace Garnet.test.cluster
         }
 
         [Test]
-        public void VectorSetMigrateByKeys()
+        public async Task VectorSetMigrateByKeysAsync()
         {
             // Based on : ClusterSimpleMigrateKeys test
 
             const int ShardCount = 3;
             const int KeyCount = 10;
 
-            _ = SimpleSetupCluster(ShardCount, primaryCount: -1, replicaCount: -1);
+            _ = await SimpleSetupClusterAsync(ShardCount, primaryCount: -1, replicaCount: -1).ConfigureAwait(false);
 
             var otherNodeIndex = 0;
             var sourceNodeIndex = 1;
@@ -1294,7 +1294,7 @@ namespace Garnet.test.cluster
             const int Secondary0Index = 2;
             const int Secondary1Index = 3;
 
-            _ = SimpleSetupCluster(DefaultMultiPrimaryShards, primaryCount: DefaultMultiPrimaryShards / 2, replicaCount: 1, onDemandCheckpoint: true, enableIncrementalSnapshots: true);
+            _ = await SimpleSetupClusterAsync(DefaultMultiPrimaryShards, primaryCount: DefaultMultiPrimaryShards / 2, replicaCount: 1, onDemandCheckpoint: true, enableIncrementalSnapshots: true);
 
             var primary0 = (IPEndPoint)context.endpoints[Primary0Index];
             var primary1 = (IPEndPoint)context.endpoints[Primary1Index];
@@ -1458,12 +1458,12 @@ namespace Garnet.test.cluster
         }
 
         [Test]
-        public void MigrateVectorSetBack()
+        public async Task MigrateVectorSetBackAsync()
         {
             const int Primary0Index = 0;
             const int Primary1Index = 1;
 
-            _ = SimpleSetupCluster(DefaultShards, primaryCount: DefaultShards, replicaCount: 0);
+            _ = await SimpleSetupClusterAsync(DefaultShards, primaryCount: DefaultShards, replicaCount: 0).ConfigureAwait(false);
 
             var primary0 = (IPEndPoint)context.endpoints[Primary0Index];
             var primary1 = (IPEndPoint)context.endpoints[Primary1Index];
@@ -1482,7 +1482,7 @@ namespace Garnet.test.cluster
 
                 while (true)
                 {
-                    vectorSetKey = $"{nameof(MigrateVectorSetBack)}_{ix}";
+                    vectorSetKey = $"{nameof(MigrateVectorSetBackAsync)}_{ix}";
                     vectorSetKeySlot = context.clusterTestUtils.HashSlot(vectorSetKey);
 
                     var isPrimary0Slot = slots.Any(x => x.nnInfo.Any(y => y.nodeid == primary0Id) && vectorSetKeySlot >= x.startSlot && vectorSetKeySlot <= x.endSlot);
@@ -1611,7 +1611,7 @@ namespace Garnet.test.cluster
 
             try
             {
-                _ = SimpleSetupCluster(DefaultMultiPrimaryShards, primaryCount: DefaultMultiPrimaryShards / 2, replicaCount: 1);
+                _ = await SimpleSetupClusterAsync(DefaultMultiPrimaryShards, primaryCount: DefaultMultiPrimaryShards / 2, replicaCount: 1);
 
                 var primary0 = (IPEndPoint)context.endpoints[Primary0Index];
                 var primary1 = (IPEndPoint)context.endpoints[Primary1Index];
@@ -2058,7 +2058,7 @@ namespace Garnet.test.cluster
             const int PrimaryIndex = 0;
             const int ReplicaIndex = 1;
 
-            _ = SimpleSetupCluster(DefaultShards, primaryCount: DefaultShards / 2, replicaCount: 1);
+            _ = await SimpleSetupClusterAsync(DefaultShards, primaryCount: DefaultShards / 2, replicaCount: 1);
 
             var primary = (IPEndPoint)context.endpoints[PrimaryIndex];
             var replica = (IPEndPoint)context.endpoints[ReplicaIndex];
@@ -2097,11 +2097,11 @@ namespace Garnet.test.cluster
             ClassicAssert.IsTrue(vsimRes.Length > 0);
         }
 
-        private (List<ShardInfo> Shards, List<ushort> Slots) SimpleSetupCluster(int shardCount, int primaryCount, int replicaCount, bool onDemandCheckpoint = false, bool enableIncrementalSnapshots = false, bool useTLS = true)
+        private Task<(List<ShardInfo> Shards, List<ushort> Slots)> SimpleSetupClusterAsync(int shardCount, int primaryCount, int replicaCount, bool onDemandCheckpoint = false, bool enableIncrementalSnapshots = false, bool useTLS = true)
         {
             context.CreateInstances(shardCount, useTLS: useTLS, enableAOF: true, AofMemorySize: DefaultAOFMemorySize, OnDemandCheckpoint: onDemandCheckpoint, EnableIncrementalSnapshots: enableIncrementalSnapshots, threadPoolMinIOCompletionThreads: 512);
             context.CreateConnection(useTLS: useTLS);
-            return context.clusterTestUtils.SimpleSetupCluster(primary_count: primaryCount, replica_count: replicaCount);
+            return context.clusterTestUtils.SimpleSetupClusterAsync(primary_count: primaryCount, replica_count: replicaCount);
         }
 
         [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "storeWrapper")]

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -352,7 +352,8 @@ namespace Garnet.test.cluster
         }
 
         [Test]
-        public async Task RepeatedCreateDeleteAsync()
+        [CancelAfter(120_000)]
+        public async Task RepeatedCreateDeleteAsync(CancellationToken testCancellationToken)
         {
             const int PrimaryIndex = 0;
             const int SecondaryIndex = 1;
@@ -1285,7 +1286,8 @@ namespace Garnet.test.cluster
         }
 
         [Test]
-        public async Task MigrateVectorSetWhileModifyingAsync()
+        [CancelAfter(120_000)]
+        public async Task MigrateVectorSetWhileModifyingAsync(CancellationToken testCancellationToken)
         {
             // Test migrating a single slot with a vector set while moving it
 
@@ -1593,7 +1595,8 @@ namespace Garnet.test.cluster
         }
 
         [Test]
-        public async Task MigrateVectorStressAsync()
+        [CancelAfter(120_000)]
+        public async Task MigrateVectorStressAsync(CancellationToken testCancellationToken)
         {
             // Move vector sets back and forth between replicas, making sure we don't drop data
             // Keeps reads and writes going continuously


### PR DESCRIPTION
Reworks `ClusterTestUtils.SimpleSetupCluster` to be async and to pause and very state between each step - this increases reliability and help with diagnosing failures as we know the cluster is in a stable state before beginning the "real" test.

Also increases timeouts (to 2 minutes) for `RepeatedCreateDeleteAsync`, `MigrateVectorSetWhileModifyingAsync`, and `MigrateVectorStressAsync` - these tests occasionally take nearly 1 minute in Debug builds on CI machines, presumably some failures just legitimately ran out of time.

As part of increasing timeouts, makes `ClusterTestContext` aware of `[CancelAfter]` and uses its value during setup if available.

TODO: 
 - [x] `dev` version (#1763)