### PR TITLE
Pause VectorManager cleanup before cluster/other resets of log

### DIFF
--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaDiskbasedSync.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaDiskbasedSync.cs
@@ -132,8 +132,31 @@ namespace Garnet.cluster
                     // Reset replication offset
                     replicationOffset.SetValue(0);
 
-                    // Reset the database in preparation for connecting to primary
-                    storeWrapper.Reset();
+                    // Reset the database in preparation for connecting to primary.
+                    // Pause VectorManager's background cleanup task first — Reset's
+                    // post-Phase-2 Initialize() rewinds HeadAddress / BeginAddress /
+                    // TailPageOffset and reallocates pages. Tsavorite's iterator path is
+                    // safe (Initializing flag), but the cleanup task's POST-iterate RMWs
+                    // on metadata records (ClearDeleteInProgress / UpdateContextMetadata)
+                    // are NOT — they can dereference freed pagePointers and AVE. The pause
+                    // serializes the entire cleanup-iteration (iterate + RMWs) with Reset
+                    // by holding cleanupGate, restoring Reset's "store is quiesced" contract.
+                    //
+                    // Pass linkedCts.Token so a slow cleanup-iteration over a large keyspace
+                    // doesn't block re-attach indefinitely if the broader replication is
+                    // cancelled (ctsRepManager / resetHandler). If PauseCleanupAsync throws
+                    // OCE, the try block isn't entered and ResumeCleanup is correctly skipped.
+                    var vectorManager = storeWrapper.DefaultDatabase.VectorManager;
+                    if (vectorManager != null)
+                        await vectorManager.PauseCleanupAsync(linkedCts.Token).ConfigureAwait(false);
+                    try
+                    {
+                        storeWrapper.Reset();
+                    }
+                    finally
+                    {
+                        vectorManager?.ResumeCleanup();
+                    }
 
                     // Suspend background tasks that may interfere with AOF
                     await storeWrapper.SuspendPrimaryOnlyTasksAsync().ConfigureAwait(false);

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaDisklessSync.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaDisklessSync.cs
@@ -79,6 +79,7 @@ namespace Garnet.cluster
                 var disklessSync = clusterProvider.serverOptions.ReplicaDisklessSync;
                 GarnetClientSession gcs = null;
                 resetHandler ??= new CancellationTokenSource();
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ctsRepManager.Token, resetHandler.Token);
                 try
                 {
                     if (!clusterProvider.serverOptions.EnableFastCommit && storeWrapper.appendOnlyFile != null)
@@ -95,9 +96,34 @@ namespace Garnet.cluster
 
                     // Reset the database in preparation for connecting to primary
                     // only if we expect to have disk checkpoint to recover from,
-                    // otherwise the replica will receive a reset message from primary if needed
+                    // otherwise the replica will receive a reset message from primary if needed.
+                    // Pause VectorManager's background cleanup task first — Reset's
+                    // post-Phase-2 Initialize() rewinds HeadAddress / BeginAddress /
+                    // TailPageOffset and reallocates pages. Tsavorite's iterator path is
+                    // safe (Initializing flag), but the cleanup task's POST-iterate RMWs
+                    // on metadata records (ClearDeleteInProgress / UpdateContextMetadata)
+                    // are NOT — they can dereference freed pagePointers and AVE. The pause
+                    // serializes the entire cleanup-iteration (iterate + RMWs) with Reset
+                    // by holding cleanupGate, restoring Reset's "store is quiesced" contract.
+                    //
+                    // Pass linkedCts.Token so a slow cleanup-iteration over a large keyspace
+                    // doesn't block re-attach indefinitely if the broader replication is
+                    // cancelled (ctsRepManager / resetHandler). If PauseCleanupAsync throws
+                    // OCE, the try block isn't entered and ResumeCleanup is correctly skipped.
                     if (!disklessSync)
-                        storeWrapper.Reset();
+                    {
+                        var vectorManager = storeWrapper.DefaultDatabase.VectorManager;
+                        if (vectorManager != null)
+                            await vectorManager.PauseCleanupAsync(linkedCts.Token).ConfigureAwait(false);
+                        try
+                        {
+                            storeWrapper.Reset();
+                        }
+                        finally
+                        {
+                            vectorManager?.ResumeCleanup();
+                        }
+                    }
 
                     // Suspend background tasks that may interfere with AOF
                     await storeWrapper.SuspendPrimaryOnlyTasksAsync().ConfigureAwait(false);
@@ -125,7 +151,6 @@ namespace Garnet.cluster
                         return errorMsg;
                     }
 
-                    using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ctsRepManager.Token, resetHandler.Token);
                     gcs = new(
                         new IPEndPoint(IPAddress.Parse(address), port),
                         networkBufferSettings: clusterProvider.replicationManager.GetIRSNetworkBufferSettings,

--- a/libs/server/Resp/Vector/VectorManager.Cleanup.cs
+++ b/libs/server/Resp/Vector/VectorManager.Cleanup.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Garnet.common;
@@ -82,12 +83,37 @@ namespace Garnet.server
         private readonly Task cleanupTask;
         private readonly Func<IMessageConsumer> getCleanupSession;
 
+        // Pause / resume coordination for the cleanup task vs concurrent Reset.
+        //
+        // Cluster re-attach paths (ReplicaDisklessSync / ReplicaDiskbasedSync) call
+        // storeWrapper.Reset() which tears down and rebuilds the main-store allocator.
+        // The cleanup task's iterator path is safe (Tsavorite's Initializing flag causes
+        // it to terminate cleanly). However the cleanup task ALSO does post-iterate RMWs
+        // on metadata records (ClearDeleteInProgress / UpdateContextMetadata) — those
+        // RMWs are NOT Reset-resilient and can dereference freed pagePointers and AVE.
+        //
+        // The pause/resume API serializes the entire cleanup-iteration (iterate + RMWs)
+        // with Reset by holding cleanupGate around the whole loop body, restoring Reset's
+        // documented "store is quiesced" contract.
+        //
+        // SemaphoreSlim used as an async-friendly mutex (initialCount=1, maxCount=1):
+        // the cleanup loop takes it around each iteration; PauseCleanupAsync takes it
+        // and holds until ResumeCleanup releases. Drops still enqueue items into
+        // cleanupTaskChannel during a pause — the cleanup task wakes, awaits the gate
+        // until the pause is lifted, then processes the backlog.
+        //
+        // Contract: PauseCleanupAsync callers MUST balance every successful invocation
+        // with ResumeCleanup, ideally in a finally block. A held pause at Dispose time
+        // would deadlock shutdown.
+        private readonly SemaphoreSlim cleanupGate = new(initialCount: 1, maxCount: 1);
+
         private async Task RunCleanupTaskAsync()
         {
             // Each drop index will queue a null object here
             // We'll handle multiple at once if possible, but using a channel simplifies cancellation and dispose
             await foreach (var ignored in cleanupTaskChannel.Reader.ReadAllAsync())
             {
+                await cleanupGate.WaitAsync().ConfigureAwait(false);
                 try
                 {
                     HashSet<ulong> needCleanup;
@@ -157,8 +183,39 @@ namespace Garnet.server
                 {
                     logger?.LogError(e, "Failure during background cleanup of deleted vector sets, implies storage leak");
                 }
+                finally
+                {
+                    _ = cleanupGate.Release();
+                }
             }
         }
+
+        /// <summary>
+        /// Block any new cleanup-task iteration from starting and wait for the current one
+        /// (if any) to finish. Callers (e.g., cluster re-attach paths) MUST balance every
+        /// invocation with <see cref="ResumeCleanup"/>, ideally in a finally block.
+        ///
+        /// While paused, drops still enqueue items into <see cref="cleanupTaskChannel"/>;
+        /// the cleanup task wakes, awaits the gate until the pause is lifted, then
+        /// processes the backlog — so no work is lost.
+        ///
+        /// Use this before invoking <see cref="StoreWrapper.Reset"/> on a running store, to
+        /// avoid the cleanup-task scan iterator racing with the allocator teardown.
+        ///
+        /// The optional <paramref name="cancellationToken"/> aborts the wait if the cleanup
+        /// task is mid-iteration over a large keyspace and the caller (e.g., cluster
+        /// re-attach) needs to give up. If cancellation throws <see cref="OperationCanceledException"/>,
+        /// the gate was NOT acquired and the caller MUST NOT call <see cref="ResumeCleanup"/>.
+        /// </summary>
+        public Task PauseCleanupAsync(CancellationToken cancellationToken = default)
+            => cleanupGate.WaitAsync(cancellationToken);
+
+        /// <summary>
+        /// Lift the pause acquired by <see cref="PauseCleanupAsync"/>. Queued cleanup
+        /// events resume processing immediately. Must be called exactly once per
+        /// successful PauseCleanupAsync — typically from a finally block.
+        /// </summary>
+        public void ResumeCleanup() => cleanupGate.Release();
 
         /// <summary>
         /// Called in response to <see cref="TryMarkDeleteInProgress"/> or <see cref="ClearDeleteInProgress"/> to update metadata in Tsavorite.

--- a/libs/server/Resp/Vector/VectorManager.cs
+++ b/libs/server/Resp/Vector/VectorManager.cs
@@ -281,10 +281,15 @@ namespace Garnet.server
 
             replicationBlockEvent.Dispose();
 
-            // Wait for any in progress cleanup to finish
+            // Wait for any in progress cleanup to finish. PauseCleanupAsync callers MUST
+            // have called ResumeCleanup before reaching here, otherwise the cleanup task
+            // is permanently blocked on cleanupGate.WaitAsync() and Dispose will hang.
             cleanupTaskChannel.Writer.Complete();
             AsyncUtils.BlockingWait(cleanupTaskChannel.Reader.Completion);
             AsyncUtils.BlockingWait(cleanupTask);
+
+            // Cleanup task has fully drained, so nothing else can take this gate.
+            cleanupGate.Dispose();
         }
 
         private static void CompletePending(ref Status status, ref VectorOutput output, ref VectorBasicContext ctx)

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
@@ -142,6 +142,23 @@ namespace Tsavorite.core
         /// </summary>
         long OngoingCloseUntilAddress;
 
+        /// <summary>
+        /// True while <see cref="Reset"/> is rebuilding allocator state (page free + per-allocator
+        /// <see cref="Initialize"/>). Operations that want to be resilient to a concurrent Reset
+        /// can observe this flag (after acquiring epoch protection) and bail out — Reset is a
+        /// wholesale wipe, so any pre-Reset work or cached state is no longer meaningful. Scan
+        /// iterators do exactly this: they terminate the iteration (return false from
+        /// <c>GetNext</c>) when this flag is set.
+        ///
+        /// IMPORTANT: this flag is opt-in defense. Tsavorite's hot-path RMW / Read / Upsert /
+        /// Delete do NOT consult it (cost on the hot path), so they remain unsafe to call
+        /// concurrently with Reset and can dereference freed pages mid-Initialize. Callers of
+        /// Reset must still quiesce all non-iterator operations on the store (per Reset's
+        /// docstring contract). For Garnet, <c>VectorManager.PauseCleanupAsync</c> serializes
+        /// the cleanup task — including its post-iterate RMWs — with Reset.
+        /// </summary>
+        internal volatile bool Initializing;
+
         /// <inheritdoc/>
         public override string ToString() => BaseToString();
 
@@ -244,8 +261,23 @@ namespace Tsavorite.core
         protected abstract void WriteAsync<TContext>(long flushPage, DeviceIOCompletionCallback callback, PageAsyncFlushResult<TContext> asyncResult);
 
         /// <summary>
-        /// Reset the hybrid log. Safe against concurrent iterators / readers / writers via a
-        /// two-phase epoch cascade that mirrors the normal flush + close paths:
+        /// Reset the hybrid log to empty.
+        ///
+        /// Concurrent-safety contract:
+        ///   * SCAN ITERATORS are safe end-to-end. The two-phase epoch cascade below
+        ///     (PR #1765) protects the page-free section, and the <see cref="Initializing"/>
+        ///     flag (set across this whole method including the per-allocator
+        ///     <see cref="Initialize"/> rewind) lets iterators terminate cleanly during the
+        ///     post-Phase-2 non-monotonic Initialize that would otherwise expose freed
+        ///     pagePointers.
+        ///   * RMW / Read / Upsert / Delete are NOT safe — Tsavorite's hot paths do not
+        ///     consult <see cref="Initializing"/>. They can race with Initialize and
+        ///     dereference freed pages. Callers MUST quiesce all non-iterator operations
+        ///     on the store before invoking Reset (per the original docstring contract).
+        ///     For Garnet, <c>VectorManager.PauseCleanupAsync</c> serializes the cleanup
+        ///     task — including its post-iterate RMWs — with Reset.
+        ///
+        /// Phase breakdown (executed by <see cref="ResetCore"/>):
         ///
         ///   Phase 1: publish new ReadOnlyAddress synchronously, then under
         ///            BumpCurrentEpoch — i.e. after writers caching the OLD ReadOnlyAddress
@@ -267,9 +299,39 @@ namespace Tsavorite.core
         ///            check routes it through LoadPageIfNeeded's disk-frame branch (frame is
         ///            iterator-owned, disk segment is intact). The invariant
         ///            BeginAddress &lt;= HeadAddress holds throughout.
+        ///
+        /// Then per-allocator <see cref="Initialize"/> runs (re-allocates pages 0/1, rewinds
+        /// addresses to FirstValidAddress). The whole sequence is wrapped in
+        /// <c>Initializing = true / false</c> so iterators that opt in to checking the flag
+        /// terminate during the rewind window.
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public virtual void Reset()
+        public void Reset()
+        {
+            // Gate Initializing-aware operations (e.g., scan iterators) for the entire
+            // reset+initialize sequence. Cleared in finally so a throw cannot leave them
+            // permanently terminating their next call.
+            Initializing = true;
+            try
+            {
+                ResetCore();
+
+                // Per-allocator Initialize re-allocates pages 0/1, resets all addresses to
+                // FirstValidAddress, and resets TailPageOffset. This non-monotonically rewinds
+                // multiple fields and is unsafe for concurrent operations — that's exactly
+                // what the Initializing flag guards iterator-aware callers against.
+                Initialize();
+            }
+            finally
+            {
+                // Volatile.Write semantics (the field is volatile) ensure all our state
+                // mutations are visible BEFORE callers observe Initializing == false.
+                Initializing = false;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ResetCore()
         {
             var newBeginAddress = GetTailAddress();
 

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/ObjectAllocatorImpl.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/ObjectAllocatorImpl.cs
@@ -114,12 +114,6 @@ namespace Tsavorite.core
 
         internal int OverflowPageCount => freePagePool.Count;
 
-        public override void Reset()
-        {
-            base.Reset();
-            Initialize();
-        }
-
         /// <inheritdoc />
         protected override void FreeAllAllocatedPages()
         {

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/ObjectScanIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/ObjectScanIterator.cs
@@ -99,12 +99,33 @@ namespace Tsavorite.core
             }
             diskLogRecord = default;
             currentAddress = nextAddress;
+
+            // Acquire the epoch BEFORE sampling Initializing / TailAddress / HeadAddress /
+            // pagePointers, so that any allocator state we read is consistent with the epoch
+            // we hold.
+            epoch?.Resume();
+
+            // If a concurrent Reset is rebuilding the allocator, terminate the iteration
+            // cleanly — Reset is a wholesale wipe, the records we were iterating are gone,
+            // and the address range we were stepping through no longer maps to live data.
+            // Also avoids dereferencing the non-monotonic mid-Initialize state (HeadAddress
+            // already rewound to FirstValidAddress while TailPageOffset still holds the
+            // pre-Reset tail and pagePointers[i] are mostly 0).
+            if (hlogBase.Initializing)
+            {
+                epoch?.Suspend();
+                stopAddress = 0;
+                return false;
+            }
+
             stopAddress = endAddress < hlogBase.GetTailAddress() ? endAddress : hlogBase.GetTailAddress();
             if (currentAddress >= stopAddress)
+            {
+                epoch?.Suspend();
                 return false;
+            }
 
-            // Success; acquire the epoch. Caller will suspend the epoch as needed.
-            epoch?.Resume();
+            // Success; caller will suspend the epoch as needed.
             return true;
         }
 

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/SpanByteAllocatorImpl.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/SpanByteAllocatorImpl.cs
@@ -23,12 +23,6 @@ namespace Tsavorite.core
 
         internal int OverflowPageCount => freePagePool.Count;
 
-        public override void Reset()
-        {
-            base.Reset();
-            Initialize();
-        }
-
         /// <inheritdoc />
         protected override void FreeAllAllocatedPages()
         {

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/SpanByteScanIterator.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/SpanByteScanIterator.cs
@@ -98,12 +98,33 @@ namespace Tsavorite.core
             }
             diskLogRecord = default;
             currentAddress = nextAddress;
+
+            // Acquire the epoch BEFORE sampling Initializing / TailAddress / HeadAddress /
+            // pagePointers, so that any allocator state we read is consistent with the epoch
+            // we hold.
+            epoch?.Resume();
+
+            // If a concurrent Reset is rebuilding the allocator, terminate the iteration
+            // cleanly — Reset is a wholesale wipe, the records we were iterating are gone,
+            // and the address range we were stepping through no longer maps to live data.
+            // Also avoids dereferencing the non-monotonic mid-Initialize state (HeadAddress
+            // already rewound to FirstValidAddress while TailPageOffset still holds the
+            // pre-Reset tail and pagePointers[i] are mostly 0).
+            if (hlogBase.Initializing)
+            {
+                epoch?.Suspend();
+                stopAddress = 0;
+                return false;
+            }
+
             stopAddress = endAddress < hlogBase.GetTailAddress() ? endAddress : hlogBase.GetTailAddress();
             if (currentAddress >= stopAddress)
+            {
+                epoch?.Suspend();
                 return false;
+            }
 
-            // Success; acquire the epoch. Caller will suspend the epoch as needed.
-            epoch?.Resume();
+            // Success; caller will suspend the epoch as needed.
             return true;
         }
 

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/TsavoriteLogAllocatorImpl.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/TsavoriteLogAllocatorImpl.cs
@@ -23,13 +23,6 @@ namespace Tsavorite.core
             freePagePool = new OverflowPool<PageUnit<Empty>>(4, p => { });
         }
 
-        /// <inheritdoc/>
-        public override void Reset()
-        {
-            base.Reset();
-            Initialize();
-        }
-
         /// <inheritdoc />
         protected override void FreeAllAllocatedPages()
         {

--- a/test/Garnet.test/VectorCleanupVsResetRaceTests.cs
+++ b/test/Garnet.test/VectorCleanupVsResetRaceTests.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Allure.NUnit;
+using Garnet.server;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using StackExchange.Redis;
@@ -16,12 +17,17 @@ namespace Garnet.test
     /// Regression test for a race between <c>VectorManager</c>'s background
     /// cleanup-task scan iterator (over the main string keyspace) and a
     /// concurrent <c>storeWrapper.Reset()</c> (e.g. triggered by a replica
-    /// re-attach). The race manifested as an AVE in
+    /// re-attach). The race originally manifested as an AVE in
     /// <c>SpanByteScanIterator.GetNext</c> dereferencing a freed page.
     ///
-    /// The test reproduces the path with no cluster overhead: add a vector
-    /// set on a single Garnet server, drop it (queues a cleanup scan), then
-    /// hammer <c>storeWrapper.Reset()</c> while the scan runs.
+    /// Production paths (cluster re-attach) wrap Reset with
+    /// <c>VectorManager.PauseCleanupAsync</c> / <c>ResumeCleanup</c> to
+    /// serialize the cleanup task (iterator + post-iterate RMWs) against
+    /// allocator teardown — Reset is only safe for concurrent SCAN iteration,
+    /// not for the cleanup task's RMWs on metadata records that follow the
+    /// iteration. This test mirrors that production pattern: add a vector set
+    /// on a single Garnet server, drop it (queues a cleanup scan), then hammer
+    /// <c>Pause + Reset + Resume</c> while the cleanup task runs.
     /// </summary>
     [AllureNUnit]
     [TestFixture]
@@ -44,24 +50,23 @@ namespace Garnet.test
             TestUtils.OnTearDown();
         }
 
-        // Reflection helpers — the storeWrapper field is internal/private on GarnetServer.
-        private static object GetStoreWrapper(global::Garnet.GarnetServer s)
-        {
-            var field = typeof(global::Garnet.GarnetServer).GetField("storeWrapper", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
-            return field?.GetValue(s);
-        }
-
-        private static void CallReset(object storeWrapper)
-        {
-            var method = storeWrapper.GetType().GetMethod("Reset", BindingFlags.Instance | BindingFlags.Public, null, [typeof(int)], null);
-            ClassicAssert.IsNotNull(method, "Reset(int) method not found on storeWrapper via reflection — signature may have changed; update CallReset()");
-            method.Invoke(storeWrapper, [0]);
-        }
+        // The storeWrapper field is private on GarnetServer; everything below it
+        // (DefaultDatabase, VectorManager, Reset(int)) is public so we access them
+        // directly through the StoreWrapper reference returned here.
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "storeWrapper")]
+        private static extern ref StoreWrapper GetStoreWrapper(global::Garnet.GarnetServer server);
 
         /// <summary>
         /// Reproducer: drop a vector set (queues full-keyspace cleanup) and concurrently
-        /// hammer storeWrapper.Reset() until the cleanup task either completes or the
-        /// process AVE's.
+        /// hammer Pause+Reset+Resume — the production pattern used by cluster re-attach
+        /// (ReplicaDisklessSync / ReplicaDiskbasedSync). Without the Pause, Reset's
+        /// post-Phase-2 Initialize() would race with the cleanup task's RMWs on metadata
+        /// records (ClearDeleteInProgress / UpdateContextMetadata) and AVE — Reset is
+        /// only safe for concurrent SCAN iteration, not for arbitrary RMW/Read/Upsert.
+        ///
+        /// Verifies:
+        ///   * Pause+Reset+Resume against an in-flight cleanup-task iteration does not AVE.
+        ///   * cleanupGate correctly serializes cleanup-iteration with Reset.
         /// </summary>
         [Test]
         [Repeat(5)]
@@ -70,8 +75,11 @@ namespace Garnet.test
             const int Vectors = 4_000;
             const string Key = nameof(DropVectorSetWhileResettingStore);
 
-            var storeWrapper = GetStoreWrapper(server);
-            ClassicAssert.IsNotNull(storeWrapper, "Could not access storeWrapper via reflection");
+            ref var storeWrapper = ref GetStoreWrapper(server);
+            ClassicAssert.IsNotNull(storeWrapper, "Could not access storeWrapper via UnsafeAccessor");
+
+            var vectorManager = storeWrapper.DefaultDatabase.VectorManager;
+            ClassicAssert.IsNotNull(vectorManager, "VectorManager not initialised — enableVectorSetPreview must be true");
 
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
@@ -88,32 +96,42 @@ namespace Garnet.test
             }
 
             // Drop the vector set. This calls VectorManager.CleanupDroppedIndex which writes to
-            // the cleanup channel; the background task then runs Iterate over the full keyspace.
+            // the cleanup channel; the background task then runs Iterate over the full keyspace
+            // and a series of RMWs to clear the in-progress-deletes metadata.
             _ = db.KeyDelete(Key);
 
-            // Race window: hammer storeWrapper.Reset() while the cleanup task iterates.
-            // If a Reset can free a page that the iterator subsequently dereferences,
-            // the test host AVEs.
+            // Race window: hammer Pause+Reset+Resume while the cleanup task iterates.
+            // Pause acquires VectorManager's cleanupGate; the cleanup-iteration body holds
+            // that gate from the start of the iterate through the post-iterate RMWs, so
+            // Pause waits for any in-flight iteration to fully finish before Reset proceeds.
             var deadline = DateTime.UtcNow.AddSeconds(5);
             int resets = 0;
             while (DateTime.UtcNow < deadline)
             {
+                vectorManager.PauseCleanupAsync().GetAwaiter().GetResult();
                 try
                 {
-                    CallReset(storeWrapper);
-                    resets++;
+                    try
+                    {
+                        storeWrapper.Reset();
+                        resets++;
+                    }
+                    catch (Exception ex)
+                    {
+                        // Reset itself can throw if the store is in an unexpected state — that's OK
+                        // for our purposes; we care about whether the cleanup iteration AVEs.
+                        TestContext.Progress.WriteLine($"[reset] threw: {ex.GetType().Name}: {ex.Message}");
+                    }
                 }
-                catch (TargetInvocationException tie) when (tie.InnerException is not null)
+                finally
                 {
-                    // Reset itself can throw if the store is in an unexpected state — that's OK
-                    // for our purposes; we care about whether the cleanup iteration AVEs.
-                    TestContext.Progress.WriteLine($"[reset] threw: {tie.InnerException.GetType().Name}: {tie.InnerException.Message}");
+                    vectorManager.ResumeCleanup();
                 }
                 Thread.Sleep(1);
             }
 
             TestContext.Progress.WriteLine($"[DropVectorSetWhileResettingStore] resets={resets}");
-            // If we reach here the cleanup iterator did not AVE the host.
+            // If we reach here the cleanup task did not AVE the host while Reset was hammering.
         }
     }
 }


### PR DESCRIPTION
1. Cover reset with a boolean Initializing check that is epoch-protected, so that concurrent iterators end gracefully.
2. Add ability to pause vector cleanup, used before we reset as a second line of defense