### PR TITLE
Bump v1 to 1.1.7 and scope external-release pipeline to release/v1

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -1,13 +1,13 @@
 ######################################
 # NOTE: Before running this pipeline to generate a the GitHub Release and new nuget packages, update the VersionPrefix value in Version.props file
 # NOTE: When Version.props file is modified, this pipeline will automatically get triggered
-# NOTE: If this pipeline is ran against a branch that isn't main, the GitHub Release task and NuGet push task will be skipped
+# NOTE: If this pipeline is ran against a branch that isn't release/v1, the GitHub Release task and NuGet push task will be skipped
 # NOTE: If this pipeline is manually started, a "Proof of Presence" (from a SAW machine) will be required before this pipeline can proceed.
 ###################################### 
 trigger:
   branches:
     include:
-    - main
+    - release/v1
   paths:
     include:
     - Version.props
@@ -15,7 +15,7 @@ resources:
   repositories:
   - repository: self
     type: git
-    ref: refs/heads/main
+    ref: refs/heads/release/v1
 
 pool:
   vmImage: 'windows-latest'
@@ -174,7 +174,7 @@ jobs:
 
   - task: GitHubRelease@1
     displayName: 'Create the GitHub release'
-    condition: eq(variables['Build.SourceBranchName'], 'main')
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/release/v1')
     inputs:    
       action: 'create'
       gitHubConnection: ADO_to_Github_ServiceConnection
@@ -200,7 +200,7 @@ jobs:
 
   - task: NuGetCommand@2
     displayName: 'Push both packages to NuGet.org'
-    condition: eq(variables['Build.SourceBranchName'], 'main')
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/release/v1')
     inputs:
       command: push
       packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- VersionPrefix property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>1.1.6</VersionPrefix>
+		<VersionPrefix>1.1.7</VersionPrefix>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Cuts a v1 patch release (`1.1.7`) and rewires `.azure/pipelines/azure-pipelines-external-release.yml` so the `release/v1` copy of that pipeline drives v1 releases, while the `main` copy continues to drive v2/preview releases from `main` and `dev`.

## Changes

- **`Version.props`**: `VersionPrefix` 1.1.6 → 1.1.7
- **`.azure/pipelines/azure-pipelines-external-release.yml`** (release/v1 copy only):
  - Header note: "branch that isn't main" → "branch that isn't release/v1"
  - `trigger.branches.include`: `main` → `release/v1`
  - `resources.repositories.self.ref`: `refs/heads/main` → `refs/heads/release/v1`
  - `GitHubRelease@1` condition: `eq(Build.SourceBranchName,'main')` → `eq(Build.SourceBranch,'refs/heads/release/v1')`
  - `NuGetCommand@2` condition: same change
  - Switched from `Build.SourceBranchName` to `Build.SourceBranch` because `SourceBranchName` is just the leaf segment (`v1` for `refs/heads/release/v1`), which is ambiguous.

## Release behavior after merge

Merging this PR pushes a `Version.props` change onto `release/v1`, which:
1. Triggers the external-release ADO pipeline (the `release/v1` copy of the YAML).
2. Builds, signs, and packs Garnet at version `1.1.7`.
3. Creates GitHub Release `Garnet v1.1.7` (tag `v1.1.7`).
4. Pushes `Microsoft.Garnet.1.1.7.nupkg` and `garnet-server.1.1.7.nupkg` to NuGet.org.

The `main` branch's pipeline is unchanged and unaffected.

## ADO checks (out-of-band, not in this PR)

- Confirm the ADO pipeline's Triggers UI does **not** "Override the YAML continuous integration trigger from here" (or, if it does, that `release/v1` is in the included branches).
- If you want manual / proof-of-presence runs to default to `release/v1`, either change the pipeline's default branch or clone the pipeline definition for the v1 line.
- Confirm `ADO_to_Github_ServiceConnection`, `GarnetCodeSignConn`, and `GarnetADO_to_Nuget` are authorized for the pipeline with no branch restriction limiting them to `main`.