### PR TITLE
[V1] Bump DiskANN to 1.0.27, bump version to 1.1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - man
+      - main
       - release/v1
   pull_request:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,12 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
-      - dev
+      - man
+      - release/v1
   pull_request:
     branches:
       - main
-      - dev
+      - release/v1
   
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="System.Numerics.Tensors" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.5" />
-    <PackageVersion Include="diskann-garnet" Version="1.0.26" />
+    <PackageVersion Include="diskann-garnet" Version="1.0.27" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
   </ItemGroup>
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- VersionPrefix property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>1.1.8</VersionPrefix>
+		<VersionPrefix>1.1.9</VersionPrefix>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
A minor release that enables more runtime safety checks.

Backport of #1813 to store v1