### PR TITLE
Use Stopwatch for INFO uptime and master_sync_last_io_seconds_ago

### DIFF
--- a/libs/cluster/Server/Replication/ReplicationManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationManager.cs
@@ -32,11 +32,11 @@ namespace Garnet.cluster
         readonly ILogger logger;
         bool _disposed;
 
-        private long primary_sync_last_time;
+        private long primary_sync_last_timestamp;
 
-        internal long LastPrimarySyncSeconds => IsRecovering ? (DateTime.UtcNow.Ticks - primary_sync_last_time) / TimeSpan.TicksPerSecond : 0;
+        internal long LastPrimarySyncSeconds => IsRecovering ? (long)Stopwatch.GetElapsedTime(primary_sync_last_timestamp).TotalSeconds : 0;
 
-        internal void UpdateLastPrimarySyncTime() => this.primary_sync_last_time = DateTime.UtcNow.Ticks;
+        internal void UpdateLastPrimarySyncTime() => this.primary_sync_last_timestamp = Stopwatch.GetTimestamp();
 
         private SingleWriterMultiReaderLock recoverLock;
         private SingleWriterMultiReaderLock recoveryStateChangeLock;

--- a/libs/server/Metrics/Info/GarnetInfoMetrics.cs
+++ b/libs/server/Metrics/Info/GarnetInfoMetrics.cs
@@ -53,7 +53,7 @@ namespace Garnet.server
 
         private void PopulateServerInfo(StoreWrapper storeWrapper)
         {
-            var uptime = TimeSpan.FromTicks(DateTimeOffset.UtcNow.Ticks - storeWrapper.startupTime);
+            var uptime = Stopwatch.GetElapsedTime(storeWrapper.startupTimestamp);
             serverInfo =
             [
                 new("garnet_version", storeWrapper.version),

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -33,7 +33,7 @@ namespace Garnet.server
         internal readonly string version;
         internal readonly string redisProtocolVersion;
         readonly IGarnetServer[] servers;
-        internal readonly long startupTime;
+        internal readonly long startupTimestamp;
 
         /// <summary>
         /// Default database (DB 0)
@@ -190,7 +190,7 @@ namespace Garnet.server
             this.version = version;
             this.redisProtocolVersion = redisProtocolVersion;
             this.servers = servers;
-            this.startupTime = DateTimeOffset.UtcNow.Ticks;
+            this.startupTimestamp = Stopwatch.GetTimestamp();
             this.serverOptions = serverOptions;
             this.subscribeBroker = subscribeBroker;
             this.customCommandManager = customCommandManager;

--- a/test/Garnet.test/RespInfoTests.cs
+++ b/test/Garnet.test/RespInfoTests.cs
@@ -76,6 +76,24 @@ namespace Garnet.test
         }
 
         [Test]
+        public void UptimeIncreasesAcrossInfoCalls()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            static long ParseUptime(string info) =>
+                long.Parse(info.Split("\r\n").First(x => x.StartsWith("uptime_in_seconds:")).Split(':')[1]);
+
+            var first = ParseUptime(db.Execute("INFO", "SERVER").ToString());
+            ClassicAssert.GreaterOrEqual(first, 0);
+
+            Thread.Sleep(TimeSpan.FromSeconds(1.1));
+
+            var second = ParseUptime(db.Execute("INFO", "SERVER").ToString());
+            ClassicAssert.Greater(second, first, "uptime_in_seconds should increase between INFO calls");
+        }
+
+        [Test]
         [TestCase("ALL")]
         [TestCase("DEFAULT")]
         [TestCase("EVERYTHING")]


### PR DESCRIPTION
`uptime_in_seconds`, `uptime_in_days`, and `master_sync_last_io_seconds_ago` in `INFO` are computed from `DateTime.UtcNow.Ticks` deltas. A wall-clock adjustment (NTP step, manual time change) shifts the reported duration — backward steps make the values overshoot, forward steps make them go small or negative. Sentinel and similar tooling read `master_sync_last_io_seconds_ago` to decide failover candidacy.

These fields are defined by Redis as durations ("seconds since X"), not timestamps, so monotonic time is what the spec actually means. Switch to `Stopwatch.GetTimestamp()` / `Stopwatch.GetElapsedTime` for the elapsed-time math. `INFO server` and `INFO replication` continue to expose the same field names and semantics, just sourced from a monotonic clock.

Same NTP-resilience reasoning was applied recently in [dotnet/runtime#127303](https://github.com/dotnet/runtime/pull/127303) for `EventCounter`'s polling timer.

## Changes

- `StoreWrapper.startupTime` → `startupTimestamp` (Stopwatch tick anchor).
- `GarnetInfoMetrics.PopulateServerInfo` reads uptime via `Stopwatch.GetElapsedTime(startupTimestamp)`.
- `ReplicationManager.primary_sync_last_time` → `primary_sync_last_timestamp`; `LastPrimarySyncSeconds` and `UpdateLastPrimarySyncTime` use `Stopwatch`.
- New test `RespInfoTests.UptimeIncreasesAcrossInfoCalls` asserts uptime monotonically increases between two `INFO` calls.

## Test plan

- [x] New test passes on `net8.0` and `net10.0`.
- [x] `Garnet.server` and `Garnet.cluster` build clean.
- [ ] CI