### PR TITLE
Add version byte to ClusterConfig and ReplicationHistory serialization

### DIFF
--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -41,6 +41,12 @@ namespace Garnet.cluster
         public const int MAX_HASH_SLOT_VALUE = 16384;
 
         /// <summary>
+        /// Version of the cluster config serialization format.
+        /// Increment when the binary layout of <see cref="ToByteArray"/>/<see cref="FromByteArray"/> changes.
+        /// </summary>
+        public const byte ClusterConfigVersion = 1;
+
+        /// <summary>
         /// 
         /// </summary>
         /// <param name="slot"></param>

--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -47,6 +47,14 @@ namespace Garnet.cluster
         public const byte ClusterConfigVersion = 1;
 
         /// <summary>
+        /// Magic bytes written at the start of serialized ClusterConfig payloads ("GC").
+        /// Used to distinguish versioned payloads from legacy format (which starts with a UInt16 segmentCount).
+        /// The value 0x4743 as little-endian UInt16 is 18243, which exceeds the maximum possible segmentCount (16384),
+        /// so it can never collide with a valid legacy payload.
+        /// </summary>
+        static readonly byte[] ClusterConfigMagic = [(byte)'G', (byte)'C'];
+
+        /// <summary>
         /// 
         /// </summary>
         /// <param name="slot"></param>

--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -57,7 +57,7 @@ namespace Garnet.cluster
         /// <c>segmentCount</c> whose low byte happens to equal 1, leading to silent corruption.
         /// </para>
         /// </summary>
-        static readonly byte[] ClusterConfigMagic = [(byte)'G', (byte)'C'];
+        static ReadOnlySpan<byte> ClusterConfigMagic => "GC"u8;
 
         /// <summary>
         /// 

--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -47,19 +47,6 @@ namespace Garnet.cluster
         public const int ClusterConfigVersion = 1;
 
         /// <summary>
-        /// Magic prefix "GC" (Garnet Config) written at the start of serialized ClusterConfig payloads.
-        /// <para>
-        /// This prefix provides backwards compatibility with the legacy (pre-versioned) serialization format.
-        /// Legacy payloads begin with a UInt16 <c>segmentCount</c> (range 1–16384). Reading the two magic bytes
-        /// as a little-endian UInt16 yields 0x4347 = 18243, which exceeds the maximum valid <c>segmentCount</c>,
-        /// so a versioned payload can never be mistaken for a legacy one and vice versa.
-        /// Without this prefix, a version value would be ambiguous with a legacy
-        /// <c>segmentCount</c> whose low byte happens to equal 1, leading to silent corruption.
-        /// </para>
-        /// </summary>
-        static ReadOnlySpan<byte> ClusterConfigMagic => "GC"u8;
-
-        /// <summary>
         /// 
         /// </summary>
         /// <param name="slot"></param>

--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -44,7 +44,7 @@ namespace Garnet.cluster
         /// Version of the cluster config serialization format.
         /// Increment when the binary layout of <see cref="ToByteArray"/>/<see cref="FromByteArray"/> changes.
         /// </summary>
-        public const byte ClusterConfigVersion = 1;
+        public const int ClusterConfigVersion = 1;
 
         /// <summary>
         /// Magic prefix "GC" (Garnet Config) written at the start of serialized ClusterConfig payloads.
@@ -53,7 +53,7 @@ namespace Garnet.cluster
         /// Legacy payloads begin with a UInt16 <c>segmentCount</c> (range 1–16384). Reading the two magic bytes
         /// as a little-endian UInt16 yields 0x4347 = 18243, which exceeds the maximum valid <c>segmentCount</c>,
         /// so a versioned payload can never be mistaken for a legacy one and vice versa.
-        /// Without this prefix, a single version byte (e.g. 0x01) would be ambiguous with a legacy
+        /// Without this prefix, a version value would be ambiguous with a legacy
         /// <c>segmentCount</c> whose low byte happens to equal 1, leading to silent corruption.
         /// </para>
         /// </summary>

--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -44,7 +44,7 @@ namespace Garnet.cluster
         /// Version of the cluster config serialization format.
         /// Increment when the binary layout of <see cref="ToByteArray"/>/<see cref="FromByteArray"/> changes.
         /// </summary>
-        public const int ClusterConfigVersion = 1;
+        public const byte ClusterConfigVersion = 1;
 
         /// <summary>
         /// 

--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -47,10 +47,15 @@ namespace Garnet.cluster
         public const byte ClusterConfigVersion = 1;
 
         /// <summary>
-        /// Magic bytes written at the start of serialized ClusterConfig payloads ("GC").
-        /// Used to distinguish versioned payloads from legacy format (which starts with a UInt16 segmentCount).
-        /// The value 0x4743 as little-endian UInt16 is 18243, which exceeds the maximum possible segmentCount (16384),
-        /// so it can never collide with a valid legacy payload.
+        /// Magic prefix "GC" (Garnet Config) written at the start of serialized ClusterConfig payloads.
+        /// <para>
+        /// This prefix provides backwards compatibility with the legacy (pre-versioned) serialization format.
+        /// Legacy payloads begin with a UInt16 <c>segmentCount</c> (range 1–16384). Reading the two magic bytes
+        /// as a little-endian UInt16 yields 0x4347 = 18243, which exceeds the maximum valid <c>segmentCount</c>,
+        /// so a versioned payload can never be mistaken for a legacy one and vice versa.
+        /// Without this prefix, a single version byte (e.g. 0x01) would be ambiguous with a legacy
+        /// <c>segmentCount</c> whose low byte happens to equal 1, leading to silent corruption.
+        /// </para>
         /// </summary>
         static readonly byte[] ClusterConfigMagic = [(byte)'G', (byte)'C'];
 

--- a/libs/cluster/Server/ClusterConfigSerializer.cs
+++ b/libs/cluster/Server/ClusterConfigSerializer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Text;
 
 namespace Garnet.cluster
 {
@@ -34,7 +33,7 @@ namespace Garnet.cluster
         public byte[] ToByteArray()
         {
             var ms = new MemoryStream();
-            var writer = new BinaryWriter(ms, Encoding.ASCII);
+            var writer = new BinaryWriter(ms);
 
             // Write magic prefix and serialization format version
             writer.Write(ClusterConfigMagic);

--- a/libs/cluster/Server/ClusterConfigSerializer.cs
+++ b/libs/cluster/Server/ClusterConfigSerializer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.IO;
 using System.Text;
 
@@ -9,12 +10,32 @@ namespace Garnet.cluster
     internal sealed partial class ClusterConfig
     {
         /// <summary>
+        /// Peek the serialization version from a config byte array without full deserialization.
+        /// </summary>
+        /// <param name="data">Serialized cluster config payload.</param>
+        /// <param name="version">The version byte found at the start of the payload.</param>
+        /// <returns>True if the payload is long enough to contain a version byte; false otherwise.</returns>
+        public static bool TryPeekVersion(ReadOnlySpan<byte> data, out byte version)
+        {
+            if (data.Length < 1)
+            {
+                version = 0;
+                return false;
+            }
+            version = data[0];
+            return true;
+        }
+
+        /// <summary>
         /// Serialize config to byte array
         /// </summary>
         public byte[] ToByteArray()
         {
             var ms = new MemoryStream();
             var writer = new BinaryWriter(ms, Encoding.ASCII);
+
+            // Write serialization format version as first byte
+            writer.Write(ClusterConfigVersion);
 
             SerializeSlotMap(ref ms, ref writer);
 
@@ -60,6 +81,7 @@ namespace Garnet.cluster
         private void SerializeSlotMap(ref MemoryStream ms, ref BinaryWriter writer)
         {
             //serialize slotMap
+            var segmentCountPosition = ms.Position;
             ms.Position += 2;
             ushort segmentCount = 0;
             ushort count = 1;
@@ -93,9 +115,9 @@ namespace Garnet.cluster
             writer.Write(workerId);
             writer.Write(state);
 
-            //Write segment count in the beginning of memory stream
+            //Write segment count at the reserved position
             var _position = ms.Position;
-            ms.Position = 0;
+            ms.Position = segmentCountPosition;
             writer.Write(segmentCount);
             ms.Position = _position;
         }
@@ -107,6 +129,11 @@ namespace Garnet.cluster
         {
             var ms = new MemoryStream(other);
             var reader = new BinaryReader(ms);
+
+            // Read and validate serialization format version
+            var version = reader.ReadByte();
+            if (version != ClusterConfigVersion)
+                throw new InvalidDataException($"Incompatible ClusterConfig version: expected {ClusterConfigVersion}, got {version}");
 
             var newSlotMap = DeserializeSlotMap(ref reader);
 

--- a/libs/cluster/Server/ClusterConfigSerializer.cs
+++ b/libs/cluster/Server/ClusterConfigSerializer.cs
@@ -12,16 +12,16 @@ namespace Garnet.cluster
         /// Peek the serialization version from a config byte array without full deserialization.
         /// </summary>
         /// <param name="data">Serialized cluster config payload.</param>
-        /// <param name="version">The version int at the start of the payload.</param>
-        /// <returns>True if the payload is large enough to contain a version int; false otherwise.</returns>
-        public static bool TryPeekVersion(ReadOnlySpan<byte> data, out int version)
+        /// <param name="version">The version byte at the start of the payload.</param>
+        /// <returns>True if the payload is large enough to contain a version byte; false otherwise.</returns>
+        public static bool TryPeekVersion(ReadOnlySpan<byte> data, out byte version)
         {
-            if (data.Length < sizeof(int))
+            if (data.Length < 1)
             {
                 version = 0;
                 return false;
             }
-            version = BitConverter.ToInt32(data);
+            version = data[0];
             return true;
         }
 
@@ -130,9 +130,9 @@ namespace Garnet.cluster
             var reader = new BinaryReader(ms);
 
             // Read and validate serialization format version
-            if (other.Length < sizeof(int))
+            if (other.Length < 1)
                 throw new InvalidDataException("Invalid ClusterConfig payload: too short to contain a version");
-            var version = reader.ReadInt32();
+            var version = reader.ReadByte();
             if (version != ClusterConfigVersion)
                 throw new InvalidDataException($"Incompatible ClusterConfig version: expected {ClusterConfigVersion}, got {version}");
 

--- a/libs/cluster/Server/ClusterConfigSerializer.cs
+++ b/libs/cluster/Server/ClusterConfigSerializer.cs
@@ -36,7 +36,8 @@ namespace Garnet.cluster
             var writer = new BinaryWriter(ms);
 
             // Write magic prefix and serialization format version
-            writer.Write(ClusterConfigMagic);
+            writer.Write(ClusterConfigMagic[0]);
+            writer.Write(ClusterConfigMagic[1]);
             writer.Write(ClusterConfigVersion);
 
             SerializeSlotMap(ref ms, ref writer);

--- a/libs/cluster/Server/ClusterConfigSerializer.cs
+++ b/libs/cluster/Server/ClusterConfigSerializer.cs
@@ -13,16 +13,18 @@ namespace Garnet.cluster
         /// Peek the serialization version from a config byte array without full deserialization.
         /// </summary>
         /// <param name="data">Serialized cluster config payload.</param>
-        /// <param name="version">The version byte found at the start of the payload.</param>
-        /// <returns>True if the payload is long enough to contain a version byte; false otherwise.</returns>
+        /// <param name="version">The version byte found after the magic prefix.</param>
+        /// <returns>True if the payload contains a valid magic prefix and version byte; false otherwise.</returns>
         public static bool TryPeekVersion(ReadOnlySpan<byte> data, out byte version)
         {
-            if (data.Length < 1)
+            if (data.Length < ClusterConfigMagic.Length + 1
+                || data[0] != ClusterConfigMagic[0]
+                || data[1] != ClusterConfigMagic[1])
             {
                 version = 0;
                 return false;
             }
-            version = data[0];
+            version = data[ClusterConfigMagic.Length];
             return true;
         }
 
@@ -34,7 +36,8 @@ namespace Garnet.cluster
             var ms = new MemoryStream();
             var writer = new BinaryWriter(ms, Encoding.ASCII);
 
-            // Write serialization format version as first byte
+            // Write magic prefix and serialization format version
+            writer.Write(ClusterConfigMagic);
             writer.Write(ClusterConfigVersion);
 
             SerializeSlotMap(ref ms, ref writer);
@@ -129,6 +132,12 @@ namespace Garnet.cluster
         {
             var ms = new MemoryStream(other);
             var reader = new BinaryReader(ms);
+
+            // Read and validate magic prefix
+            if (other.Length < ClusterConfigMagic.Length + 1
+                || reader.ReadByte() != ClusterConfigMagic[0]
+                || reader.ReadByte() != ClusterConfigMagic[1])
+                throw new InvalidDataException("Invalid ClusterConfig payload: missing or unrecognized magic prefix");
 
             // Read and validate serialization format version
             var version = reader.ReadByte();

--- a/libs/cluster/Server/ClusterConfigSerializer.cs
+++ b/libs/cluster/Server/ClusterConfigSerializer.cs
@@ -12,18 +12,18 @@ namespace Garnet.cluster
         /// Peek the serialization version from a config byte array without full deserialization.
         /// </summary>
         /// <param name="data">Serialized cluster config payload.</param>
-        /// <param name="version">The version byte found after the magic prefix.</param>
-        /// <returns>True if the payload contains a valid magic prefix and version byte; false otherwise.</returns>
-        public static bool TryPeekVersion(ReadOnlySpan<byte> data, out byte version)
+        /// <param name="version">The version int found after the magic prefix.</param>
+        /// <returns>True if the payload contains a valid magic prefix and version int; false otherwise.</returns>
+        public static bool TryPeekVersion(ReadOnlySpan<byte> data, out int version)
         {
-            if (data.Length < ClusterConfigMagic.Length + 1
+            if (data.Length < ClusterConfigMagic.Length + sizeof(int)
                 || data[0] != ClusterConfigMagic[0]
                 || data[1] != ClusterConfigMagic[1])
             {
                 version = 0;
                 return false;
             }
-            version = data[ClusterConfigMagic.Length];
+            version = BitConverter.ToInt32(data.Slice(ClusterConfigMagic.Length, sizeof(int)));
             return true;
         }
 
@@ -134,13 +134,13 @@ namespace Garnet.cluster
             var reader = new BinaryReader(ms);
 
             // Read and validate magic prefix
-            if (other.Length < ClusterConfigMagic.Length + 1
+            if (other.Length < ClusterConfigMagic.Length + sizeof(int)
                 || reader.ReadByte() != ClusterConfigMagic[0]
                 || reader.ReadByte() != ClusterConfigMagic[1])
                 throw new InvalidDataException("Invalid ClusterConfig payload: missing or unrecognized magic prefix");
 
             // Read and validate serialization format version
-            var version = reader.ReadByte();
+            var version = reader.ReadInt32();
             if (version != ClusterConfigVersion)
                 throw new InvalidDataException($"Incompatible ClusterConfig version: expected {ClusterConfigVersion}, got {version}");
 

--- a/libs/cluster/Server/ClusterConfigSerializer.cs
+++ b/libs/cluster/Server/ClusterConfigSerializer.cs
@@ -12,18 +12,16 @@ namespace Garnet.cluster
         /// Peek the serialization version from a config byte array without full deserialization.
         /// </summary>
         /// <param name="data">Serialized cluster config payload.</param>
-        /// <param name="version">The version int found after the magic prefix.</param>
-        /// <returns>True if the payload contains a valid magic prefix and version int; false otherwise.</returns>
+        /// <param name="version">The version int at the start of the payload.</param>
+        /// <returns>True if the payload is large enough to contain a version int; false otherwise.</returns>
         public static bool TryPeekVersion(ReadOnlySpan<byte> data, out int version)
         {
-            if (data.Length < ClusterConfigMagic.Length + sizeof(int)
-                || data[0] != ClusterConfigMagic[0]
-                || data[1] != ClusterConfigMagic[1])
+            if (data.Length < sizeof(int))
             {
                 version = 0;
                 return false;
             }
-            version = BitConverter.ToInt32(data.Slice(ClusterConfigMagic.Length, sizeof(int)));
+            version = BitConverter.ToInt32(data);
             return true;
         }
 
@@ -35,9 +33,7 @@ namespace Garnet.cluster
             var ms = new MemoryStream();
             var writer = new BinaryWriter(ms);
 
-            // Write magic prefix and serialization format version
-            writer.Write(ClusterConfigMagic[0]);
-            writer.Write(ClusterConfigMagic[1]);
+            // Write serialization format version
             writer.Write(ClusterConfigVersion);
 
             SerializeSlotMap(ref ms, ref writer);
@@ -133,13 +129,9 @@ namespace Garnet.cluster
             var ms = new MemoryStream(other);
             var reader = new BinaryReader(ms);
 
-            // Read and validate magic prefix
-            if (other.Length < ClusterConfigMagic.Length + sizeof(int)
-                || reader.ReadByte() != ClusterConfigMagic[0]
-                || reader.ReadByte() != ClusterConfigMagic[1])
-                throw new InvalidDataException("Invalid ClusterConfig payload: missing or unrecognized magic prefix");
-
             // Read and validate serialization format version
+            if (other.Length < sizeof(int))
+                throw new InvalidDataException("Invalid ClusterConfig payload: too short to contain a version");
             var version = reader.ReadInt32();
             if (version != ClusterConfigVersion)
                 throw new InvalidDataException($"Incompatible ClusterConfig version: expected {ClusterConfigVersion}, got {version}");

--- a/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
+++ b/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
@@ -228,7 +228,7 @@ namespace Garnet.cluster
 
                             // Check if gossip is from a node that is known and trusted before merging
                             if (current.IsKnown(other.LocalNodeId))
-                                _ = clusterProvider.clusterManager.TryMerge(ClusterConfig.FromByteArray(returnedConfigArray));
+                                _ = clusterProvider.clusterManager.TryMerge(other);
                             else
                                 logger?.LogWarning("Received gossip from unknown node: {node-id}", other.LocalNodeId);
                         }

--- a/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
+++ b/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
@@ -216,13 +216,22 @@ namespace Garnet.cluster
                     {
                         clusterProvider.clusterManager.gossipStats.UpdateGossipBytesRecv(resp.Length);
                         var returnedConfigArray = resp.Span.ToArray();
-                        var other = ClusterConfig.FromByteArray(returnedConfigArray);
 
-                        // Check if gossip is from a node that is known and trusted before merging
-                        if (current.IsKnown(other.LocalNodeId))
-                            _ = clusterProvider.clusterManager.TryMerge(ClusterConfig.FromByteArray(returnedConfigArray));
+                        // Validate config version before full deserialization
+                        if (!ClusterConfig.TryPeekVersion(returnedConfigArray, out var version) || version != ClusterConfig.ClusterConfigVersion)
+                        {
+                            logger?.LogWarning("Received failover gossip response with incompatible config version: {version}", version);
+                        }
                         else
-                            logger?.LogWarning("Received gossip from unknown node: {node-id}", other.LocalNodeId);
+                        {
+                            var other = ClusterConfig.FromByteArray(returnedConfigArray);
+
+                            // Check if gossip is from a node that is known and trusted before merging
+                            if (current.IsKnown(other.LocalNodeId))
+                                _ = clusterProvider.clusterManager.TryMerge(ClusterConfig.FromByteArray(returnedConfigArray));
+                            else
+                                logger?.LogWarning("Received gossip from unknown node: {node-id}", other.LocalNodeId);
+                        }
                     }
                 }
                 catch (Exception ex)

--- a/libs/cluster/Server/Gossip/GarnetServerNode.cs
+++ b/libs/cluster/Server/Gossip/GarnetServerNode.cs
@@ -201,7 +201,7 @@ namespace Garnet.cluster
                     var current = clusterProvider.clusterManager.CurrentConfig;
                     // Check if gossip is from a node that is known and trusted before merging
                     if (current.IsKnown(other.LocalNodeId))
-                        clusterProvider.clusterManager.TryMerge(ClusterConfig.FromByteArray(returnedConfigArray));
+                        clusterProvider.clusterManager.TryMerge(other);
                     else
                         logger?.LogWarning("Received gossip from unknown node: {node-id}", other.LocalNodeId);
                 }

--- a/libs/cluster/Server/Gossip/GarnetServerNode.cs
+++ b/libs/cluster/Server/Gossip/GarnetServerNode.cs
@@ -189,6 +189,14 @@ namespace Garnet.cluster
                 {
                     clusterProvider.clusterManager.gossipStats.UpdateGossipBytesRecv(resp.Length);
                     var returnedConfigArray = resp.Span.ToArray();
+
+                    // Validate config version before full deserialization
+                    if (!ClusterConfig.TryPeekVersion(returnedConfigArray, out var version) || version != ClusterConfig.ClusterConfigVersion)
+                    {
+                        logger?.LogWarning("Received gossip response with incompatible config version: {version}", version);
+                        return;
+                    }
+
                     var other = ClusterConfig.FromByteArray(returnedConfigArray);
                     var current = clusterProvider.clusterManager.CurrentConfig;
                     // Check if gossip is from a node that is known and trusted before merging

--- a/libs/cluster/Server/Gossip/Gossip.cs
+++ b/libs/cluster/Server/Gossip/Gossip.cs
@@ -186,21 +186,31 @@ namespace Garnet.cluster
                 resp = await gsn.TryMeetAsync(conf.ToByteArray()).ConfigureAwait(false);
                 if (resp.Length > 0)
                 {
-                    var other = ClusterConfig.FromByteArray(resp.Span.ToArray());
-                    nodeId = other.LocalNodeId;
-                    gsn.NodeId = nodeId;
+                    var respArray = resp.Span.ToArray();
 
-                    logger?.LogInformation("MEET {nodeId} {address} {port}", nodeId, address, port);
-                    // Merge without a check because node is trusted as meet was issued by admin
-                    _ = TryMerge(other, acquireLock);
+                    // Validate config version before full deserialization
+                    if (!ClusterConfig.TryPeekVersion(respArray, out var version) || version != ClusterConfig.ClusterConfigVersion)
+                    {
+                        logger?.LogWarning("MEET response has incompatible config version: {version}", version);
+                    }
+                    else
+                    {
+                        var other = ClusterConfig.FromByteArray(respArray);
+                        nodeId = other.LocalNodeId;
+                        gsn.NodeId = nodeId;
 
-                    gossipStats.UpdateMeetRequestsSucceed();
+                        logger?.LogInformation("MEET {nodeId} {address} {port}", nodeId, address, port);
+                        // Merge without a check because node is trusted as meet was issued by admin
+                        _ = TryMerge(other, acquireLock);
 
-                    // If failed to add newly created connection dispose of it to reclaim resources
-                    // Dispose only connections that this meet task has created to avoid conflicts with existing connections from gossip main thread
-                    // After connection is added we are no longer the owner. Background gossip task will be owner
-                    if (created && !await clusterConnectionStore.AddConnectionAsync(gsn).ConfigureAwait(false))
-                        gsn.Dispose();
+                        gossipStats.UpdateMeetRequestsSucceed();
+
+                        // If failed to add newly created connection dispose of it to reclaim resources
+                        // Dispose only connections that this meet task has created to avoid conflicts with existing connections from gossip main thread
+                        // After connection is added we are no longer the owner. Background gossip task will be owner
+                        if (created && !await clusterConnectionStore.AddConnectionAsync(gsn).ConfigureAwait(false))
+                            gsn.Dispose();
+                    }
                 }
             }
             catch (Exception ex)

--- a/libs/cluster/Server/Gossip/Gossip.cs
+++ b/libs/cluster/Server/Gossip/Gossip.cs
@@ -192,6 +192,8 @@ namespace Garnet.cluster
                     if (!ClusterConfig.TryPeekVersion(respArray, out var version) || version != ClusterConfig.ClusterConfigVersion)
                     {
                         logger?.LogWarning("MEET response has incompatible config version: {version}", version);
+                        if (created) gsn?.Dispose();
+                        gossipStats.UpdateMeetRequestsFailed();
                     }
                     else
                     {

--- a/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
@@ -19,19 +19,6 @@ namespace Garnet.cluster
         /// </summary>
         public const int ReplicationHistoryVersion = 1;
 
-        /// <summary>
-        /// Magic prefix "GR" (Garnet Replication) written at the start of serialized ReplicationHistory payloads.
-        /// <para>
-        /// This prefix provides backwards compatibility with the legacy (pre-versioned) serialization format.
-        /// Legacy payloads begin with a 7-bit length-prefixed string (the <c>primary_replid</c>), whose first
-        /// byte is 0x28 (40 decimal, the length of a hex node ID). The magic byte 'G' (0x47) can never appear
-        /// as the first byte of a valid legacy payload, so a versioned payload is always distinguishable from
-        /// an old one. Without this prefix, a version value would be ambiguous with legacy string lengths,
-        /// leading to silent corruption during disk recovery.
-        /// </para>
-        /// </summary>
-        static ReadOnlySpan<byte> ReplicationHistoryMagic => "GR"u8;
-
         public string PrimaryReplId => primary_replid;
         string primary_replid;
         public string PrimaryReplId2 => primary_replid2;
@@ -63,8 +50,6 @@ namespace Garnet.cluster
             using var ms = new MemoryStream();
             using var writer = new BinaryWriter(ms);
 
-            writer.Write(ReplicationHistoryMagic[0]);
-            writer.Write(ReplicationHistoryMagic[1]);
             writer.Write(ReplicationHistoryVersion);
             writer.Write(primary_replid);
             writer.Write(primary_replid2);
@@ -80,11 +65,9 @@ namespace Garnet.cluster
             using var ms = new MemoryStream(data);
             using var reader = new BinaryReader(ms);
 
-            // Read and validate magic prefix
-            if (data.Length < ReplicationHistoryMagic.Length + sizeof(int)
-                || reader.ReadByte() != ReplicationHistoryMagic[0]
-                || reader.ReadByte() != ReplicationHistoryMagic[1])
-                throw new InvalidDataException("Invalid ReplicationHistory payload: missing or unrecognized magic prefix");
+            // Read and validate serialization format version
+            if (data.Length < sizeof(int))
+                throw new InvalidDataException("Invalid ReplicationHistory payload: too short to contain a version");
 
             var version = reader.ReadInt32();
             if (version != ReplicationHistoryVersion)

--- a/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
@@ -20,6 +20,12 @@ namespace Garnet.cluster
         /// </summary>
         public const byte ReplicationHistoryVersion = 1;
 
+        /// <summary>
+        /// Magic bytes written at the start of serialized ReplicationHistory payloads ("GR").
+        /// Used to distinguish versioned payloads from the legacy format (which starts with a 7-bit encoded string length).
+        /// </summary>
+        static readonly byte[] ReplicationHistoryMagic = [(byte)'G', (byte)'R'];
+
         public string PrimaryReplId => primary_replid;
         string primary_replid;
         public string PrimaryReplId2 => primary_replid2;
@@ -51,6 +57,7 @@ namespace Garnet.cluster
             using var ms = new MemoryStream();
             using var writer = new BinaryWriter(ms, Encoding.ASCII);
 
+            writer.Write(ReplicationHistoryMagic);
             writer.Write(ReplicationHistoryVersion);
             writer.Write(primary_replid);
             writer.Write(primary_replid2);
@@ -65,6 +72,12 @@ namespace Garnet.cluster
         {
             using var ms = new MemoryStream(data);
             using var reader = new BinaryReader(ms);
+
+            // Read and validate magic prefix
+            if (data.Length < ReplicationHistoryMagic.Length + 1
+                || reader.ReadByte() != ReplicationHistoryMagic[0]
+                || reader.ReadByte() != ReplicationHistoryMagic[1])
+                throw new InvalidDataException("Invalid ReplicationHistory payload: missing or unrecognized magic prefix");
 
             var version = reader.ReadByte();
             if (version != ReplicationHistoryVersion)

--- a/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
@@ -17,7 +17,7 @@ namespace Garnet.cluster
         /// Version of the replication history serialization format.
         /// Increment when the binary layout of <see cref="ToByteArray"/>/<see cref="FromByteArray"/> changes.
         /// </summary>
-        public const byte ReplicationHistoryVersion = 1;
+        public const int ReplicationHistoryVersion = 1;
 
         /// <summary>
         /// Magic prefix "GR" (Garnet Replication) written at the start of serialized ReplicationHistory payloads.
@@ -26,7 +26,7 @@ namespace Garnet.cluster
         /// Legacy payloads begin with a 7-bit length-prefixed string (the <c>primary_replid</c>), whose first
         /// byte is 0x28 (40 decimal, the length of a hex node ID). The magic byte 'G' (0x47) can never appear
         /// as the first byte of a valid legacy payload, so a versioned payload is always distinguishable from
-        /// an old one. Without this prefix, a single version byte would be ambiguous with legacy string lengths,
+        /// an old one. Without this prefix, a version value would be ambiguous with legacy string lengths,
         /// leading to silent corruption during disk recovery.
         /// </para>
         /// </summary>
@@ -81,12 +81,12 @@ namespace Garnet.cluster
             using var reader = new BinaryReader(ms);
 
             // Read and validate magic prefix
-            if (data.Length < ReplicationHistoryMagic.Length + 1
+            if (data.Length < ReplicationHistoryMagic.Length + sizeof(int)
                 || reader.ReadByte() != ReplicationHistoryMagic[0]
                 || reader.ReadByte() != ReplicationHistoryMagic[1])
                 throw new InvalidDataException("Invalid ReplicationHistory payload: missing or unrecognized magic prefix");
 
-            var version = reader.ReadByte();
+            var version = reader.ReadInt32();
             if (version != ReplicationHistoryVersion)
                 throw new InvalidDataException($"Incompatible ReplicationHistory version: expected {ReplicationHistoryVersion}, got {version}");
 

--- a/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
@@ -30,7 +30,7 @@ namespace Garnet.cluster
         /// leading to silent corruption during disk recovery.
         /// </para>
         /// </summary>
-        static readonly byte[] ReplicationHistoryMagic = [(byte)'G', (byte)'R'];
+        static ReadOnlySpan<byte> ReplicationHistoryMagic => "GR"u8;
 
         public string PrimaryReplId => primary_replid;
         string primary_replid;
@@ -63,7 +63,8 @@ namespace Garnet.cluster
             using var ms = new MemoryStream();
             using var writer = new BinaryWriter(ms);
 
-            writer.Write(ReplicationHistoryMagic);
+            writer.Write(ReplicationHistoryMagic[0]);
+            writer.Write(ReplicationHistoryMagic[1]);
             writer.Write(ReplicationHistoryVersion);
             writer.Write(primary_replid);
             writer.Write(primary_replid2);

--- a/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
@@ -20,8 +20,15 @@ namespace Garnet.cluster
         public const byte ReplicationHistoryVersion = 1;
 
         /// <summary>
-        /// Magic bytes written at the start of serialized ReplicationHistory payloads ("GR").
-        /// Used to distinguish versioned payloads from the legacy format (which starts with a 7-bit encoded string length).
+        /// Magic prefix "GR" (Garnet Replication) written at the start of serialized ReplicationHistory payloads.
+        /// <para>
+        /// This prefix provides backwards compatibility with the legacy (pre-versioned) serialization format.
+        /// Legacy payloads begin with a 7-bit length-prefixed string (the <c>primary_replid</c>), whose first
+        /// byte is 0x28 (40 decimal, the length of a hex node ID). The magic byte 'G' (0x47) can never appear
+        /// as the first byte of a valid legacy payload, so a versioned payload is always distinguishable from
+        /// an old one. Without this prefix, a single version byte would be ambiguous with legacy string lengths,
+        /// leading to silent corruption during disk recovery.
+        /// </para>
         /// </summary>
         static readonly byte[] ReplicationHistoryMagic = [(byte)'G', (byte)'R'];
 

--- a/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
@@ -17,7 +17,7 @@ namespace Garnet.cluster
         /// Version of the replication history serialization format.
         /// Increment when the binary layout of <see cref="ToByteArray"/>/<see cref="FromByteArray"/> changes.
         /// </summary>
-        public const int ReplicationHistoryVersion = 1;
+        public const byte ReplicationHistoryVersion = 1;
 
         public string PrimaryReplId => primary_replid;
         string primary_replid;
@@ -66,10 +66,10 @@ namespace Garnet.cluster
             using var reader = new BinaryReader(ms);
 
             // Read and validate serialization format version
-            if (data.Length < sizeof(int))
+            if (data.Length < 1)
                 throw new InvalidDataException("Invalid ReplicationHistory payload: too short to contain a version");
 
-            var version = reader.ReadInt32();
+            var version = reader.ReadByte();
             if (version != ReplicationHistoryVersion)
                 throw new InvalidDataException($"Incompatible ReplicationHistory version: expected {ReplicationHistoryVersion}, got {version}");
 

--- a/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
@@ -14,6 +14,12 @@ namespace Garnet.cluster
 {
     internal sealed class ReplicationHistory
     {
+        /// <summary>
+        /// Version of the replication history serialization format.
+        /// Increment when the binary layout of <see cref="ToByteArray"/>/<see cref="FromByteArray"/> changes.
+        /// </summary>
+        public const byte ReplicationHistoryVersion = 1;
+
         public string PrimaryReplId => primary_replid;
         string primary_replid;
         public string PrimaryReplId2 => primary_replid2;
@@ -45,6 +51,7 @@ namespace Garnet.cluster
             using var ms = new MemoryStream();
             using var writer = new BinaryWriter(ms, Encoding.ASCII);
 
+            writer.Write(ReplicationHistoryVersion);
             writer.Write(primary_replid);
             writer.Write(primary_replid2);
             replicationOffset.Serialize(writer);
@@ -58,6 +65,10 @@ namespace Garnet.cluster
         {
             using var ms = new MemoryStream(data);
             using var reader = new BinaryReader(ms);
+
+            var version = reader.ReadByte();
+            if (version != ReplicationHistoryVersion)
+                throw new InvalidDataException($"Incompatible ReplicationHistory version: expected {ReplicationHistoryVersion}, got {version}");
 
             var primary_replid = reader.ReadString();
             var primary_replid2 = reader.ReadString();
@@ -105,13 +116,15 @@ namespace Garnet.cluster
         private void RecoverReplicationHistory()
         {
             var replConfig = ClusterUtils.ReadDevice(replicationConfigDevice, replicationConfigDevicePool, logger);
-            currentReplicationConfig = ReplicationHistory.FromByteArray(replConfig);
-            //TODO: handle scenario where replica crashed before became a primary and it has two replication ids
-            //var current = storeWrapper.clusterManager.CurrentConfig;
-            //if(current.GetLocalNodeRole() == NodeRole.REPLICA && !primary_replid2.Equals(Generator.DefaultHexId()))
-            //{
-
-            //}
+            try
+            {
+                currentReplicationConfig = ReplicationHistory.FromByteArray(replConfig);
+            }
+            catch (InvalidDataException ex)
+            {
+                logger?.LogWarning(ex, "Incompatible replication history format on disk, reinitializing fresh state");
+                InitializeReplicationHistory(storeWrapper.serverOptions.AofPhysicalSublogCount);
+            }
         }
 
         private void TryUpdateMyPrimaryReplId(string primaryReplicationId)

--- a/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
@@ -133,9 +133,9 @@ namespace Garnet.cluster
             {
                 currentReplicationConfig = ReplicationHistory.FromByteArray(replConfig);
             }
-            catch (InvalidDataException ex)
+            catch (Exception ex) when (ex is InvalidDataException or EndOfStreamException or IOException)
             {
-                logger?.LogWarning(ex, "Incompatible replication history format on disk, reinitializing fresh state");
+                logger?.LogWarning(ex, "Corrupt or incompatible replication history on disk, reinitializing fresh state");
                 InitializeReplicationHistory(storeWrapper.serverOptions.AofPhysicalSublogCount);
             }
         }

--- a/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Text;
 using System.Threading;
 using Garnet.common;
 using Garnet.server;
@@ -55,7 +54,7 @@ namespace Garnet.cluster
         public byte[] ToByteArray()
         {
             using var ms = new MemoryStream();
-            using var writer = new BinaryWriter(ms, Encoding.ASCII);
+            using var writer = new BinaryWriter(ms);
 
             writer.Write(ReplicationHistoryMagic);
             writer.Write(ReplicationHistoryVersion);

--- a/libs/cluster/Session/RespClusterBasicCommands.cs
+++ b/libs/cluster/Session/RespClusterBasicCommands.cs
@@ -385,28 +385,36 @@ namespace Garnet.cluster
             // Try merge if not just a ping message
             if (gossipMessage.Length > 0)
             {
-                var other = ClusterConfig.FromByteArray(gossipMessage);
-                // Accept gossip message if it is a gossipWithMeet or node from node that is already known and trusted
-                // GossipWithMeet messages are only send through a call to CLUSTER MEET at the remote node
-                if (gossipWithMeet || current.IsKnown(other.LocalNodeId))
+                // Validate config version before full deserialization
+                if (!ClusterConfig.TryPeekVersion(gossipMessage, out var version) || version != ClusterConfig.ClusterConfigVersion)
                 {
-                    // NOTE: release the epoch to avoid deadlock with MIGRATE config suspension
-                    ReleaseCurrentEpoch();
-                    try
-                    {
-                        _ = clusterProvider.clusterManager.TryMerge(other);
-                    }
-                    finally
-                    {
-                        AcquireCurrentEpoch();
-                    }
-
-                    // Remember that this connection is being used for another cluster node to talk to us
-                    Debug.Assert(RemoteNodeId is null || RemoteNodeId == other.LocalNodeId, "Node Id shouldn't change once set for a connection");
-                    RemoteNodeId = other.LocalNodeId;
+                    logger?.LogWarning("Received gossip with incompatible config version: {version}", version);
                 }
                 else
-                    logger?.LogWarning("Received gossip from unknown node: {node-id}", other.LocalNodeId);
+                {
+                    var other = ClusterConfig.FromByteArray(gossipMessage);
+                    // Accept gossip message if it is a gossipWithMeet or node from node that is already known and trusted
+                    // GossipWithMeet messages are only send through a call to CLUSTER MEET at the remote node
+                    if (gossipWithMeet || current.IsKnown(other.LocalNodeId))
+                    {
+                        // NOTE: release the epoch to avoid deadlock with MIGRATE config suspension
+                        ReleaseCurrentEpoch();
+                        try
+                        {
+                            _ = clusterProvider.clusterManager.TryMerge(other);
+                        }
+                        finally
+                        {
+                            AcquireCurrentEpoch();
+                        }
+
+                        // Remember that this connection is being used for another cluster node to talk to us
+                        Debug.Assert(RemoteNodeId is null || RemoteNodeId == other.LocalNodeId, "Node Id shouldn't change once set for a connection");
+                        RemoteNodeId = other.LocalNodeId;
+                    }
+                    else
+                        logger?.LogWarning("Received gossip from unknown node: {node-id}", other.LocalNodeId);
+                }
             }
 
             // Respond if configuration has changed or gossipWithMeet option is specified

--- a/test/Garnet.test.cluster/ClusterConfigTests.cs
+++ b/test/Garnet.test.cluster/ClusterConfigTests.cs
@@ -157,5 +157,58 @@ namespace Garnet.test.cluster
             resp = client.QuitAsync().GetAwaiter().GetResult();
             ClassicAssert.AreEqual("OK", resp);
         }
+
+        [Test, Order(4)]
+        [Category("CLUSTER-CONFIG"), CancelAfter(1000)]
+        public void ClusterConfigVersionRoundTripTest()
+        {
+            var config = new ClusterConfig().InitializeLocalWorker(
+                Generator.CreateHexId(),
+                "127.0.0.1",
+                7001,
+                configEpoch: 1,
+                Garnet.cluster.NodeRole.PRIMARY,
+                null,
+                "");
+
+            var configBytes = config.ToByteArray();
+
+            // Verify version byte is present at position 0
+            Assert.That(ClusterConfig.TryPeekVersion(configBytes, out var version), Is.True);
+            Assert.That(version, Is.EqualTo(ClusterConfig.ClusterConfigVersion));
+
+            // Round-trip should succeed
+            var restored = ClusterConfig.FromByteArray(configBytes);
+            Assert.That(restored.LocalNodeId, Is.EqualTo(config.LocalNodeId));
+        }
+
+        [Test, Order(5)]
+        [Category("CLUSTER-CONFIG"), CancelAfter(1000)]
+        public void ClusterConfigVersionMismatchThrowsTest()
+        {
+            var config = new ClusterConfig().InitializeLocalWorker(
+                Generator.CreateHexId(),
+                "127.0.0.1",
+                7001,
+                configEpoch: 1,
+                Garnet.cluster.NodeRole.PRIMARY,
+                null,
+                "");
+
+            var configBytes = config.ToByteArray();
+
+            // Corrupt the version byte
+            configBytes[0] = (byte)(ClusterConfig.ClusterConfigVersion + 1);
+
+            // Deserialization should throw
+            Assert.Throws<System.IO.InvalidDataException>(() => ClusterConfig.FromByteArray(configBytes));
+        }
+
+        [Test, Order(6)]
+        [Category("CLUSTER-CONFIG"), CancelAfter(1000)]
+        public void ClusterConfigTryPeekVersionEmptyDataTest()
+        {
+            Assert.That(ClusterConfig.TryPeekVersion([], out _), Is.False);
+        }
     }
 }

--- a/test/Garnet.test.cluster/ClusterConfigTests.cs
+++ b/test/Garnet.test.cluster/ClusterConfigTests.cs
@@ -174,9 +174,7 @@ namespace Garnet.test.cluster
 
             var configBytes = config.ToByteArray();
 
-            // Verify magic prefix and version int
-            Assert.That(configBytes[0], Is.EqualTo((byte)'G'));
-            Assert.That(configBytes[1], Is.EqualTo((byte)'C'));
+            // Verify version int at start of payload
             Assert.That(ClusterConfig.TryPeekVersion(configBytes, out var version), Is.True);
             Assert.That(version, Is.EqualTo(ClusterConfig.ClusterConfigVersion));
 
@@ -200,8 +198,8 @@ namespace Garnet.test.cluster
 
             var configBytes = config.ToByteArray();
 
-            // Corrupt the version int (at index 2, after 2-byte magic prefix)
-            BitConverter.TryWriteBytes(configBytes.AsSpan(2), ClusterConfig.ClusterConfigVersion + 1);
+            // Corrupt the version int (at index 0)
+            BitConverter.TryWriteBytes(configBytes.AsSpan(0), ClusterConfig.ClusterConfigVersion + 1);
 
             // Deserialization should throw
             Assert.Throws<System.IO.InvalidDataException>(() => ClusterConfig.FromByteArray(configBytes));
@@ -216,26 +214,13 @@ namespace Garnet.test.cluster
 
         [Test, Order(7)]
         [Category("CLUSTER-CONFIG"), CancelAfter(1000)]
-        public void ClusterConfigLegacyPayloadRejectedTest()
-        {
-            // Simulate a legacy payload that starts with a UInt16 segmentCount = 1
-            // (which was the old format before the magic prefix was added)
-            var legacyPayload = new byte[] { 0x01, 0x00, 0x00, 0x40 };
-            Assert.That(ClusterConfig.TryPeekVersion(legacyPayload, out _), Is.False);
-            Assert.Throws<System.IO.InvalidDataException>(() => ClusterConfig.FromByteArray(legacyPayload));
-        }
-
-        [Test, Order(8)]
-        [Category("CLUSTER-CONFIG"), CancelAfter(1000)]
         public void ReplicationHistoryVersionRoundTripTest()
         {
             var history = new ReplicationHistory(1);
             var bytes = history.ToByteArray();
 
-            // Verify magic prefix and version int
-            Assert.That(bytes[0], Is.EqualTo((byte)'G'));
-            Assert.That(bytes[1], Is.EqualTo((byte)'R'));
-            Assert.That(BitConverter.ToInt32(bytes, 2), Is.EqualTo(ReplicationHistory.ReplicationHistoryVersion));
+            // Verify version int at start of payload
+            Assert.That(BitConverter.ToInt32(bytes, 0), Is.EqualTo(ReplicationHistory.ReplicationHistoryVersion));
 
             // Round-trip should succeed and preserve fields
             var restored = ReplicationHistory.FromByteArray(bytes);
@@ -250,8 +235,8 @@ namespace Garnet.test.cluster
             var history = new ReplicationHistory(1);
             var bytes = history.ToByteArray();
 
-            // Corrupt the version int (at index 2, after 2-byte magic prefix)
-            BitConverter.TryWriteBytes(bytes.AsSpan(2), ReplicationHistory.ReplicationHistoryVersion + 1);
+            // Corrupt the version int (at index 0)
+            BitConverter.TryWriteBytes(bytes.AsSpan(0), ReplicationHistory.ReplicationHistoryVersion + 1);
 
             // Deserialization should throw
             Assert.Throws<System.IO.InvalidDataException>(() => ReplicationHistory.FromByteArray(bytes));

--- a/test/Garnet.test.cluster/ClusterConfigTests.cs
+++ b/test/Garnet.test.cluster/ClusterConfigTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -173,7 +174,7 @@ namespace Garnet.test.cluster
 
             var configBytes = config.ToByteArray();
 
-            // Verify magic prefix and version byte
+            // Verify magic prefix and version int
             Assert.That(configBytes[0], Is.EqualTo((byte)'G'));
             Assert.That(configBytes[1], Is.EqualTo((byte)'C'));
             Assert.That(ClusterConfig.TryPeekVersion(configBytes, out var version), Is.True);
@@ -199,8 +200,8 @@ namespace Garnet.test.cluster
 
             var configBytes = config.ToByteArray();
 
-            // Corrupt the version byte (at index 2, after 2-byte magic prefix)
-            configBytes[2] = (byte)(ClusterConfig.ClusterConfigVersion + 1);
+            // Corrupt the version int (at index 2, after 2-byte magic prefix)
+            BitConverter.TryWriteBytes(configBytes.AsSpan(2), ClusterConfig.ClusterConfigVersion + 1);
 
             // Deserialization should throw
             Assert.Throws<System.IO.InvalidDataException>(() => ClusterConfig.FromByteArray(configBytes));
@@ -231,10 +232,10 @@ namespace Garnet.test.cluster
             var history = new ReplicationHistory(1);
             var bytes = history.ToByteArray();
 
-            // Verify magic prefix and version byte
+            // Verify magic prefix and version int
             Assert.That(bytes[0], Is.EqualTo((byte)'G'));
             Assert.That(bytes[1], Is.EqualTo((byte)'R'));
-            Assert.That(bytes[2], Is.EqualTo(ReplicationHistory.ReplicationHistoryVersion));
+            Assert.That(BitConverter.ToInt32(bytes, 2), Is.EqualTo(ReplicationHistory.ReplicationHistoryVersion));
 
             // Round-trip should succeed and preserve fields
             var restored = ReplicationHistory.FromByteArray(bytes);
@@ -249,8 +250,8 @@ namespace Garnet.test.cluster
             var history = new ReplicationHistory(1);
             var bytes = history.ToByteArray();
 
-            // Corrupt the version byte (at index 2, after 2-byte magic prefix)
-            bytes[2] = (byte)(ReplicationHistory.ReplicationHistoryVersion + 1);
+            // Corrupt the version int (at index 2, after 2-byte magic prefix)
+            BitConverter.TryWriteBytes(bytes.AsSpan(2), ReplicationHistory.ReplicationHistoryVersion + 1);
 
             // Deserialization should throw
             Assert.Throws<System.IO.InvalidDataException>(() => ReplicationHistory.FromByteArray(bytes));

--- a/test/Garnet.test.cluster/ClusterConfigTests.cs
+++ b/test/Garnet.test.cluster/ClusterConfigTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -174,7 +173,7 @@ namespace Garnet.test.cluster
 
             var configBytes = config.ToByteArray();
 
-            // Verify version int at start of payload
+            // Verify version byte at start of payload
             Assert.That(ClusterConfig.TryPeekVersion(configBytes, out var version), Is.True);
             Assert.That(version, Is.EqualTo(ClusterConfig.ClusterConfigVersion));
 
@@ -198,8 +197,8 @@ namespace Garnet.test.cluster
 
             var configBytes = config.ToByteArray();
 
-            // Corrupt the version int (at index 0)
-            BitConverter.TryWriteBytes(configBytes.AsSpan(0), ClusterConfig.ClusterConfigVersion + 1);
+            // Corrupt the version byte (at index 0)
+            configBytes[0] = (byte)(ClusterConfig.ClusterConfigVersion + 1);
 
             // Deserialization should throw
             Assert.Throws<System.IO.InvalidDataException>(() => ClusterConfig.FromByteArray(configBytes));
@@ -219,8 +218,8 @@ namespace Garnet.test.cluster
             var history = new ReplicationHistory(1);
             var bytes = history.ToByteArray();
 
-            // Verify version int at start of payload
-            Assert.That(BitConverter.ToInt32(bytes, 0), Is.EqualTo(ReplicationHistory.ReplicationHistoryVersion));
+            // Verify version byte at start of payload
+            Assert.That(bytes[0], Is.EqualTo(ReplicationHistory.ReplicationHistoryVersion));
 
             // Round-trip should succeed and preserve fields
             var restored = ReplicationHistory.FromByteArray(bytes);
@@ -235,8 +234,8 @@ namespace Garnet.test.cluster
             var history = new ReplicationHistory(1);
             var bytes = history.ToByteArray();
 
-            // Corrupt the version int (at index 0)
-            BitConverter.TryWriteBytes(bytes.AsSpan(0), ReplicationHistory.ReplicationHistoryVersion + 1);
+            // Corrupt the version byte (at index 0)
+            bytes[0] = (byte)(ReplicationHistory.ReplicationHistoryVersion + 1);
 
             // Deserialization should throw
             Assert.Throws<System.IO.InvalidDataException>(() => ReplicationHistory.FromByteArray(bytes));

--- a/test/Garnet.test.cluster/ClusterConfigTests.cs
+++ b/test/Garnet.test.cluster/ClusterConfigTests.cs
@@ -210,5 +210,35 @@ namespace Garnet.test.cluster
         {
             Assert.That(ClusterConfig.TryPeekVersion([], out _), Is.False);
         }
+
+        [Test, Order(7)]
+        [Category("CLUSTER-CONFIG"), CancelAfter(1000)]
+        public void ReplicationHistoryVersionRoundTripTest()
+        {
+            var history = new ReplicationHistory(1);
+            var bytes = history.ToByteArray();
+
+            // Verify version byte is present at position 0
+            Assert.That(bytes[0], Is.EqualTo(ReplicationHistory.ReplicationHistoryVersion));
+
+            // Round-trip should succeed and preserve fields
+            var restored = ReplicationHistory.FromByteArray(bytes);
+            Assert.That(restored.PrimaryReplId, Is.EqualTo(history.PrimaryReplId));
+            Assert.That(restored.PrimaryReplId2, Is.EqualTo(history.PrimaryReplId2));
+        }
+
+        [Test, Order(8)]
+        [Category("CLUSTER-CONFIG"), CancelAfter(1000)]
+        public void ReplicationHistoryVersionMismatchThrowsTest()
+        {
+            var history = new ReplicationHistory(1);
+            var bytes = history.ToByteArray();
+
+            // Corrupt the version byte
+            bytes[0] = (byte)(ReplicationHistory.ReplicationHistoryVersion + 1);
+
+            // Deserialization should throw
+            Assert.Throws<System.IO.InvalidDataException>(() => ReplicationHistory.FromByteArray(bytes));
+        }
     }
 }

--- a/test/Garnet.test.cluster/ClusterConfigTests.cs
+++ b/test/Garnet.test.cluster/ClusterConfigTests.cs
@@ -173,7 +173,9 @@ namespace Garnet.test.cluster
 
             var configBytes = config.ToByteArray();
 
-            // Verify version byte is present at position 0
+            // Verify magic prefix and version byte
+            Assert.That(configBytes[0], Is.EqualTo((byte)'G'));
+            Assert.That(configBytes[1], Is.EqualTo((byte)'C'));
             Assert.That(ClusterConfig.TryPeekVersion(configBytes, out var version), Is.True);
             Assert.That(version, Is.EqualTo(ClusterConfig.ClusterConfigVersion));
 
@@ -197,8 +199,8 @@ namespace Garnet.test.cluster
 
             var configBytes = config.ToByteArray();
 
-            // Corrupt the version byte
-            configBytes[0] = (byte)(ClusterConfig.ClusterConfigVersion + 1);
+            // Corrupt the version byte (at index 2, after 2-byte magic prefix)
+            configBytes[2] = (byte)(ClusterConfig.ClusterConfigVersion + 1);
 
             // Deserialization should throw
             Assert.Throws<System.IO.InvalidDataException>(() => ClusterConfig.FromByteArray(configBytes));
@@ -213,13 +215,26 @@ namespace Garnet.test.cluster
 
         [Test, Order(7)]
         [Category("CLUSTER-CONFIG"), CancelAfter(1000)]
+        public void ClusterConfigLegacyPayloadRejectedTest()
+        {
+            // Simulate a legacy payload that starts with a UInt16 segmentCount = 1
+            // (which was the old format before the magic prefix was added)
+            var legacyPayload = new byte[] { 0x01, 0x00, 0x00, 0x40 };
+            Assert.That(ClusterConfig.TryPeekVersion(legacyPayload, out _), Is.False);
+            Assert.Throws<System.IO.InvalidDataException>(() => ClusterConfig.FromByteArray(legacyPayload));
+        }
+
+        [Test, Order(8)]
+        [Category("CLUSTER-CONFIG"), CancelAfter(1000)]
         public void ReplicationHistoryVersionRoundTripTest()
         {
             var history = new ReplicationHistory(1);
             var bytes = history.ToByteArray();
 
-            // Verify version byte is present at position 0
-            Assert.That(bytes[0], Is.EqualTo(ReplicationHistory.ReplicationHistoryVersion));
+            // Verify magic prefix and version byte
+            Assert.That(bytes[0], Is.EqualTo((byte)'G'));
+            Assert.That(bytes[1], Is.EqualTo((byte)'R'));
+            Assert.That(bytes[2], Is.EqualTo(ReplicationHistory.ReplicationHistoryVersion));
 
             // Round-trip should succeed and preserve fields
             var restored = ReplicationHistory.FromByteArray(bytes);
@@ -227,15 +242,15 @@ namespace Garnet.test.cluster
             Assert.That(restored.PrimaryReplId2, Is.EqualTo(history.PrimaryReplId2));
         }
 
-        [Test, Order(8)]
+        [Test, Order(9)]
         [Category("CLUSTER-CONFIG"), CancelAfter(1000)]
         public void ReplicationHistoryVersionMismatchThrowsTest()
         {
             var history = new ReplicationHistory(1);
             var bytes = history.ToByteArray();
 
-            // Corrupt the version byte
-            bytes[0] = (byte)(ReplicationHistory.ReplicationHistoryVersion + 1);
+            // Corrupt the version byte (at index 2, after 2-byte magic prefix)
+            bytes[2] = (byte)(ReplicationHistory.ReplicationHistoryVersion + 1);
 
             // Deserialization should throw
             Assert.Throws<System.IO.InvalidDataException>(() => ReplicationHistory.FromByteArray(bytes));


### PR DESCRIPTION
## Summary

Add serialization versioning to `ClusterConfig` and `ReplicationHistory` binary formats using a version byte header to enable safe detection of incompatible payloads during gossip and disk recovery.

---

## Motivation

Without version markers, nodes running different Garnet versions could exchange incompatible gossip payloads leading to deserialization failures or silent data corruption. The version byte enables:
- **Early rejection** of incompatible gossip messages with clear warnings
- **Safe disk recovery** with graceful fallback on format changes

---

## Changes

### 1️⃣ ClusterConfig Versioning

| File | Change |
|------|--------|
| `libs/cluster/Server/ClusterConfig.cs` | Added `ClusterConfigVersion` constant (version 1, byte) |
| `libs/cluster/Server/ClusterConfigSerializer.cs` | Version byte as first byte in `ToByteArray`/`FromByteArray`; added `TryPeekVersion` helper; fixed `SerializeSlotMap` to use relative stream position |
| `libs/cluster/Session/RespClusterBasicCommands.cs` | Version check in `NetworkClusterGossip` (receive path) |
| `libs/cluster/Server/Gossip/GarnetServerNode.cs` | Version check in `GossipAsync` (response path) |
| `libs/cluster/Server/Gossip/Gossip.cs` | Version check in `TryMeetAsync` (meet response path) |
| `libs/cluster/Server/Failover/ReplicaFailoverSession.cs` | Version check in failover gossip response path |

### 2️⃣ ReplicationHistory Versioning

| File | Change |
|------|--------|
| `libs/cluster/Server/Replication/ReplicationHistoryManager.cs` | Added `ReplicationHistoryVersion` constant (version 1, byte); version byte in `ToByteArray`/`FromByteArray`; graceful recovery on mismatch (reinitializes fresh state) |

> **Note:** `ReplicationHistory` is only persisted to/from local disk (not exchanged over gossip), so recovery simply reinitializes — the node will re-negotiate with its primary on next sync.

### 3️⃣ Tests

| Test | Description |
|------|-------------|
| `ClusterConfigVersionRoundTripTest` | Round-trip serialization preserves version header and data |
| `ClusterConfigVersionMismatchThrowsTest` | Corrupt version byte → `InvalidDataException` |
| `ClusterConfigTryPeekVersionEmptyDataTest` | Empty payload → `TryPeekVersion` returns false |
| `ReplicationHistoryVersionRoundTripTest` | Round-trip serialization preserves version and fields |
| `ReplicationHistoryVersionMismatchThrowsTest` | Corrupt version byte → `InvalidDataException` |

---

## All deserialization paths covered

| Call site | Guard |
|-----------|-------|
| `ClusterManager.cs` (disk recovery) | `FromByteArray` throws `InvalidDataException` |
| `NetworkClusterGossip` (gossip receive) | ✅ `TryPeekVersion` pre-check |
| `GarnetServerNode.GossipAsync` (gossip response) | ✅ `TryPeekVersion` pre-check |
| `Gossip.TryMeetAsync` (meet response) | ✅ `TryPeekVersion` pre-check |
| `ReplicaFailoverSession` (failover gossip) | ✅ `TryPeekVersion` pre-check |
| `RecoverReplicationHistory` (disk recovery) | ✅ Graceful catch + reinitialize |
