### PR TITLE
Bump version to 2.0.0-beta.4 and scope external-release pipeline to main only

### DIFF
--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -66,6 +66,12 @@ jobs:
       filePath: .azure/pipelines/extract_version.ps1
       workingDirectory: .azure/pipelines
 
+  - powershell: |
+      $isPreRelease = "$(Build.BuildNumber)".Contains('-')
+      Write-Host "Build.BuildNumber=$(Build.BuildNumber); isPreRelease=$isPreRelease"
+      Write-Host "##vso[task.setvariable variable=isPreRelease]$($isPreRelease.ToString().ToLower())"
+    displayName: 'Derive isPreRelease from version (true if SemVer prerelease)'
+
   - task: UseDotNet@2
     displayName: Use .NET 6 SDK - needed for code signing
     inputs:
@@ -232,6 +238,7 @@ jobs:
         $(Build.ArtifactStagingDirectory)/*.zip
         $(Build.ArtifactStagingDirectory)/*.tar.xz
         $(Build.ArtifactStagingDirectory)/*.7z
+      isPreRelease: $(isPreRelease)
 
   - task: NuGetCommand@2
     displayName: 'Push both packages to NuGet.org'

--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -8,7 +8,6 @@ trigger:
   branches:
     include:
     - main
-    - dev
   paths:
     include:
     - Version.props
@@ -208,26 +207,15 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'
 
-  - powershell: |
-      if ("$(Build.SourceBranchName)" -eq "main") {
-        Write-Host "##vso[task.setvariable variable=releaseTitle]Garnet v$(Build.BuildNumber)"
-      } else {
-        Write-Host "##vso[task.setvariable variable=releaseTitle]Garnet PREVIEW v$(Build.BuildNumber)"
-      }
-    displayName: 'Set releaseTitle variable'
-
   - task: GitHubRelease@1
     displayName: 'Create the GitHub release'
-    condition: or(
-        eq(variables['Build.SourceBranchName'], 'main'),
-        eq(variables['Build.SourceBranchName'], 'dev')
-      )
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
     inputs:    
       action: 'create'
       gitHubConnection: ADO_to_Github_ServiceConnection
       tagSource: userSpecifiedTag
       tag: 'v$(Build.BuildNumber)'
-      title: '$(releaseTitle)'
+      title: 'Garnet v$(Build.BuildNumber)'
       releaseNotesSource: inline
       releaseNotesInline: |
        Get NuGet binaries at:
@@ -244,14 +232,10 @@ jobs:
         $(Build.ArtifactStagingDirectory)/*.zip
         $(Build.ArtifactStagingDirectory)/*.tar.xz
         $(Build.ArtifactStagingDirectory)/*.7z
-      isPreRelease: ${{ eq(variables['Build.SourceBranchName'], 'dev') }}
 
   - task: NuGetCommand@2
     displayName: 'Push both packages to NuGet.org'
-    condition: or(
-        eq(variables['Build.SourceBranchName'], 'main'),
-        eq(variables['Build.SourceBranchName'], 'dev')
-      )
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
     inputs:
       command: push
       packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'

--- a/.azure/pipelines/azure-pipelines-external-release.yml
+++ b/.azure/pipelines/azure-pipelines-external-release.yml
@@ -68,9 +68,15 @@ jobs:
 
   - powershell: |
       $isPreRelease = "$(Build.BuildNumber)".Contains('-')
-      Write-Host "Build.BuildNumber=$(Build.BuildNumber); isPreRelease=$isPreRelease"
+      if ($isPreRelease) {
+        $releaseTitle = "Garnet PREVIEW v$(Build.BuildNumber)"
+      } else {
+        $releaseTitle = "Garnet v$(Build.BuildNumber)"
+      }
+      Write-Host "Build.BuildNumber=$(Build.BuildNumber); isPreRelease=$isPreRelease; releaseTitle=$releaseTitle"
       Write-Host "##vso[task.setvariable variable=isPreRelease]$($isPreRelease.ToString().ToLower())"
-    displayName: 'Derive isPreRelease from version (true if SemVer prerelease)'
+      Write-Host "##vso[task.setvariable variable=releaseTitle]$releaseTitle"
+    displayName: 'Derive isPreRelease and releaseTitle from version (PREVIEW prefix iff SemVer prerelease)'
 
   - task: UseDotNet@2
     displayName: Use .NET 6 SDK - needed for code signing
@@ -221,7 +227,7 @@ jobs:
       gitHubConnection: ADO_to_Github_ServiceConnection
       tagSource: userSpecifiedTag
       tag: 'v$(Build.BuildNumber)'
-      title: 'Garnet v$(Build.BuildNumber)'
+      title: '$(releaseTitle)'
       releaseNotesSource: inline
       releaseNotesInline: |
        Get NuGet binaries at:

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- VersionPrefix property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>2.0.0-beta.3</VersionPrefix>
+		<VersionPrefix>2.0.0-beta.4</VersionPrefix>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Two changes to the v2 release line on `main`:

1. **Cut next v2 beta**: `Version.props` 2.0.0-beta.3 → 2.0.0-beta.4.
2. **Scope external-release pipeline to main only**: `.azure/pipelines/azure-pipelines-external-release.yml` no longer triggers from `dev` and no longer carries any preview-release plumbing tied to `dev`. The GitHub release `Pre-release` flag is now auto-derived from the version string so v2 betas stay marked as prereleases without manual maintenance.

## YAML changes

- `trigger.branches.include`: drop `dev`, keep only `main`
- `GitHubRelease@1` condition: `or(SourceBranchName=="main", SourceBranchName=="dev")` → `eq(Build.SourceBranch, "refs/heads/main")`
- `NuGetCommand@2` condition: same simplification
- Drop the `releaseTitle` powershell shim (was only used to prefix `PREVIEW` for dev runs); title is now literal `Garnet v$(Build.BuildNumber)`
- Drop `isPreRelease: ${{ eq(SourceBranchName, "dev") }}` (was always false on main runs)
- Add a small powershell step right after `extract_version.ps1` that sets pipeline variable `isPreRelease = true` iff `Build.BuildNumber` contains `-` (a SemVer prerelease label), and wire `GitHubRelease@1` to consume it via `isPreRelease: $(isPreRelease)`

`Build.SourceBranch` is used (full `refs/heads/main`) instead of `SourceBranchName` for consistency with the v1 pipeline (#1792).

## Resulting prerelease behavior (no future maintenance)

| Version       | isPreRelease | GitHub `Latest` badge      |
| ------------- | ------------ | -------------------------- |
| 2.0.0-beta.4  | true         | no (correct — still v1.x)  |
| 2.0.0 (GA)    | false        | yes                        |
| 1.1.x patches | false        | yes (per existing v1 line) |

## Release behavior on merge

Merging this PR pushes a `Version.props` change onto `main`, which:
1. Triggers the external-release ADO pipeline (`main` copy of YAML, paths-filter on `Version.props`, branches-filter on `main`).
2. Builds, signs, and packs Garnet at version `2.0.0-beta.4`.
3. Creates GitHub Release `Garnet v2.0.0-beta.4` (tag `v2.0.0-beta.4`, **prerelease=true** via auto-detect).
4. Pushes `Microsoft.Garnet.2.0.0-beta.4.nupkg` and `garnet-server.2.0.0-beta.4.nupkg` to NuGet.org.
5. Tag-push fires `docker-linux.yml` + `docker-windows.yml` → 5 Linux + 1 Windows images published to GHCR with tag `2.0.0-beta.4`. Per `docker/metadata-action` defaults, prereleases do not get short `2`/`2.0` tags, and `:latest` is gated on default-branch tags so it is not moved by a beta release. The `release/v1` line `1`/`1.1` tags are unaffected.

## Audit checks

- NuGet: `Microsoft.Garnet` and `garnet-server` currently published up to `2.0.0-beta.3`; `2.0.0-beta.4` does not exist on either feed → push will not be rejected.
- Git: no `v2.0.0-beta.4` tag exists yet → GitHub release creation will not collide.
- After merge, dev-branch pushes (including `Version.props` changes on `dev`) will no longer trigger this pipeline.