### PR TITLE
Add NotFound callback to CustomRawStringFunctions and CustomObjectFunctions

### DIFF
--- a/libs/common/RespMemoryWriter.cs
+++ b/libs/common/RespMemoryWriter.cs
@@ -25,7 +25,7 @@ namespace Garnet.common
         ref SpanByteAndMemory output;
         public readonly bool resp3;
 
-        public unsafe RespMemoryWriter(byte respVersion, ref SpanByteAndMemory output)
+        public RespMemoryWriter(byte respVersion, ref SpanByteAndMemory output)
         {
             this.output = ref output;
             ptrHandle = default;

--- a/libs/server/Custom/CustomObjectFunctions.cs
+++ b/libs/server/Custom/CustomObjectFunctions.cs
@@ -78,7 +78,7 @@ namespace Garnet.server
         /// <summary>
         /// Called when a read command does not find a value.
         /// 
-        /// Default implementation writes a null value (either _\r\n or *-1\r\n for RESP 3 or 2 respectively).
+        /// Default implementation writes a null value (either _\r\n or $-1\r\n for RESP 3 or 2 respectively).
         /// </summary>
         public virtual void NotFound(ReadOnlySpan<byte> key, ref ObjectInput input, ref RespMemoryWriter writer)
         => writer.WriteNull();

--- a/libs/server/Custom/CustomObjectFunctions.cs
+++ b/libs/server/Custom/CustomObjectFunctions.cs
@@ -76,6 +76,14 @@ namespace Garnet.server
         public virtual bool Reader(ReadOnlySpan<byte> key, ref ObjectInput input, IGarnetObject value, ref RespMemoryWriter writer, ref ReadInfo readInfo) => throw new NotImplementedException();
 
         /// <summary>
+        /// Called when a read command does not find a value.
+        /// 
+        /// Default implementation writes a null value (either _\r\n or *-1\r\n for RESP 3 or 2 respectively).
+        /// </summary>
+        public virtual void NotFound(ReadOnlySpan<byte> key, ref ObjectInput input, ref RespMemoryWriter writer)
+        => writer.WriteNull();
+
+        /// <summary>
         /// Aborts the execution of the current object store command and outputs
         /// an error message to indicate a wrong number of arguments for the given command.
         /// </summary>

--- a/libs/server/Custom/CustomRawStringFunctions.cs
+++ b/libs/server/Custom/CustomRawStringFunctions.cs
@@ -109,7 +109,7 @@ namespace Garnet.server
         /// <summary>
         /// Called when a read command does not find a value.
         /// 
-        /// Default implementation writes a null value (either _\r\n or *-1\r\n for RESP 3 or 2 respectively).
+        /// Default implementation writes a null value (either _\r\n or $-1\r\n for RESP 3 or 2 respectively).
         /// </summary>
         public virtual void NotFound(ReadOnlySpan<byte> key, ref StringInput input, ref RespMemoryWriter writer)
         => writer.WriteNull();

--- a/libs/server/Custom/CustomRawStringFunctions.cs
+++ b/libs/server/Custom/CustomRawStringFunctions.cs
@@ -104,5 +104,14 @@ namespace Garnet.server
         /// <param name="readInfo">Advanced arguments</param>
         /// <returns>True if done, false if not found</returns>
         public abstract bool Reader(ReadOnlySpan<byte> key, ref StringInput input, ReadOnlySpan<byte> value, ref RespMemoryWriter writer, ref ReadInfo readInfo);
+
+
+        /// <summary>
+        /// Called when a read command does not find a value.
+        /// 
+        /// Default implementation writes a null value (either _\r\n or *-1\r\n for RESP 3 or 2 respectively).
+        /// </summary>
+        public virtual void NotFound(ReadOnlySpan<byte> key, ref StringInput input, ref RespMemoryWriter writer)
+        => writer.WriteNull();
     }
 }

--- a/libs/server/Custom/CustomRespCommands.cs
+++ b/libs/server/Custom/CustomRespCommands.cs
@@ -123,7 +123,7 @@ namespace Garnet.server
                         while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
                             SendAndReset();
                 }
-                else
+                else if (status == GarnetStatus.NOTFOUND)
                 {
                     Debug.Assert(output.SpanByteAndMemory.Memory == null);
                     var writer = new RespMemoryWriter(respProtocolVersion, ref output.SpanByteAndMemory);
@@ -131,6 +131,11 @@ namespace Garnet.server
                     customRawStringCommand.functions.NotFound(key, ref input, ref writer);
 
                     SendAndReset(output.SpanByteAndMemory.Memory, output.SpanByteAndMemory.Length);
+                }
+                else if (status == GarnetStatus.WRONGTYPE)
+                {
+                    while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_WRONG_TYPE, ref dcurr, dend))
+                        SendAndReset();
                 }
             }
 

--- a/libs/server/Custom/CustomRespCommands.cs
+++ b/libs/server/Custom/CustomRespCommands.cs
@@ -126,11 +126,21 @@ namespace Garnet.server
                 else if (status == GarnetStatus.NOTFOUND)
                 {
                     Debug.Assert(output.SpanByteAndMemory.Memory == null);
-                    var writer = new RespMemoryWriter(respProtocolVersion, ref output.SpanByteAndMemory);
 
+                    var notFoundOutput = new SpanByteAndMemory(PinnedSpanByte.FromPinnedPointer(dcurr, (int)(dend - dcurr)));
+                    var writer = new RespMemoryWriter(respProtocolVersion, ref notFoundOutput);
                     customRawStringCommand.functions.NotFound(key, ref input, ref writer);
 
-                    SendAndReset(output.SpanByteAndMemory.Memory, writer.AsReadOnlySpan().Length);
+                    if (!notFoundOutput.IsSpanByte)
+                    {
+                        // Couldn't write not found response in place, so copy it over
+                        SendAndReset(output.SpanByteAndMemory.Memory, writer.GetPosition());
+                    }
+                    else
+                    {
+                        // Wrote not found response in place, just advance pointer
+                        dcurr += writer.GetPosition();
+                    }
                 }
                 else if (status == GarnetStatus.WRONGTYPE)
                 {
@@ -194,10 +204,21 @@ namespace Garnet.server
                                 SendAndReset();
                         break;
                     case GarnetStatus.NOTFOUND:
-                        var writer = new RespMemoryWriter(respProtocolVersion, ref output.SpanByteAndMemory);
+                        var notFoundOutput = new SpanByteAndMemory(PinnedSpanByte.FromPinnedPointer(dcurr, (int)(dend - dcurr)));
+
+                        var writer = new RespMemoryWriter(respProtocolVersion, ref notFoundOutput);
                         customObjectCommand.functions.NotFound(key, ref input, ref writer);
 
-                        SendAndReset(output.SpanByteAndMemory.Memory, writer.AsReadOnlySpan().Length);
+                        if (!notFoundOutput.IsSpanByte)
+                        {
+                            // Couldn't write not found response in place, so copy it over
+                            SendAndReset(output.SpanByteAndMemory.Memory, writer.GetPosition());
+                        }
+                        else
+                        {
+                            // Wrote not found response in place, just advance pointer
+                            dcurr += writer.GetPosition();
+                        }
                         break;
                     case GarnetStatus.WRONGTYPE:
                         while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_WRONG_TYPE, ref dcurr, dend))
@@ -274,16 +295,24 @@ namespace Garnet.server
                         output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP_OK);
                     }
                 }
-                else
+                else if (status == GarnetStatus.NOTFOUND)
                 {
                     Debug.Assert(_output.SpanByteAndMemory.Memory == null);
 
                     var writer = new RespMemoryWriter(respProtocolVersion, ref _output.SpanByteAndMemory);
                     customCommand.functions.NotFound(key, ref stringInput, ref writer);
 
-                    output = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan[..writer.AsReadOnlySpan().Length]);
+                    output = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan[..writer.GetPosition()]);
 
                     _output.SpanByteAndMemory.Memory.Dispose();
+                }
+                else
+                {
+                    Debug.Assert(status == GarnetStatus.WRONGTYPE, "Unexpected status");
+
+                    output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP_ERR_WRONG_TYPE.Length + 1); // +1 because RESP_ERR_WRONG_TYPE doesn't contain the - prefix, but does starts with WRONGTYPE
+                    output.Span[0] = (byte)'-';
+                    CmdStrings.RESP_ERR_WRONG_TYPE.CopyTo(output.Span[1..]);
                 }
             }
 
@@ -352,11 +381,12 @@ namespace Garnet.server
                         break;
                     case GarnetStatus.NOTFOUND:
                         Debug.Assert(_output.SpanByteAndMemory.Memory == null);
+
                         var writer = new RespMemoryWriter(respProtocolVersion, ref _output.SpanByteAndMemory);
 
                         customObjCommand.functions.NotFound(key.ReadOnlySpan, ref input, ref writer);
 
-                        output = scratchBufferAllocator.CreateArgSlice(writer.AsReadOnlySpan().Length);
+                        output = scratchBufferAllocator.CreateArgSlice(writer.GetPosition());
 
                         _output.SpanByteAndMemory.Memory.Dispose();
                         break;

--- a/libs/server/Custom/CustomRespCommands.cs
+++ b/libs/server/Custom/CustomRespCommands.cs
@@ -130,7 +130,7 @@ namespace Garnet.server
 
                     customRawStringCommand.functions.NotFound(key, ref input, ref writer);
 
-                    SendAndReset(output.SpanByteAndMemory.Memory, output.SpanByteAndMemory.Length);
+                    SendAndReset(output.SpanByteAndMemory.Memory, writer.AsReadOnlySpan().Length);
                 }
                 else if (status == GarnetStatus.WRONGTYPE)
                 {
@@ -197,7 +197,7 @@ namespace Garnet.server
                         var writer = new RespMemoryWriter(respProtocolVersion, ref output.SpanByteAndMemory);
                         customObjectCommand.functions.NotFound(key, ref input, ref writer);
 
-                        SendAndReset(output.SpanByteAndMemory.Memory, output.SpanByteAndMemory.Length);
+                        SendAndReset(output.SpanByteAndMemory.Memory, writer.AsReadOnlySpan().Length);
                         break;
                     case GarnetStatus.WRONGTYPE:
                         while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_WRONG_TYPE, ref dcurr, dend))
@@ -281,7 +281,7 @@ namespace Garnet.server
                     var writer = new RespMemoryWriter(respProtocolVersion, ref _output.SpanByteAndMemory);
                     customCommand.functions.NotFound(key, ref stringInput, ref writer);
 
-                    output = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan);
+                    output = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan[..writer.AsReadOnlySpan().Length]);
 
                     _output.SpanByteAndMemory.Memory.Dispose();
                 }
@@ -356,7 +356,7 @@ namespace Garnet.server
 
                         customObjCommand.functions.NotFound(key.ReadOnlySpan, ref input, ref writer);
 
-                        output = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan);
+                        output = scratchBufferAllocator.CreateArgSlice(writer.AsReadOnlySpan().Length);
 
                         _output.SpanByteAndMemory.Memory.Dispose();
                         break;

--- a/libs/server/Custom/CustomRespCommands.cs
+++ b/libs/server/Custom/CustomRespCommands.cs
@@ -127,7 +127,7 @@ namespace Garnet.server
                 {
                     Debug.Assert(output.SpanByteAndMemory.Memory == null);
                     var writer = new RespMemoryWriter(respProtocolVersion, ref output.SpanByteAndMemory);
-                    
+
                     customRawStringCommand.functions.NotFound(key, ref input, ref writer);
 
                     SendAndReset(output.SpanByteAndMemory.Memory, output.SpanByteAndMemory.Length);
@@ -351,11 +351,11 @@ namespace Garnet.server
                     case GarnetStatus.NOTFOUND:
                         Debug.Assert(_output.SpanByteAndMemory.Memory == null);
                         var writer = new RespMemoryWriter(respProtocolVersion, ref _output.SpanByteAndMemory);
-                        
+
                         customObjCommand.functions.NotFound(key.ReadOnlySpan, ref input, ref writer);
 
                         output = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan);
-                        
+
                         _output.SpanByteAndMemory.Memory.Dispose();
                         break;
                     case GarnetStatus.WRONGTYPE:

--- a/libs/server/Custom/CustomRespCommands.cs
+++ b/libs/server/Custom/CustomRespCommands.cs
@@ -134,7 +134,7 @@ namespace Garnet.server
                     if (!notFoundOutput.IsSpanByte)
                     {
                         // Couldn't write not found response in place, so copy it over
-                        SendAndReset(output.SpanByteAndMemory.Memory, writer.GetPosition());
+                        SendAndReset(notFoundOutput.Memory, writer.GetPosition());
                     }
                     else
                     {
@@ -212,7 +212,7 @@ namespace Garnet.server
                         if (!notFoundOutput.IsSpanByte)
                         {
                             // Couldn't write not found response in place, so copy it over
-                            SendAndReset(output.SpanByteAndMemory.Memory, writer.GetPosition());
+                            SendAndReset(notFoundOutput.Memory, writer.GetPosition());
                         }
                         else
                         {

--- a/libs/server/Custom/CustomRespCommands.cs
+++ b/libs/server/Custom/CustomRespCommands.cs
@@ -131,7 +131,6 @@ namespace Garnet.server
                     customRawStringCommand.functions.NotFound(key, ref input, ref writer);
 
                     SendAndReset(output.SpanByteAndMemory.Memory, output.SpanByteAndMemory.Length);
-                    output.SpanByteAndMemory.Memory?.Dispose();
                 }
             }
 
@@ -194,8 +193,6 @@ namespace Garnet.server
                         customObjectCommand.functions.NotFound(key, ref input, ref writer);
 
                         SendAndReset(output.SpanByteAndMemory.Memory, output.SpanByteAndMemory.Length);
-
-                        output.SpanByteAndMemory.Memory.Dispose();
                         break;
                     case GarnetStatus.WRONGTYPE:
                         while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_WRONG_TYPE, ref dcurr, dend))

--- a/libs/server/Custom/CustomRespCommands.cs
+++ b/libs/server/Custom/CustomRespCommands.cs
@@ -89,16 +89,17 @@ namespace Garnet.server
         /// <summary>
         /// Custom command
         /// </summary>
-        private bool TryCustomRawStringCommand<TGarnetApi>(RespCommand cmd, long expirationTicks, CommandType type, ref TGarnetApi storageApi)
+        private bool TryCustomRawStringCommand<TGarnetApi>(RespCommand cmd, CustomRawStringCommand customRawStringCommand, ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetAdvancedApi
         {
             var key = parseState.GetArgSliceByRef(0);
 
+            var expirationTicks = customRawStringCommand.expirationTicks;
             var inputArg = expirationTicks > 0 ? DateTimeOffset.UtcNow.Ticks + expirationTicks : expirationTicks;
             var input = new StringInput(cmd, ref parseState, startIdx: 1, arg1: inputArg);
 
             var output = new StringOutput();
-            if (type == CommandType.ReadModifyWrite)
+            if (customRawStringCommand.type == CommandType.ReadModifyWrite)
             {
                 _ = storageApi.RMW_MainStore(key, ref input, ref output);
                 Debug.Assert(!output.SpanByteAndMemory.IsSpanByte);
@@ -125,7 +126,12 @@ namespace Garnet.server
                 else
                 {
                     Debug.Assert(output.SpanByteAndMemory.Memory == null);
-                    WriteNull();
+                    var writer = new RespMemoryWriter(respProtocolVersion, ref output.SpanByteAndMemory);
+                    
+                    customRawStringCommand.functions.NotFound(key, ref input, ref writer);
+
+                    SendAndReset(output.SpanByteAndMemory.Memory, output.SpanByteAndMemory.Length);
+                    output.SpanByteAndMemory.Memory?.Dispose();
                 }
             }
 
@@ -135,21 +141,21 @@ namespace Garnet.server
         /// <summary>
         /// Custom object command
         /// </summary>
-        private bool TryCustomObjectCommand<TGarnetApi>(GarnetObjectType objType, byte subid, CommandType type, ref TGarnetApi storageApi)
+        private bool TryCustomObjectCommand<TGarnetApi>(GarnetObjectType objType, CustomObjectCommand customObjectCommand, ref TGarnetApi storageApi)
             where TGarnetApi : IGarnetAdvancedApi
         {
             var key = parseState.GetArgSliceByRef(0);
 
             // Prepare input
 
-            var header = new RespInputHeader(objType) { SubId = subid };
+            var header = new RespInputHeader(objType) { SubId = customObjectCommand.subid };
             var input = new ObjectInput(header, ref parseState, startIdx: 1);
 
             var output = new ObjectOutput();
 
             GarnetStatus status;
 
-            if (type == CommandType.ReadModifyWrite)
+            if (customObjectCommand.type == CommandType.ReadModifyWrite)
             {
                 status = storageApi.RMW_ObjectStore(key, ref input, ref output);
                 Debug.Assert(!output.SpanByteAndMemory.IsSpanByte);
@@ -184,8 +190,12 @@ namespace Garnet.server
                                 SendAndReset();
                         break;
                     case GarnetStatus.NOTFOUND:
-                        Debug.Assert(output.SpanByteAndMemory.Memory == null);
-                        WriteNull();
+                        var writer = new RespMemoryWriter(respProtocolVersion, ref output.SpanByteAndMemory);
+                        customObjectCommand.functions.NotFound(key, ref input, ref writer);
+
+                        SendAndReset(output.SpanByteAndMemory.Memory, output.SpanByteAndMemory.Length);
+
+                        output.SpanByteAndMemory.Memory.Dispose();
                         break;
                     case GarnetStatus.WRONGTYPE:
                         while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_WRONG_TYPE, ref dcurr, dend))
@@ -265,10 +275,13 @@ namespace Garnet.server
                 else
                 {
                     Debug.Assert(_output.SpanByteAndMemory.Memory == null);
-                    if (respProtocolVersion >= 3)
-                        output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP3_NULL_REPLY);
-                    else
-                        output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP_ERRNOTFOUND);
+
+                    var writer = new RespMemoryWriter(respProtocolVersion, ref _output.SpanByteAndMemory);
+                    customCommand.functions.NotFound(key, ref stringInput, ref writer);
+
+                    output = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan);
+
+                    _output.SpanByteAndMemory.Memory.Dispose();
                 }
             }
 
@@ -337,10 +350,13 @@ namespace Garnet.server
                         break;
                     case GarnetStatus.NOTFOUND:
                         Debug.Assert(_output.SpanByteAndMemory.Memory == null);
-                        if (respProtocolVersion >= 3)
-                            output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP3_NULL_REPLY);
-                        else
-                            output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP_ERRNOTFOUND);
+                        var writer = new RespMemoryWriter(respProtocolVersion, ref _output.SpanByteAndMemory);
+                        
+                        customObjCommand.functions.NotFound(key.ReadOnlySpan, ref input, ref writer);
+
+                        output = scratchBufferAllocator.CreateArgSlice(_output.SpanByteAndMemory.ReadOnlySpan);
+                        
+                        _output.SpanByteAndMemory.Memory.Dispose();
                         break;
                     case GarnetStatus.WRONGTYPE:
                         output = scratchBufferAllocator.CreateArgSlice(CmdStrings.RESP_ERR_WRONG_TYPE);

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -1172,7 +1172,7 @@ namespace Garnet.server
 
             // Perform the operation
             var cmd = customCommandManagerSession.GetCustomRespCommand(currentCustomRawStringCommand.id);
-            TryCustomRawStringCommand(cmd, currentCustomRawStringCommand.expirationTicks, currentCustomRawStringCommand.type, ref storageApi);
+            TryCustomRawStringCommand(cmd, currentCustomRawStringCommand, ref storageApi);
             currentCustomRawStringCommand = null;
             return true;
         }
@@ -1188,8 +1188,7 @@ namespace Garnet.server
 
             // Perform the operation
             var type = customCommandManagerSession.GetCustomGarnetObjectType(currentCustomObjectCommand.id);
-            TryCustomObjectCommand(type, currentCustomObjectCommand.subid,
-                currentCustomObjectCommand.type, ref storageApi);
+            TryCustomObjectCommand(type, currentCustomObjectCommand, ref storageApi);
             currentCustomObjectCommand = null;
             return true;
         }

--- a/test/standalone/Garnet.test.scripting/RespCustomCommandTests.cs
+++ b/test/standalone/Garnet.test.scripting/RespCustomCommandTests.cs
@@ -221,6 +221,37 @@ namespace Garnet.test
             garnetApi.Increment(keyToIncrment, out long _, 1);
         }
     }
+
+    public sealed class CustomNotFoundFactory : CustomObjectFactory
+    {
+        public override CustomObjectBase Create(byte type) => null;
+        public override CustomObjectBase Deserialize(byte type, BinaryReader reader) => null;
+    }
+
+    public sealed class CustomNotFoundFunctions : CustomObjectFunctions
+    {
+        public override void NotFound(ReadOnlySpan<byte> key, ref ObjectInput input, ref RespMemoryWriter writer)
+        {
+            writer.WriteBulkString(Encoding.UTF8.GetBytes($"Did not find: {Encoding.UTF8.GetString(key)}"));
+        }
+    }
+
+    public sealed class CustomNotFoundStringFunctions : CustomRawStringFunctions
+    {
+        public override bool CopyUpdater(ReadOnlySpan<byte> key, ref StringInput input, ReadOnlySpan<byte> oldValue, Span<byte> newValue, ref RespMemoryWriter writer, ref RMWInfo rmwInfo) => throw new NotImplementedException();
+        public override int GetInitialLength(ref StringInput input) => throw new NotImplementedException();
+        public override int GetLength(ReadOnlySpan<byte> value, ref StringInput input) => throw new NotImplementedException();
+        public override bool InitialUpdater(ReadOnlySpan<byte> key, ref StringInput input, Span<byte> value, ref RespMemoryWriter writer, ref RMWInfo rmwInfo) => throw new NotImplementedException();
+        public override bool InPlaceUpdater(ReadOnlySpan<byte> key, ref StringInput input, Span<byte> value, ref int valueLength, ref RespMemoryWriter writer, ref RMWInfo rmwInfo) => throw new NotImplementedException();
+
+        public override bool Reader(ReadOnlySpan<byte> key, ref StringInput input, ReadOnlySpan<byte> value, ref RespMemoryWriter writer, ref ReadInfo readInfo) => throw new NotImplementedException();
+
+        public override void NotFound(ReadOnlySpan<byte> key, ref StringInput input, ref RespMemoryWriter writer)
+        {
+            writer.WriteBulkString(Encoding.UTF8.GetBytes($"Did not find: {Encoding.UTF8.GetString(key)}"));
+        }
+    }
+
     [TestFixture]
     public class RespCustomCommandTests : TestBase
     {
@@ -1492,6 +1523,48 @@ namespace Garnet.test
             {
                 ClassicAssert.Fail(rse.Message);
             }
+        }
+
+        [Test]
+        public void CustomNotFoundResponseTest()
+        {
+            _ = server.Register.NewCommand("CUSTNF", CommandType.Read, new CustomNotFoundFactory(), new CustomNotFoundFunctions(), new RespCommandsInfo { Arity = 2 });
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase();
+
+            var resp0 = (string)db.Execute("CUSTNF", "short string");
+            ClassicAssert.AreEqual("Did not find: short string", resp0);
+
+            var veryLongStringBytes = new byte[128 * 1024];
+            for (var i = 0; i < veryLongStringBytes.Length; i++)
+            {
+                veryLongStringBytes[i] = (byte)('a' + (i % 26));
+            }
+
+            var resp1 = (string)db.Execute("CUSTNF", veryLongStringBytes);
+            ClassicAssert.AreEqual($"Did not find: {Encoding.UTF8.GetString(veryLongStringBytes)}", resp1);
+        }
+
+        [Test]
+        public void CustomNotFoundStringResponseTest()
+        {
+            _ = server.Register.NewCommand("CUSTSNF", CommandType.Read, new CustomNotFoundStringFunctions(), new RespCommandsInfo { Arity = 2 });
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase();
+
+            var resp0 = (string)db.Execute("CUSTSNF", "short string");
+            ClassicAssert.AreEqual("Did not find: short string", resp0);
+
+            var veryLongStringBytes = new byte[128 * 1024];
+            for (var i = 0; i < veryLongStringBytes.Length; i++)
+            {
+                veryLongStringBytes[i] = (byte)('a' + (i % 26));
+            }
+
+            var resp1 = (string)db.Execute("CUSTSNF", veryLongStringBytes);
+            ClassicAssert.AreEqual($"Did not find: {Encoding.UTF8.GetString(veryLongStringBytes)}", resp1);
         }
     }
 }


### PR DESCRIPTION
Today custom commands that need a non-null response must register as `ReadModifyWrite` and write the response `NeedInitialUpdate`.

This isn't ideal because `NeedInitialUpdate` runs under an exclusive lock for the record, so commands which are logical reads block each other.

This PR adds: 
 - `CustomRawStringFunctions.NotFound(ReadOnlySpan<byte> key, ref StringInput input, ref RespMemoryWriter writer)`
 - `CustomObjectFunctions.NotFound(ReadOnlySpan<byte> key, ref ObjectInput input, ref RespMemoryWriter writer)`

Which can be overridden to customize behavior.  The default behavior remains writing a null (either `_\r\n` or `$-1\r\n` depending on RESP version).

These methods are called only when the custom command is registered as `CommandType.Read` when `GarnetStatus.NOTFOUND` is returned by `Read_ObjectStore` or `Read_MainStore`.