### PR TITLE
Fix MultiDatabaseSaveInProgressTest

### DIFF
--- a/libs/server/AOF/AofProcessor.cs
+++ b/libs/server/AOF/AofProcessor.cs
@@ -228,7 +228,7 @@ namespace Garnet.server
                                 if (!usingShardedLog)
                                 {
                                     // Must block here, cannot move off the thread
-                                    _ = AsyncUtils.BlockingWait(storeWrapper.TakeCheckpointAsync(background: false, logger));
+                                    _ = AsyncUtils.BlockingWait(storeWrapper.TakeCheckpointAsync(background: false, logger: logger));
                                 }
                                 else
                                 {
@@ -236,7 +236,7 @@ namespace Garnet.server
                                         virtualSublogIdx,
                                         ptr,
                                         (int)LeaderBarrierType.CHECKPOINT,
-                                        () => storeWrapper.TakeCheckpointAsync(background: false, logger));
+                                        () => storeWrapper.TakeCheckpointAsync(background: false, logger: logger));
                                 }
                             }
 

--- a/libs/server/Databases/DatabaseManagerBase.cs
+++ b/libs/server/Databases/DatabaseManagerBase.cs
@@ -38,10 +38,7 @@ namespace Garnet.server
         public abstract void RecoverCheckpoint(bool replicaRecover = false, bool recoverFromToken = false, CheckpointMetadata metadata = null);
 
         /// <inheritdoc/>
-        public abstract Task<bool> TakeCheckpointAsync(bool background, CancellationToken token = default, ILogger logger = null);
-
-        /// <inheritdoc/>
-        public abstract Task<bool> TakeCheckpointAsync(bool background, int dbId, CancellationToken token = default, ILogger logger = null);
+        public abstract Task<bool> TakeCheckpointAsync(bool background, int dbId = -1, CancellationToken token = default, ILogger logger = null);
 
         /// <inheritdoc/>
         public abstract Task TakeOnDemandCheckpointAsync(DateTimeOffset entryTime, int dbId = 0);

--- a/libs/server/Databases/DatabaseManagerBase.cs
+++ b/libs/server/Databases/DatabaseManagerBase.cs
@@ -38,10 +38,10 @@ namespace Garnet.server
         public abstract void RecoverCheckpoint(bool replicaRecover = false, bool recoverFromToken = false, CheckpointMetadata metadata = null);
 
         /// <inheritdoc/>
-        public abstract Task<bool> TakeCheckpointAsync(bool background, ILogger logger = null, CancellationToken token = default);
+        public abstract Task<bool> TakeCheckpointAsync(bool background, CancellationToken token = default, ILogger logger = null);
 
         /// <inheritdoc/>
-        public abstract Task<bool> TakeCheckpointAsync(bool background, int dbId, ILogger logger = null, CancellationToken token = default);
+        public abstract Task<bool> TakeCheckpointAsync(bool background, int dbId, CancellationToken token = default, ILogger logger = null);
 
         /// <inheritdoc/>
         public abstract Task TakeOnDemandCheckpointAsync(DateTimeOffset entryTime, int dbId = 0);

--- a/libs/server/Databases/IDatabaseManager.cs
+++ b/libs/server/Databases/IDatabaseManager.cs
@@ -85,23 +85,14 @@ namespace Garnet.server
         public void RecoverCheckpoint(bool replicaRecover = false, bool recoverFromToken = false, CheckpointMetadata metadata = null);
 
         /// <summary>
-        /// Take checkpoint of all active databases if checkpointing is not in progress
+        /// Take checkpoint of all active databases (or a specified database) if checkpointing is not in progress
         /// </summary>
         /// <param name="background">True if method can return before checkpoint is taken</param>
+        /// <param name="dbId">ID of database to checkpoint, or -1 (default) to checkpoint all active databases</param>
         /// <param name="token">Cancellation token</param>
         /// <param name="logger">Logger</param>
         /// <returns>False if another checkpointing process is already in progress</returns>
-        public Task<bool> TakeCheckpointAsync(bool background, CancellationToken token = default, ILogger logger = null);
-
-        /// <summary>
-        /// Take checkpoint of specified database ID if checkpointing is not in progress
-        /// </summary>
-        /// <param name="background">True if method can return before checkpoint is taken</param>
-        /// <param name="dbId">ID of database to checkpoint</param>
-        /// <param name="token">Cancellation token</param>
-        /// <param name="logger">Logger</param>
-        /// <returns>False if another checkpointing process is already in progress</returns>
-        public Task<bool> TakeCheckpointAsync(bool background, int dbId, CancellationToken token = default, ILogger logger = null);
+        public Task<bool> TakeCheckpointAsync(bool background, int dbId = -1, CancellationToken token = default, ILogger logger = null);
 
         /// <summary>
         /// Take a checkpoint if no checkpoint was taken after the provided time offset

--- a/libs/server/Databases/IDatabaseManager.cs
+++ b/libs/server/Databases/IDatabaseManager.cs
@@ -88,20 +88,20 @@ namespace Garnet.server
         /// Take checkpoint of all active databases if checkpointing is not in progress
         /// </summary>
         /// <param name="background">True if method can return before checkpoint is taken</param>
-        /// <param name="logger">Logger</param>
         /// <param name="token">Cancellation token</param>
+        /// <param name="logger">Logger</param>
         /// <returns>False if another checkpointing process is already in progress</returns>
-        public Task<bool> TakeCheckpointAsync(bool background, ILogger logger = null, CancellationToken token = default);
+        public Task<bool> TakeCheckpointAsync(bool background, CancellationToken token = default, ILogger logger = null);
 
         /// <summary>
         /// Take checkpoint of specified database ID if checkpointing is not in progress
         /// </summary>
         /// <param name="background">True if method can return before checkpoint is taken</param>
         /// <param name="dbId">ID of database to checkpoint</param>
-        /// <param name="logger">Logger</param>
         /// <param name="token">Cancellation token</param>
+        /// <param name="logger">Logger</param>
         /// <returns>False if another checkpointing process is already in progress</returns>
-        public Task<bool> TakeCheckpointAsync(bool background, int dbId, ILogger logger = null, CancellationToken token = default);
+        public Task<bool> TakeCheckpointAsync(bool background, int dbId, CancellationToken token = default, ILogger logger = null);
 
         /// <summary>
         /// Take a checkpoint if no checkpoint was taken after the provided time offset

--- a/libs/server/Databases/MultiDatabaseManager.cs
+++ b/libs/server/Databases/MultiDatabaseManager.cs
@@ -147,41 +147,67 @@ namespace Garnet.server
         }
 
         /// <inheritdoc/>
-        public override async Task<bool> TakeCheckpointAsync(bool background, ILogger logger = null, CancellationToken token = default)
+        public override Task<bool> TakeCheckpointAsync(bool background, ILogger logger = null, CancellationToken token = default)
         {
             var lockAcquired = TryGetDatabasesContentReadLock(token);
-            if (!lockAcquired) return false;
+            if (!lockAcquired) return Task.FromResult(false);
 
-            var checkpointTask = TakeCheckpointHelperAsync();
+            var checkpointLockTaken = false;
+            var pausedCount = 0;
 
-            if (background)
-                return true;
-
-            return await checkpointTask.ConfigureAwait(false);
-
-            async Task<bool> TakeCheckpointHelperAsync()
+            try
             {
-                // Force async 
-                await Task.Yield();
+                var activeDbIdsMapSize = activeDbIds.ActualSize;
 
-                var checkpointLockTaken = false;
-
-                try
+                if (activeDbIdsMapSize > 1)
                 {
-                    var activeDbIdsMapSize = activeDbIds.ActualSize;
-
-                    if (activeDbIdsMapSize > 1)
+                    if (!multiDbCheckpointingLock.TryWriteLock())
                     {
-                        if (!multiDbCheckpointingLock.TryWriteLock())
-                            return false;
-
-                        checkpointLockTaken = true;
+                        databasesContentLock.ReadUnlock();
+                        return Task.FromResult(false);
                     }
 
-                    var activeDbIdsMapSnapshot = activeDbIds.Map;
-                    Array.Copy(activeDbIdsMapSnapshot, dbIdsToCheckpoint, activeDbIdsMapSize);
+                    checkpointLockTaken = true;
+                }
 
-                    return await TakeDatabasesCheckpointAsync(activeDbIdsMapSize, logger: logger, token: token).ConfigureAwait(false);
+                // Synchronously pause per-DB checkpoints for all active DBs so that any per-DB BGSAVE
+                // issued after this method returns reliably observes the in-progress checkpoint.
+                // Compactly store only successfully paused DB IDs in dbIdsToCheckpoint.
+                var activeDbIdsMapSnapshot = activeDbIds.Map;
+                for (var i = 0; i < activeDbIdsMapSize; i++)
+                {
+                    var dbId = activeDbIdsMapSnapshot[i];
+                    if (TryPauseCheckpoints(dbId))
+                        dbIdsToCheckpoint[pausedCount++] = dbId;
+                }
+            }
+            catch
+            {
+                for (var i = 0; i < pausedCount; i++)
+                    ResumeCheckpoints(dbIdsToCheckpoint[i]);
+
+                if (checkpointLockTaken)
+                    multiDbCheckpointingLock.WriteUnlock();
+
+                databasesContentLock.ReadUnlock();
+                throw;
+            }
+
+            var checkpointTask = TakeCheckpointHelperAsync(pausedCount, checkpointLockTaken);
+
+            if (background)
+                return Task.FromResult(true);
+
+            return checkpointTask;
+
+            async Task<bool> TakeCheckpointHelperAsync(int dbIdsCount, bool checkpointLockTaken)
+            {
+                try
+                {
+                    // Force async 
+                    await Task.Yield();
+
+                    return await TakeDatabasesCheckpointAsync(dbIdsCount, alreadyPaused: true, logger: logger, token: token).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -989,7 +1015,7 @@ namespace Garnet.server
         /// <param name="logger">Logger</param>
         /// <param name="token">Cancellation token</param>
         /// <returns>False if checkpointing already in progress</returns>
-        private async Task<bool> TakeDatabasesCheckpointAsync(int dbIdsCount, ILogger logger = null,
+        private async Task<bool> TakeDatabasesCheckpointAsync(int dbIdsCount, bool alreadyPaused = false, ILogger logger = null,
             CancellationToken token = default)
         {
             Debug.Assert(checkpointTasks != null);
@@ -999,7 +1025,19 @@ namespace Garnet.server
                 checkpointTasks[i] = Task.CompletedTask;
 
             var lockAcquired = TryGetDatabasesContentReadLock(token);
-            if (!lockAcquired) return false;
+            if (!lockAcquired)
+            {
+                // Resume any pre-paused DB IDs since we can't proceed to hand them off
+                if (alreadyPaused)
+                {
+                    for (var i = 0; i < dbIdsCount; i++)
+                        ResumeCheckpoints(dbIdsToCheckpoint[i]);
+                }
+
+                return false;
+            }
+
+            var handedOffCount = 0;
 
             try
             {
@@ -1009,11 +1047,13 @@ namespace Garnet.server
                 {
                     var dbId = dbIdsToCheckpoint[currIdx];
 
-                    // If a checkpoint is already in progress for this database, skip it
-                    if (!TryPauseCheckpoints(dbId))
+                    // If a checkpoint is already in progress for this database, skip it.
+                    // When alreadyPaused is true, the caller has already paused checkpoints for all DBs in the list.
+                    if (!alreadyPaused && !TryPauseCheckpoints(dbId))
                         continue;
 
                     checkpointTasks[currIdx] = TakeCheckpointHelperAsync(databaseMapSnapshot, dbId);
+                    handedOffCount = currIdx + 1;
                 }
 
                 await Task.WhenAll(checkpointTasks).ConfigureAwait(false);
@@ -1021,6 +1061,14 @@ namespace Garnet.server
             catch (Exception ex)
             {
                 logger?.LogError(ex, "Checkpointing threw exception");
+
+                // For pre-paused DBs that didn't get handed off to a per-DB helper, resume their locks here.
+                // Per-DB helpers that were started always resume their own dbId in finally.
+                if (alreadyPaused)
+                {
+                    for (var i = handedOffCount; i < dbIdsCount; i++)
+                        ResumeCheckpoints(dbIdsToCheckpoint[i]);
+                }
             }
             finally
             {

--- a/libs/server/Databases/MultiDatabaseManager.cs
+++ b/libs/server/Databases/MultiDatabaseManager.cs
@@ -206,7 +206,7 @@ namespace Garnet.server
                     // Force async 
                     await Task.Yield();
 
-                    return await TakeDatabasesCheckpointAsync(pausedDbIds, pausedCount, alreadyPaused: true, logger: logger, token: token).ConfigureAwait(false);
+                    return await TakeDatabasesCheckpointAsync(pausedDbIds, pausedCount, alreadyPaused: true, contentLockAlreadyHeld: true, logger: logger, token: token).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -327,7 +327,7 @@ namespace Garnet.server
 
                 if (dbIdsIdx == 0) return;
 
-                await TakeDatabasesCheckpointAsync(dbIdsToCheckpoint, dbIdsIdx, logger: logger, token: token).ConfigureAwait(false);
+                await TakeDatabasesCheckpointAsync(dbIdsToCheckpoint, dbIdsIdx, contentLockAlreadyHeld: true, logger: logger, token: token).ConfigureAwait(false);
             }
             finally
             {
@@ -1004,28 +1004,32 @@ namespace Garnet.server
         /// <param name="dbIds">Buffer of database IDs to checkpoint (only first <paramref name="dbIdsCount"/> entries are read)</param>
         /// <param name="dbIdsCount">Number of databases to checkpoint (first dbIdsCount indexes from dbIds)</param>
         /// <param name="alreadyPaused">If true, the caller has already paused checkpoints for every DB in dbIds[0..dbIdsCount); per-DB resume is the responsibility of this method (or the per-DB helper it hands off to).</param>
+        /// <param name="contentLockAlreadyHeld">If true, the caller already holds <see cref="databasesContentLock"/> as a reader and this method must not acquire or release it.</param>
         /// <param name="logger">Logger</param>
         /// <param name="token">Cancellation token</param>
         /// <returns>False if checkpointing already in progress</returns>
-        private async Task<bool> TakeDatabasesCheckpointAsync(int[] dbIds, int dbIdsCount, bool alreadyPaused = false, ILogger logger = null,
-            CancellationToken token = default)
+        private async Task<bool> TakeDatabasesCheckpointAsync(int[] dbIds, int dbIdsCount, bool alreadyPaused = false,
+            bool contentLockAlreadyHeld = false, ILogger logger = null, CancellationToken token = default)
         {
             Debug.Assert(dbIds != null);
             Debug.Assert(dbIdsCount <= dbIds.Length);
 
             var checkpointTasks = new Task[dbIdsCount];
 
-            var lockAcquired = TryGetDatabasesContentReadLock(token);
-            if (!lockAcquired)
+            if (!contentLockAlreadyHeld)
             {
-                // Resume any pre-paused DB IDs since we can't proceed to hand them off
-                if (alreadyPaused)
+                var lockAcquired = TryGetDatabasesContentReadLock(token);
+                if (!lockAcquired)
                 {
-                    for (var i = 0; i < dbIdsCount; i++)
-                        ResumeCheckpoints(dbIds[i]);
-                }
+                    // Resume any pre-paused DB IDs since we can't proceed to hand them off
+                    if (alreadyPaused)
+                    {
+                        for (var i = 0; i < dbIdsCount; i++)
+                            ResumeCheckpoints(dbIds[i]);
+                    }
 
-                return false;
+                    return false;
+                }
             }
 
             var handedOffCount = 0;
@@ -1066,7 +1070,8 @@ namespace Garnet.server
             }
             finally
             {
-                databasesContentLock.ReadUnlock();
+                if (!contentLockAlreadyHeld)
+                    databasesContentLock.ReadUnlock();
             }
 
             return true;

--- a/libs/server/Databases/MultiDatabaseManager.cs
+++ b/libs/server/Databases/MultiDatabaseManager.cs
@@ -41,13 +41,6 @@ namespace Garnet.server
         // Lock for synchronizing checkpointing of all active DBs (if more than one)
         SingleWriterMultiReaderLock multiDbCheckpointingLock;
 
-        // Reusable task array for tracking checkpointing of multiple DBs
-        // Used by recurring checkpointing task if multiple DBs exist
-        Task[] checkpointTasks;
-
-        // Reusable array for storing database IDs for checkpointing
-        int[] dbIdsToCheckpoint;
-
         // True if StartObjectSizeTrackers was previously called
         bool sizeTrackersStarted;
 
@@ -153,6 +146,7 @@ namespace Garnet.server
             if (!lockAcquired) return Task.FromResult(false);
 
             var checkpointLockTaken = false;
+            int[] pausedDbIds = null;
             var pausedCount = 0;
 
             try
@@ -172,19 +166,24 @@ namespace Garnet.server
 
                 // Synchronously pause per-DB checkpoints for all active DBs so that any per-DB BGSAVE
                 // issued after this method returns reliably observes the in-progress checkpoint.
-                // Compactly store only successfully paused DB IDs in dbIdsToCheckpoint.
+                // The buffer is local to this operation so a concurrent HandleDatabaseAdded that resizes
+                // shared state cannot strand the IDs we already paused.
+                pausedDbIds = new int[activeDbIdsMapSize];
                 var activeDbIdsMapSnapshot = activeDbIds.Map;
                 for (var i = 0; i < activeDbIdsMapSize; i++)
                 {
                     var dbId = activeDbIdsMapSnapshot[i];
                     if (TryPauseCheckpoints(dbId))
-                        dbIdsToCheckpoint[pausedCount++] = dbId;
+                        pausedDbIds[pausedCount++] = dbId;
                 }
             }
             catch
             {
-                for (var i = 0; i < pausedCount; i++)
-                    ResumeCheckpoints(dbIdsToCheckpoint[i]);
+                if (pausedDbIds != null)
+                {
+                    for (var i = 0; i < pausedCount; i++)
+                        ResumeCheckpoints(pausedDbIds[i]);
+                }
 
                 if (checkpointLockTaken)
                     multiDbCheckpointingLock.WriteUnlock();
@@ -193,21 +192,21 @@ namespace Garnet.server
                 throw;
             }
 
-            var checkpointTask = TakeCheckpointHelperAsync(pausedCount, checkpointLockTaken);
+            var checkpointTask = TakeCheckpointHelperAsync(pausedDbIds, pausedCount, checkpointLockTaken);
 
             if (background)
                 return Task.FromResult(true);
 
             return checkpointTask;
 
-            async Task<bool> TakeCheckpointHelperAsync(int dbIdsCount, bool checkpointLockTaken)
+            async Task<bool> TakeCheckpointHelperAsync(int[] pausedDbIds, int pausedCount, bool checkpointLockTaken)
             {
                 try
                 {
                     // Force async 
                     await Task.Yield();
 
-                    return await TakeDatabasesCheckpointAsync(dbIdsCount, alreadyPaused: true, logger: logger, token: token).ConfigureAwait(false);
+                    return await TakeDatabasesCheckpointAsync(pausedDbIds, pausedCount, alreadyPaused: true, logger: logger, token: token).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -307,6 +306,8 @@ namespace Garnet.server
                 var databasesMapSnapshot = databases.Map;
                 var activeDbIdsMapSnapshot = activeDbIds.Map;
 
+                // Loop breaks after the first oversized AOF, so a buffer of size 1 suffices.
+                var dbIdsToCheckpoint = new int[1];
                 var dbIdsIdx = 0;
                 for (var i = 0; i < activeDbIdsMapSize; i++)
                 {
@@ -326,7 +327,7 @@ namespace Garnet.server
 
                 if (dbIdsIdx == 0) return;
 
-                await TakeDatabasesCheckpointAsync(dbIdsIdx, logger: logger, token: token).ConfigureAwait(false);
+                await TakeDatabasesCheckpointAsync(dbIdsToCheckpoint, dbIdsIdx, logger: logger, token: token).ConfigureAwait(false);
             }
             finally
             {
@@ -962,17 +963,6 @@ namespace Garnet.server
 
             activeDbIds.TryGetNextId(out var nextIdx);
             activeDbIds.TrySetValue(nextIdx, db.Id);
-
-            activeDbIds.mapLock.ReadLock();
-            try
-            {
-                checkpointTasks = new Task[activeDbIds.ActualSize];
-                dbIdsToCheckpoint = new int[activeDbIds.ActualSize];
-            }
-            finally
-            {
-                activeDbIds.mapLock.ReadUnlock();
-            }
         }
 
         /// <summary>
@@ -1011,18 +1001,19 @@ namespace Garnet.server
         /// <summary>
         /// Asynchronously checkpoint multiple databases and wait for all to complete
         /// </summary>
-        /// <param name="dbIdsCount">Number of databases to checkpoint (first dbIdsCount indexes from dbIdsToCheckpoint)</param>
+        /// <param name="dbIds">Buffer of database IDs to checkpoint (only first <paramref name="dbIdsCount"/> entries are read)</param>
+        /// <param name="dbIdsCount">Number of databases to checkpoint (first dbIdsCount indexes from dbIds)</param>
+        /// <param name="alreadyPaused">If true, the caller has already paused checkpoints for every DB in dbIds[0..dbIdsCount); per-DB resume is the responsibility of this method (or the per-DB helper it hands off to).</param>
         /// <param name="logger">Logger</param>
         /// <param name="token">Cancellation token</param>
         /// <returns>False if checkpointing already in progress</returns>
-        private async Task<bool> TakeDatabasesCheckpointAsync(int dbIdsCount, bool alreadyPaused = false, ILogger logger = null,
+        private async Task<bool> TakeDatabasesCheckpointAsync(int[] dbIds, int dbIdsCount, bool alreadyPaused = false, ILogger logger = null,
             CancellationToken token = default)
         {
-            Debug.Assert(checkpointTasks != null);
-            Debug.Assert(dbIdsCount <= dbIdsToCheckpoint.Length);
+            Debug.Assert(dbIds != null);
+            Debug.Assert(dbIdsCount <= dbIds.Length);
 
-            for (var i = 0; i < checkpointTasks.Length; i++)
-                checkpointTasks[i] = Task.CompletedTask;
+            var checkpointTasks = new Task[dbIdsCount];
 
             var lockAcquired = TryGetDatabasesContentReadLock(token);
             if (!lockAcquired)
@@ -1031,7 +1022,7 @@ namespace Garnet.server
                 if (alreadyPaused)
                 {
                     for (var i = 0; i < dbIdsCount; i++)
-                        ResumeCheckpoints(dbIdsToCheckpoint[i]);
+                        ResumeCheckpoints(dbIds[i]);
                 }
 
                 return false;
@@ -1045,12 +1036,15 @@ namespace Garnet.server
 
                 for (var currIdx = 0; currIdx < dbIdsCount; currIdx++)
                 {
-                    var dbId = dbIdsToCheckpoint[currIdx];
+                    var dbId = dbIds[currIdx];
 
                     // If a checkpoint is already in progress for this database, skip it.
                     // When alreadyPaused is true, the caller has already paused checkpoints for all DBs in the list.
                     if (!alreadyPaused && !TryPauseCheckpoints(dbId))
+                    {
+                        checkpointTasks[currIdx] = Task.CompletedTask;
                         continue;
+                    }
 
                     checkpointTasks[currIdx] = TakeCheckpointHelperAsync(databaseMapSnapshot, dbId);
                     handedOffCount = currIdx + 1;
@@ -1067,7 +1061,7 @@ namespace Garnet.server
                 if (alreadyPaused)
                 {
                     for (var i = handedOffCount; i < dbIdsCount; i++)
-                        ResumeCheckpoints(dbIdsToCheckpoint[i]);
+                        ResumeCheckpoints(dbIds[i]);
                 }
             }
             finally

--- a/libs/server/Databases/MultiDatabaseManager.cs
+++ b/libs/server/Databases/MultiDatabaseManager.cs
@@ -140,8 +140,11 @@ namespace Garnet.server
         }
 
         /// <inheritdoc/>
-        public override Task<bool> TakeCheckpointAsync(bool background, CancellationToken token = default, ILogger logger = null)
+        public override Task<bool> TakeCheckpointAsync(bool background, int dbId = -1, CancellationToken token = default, ILogger logger = null)
         {
+            // Acquire databasesContentLock (read) so a concurrent swap-db can't move GarnetDatabase
+            // wrappers out from under us mid-checkpoint (which would mis-attribute LASTSAVE to the
+            // swapped DB and let a second BGSAVE race against the in-flight checkpoint).
             if (!TryGetDatabasesContentReadLock(token)) return Task.FromResult(false);
 
             var multiDbLockHeld = false;
@@ -150,30 +153,48 @@ namespace Garnet.server
 
             try
             {
-                var activeDbIdsMapSize = activeDbIds.ActualSize;
-
-                if (activeDbIdsMapSize > 1)
+                if (dbId == -1)
                 {
-                    if (!multiDbCheckpointingLock.TryWriteLock())
+                    // All-active-DBs path: take multiDbCheckpointingLock if multi-db, then synchronously
+                    // pause per-DB checkpoints for every active DB so any BGSAVE issued after this method
+                    // returns reliably observes the in-progress checkpoint. The buffer is local so a
+                    // concurrent HandleDatabaseAdded that resizes shared state cannot strand the IDs.
+                    var activeDbIdsMapSize = activeDbIds.ActualSize;
+
+                    if (activeDbIdsMapSize > 1)
+                    {
+                        if (!multiDbCheckpointingLock.TryWriteLock())
+                        {
+                            databasesContentLock.ReadUnlock();
+                            return Task.FromResult(false);
+                        }
+
+                        multiDbLockHeld = true;
+                    }
+
+                    pausedDbIds = new int[activeDbIdsMapSize];
+                    var activeDbIdsMapSnapshot = activeDbIds.Map;
+                    for (var i = 0; i < activeDbIdsMapSize; i++)
+                    {
+                        var id = activeDbIdsMapSnapshot[i];
+                        if (TryPauseCheckpoints(id))
+                            pausedDbIds[pausedCount++] = id;
+                    }
+                }
+                else
+                {
+                    // Single-DB path: just pause this one DB. multiDbCheckpointingLock is not taken
+                    // because multiple per-DB BGSAVEs on different DBs are legal.
+                    Debug.Assert(dbId < databases.ActualSize && databases.Map[dbId] != null);
+
+                    if (!TryPauseCheckpoints(dbId))
                     {
                         databasesContentLock.ReadUnlock();
                         return Task.FromResult(false);
                     }
 
-                    multiDbLockHeld = true;
-                }
-
-                // Synchronously pause per-DB checkpoints for all active DBs so that any per-DB BGSAVE
-                // issued after this method returns reliably observes the in-progress checkpoint.
-                // The buffer is local to this operation so a concurrent HandleDatabaseAdded that resizes
-                // shared state cannot strand the IDs we already paused.
-                pausedDbIds = new int[activeDbIdsMapSize];
-                var activeDbIdsMapSnapshot = activeDbIds.Map;
-                for (var i = 0; i < activeDbIdsMapSize; i++)
-                {
-                    var dbId = activeDbIdsMapSnapshot[i];
-                    if (TryPauseCheckpoints(dbId))
-                        pausedDbIds[pausedCount++] = dbId;
+                    pausedDbIds = [dbId];
+                    pausedCount = 1;
                 }
             }
             catch
@@ -192,42 +213,6 @@ namespace Garnet.server
             }
 
             var checkpointTask = RunPausedCheckpointsAndReleaseLocksAsync(pausedDbIds, pausedCount, multiDbLockHeld, token, logger);
-
-            if (background)
-                return Task.FromResult(true);
-
-            return checkpointTask;
-        }
-
-        /// <inheritdoc/>
-        public override Task<bool> TakeCheckpointAsync(bool background, int dbId, CancellationToken token = default, ILogger logger = null)
-        {
-            Debug.Assert(dbId < databases.ActualSize && databases.Map[dbId] != null);
-
-            // Acquire databasesContentLock (read) so a concurrent swap-db can't move the GarnetDatabase
-            // out from under us mid-checkpoint (which would mis-attribute LASTSAVE to the swapped DB
-            // and let a second BGSAVE for the same dbId race against the in-flight checkpoint).
-            if (!TryGetDatabasesContentReadLock(token)) return Task.FromResult(false);
-
-            int[] pausedDbIds;
-            try
-            {
-                if (!TryPauseCheckpoints(dbId))
-                {
-                    databasesContentLock.ReadUnlock();
-                    return Task.FromResult(false);
-                }
-                pausedDbIds = [dbId];
-            }
-            catch
-            {
-                databasesContentLock.ReadUnlock();
-                throw;
-            }
-
-            // Reuse the shared runner. multiDbLockHeld=false because per-DB BGSAVE doesn't take the
-            // multi-DB-checkpointing mutex (multiple per-DB BGSAVEs on different DBs are legal).
-            var checkpointTask = RunPausedCheckpointsAndReleaseLocksAsync(pausedDbIds, 1, multiDbLockHeld: false, token, logger);
 
             if (background)
                 return Task.FromResult(true);

--- a/libs/server/Databases/MultiDatabaseManager.cs
+++ b/libs/server/Databases/MultiDatabaseManager.cs
@@ -142,10 +142,9 @@ namespace Garnet.server
         /// <inheritdoc/>
         public override Task<bool> TakeCheckpointAsync(bool background, ILogger logger = null, CancellationToken token = default)
         {
-            var lockAcquired = TryGetDatabasesContentReadLock(token);
-            if (!lockAcquired) return Task.FromResult(false);
+            if (!TryGetDatabasesContentReadLock(token)) return Task.FromResult(false);
 
-            var checkpointLockTaken = false;
+            var multiDbLockHeld = false;
             int[] pausedDbIds = null;
             var pausedCount = 0;
 
@@ -161,7 +160,7 @@ namespace Garnet.server
                         return Task.FromResult(false);
                     }
 
-                    checkpointLockTaken = true;
+                    multiDbLockHeld = true;
                 }
 
                 // Synchronously pause per-DB checkpoints for all active DBs so that any per-DB BGSAVE
@@ -185,100 +184,86 @@ namespace Garnet.server
                         ResumeCheckpoints(pausedDbIds[i]);
                 }
 
-                if (checkpointLockTaken)
+                if (multiDbLockHeld)
                     multiDbCheckpointingLock.WriteUnlock();
 
                 databasesContentLock.ReadUnlock();
                 throw;
             }
 
-            var checkpointTask = TakeCheckpointHelperAsync(pausedDbIds, pausedCount, checkpointLockTaken);
+            var checkpointTask = RunPausedCheckpointsAndReleaseLocksAsync(pausedDbIds, pausedCount, multiDbLockHeld, logger, token);
 
             if (background)
                 return Task.FromResult(true);
 
             return checkpointTask;
-
-            async Task<bool> TakeCheckpointHelperAsync(int[] pausedDbIds, int pausedCount, bool checkpointLockTaken)
-            {
-                try
-                {
-                    // Force async 
-                    await Task.Yield();
-
-                    return await TakeDatabasesCheckpointAsync(pausedDbIds, pausedCount, alreadyPaused: true, contentLockAlreadyHeld: true, logger: logger, token: token).ConfigureAwait(false);
-                }
-                finally
-                {
-                    if (checkpointLockTaken)
-                        multiDbCheckpointingLock.WriteUnlock();
-
-                    databasesContentLock.ReadUnlock();
-                }
-            }
         }
 
         /// <inheritdoc/>
-        public override async Task<bool> TakeCheckpointAsync(bool background, int dbId, ILogger logger = null, CancellationToken token = default)
+        public override Task<bool> TakeCheckpointAsync(bool background, int dbId, ILogger logger = null, CancellationToken token = default)
         {
-            var databasesMapSize = databases.ActualSize;
-            var databasesMapSnapshot = databases.Map;
-            Debug.Assert(dbId < databasesMapSize && databasesMapSnapshot[dbId] != null);
+            Debug.Assert(dbId < databases.ActualSize && databases.Map[dbId] != null);
 
-            // Check if checkpoint already in progress
-            if (!TryPauseCheckpoints(dbId))
-                return false;
+            // Acquire databasesContentLock (read) so a concurrent swap-db can't move the GarnetDatabase
+            // out from under us mid-checkpoint (which would mis-attribute LASTSAVE to the swapped DB
+            // and let a second BGSAVE for the same dbId race against the in-flight checkpoint).
+            if (!TryGetDatabasesContentReadLock(token)) return Task.FromResult(false);
 
-            var checkpointTask = TakeCheckpointHelperAsync(databasesMapSnapshot, dbId, logger, token);
+            int[] pausedDbIds;
+            try
+            {
+                if (!TryPauseCheckpoints(dbId))
+                {
+                    databasesContentLock.ReadUnlock();
+                    return Task.FromResult(false);
+                }
+                pausedDbIds = [dbId];
+            }
+            catch
+            {
+                databasesContentLock.ReadUnlock();
+                throw;
+            }
+
+            // Reuse the shared runner. multiDbLockHeld=false because per-DB BGSAVE doesn't take the
+            // multi-DB-checkpointing mutex (multiple per-DB BGSAVEs on different DBs are legal).
+            var checkpointTask = RunPausedCheckpointsAndReleaseLocksAsync(pausedDbIds, 1, multiDbLockHeld: false, logger, token);
 
             if (background)
-                return true;
+                return Task.FromResult(true);
 
-            await checkpointTask.ConfigureAwait(false);
-            return true;
-
-            async Task TakeCheckpointHelperAsync(GarnetDatabase[] databasesMapSnapshot, int dbId, ILogger logger, CancellationToken token)
-            {
-                try
-                {
-                    var storeTailAddress = await TakeCheckpointAsync(databasesMapSnapshot[dbId], logger: logger, token: token).ConfigureAwait(false);
-
-                    UpdateLastSaveData(dbId, storeTailAddress);
-                }
-                finally
-                {
-                    ResumeCheckpoints(dbId);
-                }
-            }
+            return checkpointTask;
         }
 
         /// <inheritdoc/>
         public override async Task TakeOnDemandCheckpointAsync(DateTimeOffset entryTime, int dbId = 0)
         {
-            var databasesMapSize = databases.ActualSize;
-            var databasesMapSnapshot = databases.Map;
-            Debug.Assert(dbId < databasesMapSize && databasesMapSnapshot[dbId] != null);
+            Debug.Assert(dbId < databases.ActualSize && databases.Map[dbId] != null);
 
-            var db = databasesMapSnapshot[dbId];
+            // Acquire databasesContentLock (read) so a concurrent swap-db can't mis-attribute LASTSAVE
+            // (UpdateLastSaveData uses databases.Map[dbId] at write time).
+            if (!TryGetDatabasesContentReadLock()) return;
 
-            // Check if checkpoint already in progress
-            var checkpointsPaused = TryPauseCheckpoints(dbId);
-
+            var checkpointsPaused = false;
             try
             {
+                checkpointsPaused = TryPauseCheckpoints(dbId);
+                var db = databases.Map[dbId];
+
                 // If another checkpoint is in progress or a checkpoint was taken beyond the provided entryTime - return
                 if (!checkpointsPaused || db.LastSaveTime > entryTime)
                     return;
 
                 // Necessary to take a checkpoint because the latest checkpoint is before entryTime
-                var result = await TakeCheckpointAsync(db, logger: Logger).ConfigureAwait(false);
-
-                var storeTailAddress = result;
+                var storeTailAddress = await TakeCheckpointAsync(db, logger: Logger).ConfigureAwait(false);
                 UpdateLastSaveData(dbId, storeTailAddress);
             }
             finally
             {
-                ResumeCheckpoints(dbId);
+                if (checkpointsPaused)
+                    ResumeCheckpoints(dbId);
+
+                databasesContentLock.ReadUnlock();
             }
         }
 
@@ -286,29 +271,26 @@ namespace Garnet.server
         public override async Task TaskCheckpointBasedOnAofSizeLimitAsync(long aofSizeLimit, CancellationToken token = default,
             ILogger logger = null)
         {
-            var lockAcquired = TryGetDatabasesContentReadLock(token);
-            if (!lockAcquired) return;
+            if (!TryGetDatabasesContentReadLock(token)) return;
 
-            var activeDbIdsMapSize = activeDbIds.ActualSize;
-
-            var checkpointLockTaken = false;
+            var multiDbLockHeld = false;
 
             try
             {
+                var activeDbIdsMapSize = activeDbIds.ActualSize;
+
                 if (activeDbIdsMapSize > 1)
                 {
                     if (!multiDbCheckpointingLock.TryWriteLock())
                         return;
 
-                    checkpointLockTaken = true;
+                    multiDbLockHeld = true;
                 }
 
+                // Find first oversized DB and synchronously pause it.
                 var databasesMapSnapshot = databases.Map;
                 var activeDbIdsMapSnapshot = activeDbIds.Map;
-
-                // Loop breaks after the first oversized AOF, so a buffer of size 1 suffices.
-                var dbIdsToCheckpoint = new int[1];
-                var dbIdsIdx = 0;
+                var pausedDbId = -1;
                 for (var i = 0; i < activeDbIdsMapSize; i++)
                 {
                     var dbId = activeDbIdsMapSnapshot[i];
@@ -320,18 +302,19 @@ namespace Garnet.server
                     {
                         logger?.LogInformation("Enforcing AOF size limit currentAofSize: {dbAofSize} > AofSizeLimit: {aofSizeLimit} (Database ID: {dbId})",
                             dbAofSize, aofSizeLimit, dbId);
-                        dbIdsToCheckpoint[dbIdsIdx++] = dbId;
+                        if (TryPauseCheckpoints(dbId))
+                            pausedDbId = dbId;
                         break;
                     }
                 }
 
-                if (dbIdsIdx == 0) return;
+                if (pausedDbId < 0) return;
 
-                await TakeDatabasesCheckpointAsync(dbIdsToCheckpoint, dbIdsIdx, contentLockAlreadyHeld: true, logger: logger, token: token).ConfigureAwait(false);
+                await RunPausedCheckpointAsync(databasesMapSnapshot[pausedDbId], pausedDbId, logger, token).ConfigureAwait(false);
             }
             finally
             {
-                if (checkpointLockTaken)
+                if (multiDbLockHeld)
                     multiDbCheckpointingLock.WriteUnlock();
 
                 databasesContentLock.ReadUnlock();
@@ -999,103 +982,68 @@ namespace Garnet.server
         }
 
         /// <summary>
-        /// Asynchronously checkpoint multiple databases and wait for all to complete
+        /// Run pre-paused per-DB checkpoints in parallel, then release the outer locks held by the caller.
+        /// Caller must hold <see cref="databasesContentLock"/> as a reader and must have synchronously
+        /// pause-locked every DB in <paramref name="pausedDbIds"/>[0..<paramref name="pausedCount"/>).
         /// </summary>
-        /// <param name="dbIds">Buffer of database IDs to checkpoint (only first <paramref name="dbIdsCount"/> entries are read)</param>
-        /// <param name="dbIdsCount">Number of databases to checkpoint (first dbIdsCount indexes from dbIds)</param>
-        /// <param name="alreadyPaused">If true, the caller has already paused checkpoints for every DB in dbIds[0..dbIdsCount); per-DB resume is the responsibility of this method (or the per-DB helper it hands off to).</param>
-        /// <param name="contentLockAlreadyHeld">If true, the caller already holds <see cref="databasesContentLock"/> as a reader and this method must not acquire or release it.</param>
-        /// <param name="logger">Logger</param>
-        /// <param name="token">Cancellation token</param>
-        /// <returns>False if checkpointing already in progress</returns>
-        private async Task<bool> TakeDatabasesCheckpointAsync(int[] dbIds, int dbIdsCount, bool alreadyPaused = false,
-            bool contentLockAlreadyHeld = false, ILogger logger = null, CancellationToken token = default)
+        private async Task<bool> RunPausedCheckpointsAndReleaseLocksAsync(int[] pausedDbIds, int pausedCount,
+            bool multiDbLockHeld, ILogger logger, CancellationToken token)
         {
-            Debug.Assert(dbIds != null);
-            Debug.Assert(dbIdsCount <= dbIds.Length);
-
-            var checkpointTasks = new Task[dbIdsCount];
-
-            if (!contentLockAlreadyHeld)
-            {
-                var lockAcquired = TryGetDatabasesContentReadLock(token);
-                if (!lockAcquired)
-                {
-                    // Resume any pre-paused DB IDs since we can't proceed to hand them off
-                    if (alreadyPaused)
-                    {
-                        for (var i = 0; i < dbIdsCount; i++)
-                            ResumeCheckpoints(dbIds[i]);
-                    }
-
-                    return false;
-                }
-            }
-
-            var handedOffCount = 0;
-
             try
             {
+                // Force async so that the entry point can return synchronously to the caller.
+                await Task.Yield();
+
                 var databaseMapSnapshot = databases.Map;
+                var checkpointTasks = new Task[pausedCount];
+                var handedOffCount = 0;
 
-                for (var currIdx = 0; currIdx < dbIdsCount; currIdx++)
+                try
                 {
-                    var dbId = dbIds[currIdx];
-
-                    // If a checkpoint is already in progress for this database, skip it.
-                    // When alreadyPaused is true, the caller has already paused checkpoints for all DBs in the list.
-                    if (!alreadyPaused && !TryPauseCheckpoints(dbId))
+                    for (var i = 0; i < pausedCount; i++)
                     {
-                        checkpointTasks[currIdx] = Task.CompletedTask;
-                        continue;
+                        checkpointTasks[i] = RunPausedCheckpointAsync(databaseMapSnapshot[pausedDbIds[i]], pausedDbIds[i], logger, token);
+                        handedOffCount = i + 1;
                     }
 
-                    checkpointTasks[currIdx] = TakeCheckpointHelperAsync(databaseMapSnapshot, dbId);
-                    handedOffCount = currIdx + 1;
+                    await Task.WhenAll(checkpointTasks).ConfigureAwait(false);
                 }
-
-                await Task.WhenAll(checkpointTasks).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                logger?.LogError(ex, "Checkpointing threw exception");
-
-                // For pre-paused DBs that didn't get handed off to a per-DB helper, resume their locks here.
-                // Per-DB helpers that were started always resume their own dbId in finally.
-                if (alreadyPaused)
+                catch (Exception ex)
                 {
-                    for (var i = handedOffCount; i < dbIdsCount; i++)
-                        ResumeCheckpoints(dbIds[i]);
+                    logger?.LogError(ex, "Checkpointing threw exception");
+
+                    // Per-DB helpers that were started always resume their own dbId in finally.
+                    // Resume locks for any pre-paused DBs that didn't get handed off (very rare —
+                    // would require the synchronous tasks[] assignment loop above to throw).
+                    for (var i = handedOffCount; i < pausedCount; i++)
+                        ResumeCheckpoints(pausedDbIds[i]);
                 }
             }
             finally
             {
-                if (!contentLockAlreadyHeld)
-                    databasesContentLock.ReadUnlock();
+                if (multiDbLockHeld)
+                    multiDbCheckpointingLock.WriteUnlock();
+
+                databasesContentLock.ReadUnlock();
             }
 
             return true;
+        }
 
-            async Task TakeCheckpointHelperAsync(GarnetDatabase[] databaseMapSnapshot, int dbId)
+        /// <summary>
+        /// Run a single pre-paused per-DB checkpoint and resume the per-DB checkpoint lock.
+        /// Caller must have already pause-locked <paramref name="dbId"/> via <see cref="TryPauseCheckpoints(int)"/>.
+        /// </summary>
+        private async Task RunPausedCheckpointAsync(GarnetDatabase db, int dbId, ILogger logger, CancellationToken token)
+        {
+            try
             {
-                var needsResume = true;
-
-                try
-                {
-                    var storeTailAddress = await TakeCheckpointAsync(databaseMapSnapshot[dbId], logger: logger, token: token).ConfigureAwait(false);
-
-                    ResumeCheckpoints(dbId);
-                    needsResume = false;
-
-                    UpdateLastSaveData(dbId, storeTailAddress);
-                }
-                finally
-                {
-                    if (needsResume)
-                    {
-                        ResumeCheckpoints(dbId);
-                    }
-                }
+                var storeTailAddress = await TakeCheckpointAsync(db, logger: logger, token: token).ConfigureAwait(false);
+                UpdateLastSaveData(dbId, storeTailAddress);
+            }
+            finally
+            {
+                ResumeCheckpoints(dbId);
             }
         }
 

--- a/libs/server/Databases/MultiDatabaseManager.cs
+++ b/libs/server/Databases/MultiDatabaseManager.cs
@@ -140,7 +140,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc/>
-        public override Task<bool> TakeCheckpointAsync(bool background, ILogger logger = null, CancellationToken token = default)
+        public override Task<bool> TakeCheckpointAsync(bool background, CancellationToken token = default, ILogger logger = null)
         {
             if (!TryGetDatabasesContentReadLock(token)) return Task.FromResult(false);
 
@@ -191,7 +191,7 @@ namespace Garnet.server
                 throw;
             }
 
-            var checkpointTask = RunPausedCheckpointsAndReleaseLocksAsync(pausedDbIds, pausedCount, multiDbLockHeld, logger, token);
+            var checkpointTask = RunPausedCheckpointsAndReleaseLocksAsync(pausedDbIds, pausedCount, multiDbLockHeld, token, logger);
 
             if (background)
                 return Task.FromResult(true);
@@ -200,7 +200,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc/>
-        public override Task<bool> TakeCheckpointAsync(bool background, int dbId, ILogger logger = null, CancellationToken token = default)
+        public override Task<bool> TakeCheckpointAsync(bool background, int dbId, CancellationToken token = default, ILogger logger = null)
         {
             Debug.Assert(dbId < databases.ActualSize && databases.Map[dbId] != null);
 
@@ -227,7 +227,7 @@ namespace Garnet.server
 
             // Reuse the shared runner. multiDbLockHeld=false because per-DB BGSAVE doesn't take the
             // multi-DB-checkpointing mutex (multiple per-DB BGSAVEs on different DBs are legal).
-            var checkpointTask = RunPausedCheckpointsAndReleaseLocksAsync(pausedDbIds, 1, multiDbLockHeld: false, logger, token);
+            var checkpointTask = RunPausedCheckpointsAndReleaseLocksAsync(pausedDbIds, 1, multiDbLockHeld: false, token, logger);
 
             if (background)
                 return Task.FromResult(true);
@@ -310,7 +310,7 @@ namespace Garnet.server
 
                 if (pausedDbId < 0) return;
 
-                await RunPausedCheckpointAsync(databasesMapSnapshot[pausedDbId], pausedDbId, logger, token).ConfigureAwait(false);
+                await RunPausedCheckpointAsync(databasesMapSnapshot[pausedDbId], pausedDbId, token, logger).ConfigureAwait(false);
             }
             finally
             {
@@ -987,7 +987,7 @@ namespace Garnet.server
         /// pause-locked every DB in <paramref name="pausedDbIds"/>[0..<paramref name="pausedCount"/>).
         /// </summary>
         private async Task<bool> RunPausedCheckpointsAndReleaseLocksAsync(int[] pausedDbIds, int pausedCount,
-            bool multiDbLockHeld, ILogger logger, CancellationToken token)
+            bool multiDbLockHeld, CancellationToken token, ILogger logger)
         {
             try
             {
@@ -1002,7 +1002,7 @@ namespace Garnet.server
                 {
                     for (var i = 0; i < pausedCount; i++)
                     {
-                        checkpointTasks[i] = RunPausedCheckpointAsync(databaseMapSnapshot[pausedDbIds[i]], pausedDbIds[i], logger, token);
+                        checkpointTasks[i] = RunPausedCheckpointAsync(databaseMapSnapshot[pausedDbIds[i]], pausedDbIds[i], token, logger);
                         handedOffCount = i + 1;
                     }
 
@@ -1034,7 +1034,7 @@ namespace Garnet.server
         /// Run a single pre-paused per-DB checkpoint and resume the per-DB checkpoint lock.
         /// Caller must have already pause-locked <paramref name="dbId"/> via <see cref="TryPauseCheckpoints(int)"/>.
         /// </summary>
-        private async Task RunPausedCheckpointAsync(GarnetDatabase db, int dbId, ILogger logger, CancellationToken token)
+        private async Task RunPausedCheckpointAsync(GarnetDatabase db, int dbId, CancellationToken token, ILogger logger)
         {
             try
             {

--- a/libs/server/Databases/SingleDatabaseManager.cs
+++ b/libs/server/Databases/SingleDatabaseManager.cs
@@ -108,7 +108,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc/>
-        public override async Task<bool> TakeCheckpointAsync(bool background, ILogger logger = null, CancellationToken token = default)
+        public override async Task<bool> TakeCheckpointAsync(bool background, CancellationToken token = default, ILogger logger = null)
         {
             // Check if checkpoint already in progress
             if (!TryPauseCheckpoints(defaultDatabase.Id))
@@ -140,11 +140,11 @@ namespace Garnet.server
         }
 
         /// <inheritdoc/>
-        public override Task<bool> TakeCheckpointAsync(bool background, int dbId, ILogger logger = null, CancellationToken token = default)
+        public override Task<bool> TakeCheckpointAsync(bool background, int dbId, CancellationToken token = default, ILogger logger = null)
         {
             ArgumentOutOfRangeException.ThrowIfNotEqual(dbId, 0);
 
-            return TakeCheckpointAsync(background, logger, token);
+            return TakeCheckpointAsync(background, token, logger);
         }
 
         /// <inheritdoc/>

--- a/libs/server/Databases/SingleDatabaseManager.cs
+++ b/libs/server/Databases/SingleDatabaseManager.cs
@@ -108,8 +108,11 @@ namespace Garnet.server
         }
 
         /// <inheritdoc/>
-        public override async Task<bool> TakeCheckpointAsync(bool background, CancellationToken token = default, ILogger logger = null)
+        public override async Task<bool> TakeCheckpointAsync(bool background, int dbId = -1, CancellationToken token = default, ILogger logger = null)
         {
+            if (dbId != -1 && dbId != 0)
+                throw new ArgumentOutOfRangeException(nameof(dbId), dbId, "SingleDatabaseManager only supports dbId 0.");
+
             // Check if checkpoint already in progress
             if (!TryPauseCheckpoints(defaultDatabase.Id))
                 return false;
@@ -137,14 +140,6 @@ namespace Garnet.server
                     ResumeCheckpoints(defaultDatabase.Id);
                 }
             }
-        }
-
-        /// <inheritdoc/>
-        public override Task<bool> TakeCheckpointAsync(bool background, int dbId, CancellationToken token = default, ILogger logger = null)
-        {
-            ArgumentOutOfRangeException.ThrowIfNotEqual(dbId, 0);
-
-            return TakeCheckpointAsync(background, token, logger);
         }
 
         /// <inheritdoc/>

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -381,31 +381,16 @@ namespace Garnet.server
         }
 
         /// <summary>
-        /// Take checkpoint of all active databases
+        /// Take checkpoint of all active databases (or a specified database)
         /// </summary>
         /// <param name="background">True if method can return before checkpoint is taken</param>
+        /// <param name="dbId">ID of database to checkpoint, or -1 (default) to checkpoint all active databases</param>
         /// <param name="token">Cancellation token</param>
         /// <param name="logger">Logger</param>
         /// <returns>False if another checkpointing process is already in progress</returns>
-        public Task<bool> TakeCheckpointAsync(bool background, CancellationToken token = default,
-            ILogger logger = null) => databaseManager.TakeCheckpointAsync(background, token, logger);
-
-        /// <summary>
-        /// Take checkpoint of all active database IDs or a specified database ID
-        /// </summary>
-        /// <param name="background">True if method can return before checkpoint is taken</param>
-        /// <param name="dbId">ID of database to checkpoint (default: -1 - checkpoint all active databases)</param>
-        /// <param name="token">Cancellation token</param>
-        /// <param name="logger">Logger</param>
-        /// <returns>False if another checkpointing process is already in progress</returns>
-        public Task<bool> TakeCheckpointAsync(bool background, int dbId, CancellationToken token = default, ILogger logger = null)
+        public Task<bool> TakeCheckpointAsync(bool background, int dbId = -1, CancellationToken token = default, ILogger logger = null)
         {
-            if (dbId == -1)
-            {
-                return databaseManager.TakeCheckpointAsync(background, token, logger);
-            }
-
-            if (dbId != 0 && !CheckMultiDatabaseCompatibility())
+            if (dbId > 0 && !CheckMultiDatabaseCompatibility())
                 throw new GarnetException($"Unable to call {nameof(databaseManager.TakeCheckpointAsync)} with DB ID: {dbId}");
 
             return databaseManager.TakeCheckpointAsync(background, dbId, token, logger);

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -384,31 +384,31 @@ namespace Garnet.server
         /// Take checkpoint of all active databases
         /// </summary>
         /// <param name="background">True if method can return before checkpoint is taken</param>
-        /// <param name="logger">Logger</param>
         /// <param name="token">Cancellation token</param>
+        /// <param name="logger">Logger</param>
         /// <returns>False if another checkpointing process is already in progress</returns>
-        public Task<bool> TakeCheckpointAsync(bool background, ILogger logger = null,
-            CancellationToken token = default) => databaseManager.TakeCheckpointAsync(background, logger, token);
+        public Task<bool> TakeCheckpointAsync(bool background, CancellationToken token = default,
+            ILogger logger = null) => databaseManager.TakeCheckpointAsync(background, token, logger);
 
         /// <summary>
         /// Take checkpoint of all active database IDs or a specified database ID
         /// </summary>
         /// <param name="background">True if method can return before checkpoint is taken</param>
         /// <param name="dbId">ID of database to checkpoint (default: -1 - checkpoint all active databases)</param>
-        /// <param name="logger">Logger</param>
         /// <param name="token">Cancellation token</param>
+        /// <param name="logger">Logger</param>
         /// <returns>False if another checkpointing process is already in progress</returns>
-        public Task<bool> TakeCheckpointAsync(bool background, int dbId = -1, ILogger logger = null, CancellationToken token = default)
+        public Task<bool> TakeCheckpointAsync(bool background, int dbId, CancellationToken token = default, ILogger logger = null)
         {
             if (dbId == -1)
             {
-                return databaseManager.TakeCheckpointAsync(background, logger, token);
+                return databaseManager.TakeCheckpointAsync(background, token, logger);
             }
 
             if (dbId != 0 && !CheckMultiDatabaseCompatibility())
                 throw new GarnetException($"Unable to call {nameof(databaseManager.TakeCheckpointAsync)} with DB ID: {dbId}");
 
-            return databaseManager.TakeCheckpointAsync(background, dbId, logger, token);
+            return databaseManager.TakeCheckpointAsync(background, dbId, token, logger);
         }
 
         /// <summary>

--- a/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
+++ b/test/Garnet.test.cluster/VectorSets/ClusterVectorSetTests.cs
@@ -608,6 +608,7 @@ namespace Garnet.test.cluster
         }
 
         [Test]
+        [CancelAfter(180_000)]
         public async Task MultipleReplicasWithVectorSetsAndDeletesAsync()
         {
             const int PrimaryIndex = 0;

--- a/test/Garnet.test/MultiDatabaseTests.cs
+++ b/test/Garnet.test/MultiDatabaseTests.cs
@@ -1397,6 +1397,43 @@ namespace Garnet.test
         }
 
         [Test]
+        public void MultiDatabaseGeneralSaveBlocksGeneralSaveTest()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db1 = redis.GetDatabase(0);
+            var db2 = redis.GetDatabase(1);
+
+            // Touch DB 1 so there are multiple active databases (which is what triggers
+            // multiDbCheckpointingLock acquisition in MultiDatabaseManager.TakeCheckpointAsync).
+            db2.StringSet("k", "v");
+
+            // Add some data so the checkpoint takes a measurable amount of time
+            for (var i = 0; i < 1024; i++)
+            {
+                db1.StringSet($"k{i}", new string('x', 256));
+                db2.StringSet($"k{i}", new string('x', 256));
+            }
+
+            // Issue general background save
+            var res = db1.Execute("BGSAVE");
+            ClassicAssert.AreEqual("Background saving started", res.ToString());
+
+            // Issuing another general BGSAVE while the first is in progress must fail. With multiple
+            // active DBs, multiDbCheckpointingLock is acquired synchronously by the first BGSAVE,
+            // so the second one reliably observes the in-progress checkpoint.
+            Assert.Throws<RedisServerException>(() => db1.Execute("BGSAVE"),
+                Encoding.ASCII.GetString(CmdStrings.RESP_ERR_CHECKPOINT_ALREADY_IN_PROGRESS));
+
+            var lastsave = 0;
+            do
+            {
+                Thread.Sleep(10);
+                lastsave = (int)db1.Execute("LASTSAVE");
+            }
+            while (lastsave == 0);
+        }
+
+        [Test]
         [TestCase(false)]
         [TestCase(true)]
         public void MultiDatabaseSaveRecoverByDbIdTest(bool backgroundSave)

--- a/test/Garnet.test/MultiDatabaseTests.cs
+++ b/test/Garnet.test/MultiDatabaseTests.cs
@@ -1400,37 +1400,49 @@ namespace Garnet.test
         public void MultiDatabaseGeneralSaveBlocksGeneralSaveTest()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
-            var db1 = redis.GetDatabase(0);
-            var db2 = redis.GetDatabase(1);
+            var db0 = redis.GetDatabase(0);
+            var db1 = redis.GetDatabase(1);
 
-            // Touch DB 1 so there are multiple active databases (which is what triggers
-            // multiDbCheckpointingLock acquisition in MultiDatabaseManager.TakeCheckpointAsync).
-            db2.StringSet("k", "v");
+            // Touch DB 1 so there are at least two active databases. With multiple active DBs,
+            // MultiDatabaseManager.TakeCheckpointAsync acquires multiDbCheckpointingLock, which is
+            // what makes the second concurrent general BGSAVE fail synchronously below.
+            db1.StringSet("k", "v");
 
-            // Add some data so the checkpoint takes a measurable amount of time
+            // Add some data so the checkpoint takes a measurable amount of time.
             for (var i = 0; i < 1024; i++)
             {
+                db0.StringSet($"k{i}", new string('x', 256));
                 db1.StringSet($"k{i}", new string('x', 256));
-                db2.StringSet($"k{i}", new string('x', 256));
             }
 
-            // Issue general background save
-            var res = db1.Execute("BGSAVE");
+            // Capture LASTSAVE baseline (long to avoid 2038 truncation in the wait loop below).
+            var lastsaveBaseline = (long)db0.Execute("LASTSAVE");
+
+            // Issue general background save.
+            var res = db0.Execute("BGSAVE");
             ClassicAssert.AreEqual("Background saving started", res.ToString());
 
             // Issuing another general BGSAVE while the first is in progress must fail. With multiple
             // active DBs, multiDbCheckpointingLock is acquired synchronously by the first BGSAVE,
             // so the second one reliably observes the in-progress checkpoint.
-            Assert.Throws<RedisServerException>(() => db1.Execute("BGSAVE"),
-                Encoding.ASCII.GetString(CmdStrings.RESP_ERR_CHECKPOINT_ALREADY_IN_PROGRESS));
+            // Note: Assert.Throws's second argument is a *failure* message, not the expected exception
+            // message - assert on Message explicitly.
+            var ex = Assert.Throws<RedisServerException>(() => db0.Execute("BGSAVE"));
+            ClassicAssert.AreEqual(
+                Encoding.ASCII.GetString(CmdStrings.RESP_ERR_CHECKPOINT_ALREADY_IN_PROGRESS),
+                ex.Message);
 
-            var lastsave = 0;
+            // Wait (bounded) for the in-flight save to complete by observing LASTSAVE advance past baseline.
+            var deadline = DateTime.UtcNow.AddSeconds(30);
+            long lastsave;
             do
             {
                 Thread.Sleep(10);
-                lastsave = (int)db1.Execute("LASTSAVE");
+                lastsave = (long)db0.Execute("LASTSAVE");
             }
-            while (lastsave == 0);
+            while (lastsave <= lastsaveBaseline && DateTime.UtcNow < deadline);
+
+            ClassicAssert.Greater(lastsave, lastsaveBaseline, "LASTSAVE did not advance within timeout");
         }
 
         [Test]


### PR DESCRIPTION
The general BGSAVE path returned 'Background saving started' before its async helper had pause-locked any per-DB checkpoint locks. A subsequent BGSAVE <dbId> could win the race against TryPauseCheckpoints(dbId) and succeed, instead of failing with 'ERR checkpoint already in progress'.

This caused MultiDatabaseTests.MultiDatabaseSaveInProgressTest to flake in CI. SingleDatabaseManager.TakeCheckpointAsync already does the right thing by pausing synchronously before returning, which is why the single-DB equivalent test (SeSaveInProgressTest) does not flake.

Fix:
- Restructure MultiDatabaseManager.TakeCheckpointAsync(bool, ILogger, CancellationToken) so the synchronous portion now acquires databasesContentLock, multiDbCheckpointingLock (when multi-db), AND calls TryPauseCheckpoints(dbId) for every active DB before returning. Compactly store only successfully paused DB IDs in dbIdsToCheckpoint. Roll back any partially-acquired state on exception in the sync phase.
- Add alreadyPaused parameter to TakeDatabasesCheckpointAsync so the new caller can skip the inline TryPauseCheckpoints. Add a catch fallback that resumes pre-paused DB IDs not yet handed off to per-DB helpers, preventing stranded locks.
- Existing AOF-size-driven caller (TaskCheckpointBasedOnAofSizeLimitAsync) is unaffected; it uses the default alreadyPaused=false.

Regression test: MultiDatabaseGeneralSaveBlocksGeneralSaveTest verifies that a second general BGSAVE while one is in flight (multi-db) reliably returns 'ERR checkpoint already in progress' (multiDbCheckpointingLock is now held synchronously).