### PR TITLE
Adjust v2 defaults

### DIFF
--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -52,7 +52,7 @@
 	"ReadCacheMemorySize" : "1g",
 
 	/* Size of each read cache page in bytes (rounds down to power of 2). Minimum 512 bytes (same record-fit constraint as PageSize). */
-	"ReadCachePageSize" : "1m",
+	"ReadCachePageSize" : "4m",
 
 	/* Number of readcache-log pages (rounds down to power of 2). This allows specifying less pages initially than ReadCacheMemorySize divided by ReadCachePageSize. */
 	"ReadCachePageCount" : 0,

--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -25,7 +25,7 @@
 	"LogMemorySize" : "16g",
 
 	/* Size of each main-log page in bytes (rounds down to power of 2). Minimum 512 bytes to ensure a worst-case record (header + max inline key + max inline value + optionals + filler + page header) fits within a single page. */
-	"PageSize" : "4m",
+	"PageSize" : "16m",
 
 	/* Number of main-log pages (rounds down to power of 2). This allows specifying less pages initially than LogMemorySize divided by PageSize. */
 	"PageCount" : 0,

--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -25,7 +25,7 @@
 	"LogMemorySize" : "16g",
 
 	/* Size of each main-log page in bytes (rounds down to power of 2). Minimum 512 bytes to ensure a worst-case record (header + max inline key + max inline value + optionals + filler + page header) fits within a single page. */
-	"PageSize" : "32m",
+	"PageSize" : "4m",
 
 	/* Number of main-log pages (rounds down to power of 2). This allows specifying less pages initially than LogMemorySize divided by PageSize. */
 	"PageCount" : 0,
@@ -52,7 +52,7 @@
 	"ReadCacheMemorySize" : "1g",
 
 	/* Size of each read cache page in bytes (rounds down to power of 2). Minimum 512 bytes (same record-fit constraint as PageSize). */
-	"ReadCachePageSize" : "32m",
+	"ReadCachePageSize" : "1m",
 
 	/* Number of readcache-log pages (rounds down to power of 2). This allows specifying less pages initially than ReadCacheMemorySize divided by ReadCachePageSize. */
 	"ReadCachePageCount" : 0,
@@ -387,7 +387,7 @@
 	"IndexResizeThreshold": 50,
 
 	/* Max size of a value stored inline in the main-log page (larger values overflow to the heap). Accepts a memory size (e.g. "4k", "1m"). Minimum 64 bytes; must be less than PageSize. */
-	"ValueOverflowThreshold": "4k",
+	"ValueOverflowThreshold": "16k",
 
 	/* List of module paths to be loaded at startup */
 	"LoadModuleCS": null,

--- a/libs/server/Servers/GarnetServerOptions.cs
+++ b/libs/server/Servers/GarnetServerOptions.cs
@@ -118,7 +118,7 @@ namespace Garnet.server
         /// The size at which a value string becomes an overflow byte[]. Accepts bytes or k/m/g suffixes (e.g. "4k", "1m").
         /// Valid range: 64 bytes to 256m. Rounds down to previous power of 2 by Tsavorite.
         /// </summary>
-        public string ValueOverflowThreshold = "4k";
+        public string ValueOverflowThreshold = "16k";
 
         /// <summary>
         /// Wait for AOF to commit before returning results to client.
@@ -447,7 +447,7 @@ namespace Garnet.server
         /// <summary>
         /// Size of each read cache page in bytes (rounds down to power of 2)
         /// </summary>
-        public string ReadCachePageSize = "32m";
+        public string ReadCachePageSize = "1m";
 
         /// <summary>
         /// Number of readcache-log pages (rounds down to power of 2). This allows specifying less pages initially than ReadCacheMemorySize divided by ReadCachePageSize.

--- a/libs/server/Servers/GarnetServerOptions.cs
+++ b/libs/server/Servers/GarnetServerOptions.cs
@@ -447,7 +447,7 @@ namespace Garnet.server
         /// <summary>
         /// Size of each read cache page in bytes (rounds down to power of 2)
         /// </summary>
-        public string ReadCachePageSize = "1m";
+        public string ReadCachePageSize = "4m";
 
         /// <summary>
         /// Number of readcache-log pages (rounds down to power of 2). This allows specifying less pages initially than ReadCacheMemorySize divided by ReadCachePageSize.

--- a/libs/server/Servers/ServerOptions.cs
+++ b/libs/server/Servers/ServerOptions.cs
@@ -43,7 +43,7 @@ namespace Garnet.server
         /// <summary>
         /// Size of each main-log page in bytes (rounds down to power of 2).
         /// </summary>
-        public string PageSize = "32m";
+        public string PageSize = "4m";
 
         /// <summary>
         /// Number of main-log pages (rounds down to power of 2). This allows specifying less pages initially than <see cref="LogMemorySize"/> divided by <see cref="PageSize"/>

--- a/libs/server/Servers/ServerOptions.cs
+++ b/libs/server/Servers/ServerOptions.cs
@@ -43,7 +43,7 @@ namespace Garnet.server
         /// <summary>
         /// Size of each main-log page in bytes (rounds down to power of 2).
         /// </summary>
-        public string PageSize = "4m";
+        public string PageSize = "16m";
 
         /// <summary>
         /// Number of main-log pages (rounds down to power of 2). This allows specifying less pages initially than <see cref="LogMemorySize"/> divided by <see cref="PageSize"/>

--- a/test/standalone/Garnet.test/GarnetServerConfigTests.cs
+++ b/test/standalone/Garnet.test/GarnetServerConfigTests.cs
@@ -114,7 +114,7 @@ namespace Garnet.test
             parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(null, out options, out invalidOptions, out var optionsJson, out exitGracefully, silentMode: true);
             ClassicAssert.IsTrue(parseSuccessful);
             ClassicAssert.AreEqual(invalidOptions.Count, 0);
-            ClassicAssert.AreEqual("32m", options.PageSize);
+            ClassicAssert.AreEqual("4m", options.PageSize);
             ClassicAssert.AreEqual("16g", options.LogMemorySize);
             var nonDefaultOptions = JsonSerializer.Deserialize<Dictionary<string, object>>(optionsJson);
             ClassicAssert.IsEmpty(nonDefaultOptions);
@@ -125,11 +125,11 @@ namespace Garnet.test
             var binPaths = new[] { GetFullExtensionBinPath(Path.Combine("standalone", "Garnet.test")), GetFullExtensionBinPath(Path.Combine("cluster", "Garnet.test.cluster")) };
             var modules = new[] { Assembly.GetExecutingAssembly().Location };
 
-            var args = new[] { "--config-export-path", configPath, "-p", "4m", "-m", "128m", "-s", "2g", "--index", "128m", "--recover", "--port", "53", "--reviv-fraction", "0.5", "--reviv-bin-record-counts", "1,2,3", "--extension-bin-paths", string.Join(',', binPaths), "--loadmodulecs", string.Join(',', modules) };
+            var args = new[] { "--config-export-path", configPath, "-p", "8m", "-m", "128m", "-s", "2g", "--index", "128m", "--recover", "--port", "53", "--reviv-fraction", "0.5", "--reviv-bin-record-counts", "1,2,3", "--extension-bin-paths", string.Join(',', binPaths), "--loadmodulecs", string.Join(',', modules) };
             parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out options, out invalidOptions, out optionsJson, out exitGracefully, silentMode: true);
             ClassicAssert.IsTrue(parseSuccessful);
             ClassicAssert.AreEqual(invalidOptions.Count, 0);
-            ClassicAssert.AreEqual("4m", options.PageSize);
+            ClassicAssert.AreEqual("8m", options.PageSize);
             ClassicAssert.AreEqual("128m", options.LogMemorySize);
             ClassicAssert.AreEqual("2g", options.SegmentSize);
             ClassicAssert.AreEqual(53, options.Port);
@@ -144,7 +144,7 @@ namespace Garnet.test
             nonDefaultOptions = JsonSerializer.Deserialize<Dictionary<string, object>>(optionsJson);
             ClassicAssert.AreEqual(9, nonDefaultOptions.Count);
             ClassicAssert.IsTrue(nonDefaultOptions.ContainsKey(nameof(Options.PageSize)));
-            ClassicAssert.AreEqual("4m", ((JsonElement)nonDefaultOptions[nameof(Options.PageSize)]).GetString());
+            ClassicAssert.AreEqual("8m", ((JsonElement)nonDefaultOptions[nameof(Options.PageSize)]).GetString());
             ClassicAssert.IsTrue(nonDefaultOptions.ContainsKey(nameof(Options.Port)));
             ClassicAssert.AreEqual(53, ((JsonElement)nonDefaultOptions[nameof(Options.Port)]).GetInt32());
             ClassicAssert.IsTrue(nonDefaultOptions.ContainsKey(nameof(Options.RevivifiableFraction)));
@@ -166,7 +166,7 @@ namespace Garnet.test
             parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out options, out invalidOptions, out optionsJson, out exitGracefully, silentMode: true);
             ClassicAssert.IsTrue(parseSuccessful);
             ClassicAssert.AreEqual(invalidOptions.Count, 0);
-            ClassicAssert.IsTrue(options.PageSize == "4m");
+            ClassicAssert.IsTrue(options.PageSize == "8m");
             ClassicAssert.IsTrue(options.LogMemorySize == "128m");
             CollectionAssert.AreEqual(new[] { 1, 2, 3 }, options.RevivBinRecordCounts);
             CollectionAssert.AreEqual(binPaths, options.ExtensionBinPaths);
@@ -176,7 +176,7 @@ namespace Garnet.test
             nonDefaultOptions = JsonSerializer.Deserialize<Dictionary<string, object>>(optionsJson);
             ClassicAssert.AreEqual(9, nonDefaultOptions.Count);
             ClassicAssert.IsTrue(nonDefaultOptions.ContainsKey(nameof(Options.PageSize)));
-            ClassicAssert.AreEqual("4m", ((JsonElement)nonDefaultOptions[nameof(Options.PageSize)]).GetString());
+            ClassicAssert.AreEqual("8m", ((JsonElement)nonDefaultOptions[nameof(Options.PageSize)]).GetString());
 
             // Import from previous export command, include command line args, export to file
             // Check values from import path override values from default.conf, and values from command line override values from default.conf and import path
@@ -310,17 +310,17 @@ namespace Garnet.test
             var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(null, out var options, out var invalidOptions, out _, out _, silentMode: true);
             ClassicAssert.IsTrue(parseSuccessful);
             ClassicAssert.AreEqual(invalidOptions.Count, 0);
-            ClassicAssert.IsTrue(options.PageSize == "32m");
+            ClassicAssert.IsTrue(options.PageSize == "4m");
             ClassicAssert.IsTrue(options.LogMemorySize == "16g");
             ClassicAssert.IsNull(options.AzureStorageServiceUri);
             ClassicAssert.IsNull(options.AzureStorageManagedIdentity);
             ClassicAssert.AreNotEqual(DeviceType.AzureStorage, options.GetDeviceType());
 
-            var args = new[] { "--storage-string", AzureEmulatedStorageString, "--use-azure-storage-for-config-export", "true", "--config-export-path", configPath, "-p", "4m", "-m", "128m", "--storage-service-uri", "https://demo.blob.core.windows.net", "--storage-managed-identity", "demo" };
+            var args = new[] { "--storage-string", AzureEmulatedStorageString, "--use-azure-storage-for-config-export", "true", "--config-export-path", configPath, "-p", "8m", "-m", "128m", "--storage-service-uri", "https://demo.blob.core.windows.net", "--storage-managed-identity", "demo" };
             parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out options, out invalidOptions, out _, out _, silentMode: true);
             ClassicAssert.IsTrue(parseSuccessful);
             ClassicAssert.AreEqual(invalidOptions.Count, 0);
-            ClassicAssert.IsTrue(options.PageSize == "4m");
+            ClassicAssert.IsTrue(options.PageSize == "8m");
             ClassicAssert.IsTrue(options.LogMemorySize == "128m");
             ClassicAssert.IsTrue(options.AzureStorageServiceUri == "https://demo.blob.core.windows.net");
             ClassicAssert.IsTrue(options.AzureStorageManagedIdentity == "demo");
@@ -329,7 +329,7 @@ namespace Garnet.test
             parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out options, out invalidOptions, out _, out _, silentMode: true);
             ClassicAssert.IsTrue(parseSuccessful);
             ClassicAssert.AreEqual(invalidOptions.Count, 0);
-            ClassicAssert.IsTrue(options.PageSize == "4m");
+            ClassicAssert.IsTrue(options.PageSize == "8m");
             ClassicAssert.IsTrue(options.LogMemorySize == "128m");
             ClassicAssert.IsTrue(options.AzureStorageServiceUri == "https://demo.blob.core.windows.net");
             ClassicAssert.IsTrue(options.AzureStorageManagedIdentity == "demo");
@@ -1391,16 +1391,16 @@ namespace Garnet.test
         [Test]
         public void ValueOverflowThresholdParsing()
         {
-            // Default value from defaults.conf is "4k"
+            // Default value from defaults.conf is "16k"
             {
                 var args = Array.Empty<string>();
                 var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
                 ClassicAssert.IsTrue(parseSuccessful);
                 ClassicAssert.AreEqual(0, invalidOptions.Count);
-                ClassicAssert.AreEqual("4k", options.ValueOverflowThreshold);
+                ClassicAssert.AreEqual("16k", options.ValueOverflowThreshold);
                 var serverOptions = options.GetServerOptions();
-                ClassicAssert.AreEqual("4k", serverOptions.ValueOverflowThreshold);
-                ClassicAssert.AreEqual(4096, serverOptions.ValueOverflowThresholdBytes());
+                ClassicAssert.AreEqual("16k", serverOptions.ValueOverflowThreshold);
+                ClassicAssert.AreEqual(16384, serverOptions.ValueOverflowThresholdBytes());
             }
 
             // Various valid memory size strings (CLI). Use a 1g page size so the upper-bound case (256m) passes the cross-property fit check.

--- a/test/standalone/Garnet.test/GarnetServerConfigTests.cs
+++ b/test/standalone/Garnet.test/GarnetServerConfigTests.cs
@@ -114,7 +114,7 @@ namespace Garnet.test
             parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(null, out options, out invalidOptions, out var optionsJson, out exitGracefully, silentMode: true);
             ClassicAssert.IsTrue(parseSuccessful);
             ClassicAssert.AreEqual(invalidOptions.Count, 0);
-            ClassicAssert.AreEqual("4m", options.PageSize);
+            ClassicAssert.AreEqual("16m", options.PageSize);
             ClassicAssert.AreEqual("16g", options.LogMemorySize);
             var nonDefaultOptions = JsonSerializer.Deserialize<Dictionary<string, object>>(optionsJson);
             ClassicAssert.IsEmpty(nonDefaultOptions);
@@ -310,7 +310,7 @@ namespace Garnet.test
             var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(null, out var options, out var invalidOptions, out _, out _, silentMode: true);
             ClassicAssert.IsTrue(parseSuccessful);
             ClassicAssert.AreEqual(invalidOptions.Count, 0);
-            ClassicAssert.IsTrue(options.PageSize == "4m");
+            ClassicAssert.IsTrue(options.PageSize == "16m");
             ClassicAssert.IsTrue(options.LogMemorySize == "16g");
             ClassicAssert.IsNull(options.AzureStorageServiceUri);
             ClassicAssert.IsNull(options.AzureStorageManagedIdentity);


### PR DESCRIPTION
Updates Garnet's v2 defaults to better reflect typical operational deployments and the vector-database workload.

```
PageSize               : 32m → 16m
ReadCachePageSize      : 32m → 4m
ValueOverflowThreshold : 4k  → 16k
```

## Rationale

### `PageSize = 16m` (was `32m`)

A modest 2× reduction. Earlier drafts proposed 4 MB; after a critical re-examination (see below), 16 MB is the more defensible compromise.

**Real benefits over 32 MB:**
- Halves flush-completion latency at the device level (~5 ms vs ~10 ms for 16 MB vs 32 MB on a 3 GB/s NVMe). Flush completion gates `FlushedUntilAddress`, which gates replication acks and AOF commit cadence.
- 2× finer `HeadAddress` step → `LogSizeTracker` keeps memory closer to target on tight budgets.
- Halves the worst-case tail-page memory waste (16 MB pinned for a nearly-empty tail page vs 32 MB).
- Page allocation zero-fill is 2× faster — less latency on the unlucky thread that crosses a page boundary into an unallocated page.

**Cache behavior is preserved.** For a 64 GB typical deployment:
- 32 MB pages → 2,048 entries → `pagePointers` 16 KB → L1d.
- 16 MB pages → 4,096 entries → `pagePointers` 32 KB → still L1d on every mainstream server CPU.
- (4 MB pages would have been 16,384 entries → 128 KB → spills to L2. That's why we backed off 4 MB.)

**Costs are modest:**
- 2× more page-boundary crossings (more `PageOffset` CAS / `HandlePageOverflow` invocations).
- 2× faster RCU onset (records age from mutable → read-only 2× sooner).
- 2× larger per-page metadata arrays (`PageStatusIndicator`, `objectPages`, etc.).

### `ReadCachePageSize = 4m` (was `32m`)

The previous 32 MB default was clearly broken for the read cache; 4 MB is the right operational point.

- **Avoid the broken-at-32m regime.** With a 1 GB `ReadCacheMemorySize` default and 32 MB pages, there are only ~32 pages total — too coarse for any useful eviction or second-chance behavior. 4 MB gives 256 pages, which is plenty.
- **Eviction is byte-granular.** `LogSizeTracker.DetermineEvictionRange` evicts at record granularity; the page-size choice only governs when the underlying page buffer is freed back to the allocator. At 256 pages on a 1 GB budget, each freed page is a 0.4% memory step — comfortably smooth.
- **Why not 1 MB?** Earlier drafts proposed 1 MB. At 1,024 pages the eviction granularity (0.1% per page free) is overkill, and you pay 4× the per-page metadata (`ObjectIdMap`, `PageStatusIndicator`) and 4× the page-allocation churn during cache fills. 4 MB captures the win at a fraction of the overhead and matches the 4:1 ratio with the 16 MB main-log page.
- **No flush penalty either way.** Read cache uses `NullDevice` — there is no flush IO whose cost grows with page count, so smaller pages are essentially free on that axis.

### `ValueOverflowThreshold = 16k` (was `4k`)

Critical for the vector-database use case.

- **DiskANN "1 IO per hop" invariant.** Garnet's vector-set surface uses DiskANN, whose disk-graph traversal performance hinges on each hop being a single IO. Records stored as overflow byte[] currently incur **2 IOs** on cold reads (one for the main-log record header to learn the overflow offset, one for the overflow payload itself) and cannot be coalesced because the overflow position lives in the header.
- **Covers all mainstream embeddings inline.** Typical embedding vector sizes (FP32, plus ~24 B record header):
  - BGE-Base (768d): ~3.1 KB
  - text-embedding-ada-002 (1536d): ~6.3 KB
  - text-embedding-3-large (3072d): ~12.3 KB
- 16 KB inline keeps all of those in a single IO. The next jump (4096d FP32, Cohere v4 / Mistral-embed at ~16.3 KB) still overflows, but those models are uncommon enough that the page-density trade-off of moving to 32 KB was judged not worth it.
- **Optional optimization assumed.** Maximum benefit requires `IStreamBuffer.InitialIOSize` to be hinted up to the record size so the first IO grabs the entire inline record; without that hint the OS-page-sized initial read (4 KB on Linux x64) wastes one IO for inline records > 4 KB. That fix is straightforward and orthogonal.

## Why not 4 MB? (notes from review)

Earlier iterations proposed `PageSize = 4m`. Critical review concluded the operational arguments for going that small don't hold up:

- **"Smaller flush bursts"** — Flush is async; the writer never waits on it. Total bytes pushed are identical; smaller IOs may be *less* device-efficient. Only matters for `FlushedUntilAddress` tick frequency, which is a marginal effect.
- **"Finer `ReadOnlyAddress` granularity"** — Actually a *negative*. Records age into immutable 8× faster, causing more RCU traffic on writes.
- **"Smaller blast radius on corruption"** — Tsavorite doesn't have page-checksum-and-discard recovery; corruption typically fails recovery rather than discarding a page.
- **Cache fit** — `pagePointers` for 4 MB / 64 GB log is 128 KB, which spills out of L1d on every modern server CPU.
- **YCSB delta** — The 5–6% in-memory-read advantage seen at 4 MB was on a dataset that fit entirely in memory (no flush/eviction), within run-to-run noise, and likely an artifact of insert-phase contention patterns rather than a steady-state read win.

16 MB captures the meaningful operational wins without these downsides.

## Testing

`GarnetServerConfigTests` (`ImportExportConfigLocal`, `ImportExportConfigAzure`, `ValueOverflowThresholdParsing`) had hard-coded `"32m"` and `"4k"` assertions; updated to the new defaults. Affected tests pass locally.
