### PR TITLE
Bump DiskANN to 1.0.27, bump version to 2.0.0-beta.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="System.Numerics.Tensors" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.5" />
-    <PackageVersion Include="diskann-garnet" Version="1.0.26" />
+    <PackageVersion Include="diskann-garnet" Version="1.0.27" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
   </ItemGroup>
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- VersionPrefix property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>2.0.0-beta.5</VersionPrefix>
+		<VersionPrefix>2.0.0-beta.6</VersionPrefix>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
A minor release that enables more runtime safety checks.