### PR TITLE
Tighten InstanceIndexBuffer GC-safety

### DIFF
--- a/libs/client/LightEpoch.cs
+++ b/libs/client/LightEpoch.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -19,7 +20,7 @@ namespace Garnet.client
         /// (1) in AssignInstance, to assign a unique instanceId to each LightEpoch instance, and
         /// (2) in Metadata, to track per-thread epoch table entries for each LightEpoch instance.
         /// </summary>
-        [StructLayout(LayoutKind.Explicit, Size = MaxInstances * sizeof(int))]
+        [InlineArray(MaxInstances)]
         private struct InstanceIndexBuffer
         {
             /// <summary>
@@ -30,17 +31,17 @@ namespace Garnet.client
             /// <summary>
             /// Anchor field for the buffer.
             /// </summary>
-            [FieldOffset(0)]
             int field0;
 
             /// <summary>
             /// Reference to the entry for the given instance ID.
             /// </summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [UnscopedRef]
             internal ref int GetRef(int instanceId)
             {
                 Debug.Assert(instanceId >= 0 && instanceId < MaxInstances);
-                return ref Unsafe.AsRef<int>((int*)Unsafe.AsPointer(ref field0) + instanceId);
+                return ref Unsafe.Add(ref field0, instanceId);
             }
         }
 

--- a/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -19,7 +20,7 @@ namespace Tsavorite.core
         /// (1) in AssignInstance, to assign a unique instanceId to each LightEpoch instance, and
         /// (2) in Metadata, to track per-thread epoch table entries for each LightEpoch instance.
         /// </summary>
-        [StructLayout(LayoutKind.Explicit, Size = MaxInstances * sizeof(int))]
+        [InlineArray(MaxInstances)]
         private struct InstanceIndexBuffer
         {
             /// <summary>
@@ -30,17 +31,17 @@ namespace Tsavorite.core
             /// <summary>
             /// Anchor field for the buffer.
             /// </summary>
-            [FieldOffset(0)]
             int field0;
 
             /// <summary>
             /// Reference to the entry for the given instance ID.
             /// </summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [UnscopedRef]
             internal ref int GetRef(int instanceId)
             {
                 Debug.Assert(instanceId >= 0 && instanceId < MaxInstances);
-                return ref Unsafe.AsRef<int>((int*)Unsafe.AsPointer(ref field0) + instanceId);
+                return ref Unsafe.Add(ref field0, instanceId);
             }
         }
 


### PR DESCRIPTION
Earlier LightEpoch [finding](https://github.com/microsoft/garnet/pull/1691#issue-4241655618) by @kevin-montrose was verified in repro, so porting that fix over.