### PR TITLE
Verbatim String Fixes

### DIFF
--- a/libs/common/RespWriteUtils.cs
+++ b/libs/common/RespWriteUtils.cs
@@ -762,6 +762,34 @@ namespace Garnet.common
         }
 
         /// <summary>
+        /// Write verbtatim string header.
+        /// 
+        /// That is ={len}\r\n{ext}:
+        /// </summary>
+        public static bool TryWriteVerbatimStringHeader(ReadOnlySpan<byte> str, ReadOnlySpan<byte> ext, ref byte* curr, byte* end)
+        {
+            Debug.Assert(ext.Length == 3);
+
+            // Verbatim string length includes the type metadata.
+            // So ext (3 bytes) + ':' (1 byte separator) + str
+            var actualLength = 3 + 1 + str.Length;
+            var itemDigits = NumUtils.CountDigits(actualLength);
+
+            var headerLen = 1 + itemDigits + 2 + 3 + 1;
+            if (headerLen > (int)(end - curr))
+                return false;
+
+            *curr++ = (byte)'=';
+            NumUtils.WriteInt32(actualLength, itemDigits, ref curr);
+            WriteNewline(ref curr);
+            ext.CopyTo(new Span<byte>(curr, 3));
+            curr += 3;
+            *curr++ = (byte)':';
+
+            return true;
+        }
+
+        /// <summary>
         /// Write RESP3 true
         /// </summary>
         public static bool TryWriteTrue(ref byte* curr, byte* end)

--- a/libs/server/Metrics/Info/InfoCommand.cs
+++ b/libs/server/Metrics/Info/InfoCommand.cs
@@ -71,12 +71,11 @@ namespace Garnet.server
                 var info = garnetInfo.GetRespInfo(sectionsArr, activeDbId, storeWrapper);
                 if (!string.IsNullOrEmpty(info))
                 {
-                    WriteVerbatimString(Encoding.ASCII.GetBytes(info));
+                    WriteLargeVerbatimString(Encoding.ASCII.GetBytes(info));
                 }
                 else
                 {
-                    while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_EMPTY, ref dcurr, dend))
-                        SendAndReset();
+                    WriteDirect(CmdStrings.RESP_EMPTY);
                 }
             }
             return true;

--- a/libs/server/Metrics/Info/InfoCommand.cs
+++ b/libs/server/Metrics/Info/InfoCommand.cs
@@ -75,7 +75,8 @@ namespace Garnet.server
                 }
                 else
                 {
-                    WriteDirect(CmdStrings.RESP_EMPTY);
+                    while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_EMPTY, ref dcurr, dend))
+                        SendAndReset();
                 }
             }
             return true;

--- a/libs/server/Resp/ClientCommands.cs
+++ b/libs/server/Resp/ClientCommands.cs
@@ -160,7 +160,7 @@ namespace Garnet.server
 
                     resultSb.Append("\n");
                     var result = resultSb.ToString();
-                    WriteVerbatimString(Encoding.ASCII.GetBytes(result));
+                    WriteLargeVerbatimString(Encoding.ASCII.GetBytes(result));
 
                     return true;
                 }
@@ -194,7 +194,7 @@ namespace Garnet.server
 
             resultSb.Append("\n");
             var result = resultSb.ToString();
-            WriteVerbatimString(Encoding.ASCII.GetBytes(result));
+            WriteLargeVerbatimString(Encoding.ASCII.GetBytes(result));
 
             return true;
         }

--- a/libs/server/Resp/RespServerSessionOutput.cs
+++ b/libs/server/Resp/RespServerSessionOutput.cs
@@ -298,7 +298,7 @@ namespace Garnet.server
                 Unsafe.WriteUnaligned(dcurr, MemoryMarshal.Read<ushort>("\r\n"u8));
                 dcurr += 2;
 
-                // Write oute <ext>:
+                // Write out <ext>:
                 WriteDirectLarge(ext);
                 if ((int)(dend - dcurr) < 1)
                 {

--- a/libs/server/Resp/RespServerSessionOutput.cs
+++ b/libs/server/Resp/RespServerSessionOutput.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Garnet.common;
 using Tsavorite.core;
 
@@ -272,17 +274,54 @@ namespace Garnet.server
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteVerbatimString(scoped ReadOnlySpan<byte> item, scoped ReadOnlySpan<byte> ext = default)
+        private void WriteLargeVerbatimString(scoped ReadOnlySpan<byte> item, scoped ReadOnlySpan<byte> ext = default)
         {
             if (respProtocolVersion >= 3)
             {
-                while (!RespWriteUtils.TryWriteVerbatimString(item, ext.IsEmpty ? RespStrings.VerbatimTxt : ext, ref dcurr, dend))
+                ext = ext.IsEmpty ? RespStrings.VerbatimTxt : ext;
+                Debug.Assert(ext.Length == 3);
+
+                var actualLength = 3 + 1 + item.Length;
+                var itemDigits = NumUtils.CountDigits(actualLength);
+
+                var lenSpace = 1 + itemDigits + 2; // =<digits>\r\n
+                if (lenSpace > (int)(dend - dcurr))
+                {
                     SendAndReset();
+                }
+                Debug.Assert((int)(dend - dcurr) >= lenSpace, "Should always have enough space for length after a flush");
+
+                // Write out: =<digits>\r\n
+                *dcurr = (byte)'=';
+                dcurr++;
+                NumUtils.WriteInt32(actualLength, itemDigits, ref dcurr);
+                Unsafe.WriteUnaligned(dcurr, MemoryMarshal.Read<ushort>("\r\n"u8));
+                dcurr += 2;
+
+                // Write oute <ext>:
+                WriteDirectLarge(ext);
+                if ((int)(dend - dcurr) < 1)
+                {
+                    SendAndReset();
+                }
+                WriteDirect(":"u8);
+
+                // Write out item
+                WriteDirectLarge(item);
+
+                if ((int)(dend - dcurr) < 2)
+                {
+                    SendAndReset();
+                }
+
+                // Write out trailing \r\n
+                Unsafe.WriteUnaligned(dcurr, MemoryMarshal.Read<ushort>("\r\n"u8));
+                dcurr += 2;
             }
             else
             {
-                while (!RespWriteUtils.TryWriteBulkString(item, ref dcurr, dend))
-                    SendAndReset();
+                // RESP2 just gets a bulk string
+                WriteDirectLargeRespString(item);
             }
         }
     }

--- a/libs/server/Resp/RespServerSessionOutput.cs
+++ b/libs/server/Resp/RespServerSessionOutput.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Garnet.common;
 using Tsavorite.core;
 
@@ -279,44 +277,15 @@ namespace Garnet.server
             if (respProtocolVersion >= 3)
             {
                 ext = ext.IsEmpty ? RespStrings.VerbatimTxt : ext;
-                Debug.Assert(ext.Length == 3);
 
-                var actualLength = 3 + 1 + item.Length;
-                var itemDigits = NumUtils.CountDigits(actualLength);
-
-                var lenSpace = 1 + itemDigits + 2; // =<digits>\r\n
-                if (lenSpace > (int)(dend - dcurr))
-                {
+                while (!RespWriteUtils.TryWriteVerbatimStringHeader(item, ext, ref dcurr, dend))
                     SendAndReset();
-                }
-                Debug.Assert((int)(dend - dcurr) >= lenSpace, "Should always have enough space for length after a flush");
-
-                // Write out: =<digits>\r\n
-                *dcurr = (byte)'=';
-                dcurr++;
-                NumUtils.WriteInt32(actualLength, itemDigits, ref dcurr);
-                Unsafe.WriteUnaligned(dcurr, MemoryMarshal.Read<ushort>("\r\n"u8));
-                dcurr += 2;
-
-                // Write out <ext>:
-                WriteDirectLarge(ext);
-                if ((int)(dend - dcurr) < 1)
-                {
-                    SendAndReset();
-                }
-                WriteDirect(":"u8);
 
                 // Write out item
                 WriteDirectLarge(item);
 
-                if ((int)(dend - dcurr) < 2)
-                {
+                while (!RespWriteUtils.TryWriteNewLine(ref dcurr, dend))
                     SendAndReset();
-                }
-
-                // Write out trailing \r\n
-                Unsafe.WriteUnaligned(dcurr, MemoryMarshal.Read<ushort>("\r\n"u8));
-                dcurr += 2;
             }
             else
             {

--- a/test/Garnet.test/RespInfoTests.cs
+++ b/test/Garnet.test/RespInfoTests.cs
@@ -34,7 +34,6 @@ namespace Garnet.test
             TestUtils.OnTearDown();
         }
 
-        [Test]
         [TestCase(RedisProtocol.Resp2)]
         [TestCase(RedisProtocol.Resp3)]
         public void ResetStatsTest(RedisProtocol protocol)
@@ -77,7 +76,6 @@ namespace Garnet.test
             ClassicAssert.AreEqual("total_found:1", totalFound, "Expected total_found to be one after sending one successful request");
         }
 
-        [Test]
         [TestCase("ALL", RedisProtocol.Resp2)]
         [TestCase("ALL", RedisProtocol.Resp3)]
         [TestCase("DEFAULT", RedisProtocol.Resp2)]
@@ -119,7 +117,6 @@ namespace Garnet.test
             ClassicAssert.IsFalse(infoResult.Contains("# Commandstats"), $"INFO {option} should not contain Commandstats section");
         }
 
-        [Test]
         [TestCase(RedisProtocol.Resp2)]
         [TestCase(RedisProtocol.Resp3)]
         public void InfoDefaultMatchesNoArgsTest(RedisProtocol protocol)

--- a/test/Garnet.test/RespInfoTests.cs
+++ b/test/Garnet.test/RespInfoTests.cs
@@ -35,10 +35,12 @@ namespace Garnet.test
         }
 
         [Test]
-        public void ResetStatsTest()
+        [TestCase(RedisProtocol.Resp2)]
+        [TestCase(RedisProtocol.Resp3)]
+        public void ResetStatsTest(RedisProtocol protocol)
         {
             TimeSpan metricsUpdateDelay = TimeSpan.FromSeconds(1.1);
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol));
             var db = redis.GetDatabase(0);
 
             var infoResult = db.Execute("INFO").ToString();
@@ -76,12 +78,15 @@ namespace Garnet.test
         }
 
         [Test]
-        [TestCase("ALL")]
-        [TestCase("DEFAULT")]
-        [TestCase("EVERYTHING")]
-        public void InfoSectionOptionsTest(string option)
+        [TestCase("ALL", RedisProtocol.Resp2)]
+        [TestCase("ALL", RedisProtocol.Resp3)]
+        [TestCase("DEFAULT", RedisProtocol.Resp2)]
+        [TestCase("DEFAULT", RedisProtocol.Resp3)]
+        [TestCase("EVERYTHING", RedisProtocol.Resp2)]
+        [TestCase("EVERYTHING", RedisProtocol.Resp3)]
+        public void InfoSectionOptionsTest(string option, RedisProtocol protocol)
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol));
             var db = redis.GetDatabase(0);
 
             var infoResult = db.Execute("INFO", option).ToString();
@@ -115,9 +120,11 @@ namespace Garnet.test
         }
 
         [Test]
-        public void InfoDefaultMatchesNoArgsTest()
+        [TestCase(RedisProtocol.Resp2)]
+        [TestCase(RedisProtocol.Resp3)]
+        public void InfoDefaultMatchesNoArgsTest(RedisProtocol protocol)
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol));
             var db = redis.GetDatabase(0);
 
             var infoNoArgs = db.Execute("INFO").ToString();


### PR DESCRIPTION
Noticed in in `INFO` but generally possible in other cases, we don't always handle response that would fill the send buffer correctly.

This fixes all the verbatim string cases (since those are easy to identify) a more general fix is probably necessary.

TODO:
 - [x] `dev` targeting branch: #1777