### PR TITLE
Update ValueOverflowThreshold

### DIFF
--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -64,7 +64,7 @@ namespace Garnet
         public string LogMemorySize { get; set; }
 
         [MemorySizeValidation]
-        [Option('p', "page", Required = false, HelpText = "Size of each main-log page in bytes (rounds down to power of 2).")]
+        [Option('p', "page", Required = false, HelpText = "Size of each main-log page in bytes (rounds down to power of 2; minimum 512).")]
         public string PageSize { get; set; }
 
         [IntRangeValidation(0, MemoryUtils.ArrayMaxLength)]
@@ -100,7 +100,7 @@ namespace Garnet
         public string ReadCacheMemorySize { get; set; }
 
         [MemorySizeValidation]
-        [Option("readcache-page", Required = false, HelpText = "Size of each read cache page in bytes (rounds down to power of 2)")]
+        [Option("readcache-page", Required = false, HelpText = "Size of each read cache page in bytes (rounds down to power of 2; minimum 512).")]
         public string ReadCachePageSize { get; set; }
 
         [IntRangeValidation(0, MemoryUtils.ArrayMaxLength)]
@@ -563,9 +563,11 @@ namespace Garnet
         [Option("index-resize-threshold", Required = false, HelpText = "Hash-index Overflow bucket count over total index size in percentage to trigger index resize")]
         public int IndexResizeThreshold { get; set; }
 
-        [IntRangeValidation(1, int.MaxValue, isRequired: false)]
-        [Option("value-overflow-threshold", Required = false, HelpText = "The length at which a value string becomes an overflow byte[]")]
-        public int ValueOverflowThreshold { get; set; }
+        // ValueOverflowThreshold must be at least 64 bytes and strictly less than PageSize (both after rounding down to the previous power of 2).
+        // Validated at server-options consumption time; see GarnetServerOptions.ValueOverflowThresholdBytes.
+        [MemorySizeValidation(isRequired: false)]
+        [Option("value-overflow-threshold", Required = false, HelpText = "Max size of a value stored inline in the main-log page (larger values overflow to the heap). Accepts a memory size (e.g. 4k, 1m). Minimum 64 bytes; must be less than PageSize.")]
+        public string ValueOverflowThreshold { get; set; }
 
         [OptionValidation]
         [Option("fail-on-recovery-error", Required = false, HelpText = "Server bootup should fail if errors happen during bootup of AOF and checkpointing")]

--- a/libs/host/Configuration/OptionsValidators.cs
+++ b/libs/host/Configuration/OptionsValidators.cs
@@ -379,14 +379,14 @@ namespace Garnet
     [AttributeUsage(AttributeTargets.Property)]
     internal sealed class MemorySizeValidationAttribute : OptionValidationAttribute
     {
-        private const string MemorySizePattern = @"^\d+([K|k|M|m|G|g][B|b]{0,1})?$";
+        private const string MemorySizePattern = @"^\d+([KkMmGg][Bb]?)?$";
 
         internal MemorySizeValidationAttribute(bool isRequired = true) : base(isRequired)
         {
         }
 
         /// <summary>
-        /// Memory size validation logic, checks if string matches memory size regex pattern
+        /// Memory size validation logic, checks if string matches memory size regex pattern.
         /// </summary>
         /// <param name="value">String containing memory size</param>
         /// <param name="validationContext">Validation context</param>
@@ -396,12 +396,14 @@ namespace Garnet
             if (TryInitialValidation<string>(value, validationContext, out var initValidationResult, out var memorySize))
                 return initValidationResult;
 
-            if (Regex.IsMatch(memorySize, MemorySizePattern))
-                return ValidationResult.Success;
+            if (!Regex.IsMatch(memorySize, MemorySizePattern))
+            {
+                var baseError = validationContext.MemberName != null ? base.FormatErrorMessage(validationContext.MemberName) : string.Empty;
+                var errorMessage = $"{baseError} Expected string in memory size format (e.g. 1k, 1kb, 10m, 10mb, 50g, 50gb etc). Actual value: {memorySize}";
+                return new ValidationResult(errorMessage, [validationContext.MemberName]);
+            }
 
-            var baseError = validationContext.MemberName != null ? base.FormatErrorMessage(validationContext.MemberName) : string.Empty;
-            var errorMessage = $"{baseError} Expected string in memory size format (e.g. 1k, 1kb, 10m, 10mb, 50g, 50gb etc). Actual value: {memorySize}";
-            return new ValidationResult(errorMessage, [validationContext.MemberName]);
+            return ValidationResult.Success;
         }
     }
 

--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -24,7 +24,7 @@
 	/* Total main-log memory (inline and heap) to use, in bytes. Does not need to be a power of 2 */
 	"LogMemorySize" : "16g",
 
-	/* Size of each main-log page in bytes (rounds down to power of 2). */
+	/* Size of each main-log page in bytes (rounds down to power of 2). Minimum 512 bytes to ensure a worst-case record (header + max inline key + max inline value + optionals + filler + page header) fits within a single page. */
 	"PageSize" : "32m",
 
 	/* Number of main-log pages (rounds down to power of 2). This allows specifying less pages initially than LogMemorySize divided by PageSize. */
@@ -51,7 +51,7 @@
 	/* Total readcache-log memory (inline and heap) to use if readcache is enabled, in bytes. Does not need to be a power of 2 */
 	"ReadCacheMemorySize" : "1g",
 
-	/* Size of each read cache page in bytes (rounds down to power of 2) */
+	/* Size of each read cache page in bytes (rounds down to power of 2). Minimum 512 bytes (same record-fit constraint as PageSize). */
 	"ReadCachePageSize" : "32m",
 
 	/* Number of readcache-log pages (rounds down to power of 2). This allows specifying less pages initially than ReadCacheMemorySize divided by ReadCachePageSize. */
@@ -386,8 +386,8 @@
 	/* Overflow bucket count over total index size in percentage to trigger index resize */
 	"IndexResizeThreshold": 50,
 
-	/* The length at which a value string becomes an overflow byte[] */
-	"ValueOverflowThreshold": 4096,
+	/* Max size of a value stored inline in the main-log page (larger values overflow to the heap). Accepts a memory size (e.g. "4k", "1m"). Minimum 64 bytes; must be less than PageSize. */
+	"ValueOverflowThreshold": "4k",
 
 	/* List of module paths to be loaded at startup */
 	"LoadModuleCS": null,

--- a/libs/server/Servers/GarnetServerOptions.cs
+++ b/libs/server/Servers/GarnetServerOptions.cs
@@ -115,9 +115,10 @@ namespace Garnet.server
         public int IndexResizeThreshold = 50;
 
         /// <summary>
-        /// The length at which a value string becomes an overflow byte[]
+        /// The size at which a value string becomes an overflow byte[]. Accepts bytes or k/m/g suffixes (e.g. "4k", "1m").
+        /// Valid range: 64 bytes to 256m. Rounds down to previous power of 2 by Tsavorite.
         /// </summary>
-        public int ValueOverflowThreshold = 4096;   // TODO Tsavorite.core.LogSettings.MaxInlineValueSize
+        public string ValueOverflowThreshold = "4k";
 
         /// <summary>
         /// Wait for AOF to commit before returning results to client.
@@ -604,7 +605,7 @@ namespace Garnet.server
                 PageSize = 1L << PageSizeBits(),
                 Epoch = epoch,
                 StateMachineDriver = stateMachineDriver,
-                MaxInlineValueSize = ValueOverflowThreshold,
+                MaxInlineValueSize = ValueOverflowThresholdBytes(),
                 loggerFactory = loggerFactory,
                 logger = loggerFactory?.CreateLogger("TsavoriteKV [main]")
             };
@@ -678,7 +679,7 @@ namespace Garnet.server
                 if (ReadCachePageCount != 0)
                     kvSettings.ReadCachePageCount = ReadCachePageCount;
 
-                kvSettings.ReadCachePageSize = ParseSize(ReadCachePageSize, out _);
+                kvSettings.ReadCachePageSize = 1L << ReadCachePageSizeBits();
                 kvSettings.ReadCacheMemorySize = ParseSize(ReadCacheMemorySize, out _);
 
                 if (kvSettings.ReadCacheMemorySize > 0)
@@ -787,6 +788,55 @@ namespace Garnet.server
             if (size != adjustedSize)
                 logger?.LogInformation("Warning: using lower memory size than specified (power of 2)");
             return (int)Math.Log(adjustedSize, 2);
+        }
+
+        /// <summary>
+        /// Get read-cache page size in bits, enforcing the shared <see cref="ServerOptions.MinPageSizeBytes"/> minimum.
+        /// </summary>
+        internal int ReadCachePageSizeBits() => ValidatedPageSizeBits(ReadCachePageSize, nameof(ReadCachePageSize));
+
+        /// <summary>
+        /// Parse and validate <see cref="ValueOverflowThreshold"/> as a byte count.
+        /// Tsavorite requires this to be at least 64 bytes (1 &lt;&lt; LogSettings.kLowestMaxInlineSizeBits)
+        /// and at most 256 MB (1 &lt;&lt; (LogSettings.kMaxStringSizeBits - 1)). The value will be rounded down to the previous power of 2.
+        /// Additionally, the effective (power-of-2) value must be strictly less than the effective PageSize
+        /// so that a value of this size, plus per-record overhead, can be allocated within a single page;
+        /// if not, it is clamped down to the largest valid value (with a warning).
+        /// </summary>
+        /// <returns>The byte value used for <c>KVSettings.MaxInlineValueSize</c>.</returns>
+        /// <exception cref="Exception">Thrown when the value cannot be parsed or is outside the allowed byte range.</exception>
+        public int ValueOverflowThresholdBytes()
+        {
+            const long MinBytes = 64L;                  // 1 << LogSettings.kLowestMaxInlineSizeBits
+            const long MaxBytes = 1L << 28;             // 1 << (LogSettings.kMaxStringSizeBits - 1)
+
+            if (string.IsNullOrEmpty(ValueOverflowThreshold))
+                throw new Exception($"{nameof(ValueOverflowThreshold)} must be specified");
+
+            if (!TryParseSize(ValueOverflowThreshold, out var sizeInBytes))
+                throw new Exception($"Unable to parse {nameof(ValueOverflowThreshold)} value '{ValueOverflowThreshold}'. Expected a memory size string (e.g. '4k', '1m').");
+
+            if (sizeInBytes < MinBytes || sizeInBytes > MaxBytes)
+                throw new Exception($"{nameof(ValueOverflowThreshold)} value '{ValueOverflowThreshold}' ({sizeInBytes} bytes) is outside the allowed range [{MinBytes}, {MaxBytes}] bytes.");
+
+            // Cross-property check: a value of MaxInlineValueSize plus per-record overhead must fit on a page.
+            // Both PageSize and MaxInlineValueSize are rounded down to the previous power of 2 by Tsavorite,
+            // so we require effectiveValue < effectivePage (i.e., value bits < page bits), which guarantees the
+            // value occupies at most half the page and leaves room for the record header, key, and optional fields.
+            // If not satisfied (e.g. defaults combined with an unusually small PageSize), clamp down with a warning
+            // rather than failing — this preserves the "rounds down silently" behavior of other size settings.
+            var valueBits = (int)Math.Log(PreviousPowerOf2(sizeInBytes), 2);
+            var pageBits = PageSizeBits();
+            if (valueBits >= pageBits)
+            {
+                var clampedBits = pageBits - 1;
+                var clampedBytes = 1L << clampedBits;
+                logger?.LogWarning("Warning: clamping {Name} '{Value}' (effective {EffectiveValue} bytes) down to {Clamped} bytes so it fits within PageSize '{Page}' (effective {EffectivePage} bytes).",
+                    nameof(ValueOverflowThreshold), ValueOverflowThreshold, 1L << valueBits, clampedBytes, PageSize, 1L << pageBits);
+                return (int)clampedBytes;
+            }
+
+            return (int)sizeInBytes;
         }
 
         /// <summary>

--- a/libs/server/Servers/ServerOptions.cs
+++ b/libs/server/Servers/ServerOptions.cs
@@ -143,17 +143,33 @@ namespace Garnet.server
         }
 
         /// <summary>
+        /// Minimum main-log / read-cache page size in bytes. A worst-case inline record at default Garnet settings
+        /// (MaxInlineKeySize = 128B Tsavorite default, single-byte namespace, all optional fields, max length-byte
+        /// encoding, max filler) plus the 64-byte page header is ~490 bytes when the value-overflow threshold is
+        /// at its largest allowed value relative to PageSize (effective value &lt; effective page); 512 bytes is the
+        /// smallest power-of-2 page size that accommodates this and prevents Tsavorite's "Entry does not fit on page".
+        /// </summary>
+        public const long MinPageSizeBytes = 512L;
+
+        /// <summary>
+        /// Validate and convert a page-size configuration value to bits, enforcing <see cref="MinPageSizeBytes"/>.
+        /// </summary>
+        protected int ValidatedPageSizeBits(string value, string propName)
+        {
+            var size = ParseSize(value, out _);
+            var adjustedSize = PreviousPowerOf2(size);
+            if (size != adjustedSize)
+                logger?.LogInformation("Warning: using lower {PropName} than specified (power of 2)", propName);
+            if (adjustedSize < MinPageSizeBytes)
+                throw new Exception($"{propName} '{value}' (effective {adjustedSize} bytes after rounding to previous power of 2) must be at least {MinPageSizeBytes} bytes to ensure a worst-case record fits within a single page.");
+            return (int)Math.Log(adjustedSize, 2);
+        }
+
+        /// <summary>
         /// Get page size
         /// </summary>
         /// <returns></returns>
-        public int PageSizeBits()
-        {
-            var size = ParseSize(PageSize, out _);
-            var adjustedSize = PreviousPowerOf2(size);
-            if (size != adjustedSize)
-                logger?.LogInformation("Warning: using lower page size than specified (power of 2)");
-            return (int)Math.Log(adjustedSize, 2);
-        }
+        public int PageSizeBits() => ValidatedPageSizeBits(PageSize, nameof(PageSize));
 
         /// <summary>
         /// Get pub/sub page size

--- a/test/Garnet.test/GarnetServerConfigTests.cs
+++ b/test/Garnet.test/GarnetServerConfigTests.cs
@@ -1389,5 +1389,271 @@ namespace Garnet.test
             var ex = Assert.Throws<Exception>(() => serverOptions.GetAofSettings(0, out _));
             ClassicAssert.IsTrue(ex.Message.Contains("AOF Page size cannot be more than the AOF segment size."));
         }
+
+        [Test]
+        public void ValueOverflowThresholdParsing()
+        {
+            // Default value from defaults.conf is "4k"
+            {
+                var args = Array.Empty<string>();
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                ClassicAssert.AreEqual("4k", options.ValueOverflowThreshold);
+                var serverOptions = options.GetServerOptions();
+                ClassicAssert.AreEqual("4k", serverOptions.ValueOverflowThreshold);
+                ClassicAssert.AreEqual(4096, serverOptions.ValueOverflowThresholdBytes());
+            }
+
+            // Various valid memory size strings (CLI). Use a 1g page size so the upper-bound case (256m) passes the cross-property fit check.
+            foreach (var (input, expectedBytes) in new[] { ("64", 64), ("1k", 1024), ("4k", 4096), ("1m", 1048576), ("256m", 1 << 28) })
+            {
+                var args = new[] { "--page", "1g", "--value-overflow-threshold", input };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful, $"CLI parsing failed for '{input}'");
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                ClassicAssert.AreEqual(input, options.ValueOverflowThreshold);
+                var serverOptions = options.GetServerOptions();
+                ClassicAssert.AreEqual(expectedBytes, serverOptions.ValueOverflowThresholdBytes(), $"Expected {expectedBytes} bytes for '{input}'");
+            }
+
+            // JSON parsing of a valid memory size string
+            {
+                const string JSON = @"{ ""ValueOverflowThreshold"": ""1m"" }";
+                var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out var invalidOptions, out _);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                ClassicAssert.AreEqual("1m", options.ValueOverflowThreshold);
+                ClassicAssert.AreEqual(1048576, options.GetServerOptions().ValueOverflowThresholdBytes());
+            }
+        }
+
+        [Test]
+        public void ValueOverflowThresholdValidation()
+        {
+            // Reject invalid format (CLI)
+            {
+                var args = new[] { "--value-overflow-threshold", "abc" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out _, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsFalse(parseSuccessful);
+                ClassicAssert.IsTrue(invalidOptions.Contains(nameof(Options.ValueOverflowThreshold)));
+            }
+
+            // Regression: the previous regex used a `[K|k|M|m|G|g]` character class which treated the pipe as a literal,
+            // so inputs like '4|' were silently accepted. The tightened regex rejects them.
+            {
+                var args = new[] { "--value-overflow-threshold", "4|" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out _, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsFalse(parseSuccessful);
+                ClassicAssert.IsTrue(invalidOptions.Contains(nameof(Options.ValueOverflowThreshold)));
+            }
+
+            // Reject below minimum (32 bytes < 64 bytes minimum) — enforced at server-options time.
+            {
+                var args = new[] { "--value-overflow-threshold", "32" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                var ex = Assert.Throws<Exception>(() => serverOptions.ValueOverflowThresholdBytes());
+                ClassicAssert.IsTrue(ex.Message.Contains(nameof(serverOptions.ValueOverflowThreshold)));
+            }
+
+            // Reject above maximum (512m > 256m maximum) — enforced at server-options time.
+            {
+                var args = new[] { "--value-overflow-threshold", "512m" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                var ex = Assert.Throws<Exception>(() => serverOptions.ValueOverflowThresholdBytes());
+                ClassicAssert.IsTrue(ex.Message.Contains(nameof(serverOptions.ValueOverflowThreshold)));
+            }
+
+            // Accept exactly the minimum (64 bytes)
+            {
+                var args = new[] { "--value-overflow-threshold", "64" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                ClassicAssert.AreEqual(64, options.GetServerOptions().ValueOverflowThresholdBytes());
+            }
+
+            // Accept exactly the maximum (256m = 1<<28). Use a 1g PageSize so the cross-property fit check passes.
+            {
+                var args = new[] { "--page", "1g", "--value-overflow-threshold", "256m" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                ClassicAssert.AreEqual(1 << 28, options.GetServerOptions().ValueOverflowThresholdBytes());
+            }
+
+            // JSON: reject invalid format
+            {
+                const string JSON = @"{ ""ValueOverflowThreshold"": ""xyz"" }";
+                var parseSuccessful = TryParseGarnetConfOptions(JSON, out _, out var invalidOptions, out _);
+                ClassicAssert.IsFalse(parseSuccessful);
+                ClassicAssert.IsTrue(invalidOptions.Contains(nameof(Options.ValueOverflowThreshold)));
+            }
+
+            // JSON: reject below minimum (enforced at server-options time)
+            {
+                const string JSON = @"{ ""ValueOverflowThreshold"": ""32"" }";
+                var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out var invalidOptions, out _);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                Assert.Throws<Exception>(() => serverOptions.ValueOverflowThresholdBytes());
+            }
+
+            // JSON: reject above maximum (enforced at server-options time)
+            {
+                const string JSON = @"{ ""ValueOverflowThreshold"": ""512m"" }";
+                var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out var invalidOptions, out _);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                Assert.Throws<Exception>(() => serverOptions.ValueOverflowThresholdBytes());
+            }
+        }
+
+        [Test]
+        public void ValueOverflowThresholdMustFitOnPage()
+        {
+            // ValueOverflowThreshold equal to PageSize is clamped down to PageSize/2 (next power of 2 down).
+            {
+                var args = new[] { "--page", "4k", "--value-overflow-threshold", "4k" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                ClassicAssert.AreEqual(2048, serverOptions.ValueOverflowThresholdBytes());
+            }
+
+            // ValueOverflowThreshold greater than PageSize is clamped down to PageSize/2.
+            {
+                var args = new[] { "--page", "1k", "--value-overflow-threshold", "4k" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                ClassicAssert.AreEqual(512, serverOptions.ValueOverflowThresholdBytes());
+            }
+
+            // ValueOverflowThreshold strictly less than PageSize (next power-of-2 down) is returned as-is.
+            {
+                var args = new[] { "--page", "8k", "--value-overflow-threshold", "4k" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                ClassicAssert.AreEqual(4096, serverOptions.ValueOverflowThresholdBytes());
+            }
+
+            // Effective comparison uses post-rounding (previous power of 2): "5k" rounds to 4k, "8k" stays 8k -> ok.
+            {
+                var args = new[] { "--page", "8k", "--value-overflow-threshold", "5k" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                // Raw bytes 5120 are returned by the helper; Tsavorite rounds to 4096 internally.
+                ClassicAssert.AreEqual(5120, serverOptions.ValueOverflowThresholdBytes());
+            }
+        }
+
+        [Test]
+        public void MinimumPageSize()
+        {
+            // PageSize below 512 bytes must be rejected at server-options consumption time.
+            // 256B is a valid memory-size string at parse time but is rejected by PageSizeBits().
+            {
+                var args = new[] { "--page", "256" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                var ex = Assert.Throws<Exception>(() => serverOptions.PageSizeBits());
+                ClassicAssert.IsTrue(ex.Message.Contains(nameof(serverOptions.PageSize)));
+                ClassicAssert.IsTrue(ex.Message.Contains("512"));
+            }
+
+            // 384B rounds down to 256B (previous power of 2) and is rejected.
+            {
+                var args = new[] { "--page", "384" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                Assert.Throws<Exception>(() => serverOptions.PageSizeBits());
+            }
+
+            // Exactly 512B is accepted.
+            {
+                var args = new[] { "--page", "512" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                ClassicAssert.AreEqual(9, serverOptions.PageSizeBits());
+            }
+
+            // 1k is accepted.
+            {
+                var args = new[] { "--page", "1k" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                ClassicAssert.AreEqual(10, serverOptions.PageSizeBits());
+            }
+        }
+
+        [Test]
+        public void MinimumReadCachePageSize()
+        {
+            // ReadCachePageSize below 512 bytes must be rejected.
+            // 256B is a valid memory-size string at parse time but is rejected by ReadCachePageSizeBits().
+            {
+                var args = new[] { "--readcache-page", "256" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                var ex = Assert.Throws<Exception>(() => serverOptions.ReadCachePageSizeBits());
+                ClassicAssert.IsTrue(ex.Message.Contains(nameof(serverOptions.ReadCachePageSize)));
+                ClassicAssert.IsTrue(ex.Message.Contains("512"));
+            }
+
+            // 384B rounds down to 256B (previous power of 2) and is rejected.
+            {
+                var args = new[] { "--readcache-page", "384" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                Assert.Throws<Exception>(() => serverOptions.ReadCachePageSizeBits());
+            }
+
+            // Exactly 512B is accepted.
+            {
+                var args = new[] { "--readcache-page", "512" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                ClassicAssert.AreEqual(9, serverOptions.ReadCachePageSizeBits());
+            }
+
+            // 1k is accepted.
+            {
+                var args = new[] { "--readcache-page", "1k" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                var serverOptions = options.GetServerOptions();
+                ClassicAssert.AreEqual(10, serverOptions.ReadCachePageSizeBits());
+            }
+        }
     }
 }


### PR DESCRIPTION
ValueOverflowThreshold (Options and GarnetServerOptions) changes from int to a memory-size string (e.g. '4k', '1m'); default is '4k'.

All byte-level validation lives in GarnetServerOptions.ValueOverflowThresholdBytes() (single source of truth, no attribute-level duplication):
  * Parsed via ServerOptions.TryParseSize.
  * Range enforced as [64 B, 256 MB], matching Tsavorite's MaxInlineValueSize bounds (1 << LogSettings.kLowestMaxInlineSizeBits .. 1 << (LogSettings.kMaxStringSizeBits - 1)).
  * Cross-property check: the value (after rounding down to previous power of 2) must be strictly less than the (rounded) PageSize, so an inline value of this size plus per-record overhead can fit on a page.

ServerOptions.PageSizeBits() enforces a minimum PageSize of 512 bytes (MinPageSizeBytes constant). At Garnet's defaults (MaxInlineKeySize = 128 B Tsavorite default, single-byte namespace), the worst-case inline record at PageSize = 512 B with the cross-check applied (effective MaxInlineValueSize <= 256 B) plus the 64 B page header is ~490 B; 512 B is the smallest power-of-2 page size that accommodates this and prevents Tsavorite's 'Entry does not fit on page' exception.

Help text on PageSize and ReadCachePageSize updated to mention the 512 B minimum.

Side fix: tighten MemorySizeValidationAttribute regex from
  '^\d+([K|k|M|m|G|g][B|b]{0,1})?$' to '^\d+([KkMmGg][Bb]?)?$'.
The old form treated '|' as a literal inside the character class and accepted strings like '4|'.

defaults.conf updated: ValueOverflowThreshold value '4096' -> '"4k"', and PageSize / ReadCachePageSize comments note the 512 B minimum.

Tests added in GarnetServerConfigTests:
  * ValueOverflowThresholdParsing (default + valid CLI/JSON values).
  * ValueOverflowThresholdValidation (invalid format + out-of-range rejected at server-options consumption time).
  * ValueOverflowThresholdMustFitOnPage (cross-check vs PageSize).
  * MinimumPageSize (PageSize below 512 B rejected).

Breaking change: existing JSON configs that used a numeric ValueOverflowThreshold (e.g. 4096) must switch to a string ('4k' or '4096').