### PR TITLE
Cherry-pick: Add input validation and bounds checks (808e438)

### DIFF
--- a/libs/common/Parsing/RespParsingException.cs
+++ b/libs/common/Parsing/RespParsingException.cs
@@ -55,6 +55,17 @@ namespace Garnet.common.Parsing
         }
 
         /// <summary>
+        /// Throw an exception indicating that the RESP array argument count exceeds the allowed maximum.
+        /// </summary>
+        /// <param name="count">The argument count that was received.</param>
+        /// <param name="maxCount">The maximum allowed argument count.</param>
+        [DoesNotReturn]
+        public static void ThrowExcessiveArgumentCount(int count, int maxCount)
+        {
+            Throw($"RESP array argument count '{count}' exceeds maximum allowed count of '{maxCount}'.");
+        }
+
+        /// <summary>
         /// Throw NaN (not a number) exception.
         /// </summary>
         /// <param name="buffer">Pointer to an ASCII-encoded byte buffer containing the string that could not be converted.</param>

--- a/libs/server/Resp/Parser/RespCommand.cs
+++ b/libs/server/Resp/Parser/RespCommand.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Garnet.common;
+using Garnet.common.Parsing;
 using Microsoft.Extensions.Logging;
 
 namespace Garnet.server
@@ -661,6 +662,12 @@ namespace Garnet.server
     /// </summary>
     internal sealed unsafe partial class RespServerSession : ServerSessionBase
     {
+        /// <summary>
+        /// Maximum number of arguments (excluding the command name) allowed in a single RESP command.
+        /// Prevents pre-auth memory exhaustion from oversized RESP array headers.
+        /// </summary>
+        const int MaxRespArrayLength = 1 << 20; // 1,048,576
+
         /// <summary>
         /// Fast-parses command type for inline RESP commands, starting at the current read head in the receive buffer
         /// and advances read head.
@@ -2820,6 +2827,11 @@ namespace Garnet.server
             {
                 cmd = ArrayParseCommand(writeErrorOnFailure, ref count, ref success);
                 if (!success) return cmd;
+            }
+
+            if (count > MaxRespArrayLength)
+            {
+                RespParsingException.ThrowExcessiveArgumentCount(count, MaxRespArrayLength);
             }
 
             // Set up parse state

--- a/libs/server/Resp/Vector/RespServerSessionVectors.cs
+++ b/libs/server/Resp/Vector/RespServerSessionVectors.cs
@@ -51,6 +51,7 @@ namespace Garnet.server
             }
 
             var valueType = VectorValueType.Invalid;
+            int vectorDims = 0;
             byte[] rentedValues = null;
             Span<byte> values = stackalloc byte[64 * sizeof(float)];
 
@@ -70,6 +71,12 @@ namespace Garnet.server
                         return AbortWithErrorMessage("ERR invalid vector specification");
                     }
 
+                    vectorDims = asBytes.Length / sizeof(float);
+                    if (vectorDims > VectorManager.MaxVectorDimensions)
+                    {
+                        return AbortWithErrorMessage($"ERR vector exceeds maximum of {VectorManager.MaxVectorDimensions} dimensions");
+                    }
+
                     curIx++;
                     valueType = VectorValueType.FP32;
                     values = asBytes;
@@ -82,27 +89,33 @@ namespace Garnet.server
                         return AbortWithWrongNumberOfArguments("VADD");
                     }
 
-                    if (!parseState.TryGetInt(curIx, out var valueCount) || valueCount <= 0)
+                    if (!parseState.TryGetInt(curIx, out vectorDims) || vectorDims <= 0)
                     {
                         return AbortWithErrorMessage("ERR invalid vector specification");
                     }
+
                     curIx++;
 
-                    if (valueCount * sizeof(float) > values.Length)
+                    if (vectorDims > VectorManager.MaxVectorDimensions)
                     {
-                        values = rentedValues = ArrayPool<byte>.Shared.Rent(valueCount * sizeof(float));
+                        return AbortWithErrorMessage($"ERR vector exceeds maximum of {VectorManager.MaxVectorDimensions} dimensions");
                     }
-                    values = values[..(valueCount * sizeof(float))];
 
-                    if (curIx + valueCount > parseState.Count)
+                    if (curIx + vectorDims > parseState.Count)
                     {
                         return AbortWithWrongNumberOfArguments("VADD");
                     }
 
+                    if (vectorDims * sizeof(float) > values.Length)
+                    {
+                        values = rentedValues = ArrayPool<byte>.Shared.Rent(vectorDims * sizeof(float));
+                    }
+                    values = values[..(vectorDims * sizeof(float))];
+
                     valueType = VectorValueType.FP32;
                     var floatValues = MemoryMarshal.Cast<byte, float>(values);
 
-                    for (var valueIx = 0; valueIx < valueCount; valueIx++)
+                    for (var valueIx = 0; valueIx < vectorDims; valueIx++)
                     {
                         if (!parseState.TryGetFloat(curIx, out floatValues[valueIx]))
                         {
@@ -121,10 +134,25 @@ namespace Garnet.server
                     }
 
                     var asBytes = parseState.GetArgSliceByRef(curIx).Span;
-                    curIx++;
 
+                    vectorDims = asBytes.Length;
+                    if (vectorDims > VectorManager.MaxVectorDimensions)
+                    {
+                        return AbortWithErrorMessage($"ERR vector exceeds maximum of {VectorManager.MaxVectorDimensions} dimensions");
+                    }
+
+                    curIx++;
                     valueType = VectorValueType.XB8;
                     values = asBytes;
+                }
+                else
+                {
+                    return AbortWithErrorMessage("ERR invalid vector specification");
+                }
+
+                if (reduceDim > vectorDims)
+                {
+                    return AbortWithErrorMessage("ERR REDUCE dimension must be <= vector dimensions");
                 }
 
                 if (curIx >= parseState.Count)
@@ -231,9 +259,9 @@ namespace Garnet.server
                             return AbortWithErrorMessage("ERR invalid option after element");
                         }
 
-                        if (!parseState.TryGetInt(curIx, out var buildExplorationFactorNonNull) || buildExplorationFactorNonNull <= 0)
+                        if (!parseState.TryGetInt(curIx, out var buildExplorationFactorNonNull) || buildExplorationFactorNonNull <= 0 || buildExplorationFactorNonNull > VectorManager.MaxExplorationFactor)
                         {
-                            return AbortWithErrorMessage("ERR invalid EF");
+                            return AbortWithErrorMessage($"ERR EF must be an integer between 1 and {VectorManager.MaxExplorationFactor}");
                         }
 
                         buildExplorationFactor = buildExplorationFactorNonNull;
@@ -279,7 +307,7 @@ namespace Garnet.server
 
                         if (!parseState.TryGetInt(curIx, out var numLinksNonNull) || numLinksNonNull < MinM || numLinksNonNull > MaxM)
                         {
-                            return AbortWithErrorMessage("ERR invalid M");
+                            return AbortWithErrorMessage($"ERR M must be an integer between {MinM} and {MaxM}");
                         }
 
                         numLinks = numLinksNonNull;
@@ -499,6 +527,11 @@ namespace Garnet.server
                             return AbortWithErrorMessage("FP32 values must be multiple of 4-bytes in size");
                         }
 
+                        if (asBytes.Length / sizeof(float) > VectorManager.MaxVectorDimensions)
+                        {
+                            return AbortWithErrorMessage($"ERR vector exceeds maximum of {VectorManager.MaxVectorDimensions} dimensions");
+                        }
+
                         valueType = VectorValueType.FP32;
                         values = asBytes;
                         curIx++;
@@ -511,6 +544,11 @@ namespace Garnet.server
                         }
 
                         var asBytes = parseState.GetArgSliceByRef(curIx).Span;
+
+                        if (asBytes.Length > VectorManager.MaxVectorDimensions)
+                        {
+                            return AbortWithErrorMessage($"ERR vector exceeds maximum of {VectorManager.MaxVectorDimensions} dimensions");
+                        }
 
                         valueType = VectorValueType.XB8;
                         values = asBytes;
@@ -527,6 +565,12 @@ namespace Garnet.server
                         {
                             return AbortWithErrorMessage("VALUES count must > 0");
                         }
+
+                        if (valueCount > VectorManager.MaxVectorDimensions)
+                        {
+                            return AbortWithErrorMessage($"ERR vector exceeds maximum of {VectorManager.MaxVectorDimensions} dimensions");
+                        }
+
                         curIx++;
 
                         if (valueCount * sizeof(float) > values.Length)
@@ -611,9 +655,9 @@ namespace Garnet.server
                             return AbortWithWrongNumberOfArguments("VSIM");
                         }
 
-                        if (!parseState.TryGetInt(curIx, out var countNonNull) || countNonNull < 0)
+                        if (!parseState.TryGetInt(curIx, out var countNonNull) || countNonNull < 0 || countNonNull > VectorManager.MaxRetrieveCount)
                         {
-                            return AbortWithErrorMessage("COUNT must be integer >= 0");
+                            return AbortWithErrorMessage($"ERR COUNT must be an integer between 0 and {VectorManager.MaxRetrieveCount}");
                         }
 
                         count = countNonNull;
@@ -659,9 +703,9 @@ namespace Garnet.server
                             return AbortWithWrongNumberOfArguments("VSIM");
                         }
 
-                        if (!parseState.TryGetInt(curIx, out var searchExplorationFactorNonNull) || searchExplorationFactorNonNull < 0)
+                        if (!parseState.TryGetInt(curIx, out var searchExplorationFactorNonNull) || searchExplorationFactorNonNull <= 0 || searchExplorationFactorNonNull > VectorManager.MaxExplorationFactor)
                         {
-                            return AbortWithErrorMessage("EF must be >= 0");
+                            return AbortWithErrorMessage($"ERR EF must be an integer between 1 and {VectorManager.MaxExplorationFactor}");
                         }
 
                         searchExplorationFactor = searchExplorationFactorNonNull;
@@ -705,9 +749,9 @@ namespace Garnet.server
                             return AbortWithWrongNumberOfArguments("VSIM");
                         }
 
-                        if (!parseState.TryGetInt(curIx, out var maxFilteringEffortNonNull) || maxFilteringEffortNonNull < 0)
+                        if (!parseState.TryGetInt(curIx, out var maxFilteringEffortNonNull) || maxFilteringEffortNonNull < 0 || maxFilteringEffortNonNull > VectorManager.MaxRetrieveCount)
                         {
-                            return AbortWithErrorMessage("FILTER-EF must be >= 0");
+                            return AbortWithErrorMessage($"ERR FILTER-EF must be an integer between 0 and {VectorManager.MaxRetrieveCount}");
                         }
 
                         maxFilteringEffort = maxFilteringEffortNonNull;
@@ -754,7 +798,7 @@ namespace Garnet.server
                 delta ??= 2f;
                 searchExplorationFactor ??= 100;
                 filter ??= default;
-                maxFilteringEffort ??= count.Value * 200;
+                maxFilteringEffort ??= (int)Math.Min((long)count.Value * 200, VectorManager.MaxRetrieveCount);
 
                 // TODO: these stackallocs are dangerous, need logic to avoid stack overflow
                 Span<byte> idSpace = stackalloc byte[(DefaultResultSetSize * DefaultIdSize) + (DefaultResultSetSize * sizeof(int))];

--- a/libs/server/Resp/Vector/VectorManager.cs
+++ b/libs/server/Resp/Vector/VectorManager.cs
@@ -51,6 +51,69 @@ namespace Garnet.server
         private const int MinimumSpacePerId = sizeof(int) + 8;
 
         /// <summary>
+        /// Maximum number of dimensions a vector can have.
+        /// Matches Redis's VSET_MAX_VECTOR_DIM (65,536).
+        /// </summary>
+        internal const int MaxVectorDimensions = 1 << 16;
+
+        /// <summary>
+        /// Maximum number of results that can be requested in a single VSIM query.
+        /// Practical limit to prevent integer overflow when computing buffer sizes
+        /// (e.g. retrieveCount * MinimumSpacePerId) and to avoid excessive allocations
+        /// from a single command (at 100M: ~400 MB for distances + ~1.2 GB for ids).
+        /// </summary>
+        internal const int MaxRetrieveCount = 100_000_000;
+
+        /// <summary>
+        /// Maximum exploration factor (EF) for build and search operations.
+        /// Matches Redis's hardcoded limit of 1,000,000.
+        /// </summary>
+        internal const int MaxExplorationFactor = 1_000_000;
+
+        /// <summary>
+        /// Ensures the VSIM distance output buffer has at least <paramref name="retrieveCount"/> * sizeof(float) bytes.
+        /// Rents from <see cref="MemoryPool{T}"/> if the current buffer is too small.
+        /// </summary>
+        private static void EnsureDistanceBufferSize(ref SpanByteAndMemory buffer, int retrieveCount)
+        {
+            // Verify no overflow: checked() ensures MaxRetrieveCount * sizeof(float) fits in int32
+            Debug.Assert(retrieveCount <= MaxRetrieveCount && checked(MaxRetrieveCount * sizeof(float)) > 0);
+            var sizeBytes = retrieveCount * sizeof(float);
+            if (sizeBytes > buffer.Length)
+            {
+                if (!buffer.IsSpanByte)
+                {
+                    buffer.Memory.Dispose();
+                }
+
+                buffer = new SpanByteAndMemory(MemoryPool<byte>.Shared.Rent(sizeBytes), sizeBytes);
+            }
+
+            buffer.Length = sizeBytes;
+        }
+
+        /// <summary>
+        /// Ensures the VSIM id output buffer has at least <paramref name="retrieveCount"/> * <see cref="MinimumSpacePerId"/> bytes.
+        /// Rents from <see cref="MemoryPool{T}"/> if the current buffer is too small.
+        /// If we're still wrong, we'll end up using continuation callbacks which have more overhead.
+        /// </summary>
+        private static void EnsureIdBufferSize(ref SpanByteAndMemory buffer, int retrieveCount)
+        {
+            // Verify no overflow: checked() ensures MaxRetrieveCount * MinimumSpacePerId fits in int32
+            Debug.Assert(retrieveCount <= MaxRetrieveCount && checked(MaxRetrieveCount * MinimumSpacePerId) > 0);
+            var sizeBytes = retrieveCount * MinimumSpacePerId;
+            if (sizeBytes > buffer.Length)
+            {
+                if (!buffer.IsSpanByte)
+                {
+                    buffer.Memory.Dispose();
+                }
+
+                buffer = new SpanByteAndMemory(MemoryPool<byte>.Shared.Rent(sizeBytes), sizeBytes);
+            }
+        }
+
+        /// <summary>
         /// The process wide instances of DiskANN.
         /// 
         /// We only need the one, even if we have multiple DBs, because all context is provided by DiskANN instances and Garnet storage.
@@ -525,32 +588,8 @@ namespace Garnet.server
                 retrieveCount = effectiveEF;
             }
 
-            // Make sure enough space in distances for requested count
-            if (retrieveCount > outputDistances.Length)
-            {
-                if (!outputDistances.IsSpanByte)
-                {
-                    outputDistances.Memory.Dispose();
-                }
-
-                outputDistances = new SpanByteAndMemory(MemoryPool<byte>.Shared.Rent(retrieveCount * sizeof(float)), retrieveCount * sizeof(float));
-            }
-
-            // Indicate requested # of matches
-            outputDistances.Length = retrieveCount * sizeof(float);
-
-            // If we're fairly sure the ids won't fit, go ahead and grab more memory now
-            //
-            // If we're still wrong, we'll end up using continuation callbacks which have more overhead
-            if (retrieveCount * MinimumSpacePerId > outputIds.Length)
-            {
-                if (!outputIds.IsSpanByte)
-                {
-                    outputIds.Memory.Dispose();
-                }
-
-                outputIds = new SpanByteAndMemory(MemoryPool<byte>.Shared.Rent(retrieveCount * MinimumSpacePerId), retrieveCount * MinimumSpacePerId);
-            }
+            EnsureDistanceBufferSize(ref outputDistances, retrieveCount);
+            EnsureIdBufferSize(ref outputIds, retrieveCount);
 
             var found =
                 Service.SearchVector(
@@ -653,32 +692,8 @@ namespace Garnet.server
                 retrieveCount = effectiveEF;
             }
 
-            // Make sure enough space in distances for requested count
-            if (retrieveCount * sizeof(float) > outputDistances.Length)
-            {
-                if (!outputDistances.IsSpanByte)
-                {
-                    outputDistances.Memory.Dispose();
-                }
-
-                outputDistances = new SpanByteAndMemory(MemoryPool<byte>.Shared.Rent(retrieveCount * sizeof(float)), retrieveCount * sizeof(float));
-            }
-
-            // Indicate requested # of matches
-            outputDistances.Length = retrieveCount * sizeof(float);
-
-            // If we're fairly sure the ids won't fit, go ahead and grab more memory now
-            //
-            // If we're still wrong, we'll end up using continuation callbacks which have more overhead
-            if (retrieveCount * MinimumSpacePerId > outputIds.Length)
-            {
-                if (!outputIds.IsSpanByte)
-                {
-                    outputIds.Memory.Dispose();
-                }
-
-                outputIds = new SpanByteAndMemory(MemoryPool<byte>.Shared.Rent(retrieveCount * MinimumSpacePerId), retrieveCount * MinimumSpacePerId);
-            }
+            EnsureDistanceBufferSize(ref outputDistances, retrieveCount);
+            EnsureIdBufferSize(ref outputIds, retrieveCount);
 
             var found =
                 Service.SearchElement(
@@ -896,7 +911,7 @@ namespace Garnet.server
                 internalIdBytes.Memory?.Dispose();
             }
 
-            Span<byte> asBytesSpan = stackalloc byte[(int)dimensions];
+            Span<byte> asBytesSpan = stackalloc byte[1024];
             var asBytes = SpanByteAndMemory.FromPinnedSpan(asBytesSpan);
             try
             {

--- a/test/Garnet.test/Resp/ACL/RespCommandTests.cs
+++ b/test/Garnet.test/Resp/ACL/RespCommandTests.cs
@@ -7528,7 +7528,7 @@ namespace Garnet.test.Resp.ACL
             {
                 var elem = Encoding.ASCII.GetString("\x0\x1\x2\x3"u8);
 
-                long val = await client.ExecuteForLongResultAsync("VADD", ["foo", "REDUCE", "50", "VALUES", "4", "1.0", "2.0", "3.0", "4.0", elem, "CAS", "NOQUANT", "EF", "16", "SETATTR", "{ 'hello': 'world' }", "M", "32"]).ConfigureAwait(false);
+                long val = await client.ExecuteForLongResultAsync("VADD", ["foo", "REDUCE", "2", "VALUES", "4", "1.0", "2.0", "3.0", "4.0", elem, "CAS", "NOQUANT", "EF", "16", "SETATTR", "{ 'hello': 'world' }", "M", "32"]).ConfigureAwait(false);
                 ClassicAssert.AreEqual(1, val);
             }
         }

--- a/test/Garnet.test/RespTests.cs
+++ b/test/Garnet.test/RespTests.cs
@@ -5183,5 +5183,86 @@ namespace Garnet.test
 
             Assert.Throws<RedisServerException>(() => mainDB.Execute("CLIENT", "UNBLOCK", 123, "INVALID"));
         }
+
+        [Test]
+        public void ExcessiveArgumentCountRejected()
+        {
+            // Send a RESP array header with an argument count exceeding the maximum allowed,
+            // followed by a command name so parsing proceeds far enough to hit the guard.
+            // The server should reject the command with a protocol error and close the connection.
+            using var socket = new System.Net.Sockets.Socket(
+                System.Net.Sockets.AddressFamily.InterNetwork,
+                System.Net.Sockets.SocketType.Stream,
+                System.Net.Sockets.ProtocolType.Tcp);
+            socket.ReceiveTimeout = 5000;
+            socket.Connect(System.Net.IPAddress.Loopback, TestUtils.TestPort);
+
+            // *2000000\r\n$3\r\nFOO\r\n — array with 2M elements, command name "FOO"
+            // The command will be identified as unknown but count (1999999) exceeds MaxParams (1,048,576)
+            var payload = Encoding.ASCII.GetBytes("*2000000\r\n$3\r\nFOO\r\n");
+            socket.Send(payload);
+
+            // Read the response - server should send an error and close the connection
+            var buffer = new byte[4096];
+            var totalRead = 0;
+            try
+            {
+                while (totalRead < buffer.Length)
+                {
+                    var bytesRead = socket.Receive(buffer, totalRead, buffer.Length - totalRead, System.Net.Sockets.SocketFlags.None);
+                    if (bytesRead == 0) break;
+                    totalRead += bytesRead;
+                }
+            }
+            catch (System.Net.Sockets.SocketException)
+            {
+                // Connection may be reset by server - this is expected
+            }
+
+            var response = Encoding.ASCII.GetString(buffer, 0, totalRead);
+            var expectedResponse =
+                "-ERR unknown command\r\n" +
+                "-ERR Protocol Error: RESP array argument count '1999999' exceeds maximum allowed count of '1048576'.\r\n";
+            ClassicAssert.AreEqual(expectedResponse, response);
+
+            // Same test with a known command (PING) — should still be rejected due to excessive count
+            using var socket2 = new System.Net.Sockets.Socket(
+                System.Net.Sockets.AddressFamily.InterNetwork,
+                System.Net.Sockets.SocketType.Stream,
+                System.Net.Sockets.ProtocolType.Tcp);
+            socket2.ReceiveTimeout = 5000;
+            socket2.Connect(System.Net.IPAddress.Loopback, TestUtils.TestPort);
+
+            // *2000000\r\n$4\r\nPING\r\n — known command but excessive count
+            var payload2 = Encoding.ASCII.GetBytes("*2000000\r\n$4\r\nPING\r\n");
+            socket2.Send(payload2);
+
+            var buffer2 = new byte[4096];
+            var totalRead2 = 0;
+            try
+            {
+                while (totalRead2 < buffer2.Length)
+                {
+                    var bytesRead = socket2.Receive(buffer2, totalRead2, buffer2.Length - totalRead2, System.Net.Sockets.SocketFlags.None);
+                    if (bytesRead == 0) break;
+                    totalRead2 += bytesRead;
+                }
+            }
+            catch (System.Net.Sockets.SocketException)
+            {
+                // Connection may be reset by server - this is expected
+            }
+
+            var response2 = Encoding.ASCII.GetString(buffer2, 0, totalRead2);
+            var expectedResponse2 =
+                "-ERR Protocol Error: RESP array argument count '1999999' exceeds maximum allowed count of '1048576'.\r\n";
+            ClassicAssert.AreEqual(expectedResponse2, response2);
+
+            // Verify the server is still operational after rejecting the malicious connection
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+            db.StringSet("testkey", "testvalue");
+            ClassicAssert.AreEqual("testvalue", db.StringGet("testkey").ToString());
+        }
     }
 }

--- a/test/Garnet.test/RespVectorSetTests.cs
+++ b/test/Garnet.test/RespVectorSetTests.cs
@@ -207,7 +207,7 @@ namespace Garnet.test
 
             // Mismatch vector size for projection
             var exc3 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", ["fizz", "REDUCE", "50", "VALUES", "5", "1.0", "2.0", "3.0", "4.0", "5.0", new byte[] { 0, 0, 0, 0 }, "CAS", "NOQUANT", "EF", "16", "M", "32"]));
-            ClassicAssert.AreEqual("ERR Vector dimension mismatch - got 5 but set has 75", exc3.Message);
+            ClassicAssert.AreEqual("ERR REDUCE dimension must be <= vector dimensions", exc3.Message);
         }
 
         [Test]
@@ -326,15 +326,15 @@ namespace Garnet.test
 
             // M out of range (Redis imposes M >= 4 and m <= 4096
             var exc13 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", [vectorSetKey, "VALUES", "1", "2.0", "bar", "M", "1"]));
-            ClassicAssert.AreEqual("ERR invalid M", exc13.Message);
+            ClassicAssert.AreEqual("ERR M must be an integer between 4 and 4096", exc13.Message);
             var exc14 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", [vectorSetKey, "VALUES", "1", "2.0", "bar", "M", "10000"]));
-            ClassicAssert.AreEqual("ERR invalid M", exc14.Message);
+            ClassicAssert.AreEqual("ERR M must be an integer between 4 and 4096", exc14.Message);
 
             // Missing/bad option value
             var exc20 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", [vectorSetKey, "VALUES", "1", "2.0", "bar", "EF"]));
             ClassicAssert.AreEqual("ERR invalid option after element", exc20.Message);
             var exc21 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", [vectorSetKey, "VALUES", "1", "2.0", "bar", "EF", "0"]));
-            ClassicAssert.AreEqual("ERR invalid EF", exc21.Message);
+            ClassicAssert.AreEqual("ERR EF must be an integer between 1 and 1000000", exc21.Message);
             var exc22 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", [vectorSetKey, "VALUES", "1", "2.0", "bar", "SETATTR"]));
             ClassicAssert.AreEqual("ERR invalid option after element", exc22.Message);
             var exc23 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", [vectorSetKey, "VALUES", "1", "2.0", "bar", "M"]));
@@ -387,6 +387,22 @@ namespace Garnet.test
             ClassicAssert.AreEqual("ERR invalid option after element", exc31.Message);
             var exc32 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", [vectorSetKey, "VALUES", "75", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "bar", "NOQUANT", "XDISTANCE_METRIC", "FOO"]));
             ClassicAssert.AreEqual("ERR invalid XDISTANCE_METRIC", exc32.Message);
+
+            // Invalid vector type keyword (not FP32, VALUES, or XB8)
+            var exc40 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", ["mykey", "GARBAGE", "data", "elem1"]));
+            ClassicAssert.AreEqual("ERR invalid vector specification", exc40.Message);
+
+            // VALUES count exceeding MaxVectorDimensions (65536) must be rejected
+            var exc41 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", ["foo", "VALUES", "100000", "1.0", "elem"]));
+            ClassicAssert.IsTrue(exc41.Message.Contains("maximum"), $"Expected dimension limit error, got: {exc41.Message}");
+
+            // EF exceeding MaxExplorationFactor (1,000,000) must be rejected
+            var exc42 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", ["foo", "VALUES", "3", "1.0", "2.0", "3.0", new byte[] { 0, 0, 0, 0 }, "CAS", "NOQUANT", "EF", "2000000000", "M", "32"]));
+            ClassicAssert.IsTrue(exc42.Message.Contains("EF must be an integer between"), $"Expected EF validation error, got: {exc42.Message}");
+
+            // REDUCE dim exceeding vector dimensions must be rejected
+            var exc43 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", ["foo", "REDUCE", "100000", "VALUES", "3", "1.0", "2.0", "3.0", new byte[] { 0, 0, 0, 0 }, "CAS", "NOQUANT", "EF", "16", "M", "32"]));
+            ClassicAssert.IsTrue(exc43.Message.Contains("REDUCE dimension must be <= vector dimensions"), $"Expected REDUCE dimension limit error, got: {exc43.Message}");
             var exc33 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VADD", [vectorSetKey, "VALUES", "75", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "bar", "NOQUANT", "XDISTANCE_METRIC", "XCOSINE_NORMALIZED"]));
             ClassicAssert.AreEqual("ERR Distance metric mismatch - got XCosine_Normalized but set has L2", exc33.Message);
         }
@@ -839,6 +855,61 @@ namespace Garnet.test
             var res3 = (byte[][])db.Execute("VSIM", ["movies", "ELE", queryElementId,
                 "FILTER", ".rating / 2 > 2 and .year >= 1980", "COUNT", "3"]);
             ClassicAssert.AreEqual(2, res3.Length, "ELE + FILTER without WITHATTRIBS: arithmetic and comparison");
+        }
+
+        [Test]
+        public void VSIMErrors()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            _ = db.KeyDelete("foo");
+
+            // Add a vector so the key exists (needed for FILTER-EF test)
+            var res1 = db.Execute("VADD", ["foo", "VALUES", "3", "1.0", "2.0", "3.0", new byte[] { 0, 0, 0, 0 }, "CAS", "NOQUANT", "EF", "16", "M", "32", "SETATTR", "{\"year\":1980}"]);
+            ClassicAssert.AreEqual(1, (int)res1);
+
+            // FILTER-EF exceeding MaxRetrieveCount must be rejected
+            var exc1 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VSIM", ["foo", "VALUES", "3", "0.0", "0.0", "0.0", "FILTER", ".year > 1950", "FILTER-EF", "999999999", "COUNT", "3", "WITHATTRIBS"]));
+            ClassicAssert.AreEqual("ERR FILTER-EF must be an integer between 0 and 100000000", exc1.Message);
+
+            // COUNT exceeding MaxRetrieveCount must be rejected
+            var exc2 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VSIM", ["foo", "VALUES", "3", "0.0", "0.0", "0.0", "COUNT", "999999999"]));
+            ClassicAssert.AreEqual("ERR COUNT must be an integer between 0 and 100000000", exc2.Message);
+
+            // VALUES count exceeding MaxVectorDimensions (65536) must be rejected
+            var exc3 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VSIM", ["foo", "VALUES", "100000", "1.0"]));
+            ClassicAssert.AreEqual("ERR vector exceeds maximum of 65536 dimensions", exc3.Message);
+
+            // EF exceeding MaxExplorationFactor (1,000,000) must be rejected
+            var exc4 = ClassicAssert.Throws<RedisServerException>(() => db.Execute("VSIM", ["foo", "VALUES", "3", "0.0", "0.0", "0.0", "EF", "2000000000"]));
+            ClassicAssert.AreEqual("ERR EF must be an integer between 1 and 1000000", exc4.Message);
+        }
+
+        [Test]
+        public void VSIMWithDefaultFilterEFOverflowDoesNotCrash()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            _ = db.KeyDelete("foo");
+
+            // Add a vector with attributes so FILTER can be used
+            var res1 = db.Execute("VADD", ["foo", "VALUES", "3", "1.0", "2.0", "3.0", new byte[] { 0, 0, 0, 0 }, "CAS", "NOQUANT", "EF", "16", "M", "32", "SETATTR", "{\"year\":1980}"]);
+            ClassicAssert.AreEqual(1, (int)res1);
+
+            // Verify that a moderate COUNT with FILTER (no explicit FILTER-EF) works correctly.
+            // The default maxFilteringEffort = count*200. With count=1000, that's 200,000 which is safe.
+            // This validates the code path through the (long) cast fix without hitting resource limits.
+            var res = (byte[][])db.Execute("VSIM", ["foo", "VALUES", "3", "0.0", "0.0", "0.0", "FILTER", ".year > 1950", "COUNT", "1000", "WITHATTRIBS"]);
+            ClassicAssert.AreEqual(2, res.Length, "Should return 1 result (1 pair of id+attribute) for year > 1950");
+
+            // Verify that COUNT values which would overflow count*200 in int32 are rejected.
+            // 10,737,419 * 200 = 2,147,483,800 > int32.MaxValue.
+            // Our (long) cast prevents the overflow, but MaxRetrieveCount caps COUNT itself.
+            // Any COUNT above MaxRetrieveCount (~178M) is rejected at parse time.
+            var ex = Assert.Throws<RedisServerException>(() => db.Execute("VSIM", ["foo", "VALUES", "3", "0.0", "0.0", "0.0", "FILTER", ".year > 1950", "COUNT", "999999999", "WITHATTRIBS"]));
+            ClassicAssert.IsTrue(ex.Message.Contains("COUNT must be an integer between"), $"Expected COUNT validation error, got: {ex.Message}");
         }
 
         private static byte[] SeedMoviesForAdvancedFiltering(IDatabase db)


### PR DESCRIPTION
Cherry-pick of #1810 (808e438) to release/v1.

Adds input validation and bounds checking for RESP parsing and VectorSet commands.

**Note:** The \GetSerializedRecordSpan\ bounds check fix and its tests were excluded from this cherry-pick as the method does not exist on release/v1 (migration uses \TryReadSerializedData\ which already has bounds checks).