### PR TITLE
ci: add release/* wildcard to GitHub Actions triggers

### DIFF
--- a/.github/workflows/ci-bdnbenchmark.yml
+++ b/.github/workflows/ci-bdnbenchmark.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'release/*'
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - dev
+      - 'release/*'
   pull_request:
     branches:
       - main
       - dev
+      - 'release/*'
   
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,9 +6,9 @@ name: "CodeQL Advanced"
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   schedule:
     - cron: '38 11 * * 1'
 

--- a/.github/workflows/docker-linux.yml
+++ b/.github/workflows/docker-linux.yml
@@ -5,7 +5,7 @@ on:
   workflow_run:
     workflows: ['Garnet .NET CI']
     types: [completed]
-    branches: [main]
+    branches: [main, 'release/*']
   push:
     tags: 'v*'
 

--- a/.github/workflows/docker-windows.yml
+++ b/.github/workflows/docker-windows.yml
@@ -5,7 +5,7 @@ on:
   workflow_run:
     workflows: ['Garnet .NET CI']
     types: [completed]
-    branches: [main]
+    branches: [main, 'release/*']
   push:
     tags: 'v*'
 


### PR DESCRIPTION
## Summary

Future-proofs GitHub Actions CI triggers by adding \elease/*\ wildcard patterns, so any new release branch (e.g., \elease/v1\, \elease/v2\) automatically gets CI coverage.

## Changes

Added \elease/*\ to push/pull_request/workflow_run triggers for:
- **ci.yml** — main CI tests (push + PR)
- **codeql.yml** — CodeQL security scanning (push + PR)
- **ci-bdnbenchmark.yml** — benchmark CI (push)
- **docker-linux.yml** — Docker image builds (workflow_run)
- **docker-windows.yml** — Docker image builds (workflow_run)

## Not changed
- **ADO compliance pipelines** — already use exclude-only patterns, trigger on all branches
- **deploy-website.yml**, **helm-chart.yml** — main-only deployment workflows
- **azure-pipelines-external-release.yml**, **azure-pipelines-mirror.yml** — main-only release/mirror pipelines

## Related
Companion PR: https://github.com/microsoft/garnet/pull/1817 (targets \elease/v1\ with explicit branch name)