### PR TITLE
Add INT8 vector support for vector sets

### DIFF
--- a/libs/server/Resp/Vector/DiskANNService.cs
+++ b/libs/server/Resp/Vector/DiskANNService.cs
@@ -96,12 +96,16 @@ namespace Garnet.server
             {
                 vector_len = vector.Length;
             }
+            else if (vectorType == VectorValueType.SB8)
+            {
+                vector_len = vector.Length;
+            }
             else
             {
                 throw new NotImplementedException($"{vectorType}");
             }
 
-            var attributes_data = Unsafe.AsPointer(ref MemoryMarshal.GetReference(attributes));
+            var attributes_data= Unsafe.AsPointer(ref MemoryMarshal.GetReference(attributes));
             var attributes_len = attributes.Length;
 
             return NativeDiskANNMethods.insert(context, index, (nint)id_data, (nuint)id_len, vectorType, (nint)vector_data, (nuint)vector_len, (nint)attributes_data, (nuint)attributes_len) == 1;
@@ -140,12 +144,16 @@ namespace Garnet.server
             {
                 vector_len = vector.Length;
             }
+            else if (vectorType == VectorValueType.SB8)
+            {
+                vector_len = vector.Length;
+            }
             else
             {
                 throw new NotImplementedException($"{vectorType}");
             }
 
-            var filter_data = Unsafe.AsPointer(ref MemoryMarshal.GetReference(filter));
+            var filter_data= Unsafe.AsPointer(ref MemoryMarshal.GetReference(filter));
             var filter_len = filter.Length;
 
             void* output_ids;

--- a/libs/server/Resp/Vector/DiskANNService.cs
+++ b/libs/server/Resp/Vector/DiskANNService.cs
@@ -105,7 +105,7 @@ namespace Garnet.server
                 throw new NotImplementedException($"{vectorType}");
             }
 
-            var attributes_data= Unsafe.AsPointer(ref MemoryMarshal.GetReference(attributes));
+            var attributes_data = Unsafe.AsPointer(ref MemoryMarshal.GetReference(attributes));
             var attributes_len = attributes.Length;
 
             return NativeDiskANNMethods.insert(context, index, (nint)id_data, (nuint)id_len, vectorType, (nint)vector_data, (nuint)vector_len, (nint)attributes_data, (nuint)attributes_len) == 1;
@@ -153,7 +153,7 @@ namespace Garnet.server
                 throw new NotImplementedException($"{vectorType}");
             }
 
-            var filter_data= Unsafe.AsPointer(ref MemoryMarshal.GetReference(filter));
+            var filter_data = Unsafe.AsPointer(ref MemoryMarshal.GetReference(filter));
             var filter_len = filter.Length;
 
             void* output_ids;

--- a/libs/server/Resp/Vector/RespServerSessionVectors.cs
+++ b/libs/server/Resp/Vector/RespServerSessionVectors.cs
@@ -14,9 +14,10 @@ namespace Garnet.server
         private bool NetworkVADD<TGarnetApi>(ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetApi
         {
-            // VADD key [REDUCE dim] (FP32 | XB8 | VALUES num) vector element [CAS] [NOQUANT | Q8 | BIN | XPREQ8] [EF build-exploration-factor] [SETATTR attributes] [M numlinks]
+            // VADD key [REDUCE dim] (FP32 | XB8 | SB8 | VALUES num) vector element [CAS] [NOQUANT | Q8 | BIN | XPREQ8] [EF build-exploration-factor] [SETATTR attributes] [M numlinks]
             //
             // XB8 is a non-Redis extension, stands for: eXtension Binary 8-bit values - encodes [0, 255] per dimension
+            // SB8 is a non-Redis extension, stands for: Signed Binary 8-bit values - encodes [-128, 127] per dimension
             // XPREQ8 is a non-Redis extension, stands for: eXtension PREcalculated Quantization 8-bit - requests no quantization on pre-calculated [0, 255] values
 
             const int MinM = 4;
@@ -472,7 +473,7 @@ namespace Garnet.server
             const int DefaultIdSize = sizeof(ulong);
             const int DefaultAttributeSize = 32;
 
-            // VSIM key (ELE | FP32 | XB8 | VALUES num) (vector | element) [WITHSCORES] [WITHATTRIBS] [COUNT num] [EPSILON delta] [EF search-exploration - factor] [FILTER expression][FILTER-EF max - filtering - effort] [TRUTH][NOTHREAD]
+            // VSIM key (ELE | FP32 | XB8 | SB8 | VALUES num) (vector | element) [WITHSCORES] [WITHATTRIBS] [COUNT num] [EPSILON delta] [EF search-exploration - factor] [FILTER expression][FILTER-EF max - filtering - effort] [TRUTH][NOTHREAD]
             //
             // XB8 is a non-Redis extension, stands for: eXtension Binary 8-bit values - encodes [0, 255] per dimension
 

--- a/libs/server/Resp/Vector/RespServerSessionVectors.cs
+++ b/libs/server/Resp/Vector/RespServerSessionVectors.cs
@@ -366,20 +366,6 @@ namespace Garnet.server
                 numLinks ??= 16;
                 distanceMetric ??= VectorDistanceMetricType.L2;
 
-                // Validate that DiskANN is expected to succeed given data sizes
-                //
-                // Note that this goes away in store v2
-                if (values.Length > maximumVectorSetValueBytes)
-                {
-                    WriteError("ERR Vector exceed configured page size"u8);
-                    return true;
-                }
-
-                if (attributes.Value.Length > maximumVectorSetValueBytes)
-                {
-                    WriteError("ERR Attribute exceed configured page size"u8);
-                    return true;
-                }
 
                 if (quantType != VectorQuantType.XPreQ8 && quantType != VectorQuantType.NoQuant && quantType != VectorQuantType.Q8)
                 {

--- a/libs/server/Resp/Vector/RespServerSessionVectors.cs
+++ b/libs/server/Resp/Vector/RespServerSessionVectors.cs
@@ -126,6 +126,20 @@ namespace Garnet.server
                     valueType = VectorValueType.XB8;
                     values = asBytes;
                 }
+                else if (parseState.GetArgSliceByRef(curIx).Span.EqualsUpperCaseSpanIgnoringCase("SB8"u8))
+                {
+                    curIx++;
+                    if (curIx >= parseState.Count)
+                    {
+                        return AbortWithWrongNumberOfArguments("VADD");
+                    }
+
+                    var asBytes = parseState.GetArgSliceByRef(curIx).Span;
+                    curIx++;
+
+                    valueType = VectorValueType.SB8;
+                    values = asBytes;
+                }
 
                 if (curIx >= parseState.Count)
                 {
@@ -346,7 +360,22 @@ namespace Garnet.server
                 numLinks ??= 16;
                 distanceMetric ??= VectorDistanceMetricType.L2;
 
-                if (quantType != VectorQuantType.XPreQ8 && quantType != VectorQuantType.NoQuant)
+                // Validate that DiskANN is expected to succeed given data sizes
+                //
+                // Note that this goes away in store v2
+                if (values.Length > maximumVectorSetValueBytes)
+                {
+                    WriteError("ERR Vector exceed configured page size"u8);
+                    return true;
+                }
+
+                if (attributes.Value.Length > maximumVectorSetValueBytes)
+                {
+                    WriteError("ERR Attribute exceed configured page size"u8);
+                    return true;
+                }
+
+                if (quantType != VectorQuantType.XPreQ8 && quantType != VectorQuantType.NoQuant && quantType != VectorQuantType.Q8)
                 {
                     WriteError("ERR Unsupported quantization type"u8);
                     return true;
@@ -505,6 +534,19 @@ namespace Garnet.server
                         var asBytes = parseState.GetArgSliceByRef(curIx).Span;
 
                         valueType = VectorValueType.XB8;
+                        values = asBytes;
+                        curIx++;
+                    }
+                    else if (kind.Span.EqualsUpperCaseSpanIgnoringCase("SB8"u8))
+                    {
+                        if (curIx >= parseState.Count)
+                        {
+                            return AbortWithWrongNumberOfArguments("VSIM");
+                        }
+
+                        var asBytes = parseState.GetArgSliceByRef(curIx).Span;
+
+                        valueType = VectorValueType.SB8;
                         values = asBytes;
                         curIx++;
                     }

--- a/libs/server/Resp/Vector/RespServerSessionVectors.cs
+++ b/libs/server/Resp/Vector/RespServerSessionVectors.cs
@@ -142,6 +142,11 @@ namespace Garnet.server
                     values = asBytes;
                 }
 
+                if (values.IsEmpty)
+                {
+                    return AbortWithErrorMessage("ERR vector values must be non-empty");
+                }
+
                 if (curIx >= parseState.Count)
                 {
                     return AbortWithWrongNumberOfArguments("VADD");
@@ -592,6 +597,11 @@ namespace Garnet.server
                     {
                         return AbortWithErrorMessage("VSIM expected ELE, FP32, or VALUES");
                     }
+                }
+
+                if (!element.HasValue && values.IsEmpty)
+                {
+                    return AbortWithErrorMessage("ERR vector values must be non-empty");
                 }
 
                 bool? withScores = null;

--- a/libs/server/Resp/Vector/VectorManager.cs
+++ b/libs/server/Resp/Vector/VectorManager.cs
@@ -862,9 +862,16 @@ namespace Garnet.server
                         into[i] = from[i];
                     }
                 }
+                else if (quantType == VectorQuantType.Q8)
+                {
+                    // Q8 stores signed bytes; dequantize by sign-extending to float
+                    for (var i = 0; i < asBytes.Length; i++)
+                    {
+                        into[i] = (float)(sbyte)from[i];
+                    }
+                }
                 else
                 {
-                    // TODO: Handle Q8 and BIN as they are implemented
                     throw new NotImplementedException($"Unexpected quantization: {quantType}");
                 }
 
@@ -887,6 +894,10 @@ namespace Garnet.server
                 return (uint)(values.Length / sizeof(float));
             }
             else if (valueType == VectorValueType.XB8)
+            {
+                return (uint)(values.Length);
+            }
+            else if (valueType == VectorValueType.SB8)
             {
                 return (uint)(values.Length);
             }

--- a/libs/server/Storage/Session/MainStore/VectorStoreOps.cs
+++ b/libs/server/Storage/Session/MainStore/VectorStoreOps.cs
@@ -61,6 +61,11 @@ namespace Garnet.server
         /// Bytes (8 bit).
         /// </summary>
         XB8,
+
+        /// <summary>
+        /// Signed bytes (int8, [-128, 127]).
+        /// </summary>
+        SB8,
     }
 
     /// <summary>

--- a/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
+++ b/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
@@ -164,6 +164,15 @@ namespace Garnet.test
             var res4 = db.Execute("VADD", ["foo", "REDUCE", "50", "XB8", byte4, new byte[] { 3, 0, 0, 0 }, "CAS", "NOQUANT", "EF", "16", "M", "32"]);
             ClassicAssert.AreEqual(1, (int)res4);
 
+            // SB8 (signed bytes [-128, 127])
+            var sbyte5 = new byte[75];
+            for (var i = 0; i < sbyte5.Length; i++)
+            {
+                sbyte5[i] = (byte)(sbyte)(i - 37);  // range around zero: [-37 .. +37]
+            }
+            var res4b = db.Execute("VADD", ["foo", "REDUCE", "50", "SB8", sbyte5, new byte[] { 4, 0, 0, 0 }, "CAS", "NOQUANT", "EF", "16", "M", "32"]);
+            ClassicAssert.AreEqual(1, (int)res4b);
+
             // TODO: exact duplicates - what does Redis do?
 
             // Add without specifying reductions after first vector
@@ -267,6 +276,46 @@ namespace Garnet.test
         }
 
         [Test]
+        public void VADDSB8Q8()
+        {
+            // Dedicated test for SB8 input with Q8 quantization (mirrors VADDXPREQB8 for the int8 path)
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            var vectorData1 = new byte[75];
+            for (var i = 0; i < vectorData1.Length; i++)
+            {
+                vectorData1[i] = (byte)(sbyte)(i - 37);  // [-37 .. +37]
+            }
+
+            var vectorData2 = new byte[75];
+            for (var i = 0; i < vectorData2.Length; i++)
+            {
+                vectorData2[i] = (byte)(sbyte)(i + 50);  // [50 .. 124]
+            }
+
+            // Create a vector set with SB8 + Q8
+            var res1 = db.Execute("VADD", ["buzz", "SB8", vectorData1, new byte[] { 0, 0, 0, 0 }, "Q8"]);
+            ClassicAssert.AreEqual(1, (int)res1);
+
+            // Add another element
+            var res2 = db.Execute("VADD", ["buzz", "SB8", vectorData2, new byte[] { 0, 0, 0, 1 }, "Q8"]);
+            ClassicAssert.AreEqual(1, (int)res2);
+
+            // Verify VEMB returns dequantized signed values: (float)(sbyte)byte
+            var embRes = (string[])db.Execute("VEMB", ["buzz", new byte[] { 0, 0, 0, 0 }]);
+            ClassicAssert.AreEqual(75, embRes.Length);
+            for (var i = 0; i < embRes.Length; i++)
+            {
+                ClassicAssert.AreEqual((float)(sbyte)vectorData1[i], float.Parse(embRes[i]));
+            }
+
+            // Verify non-existent element returns empty
+            var embEmpty = (string[])db.Execute("VEMB", ["buzz", new byte[] { 0, 0, 0, 9 }]);
+            ClassicAssert.AreEqual(0, embEmpty.Length);
+        }
+
+        [Test]
         public void VADDErrors()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
@@ -350,11 +399,13 @@ namespace Garnet.test
             var exc19 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", ["", "VALUES", "75", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", new byte[] { 0, 0, 0, 0 }, "XPREQ8"]));
             ClassicAssert.AreEqual("ERR Vector Set key cannot be empty", exc19.Message);
 
-            // Unsupported quantization types (Q8 and BIN are not yet supported)
+            // Unsupported quantization types (BIN is not yet supported; Q8 is now supported)
+            // exc28: default quant on a NOQUANT index with wrong dims → dim mismatch takes precedence
             var exc28 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", [vectorSetKey, "VALUES", "1", "2.0", "bar"]));
-            ClassicAssert.AreEqual("ERR Unsupported quantization type", exc28.Message);
+            ClassicAssert.AreEqual("ERR Vector dimension mismatch - got 1 but set has 75", exc28.Message);
+            // exc29: Q8 is now a supported quantization type, so quant mismatch with NOQUANT index
             var exc29 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", [vectorSetKey, "VALUES", "1", "2.0", "bar", "Q8"]));
-            ClassicAssert.AreEqual("ERR Unsupported quantization type", exc29.Message);
+            ClassicAssert.AreEqual("ERR Vector dimension mismatch - got 1 but set has 75", exc29.Message);
             var exc30 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", [vectorSetKey, "VALUES", "1", "2.0", "bar", "BIN"]));
             ClassicAssert.AreEqual("ERR Unsupported quantization type", exc30.Message);
 
@@ -505,6 +556,17 @@ namespace Garnet.test
             ClassicAssert.AreEqual(2, res6.Length);
             ClassicAssert.IsTrue(res6.Any(static x => x.SequenceEqual(new byte[] { 0, 0, 0, 0 })));
             ClassicAssert.IsTrue(res6.Any(static x => x.SequenceEqual(new byte[] { 0, 0, 0, 1 })));
+
+            // SB8
+            var sbyte6b = new byte[75];
+            for (var i = 0; i < sbyte6b.Length; i++)
+            {
+                sbyte6b[i] = (byte)(sbyte)(i + 5);
+            }
+            var res6b = (byte[][])db.Execute("VSIM", ["foo", "SB8", sbyte6b, "COUNT", "5", "EPSILON", "1.0", "EF", "40"]);
+            ClassicAssert.AreEqual(2, res6b.Length);
+            ClassicAssert.IsTrue(res6b.Any(static x => x.SequenceEqual(new byte[] { 0, 0, 0, 0 })));
+            ClassicAssert.IsTrue(res6b.Any(static x => x.SequenceEqual(new byte[] { 0, 0, 0, 1 })));
 
             // COUNT > EF
             var byte7 = new byte[75];

--- a/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
+++ b/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
@@ -381,6 +381,14 @@ namespace Garnet.test
             var exc15 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", [vectorSetKey, "FP32", blob, "bar"]));
             ClassicAssert.AreEqual("ERR invalid vector specification", exc15.Message);
 
+            // Empty vector payloads should be rejected for all binary types
+            var excEmptyFP32 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", [vectorSetKey, "FP32", Array.Empty<byte>(), "bar"]));
+            ClassicAssert.AreEqual("ERR vector values must be non-empty", excEmptyFP32.Message);
+            var excEmptyXB8 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", [vectorSetKey, "XB8", Array.Empty<byte>(), "bar"]));
+            ClassicAssert.AreEqual("ERR vector values must be non-empty", excEmptyXB8.Message);
+            var excEmptySB8 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", [vectorSetKey, "SB8", Array.Empty<byte>(), "bar"]));
+            ClassicAssert.AreEqual("ERR vector values must be non-empty", excEmptySB8.Message);
+
             // Mismatch after creating a vector set
             _ = db.KeyDelete(vectorSetKey);
 


### PR DESCRIPTION
Added copilot-generated patch for INT8 vectors support in vector sets.