### PR TITLE
Fix missing cluster slot verification for CustomRawStringCmd and CustomObjCmd

### DIFF
--- a/libs/server/Resp/RespServerSessionSlotVerify.cs
+++ b/libs/server/Resp/RespServerSessionSlotVerify.cs
@@ -10,7 +10,7 @@ namespace Garnet.server
     /// </summary>
     internal sealed unsafe partial class RespServerSession : ServerSessionBase
     {
-        // Single-key spec for custom raw-string/object commands (key at parseState[0])
+        // Key spec for CustomRawStringCmd and CustomObjCmd: a single key at arg index 1.
         private static readonly SimpleRespKeySpec[] CustomCommandSingleKeySpec =
         [
             new SimpleRespKeySpec
@@ -21,7 +21,7 @@ namespace Garnet.server
         ];
 
         /// <summary>
-        /// Validate if this command can be served based on the current slot assignment
+        /// Validates whether a command can be served based on the current slot assignment
         /// </summary>
         /// <param name="cmd"></param>
         /// <returns></returns>
@@ -29,27 +29,14 @@ namespace Garnet.server
         {
             Debug.Assert(clusterSession != null);
 
-            // CustomRawStringCmd and CustomObjCmd fall outside IsDataCommand()'s range and
-            // would otherwise skip slot verification, so route them through a synthetic
-            // single-key spec (both dispatch via parseState[0] as the only key)
-            if (cmd is RespCommand.CustomRawStringCmd or RespCommand.CustomObjCmd)
-            {
-                // We can't use cmd.IsReadOnly() since both custom enum values fall above LastReadCommand
-                var isReadOnly = cmd == RespCommand.CustomRawStringCmd
-                    ? currentCustomRawStringCommand.type == CommandType.Read
-                    : currentCustomObjectCommand.type == CommandType.Read;
-
-                csvi.keySpecs = CustomCommandSingleKeySpec;
-                csvi.isSubCommand = false;
-                csvi.readOnly = isReadOnly;
-                csvi.sessionAsking = SessionAsking;
-                csvi.waitForStableSlot = false;
-                return !clusterSession.NetworkMultiKeySlotVerify(ref parseState, ref csvi, ref dcurr, ref dend);
-            }
-
-            // Verify slot for command if it falls into data command category
             if (!cmd.IsDataCommand())
+            {
+                // Custom commands sit outside IsDataCommand but still touch user keys.
+                if (cmd is RespCommand.CustomRawStringCmd or RespCommand.CustomObjCmd)
+                    return CanServeSlotForCustomCommand(cmd);
+
                 return true;
+            }
 
             cmd = cmd.NormalizeForACLs();
             if (!RespCommandsInfo.TryGetSimpleRespCommandInfo(cmd, out var cmdInfo))
@@ -68,6 +55,26 @@ namespace Garnet.server
             csvi.readOnly = cmd.IsReadOnly();
             csvi.sessionAsking = SessionAsking;
             csvi.waitForStableSlot = cmd is RespCommand.VADD or RespCommand.VREM or RespCommand.VSETATTR;
+            return !clusterSession.NetworkMultiKeySlotVerify(ref parseState, ref csvi, ref dcurr, ref dend);
+        }
+
+        /// <summary>
+        /// Validates whether a custom command can be served based on the current slot assignment
+        /// </summary>
+        /// <param name="cmd"></param>
+        /// <returns></returns>
+        bool CanServeSlotForCustomCommand(RespCommand cmd)
+        {
+            // cmd.IsReadOnly() can't be used here since both custom enum values sort past LastReadCommand.
+            var isReadOnly = cmd == RespCommand.CustomRawStringCmd
+                ? currentCustomRawStringCommand.type == CommandType.Read
+                : currentCustomObjectCommand.type == CommandType.Read;
+
+            csvi.keySpecs = CustomCommandSingleKeySpec;
+            csvi.isSubCommand = false;
+            csvi.readOnly = isReadOnly;
+            csvi.sessionAsking = SessionAsking;
+            csvi.waitForStableSlot = false;
             return !clusterSession.NetworkMultiKeySlotVerify(ref parseState, ref csvi, ref dcurr, ref dend);
         }
     }

--- a/libs/server/Resp/RespServerSessionSlotVerify.cs
+++ b/libs/server/Resp/RespServerSessionSlotVerify.cs
@@ -10,6 +10,16 @@ namespace Garnet.server
     /// </summary>
     internal sealed unsafe partial class RespServerSession : ServerSessionBase
     {
+        // Single-key spec for custom raw-string/object commands (key at parseState[0])
+        private static readonly SimpleRespKeySpec[] CustomCommandSingleKeySpec =
+        [
+            new SimpleRespKeySpec
+            {
+                BeginSearch = new SimpleRespKeySpecBeginSearch(index: 1),
+                FindKeys = new SimpleRespKeySpecFindKeys(keyStep: 1, lastKeyOrLimit: 0, isLimit: false),
+            }
+        ];
+
         /// <summary>
         /// Validate if this command can be served based on the current slot assignment
         /// </summary>
@@ -18,6 +28,24 @@ namespace Garnet.server
         bool CanServeSlot(RespCommand cmd)
         {
             Debug.Assert(clusterSession != null);
+
+            // CustomRawStringCmd and CustomObjCmd fall outside IsDataCommand()'s range and
+            // would otherwise skip slot verification, so route them through a synthetic
+            // single-key spec (both dispatch via parseState[0] as the only key)
+            if (cmd is RespCommand.CustomRawStringCmd or RespCommand.CustomObjCmd)
+            {
+                // We can't use cmd.IsReadOnly() since both custom enum values fall above LastReadCommand
+                var isReadOnly = cmd == RespCommand.CustomRawStringCmd
+                    ? currentCustomRawStringCommand.type == CommandType.Read
+                    : currentCustomObjectCommand.type == CommandType.Read;
+
+                csvi.keySpecs = CustomCommandSingleKeySpec;
+                csvi.isSubCommand = false;
+                csvi.readOnly = isReadOnly;
+                csvi.sessionAsking = SessionAsking;
+                csvi.waitForStableSlot = false;
+                return !clusterSession.NetworkMultiKeySlotVerify(ref parseState, ref csvi, ref dcurr, ref dend);
+            }
 
             // Verify slot for command if it falls into data command category
             if (!cmd.IsDataCommand())

--- a/test/cluster/Garnet.test.cluster.migrate/RedirectTests/ClusterSlotVerificationTests.cs
+++ b/test/cluster/Garnet.test.cluster.migrate/RedirectTests/ClusterSlotVerificationTests.cs
@@ -152,6 +152,10 @@ namespace Garnet.test.cluster
                 new HCOLLECT(),
                 new CLUSTERGETPROC(),
                 new CLUSTERSETPROC(),
+                new CLUSTERTESTRAWCMD(),
+                new CLUSTERTESTOBJCMD(),
+                new CLUSTERTESTRAWREADCMD(),
+                new CLUSTERTESTOBJREADCMD(),
                 new WATCH(),
                 new WATCHMS(),
                 new WATCHOS(),
@@ -229,6 +233,38 @@ namespace Garnet.test.cluster
                 "CLUSTERSETPROC",
                 () => new TestClusterReadWriteCustomTxn(),
                 new RespCommandsInfo { Arity = TestClusterReadWriteCustomTxn.Arity });
+
+            // Register write and read variants of CustomRawStringCmd and CustomObjCmd so the
+            // readOnly=true and readOnly=false branches of CanServeSlot are exercised by the
+            // standard CLUSTERDOWN/OK/MOVED/ASK tests
+            foreach (var node in context.nodes)
+            {
+                _ = node.Register.NewCommand(
+                    "CLUSTERTESTRAWCMD",
+                    CommandType.ReadModifyWrite,
+                    new TestClusterRawStringCmd(),
+                    new RespCommandsInfo { Arity = 3 });
+
+                _ = node.Register.NewCommand(
+                    "CLUSTERTESTOBJCMD",
+                    CommandType.ReadModifyWrite,
+                    new TestClusterObjFactory(),
+                    new TestClusterObjSet(),
+                    new RespCommandsInfo { Arity = 3 });
+
+                _ = node.Register.NewCommand(
+                    "CLUSTERTESTRAWREADCMD",
+                    CommandType.Read,
+                    new TestClusterRawStringReadCmd(),
+                    new RespCommandsInfo { Arity = 2 });
+
+                _ = node.Register.NewCommand(
+                    "CLUSTERTESTOBJREADCMD",
+                    CommandType.Read,
+                    new TestClusterObjFactory(),
+                    new TestClusterObjGet(),
+                    new RespCommandsInfo { Arity = 2 });
+            }
 
             context.CreateConnection();
 

--- a/test/cluster/Garnet.test.cluster.migrate/RedirectTests/TestClusterCustomCommands.cs
+++ b/test/cluster/Garnet.test.cluster.migrate/RedirectTests/TestClusterCustomCommands.cs
@@ -1,0 +1,203 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Garnet.common;
+using Garnet.server;
+using Tsavorite.core;
+
+namespace Garnet.test.cluster
+{
+    // Write-only custom raw-string command: overwrites the value with the first input arg
+    sealed class TestClusterRawStringCmd : CustomRawStringFunctions
+    {
+        public override bool Reader(ReadOnlySpan<byte> key, ref StringInput input, ReadOnlySpan<byte> value, ref RespMemoryWriter writer, ref ReadInfo readInfo)
+            => throw new InvalidOperationException();
+
+        public override bool NeedInitialUpdate(scoped ReadOnlySpan<byte> key, ref StringInput input, ref RespMemoryWriter writer)
+            => true;
+
+        public override int GetInitialLength(ref StringInput input)
+            => GetFirstArg(ref input).Length;
+
+        public override bool InitialUpdater(ReadOnlySpan<byte> key, ref StringInput input, Span<byte> value, ref RespMemoryWriter writer, ref RMWInfo rmwInfo)
+        {
+            GetFirstArg(ref input).CopyTo(value);
+            return true;
+        }
+
+        public override bool InPlaceUpdater(ReadOnlySpan<byte> key, ref StringInput input, Span<byte> value, ref int valueLength, ref RespMemoryWriter writer, ref RMWInfo rmwInfo)
+        {
+            var newVal = GetFirstArg(ref input);
+            if (newVal.Length > value.Length)
+                return false; // fall back to CopyUpdater
+
+            newVal.CopyTo(value);
+            valueLength = newVal.Length;
+            return true;
+        }
+
+        public override bool NeedCopyUpdate(ReadOnlySpan<byte> key, ref StringInput input, ReadOnlySpan<byte> oldValue, ref RespMemoryWriter writer)
+            => true;
+
+        public override int GetLength(ReadOnlySpan<byte> value, ref StringInput input)
+            => GetFirstArg(ref input).Length;
+
+        public override bool CopyUpdater(ReadOnlySpan<byte> key, ref StringInput input, ReadOnlySpan<byte> oldValue, Span<byte> newValue, ref RespMemoryWriter writer, ref RMWInfo rmwInfo)
+        {
+            GetFirstArg(ref input).CopyTo(newValue);
+            return true;
+        }
+    }
+
+    // Read-only custom raw-string command for the readOnly=true slot-verification branch
+    sealed class TestClusterRawStringReadCmd : CustomRawStringFunctions
+    {
+        public override bool Reader(ReadOnlySpan<byte> key, ref StringInput input, ReadOnlySpan<byte> value, ref RespMemoryWriter writer, ref ReadInfo readInfo)
+        {
+            writer.WriteBulkString(value);
+            return true;
+        }
+
+        // The dispatcher only invokes write methods for ReadModifyWrite commands, so throws
+        // here surface accidental write-path invocations as test failures instead of silent state corruption
+        public override bool NeedInitialUpdate(scoped ReadOnlySpan<byte> key, ref StringInput input, ref RespMemoryWriter writer)
+            => throw new InvalidOperationException();
+
+        public override int GetInitialLength(ref StringInput input)
+            => throw new InvalidOperationException();
+
+        public override bool InitialUpdater(ReadOnlySpan<byte> key, ref StringInput input, Span<byte> value, ref RespMemoryWriter writer, ref RMWInfo rmwInfo)
+            => throw new InvalidOperationException();
+
+        public override bool InPlaceUpdater(ReadOnlySpan<byte> key, ref StringInput input, Span<byte> value, ref int valueLength, ref RespMemoryWriter writer, ref RMWInfo rmwInfo)
+            => throw new InvalidOperationException();
+
+        public override int GetLength(ReadOnlySpan<byte> value, ref StringInput input)
+            => throw new InvalidOperationException();
+
+        public override bool CopyUpdater(ReadOnlySpan<byte> key, ref StringInput input, ReadOnlySpan<byte> oldValue, Span<byte> newValue, ref RespMemoryWriter writer, ref RMWInfo rmwInfo)
+            => throw new InvalidOperationException();
+    }
+
+    sealed class TestClusterObjFactory : CustomObjectFactory
+    {
+        public override CustomObjectBase Create(byte type)
+            => new TestClusterObj(type);
+
+        public override CustomObjectBase Deserialize(byte type, BinaryReader reader)
+            => new TestClusterObj(type);
+    }
+
+    // Empty stub used only to satisfy the CustomObjectBase contract; tests assert dispatch routing only
+    sealed class TestClusterObj : CustomObjectBase
+    {
+        public TestClusterObj(byte type) : base(type) { }
+
+        public TestClusterObj(TestClusterObj obj) : base(obj) { }
+
+        public override CustomObjectBase CloneObject() => new TestClusterObj(this);
+
+        public override void SerializeObject(BinaryWriter writer) { }
+
+        public override void Dispose() { }
+
+        public override unsafe void Scan(long start, out List<byte[]> items, out long cursor, int count = 10, byte* pattern = null, int patternLength = 0, bool isNoValue = false)
+        {
+            items = [];
+            cursor = 0;
+        }
+    }
+
+    sealed class TestClusterObjSet : CustomObjectFunctions
+    {
+        public override bool NeedInitialUpdate(scoped ReadOnlySpan<byte> key, ref ObjectInput input, ref RespMemoryWriter writer)
+            => true;
+
+        // No-op; returning true emits the default +OK reply
+        public override bool Updater(ReadOnlySpan<byte> key, ref ObjectInput input, IGarnetObject value, ref RespMemoryWriter writer, ref RMWInfo rmwInfo)
+            => true;
+    }
+
+    // Read-only custom object command for the readOnly=true slot-verification branch
+    sealed class TestClusterObjGet : CustomObjectFunctions
+    {
+        public override bool Reader(ReadOnlySpan<byte> key, ref ObjectInput input, IGarnetObject value, ref RespMemoryWriter writer, ref ReadInfo readInfo)
+        {
+            writer.WriteNull();
+            return true;
+        }
+    }
+
+    internal class CLUSTERTESTRAWCMD : BaseCommand
+    {
+        public override bool IsArrayCommand => false;
+        public override bool ArrayResponse => false;
+        public override string Command => nameof(CLUSTERTESTRAWCMD);
+
+        public override string[] GetSingleSlotRequest()
+        {
+            var ssk = GetSingleSlotKeys;
+            return [ssk[0], "value"];
+        }
+
+        public override string[] GetCrossSlotRequest() => throw new NotImplementedException();
+
+        public override ArraySegment<string>[] SetupSingleSlotRequest() => throw new NotImplementedException();
+    }
+
+    internal class CLUSTERTESTOBJCMD : BaseCommand
+    {
+        public override bool IsArrayCommand => false;
+        public override bool ArrayResponse => false;
+        public override string Command => nameof(CLUSTERTESTOBJCMD);
+
+        public override string[] GetSingleSlotRequest()
+        {
+            var ssk = GetSingleSlotKeys;
+            return [ssk[0], "value"];
+        }
+
+        public override string[] GetCrossSlotRequest() => throw new NotImplementedException();
+
+        public override ArraySegment<string>[] SetupSingleSlotRequest() => throw new NotImplementedException();
+    }
+
+    // Read-mode custom raw-string command: only the key argument is needed
+    internal class CLUSTERTESTRAWREADCMD : BaseCommand
+    {
+        public override bool IsArrayCommand => false;
+        public override bool ArrayResponse => false;
+        public override string Command => nameof(CLUSTERTESTRAWREADCMD);
+
+        public override string[] GetSingleSlotRequest()
+        {
+            var ssk = GetSingleSlotKeys;
+            return [ssk[0]];
+        }
+
+        public override string[] GetCrossSlotRequest() => throw new NotImplementedException();
+
+        public override ArraySegment<string>[] SetupSingleSlotRequest() => throw new NotImplementedException();
+    }
+
+    // Read-mode custom object command: only the key argument is needed
+    internal class CLUSTERTESTOBJREADCMD : BaseCommand
+    {
+        public override bool IsArrayCommand => false;
+        public override bool ArrayResponse => false;
+        public override string Command => nameof(CLUSTERTESTOBJREADCMD);
+
+        public override string[] GetSingleSlotRequest()
+        {
+            var ssk = GetSingleSlotKeys;
+            return [ssk[0]];
+        }
+
+        public override string[] GetCrossSlotRequest() => throw new NotImplementedException();
+
+        public override ArraySegment<string>[] SetupSingleSlotRequest() => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Closes #1826

## Problem

`RespServerSession.CanServeSlot` decides whether a command needs cluster slot verification by checking `RespCommand.IsDataCommand()`. That check returns `false` for the four custom-command enum values (`CustomRawStringCmd`, `CustomObjCmd`, `CustomTxn`, `CustomProcedure`) because they sit past `LastDataCommand` (EVALSHA) in the enum range.

As a result, `CustomRawStringCmd` and `CustomObjCmd` skipped slot verification entirely in cluster mode, so a client could hit a node that doesn't own the key and never get a `MOVED` redirect back. `CustomTxn` was unaffected because `CustomTransactionProcedure.RegisterKey` already runs every key through `txnManager.VerifyKeyOwnership`. `CustomProcedure` is left to the procedure author since procedures can touch arbitrary keys. The gap this PR closes is the two remaining types, both of which have a fixed contract: the key is always at `parseState[0]`, enforced by `TryCustomRawStringCommand` and `TryCustomObjectCommand`.

## What this change does

Adds an explicit switch arm at the top of `CanServeSlot` that handles `CustomRawStringCmd` and `CustomObjCmd` by driving `NetworkMultiKeySlotVerify` with a synthetic single-key spec.

- A `static readonly` `CustomCommandSingleKeySpec` (`SimpleRespKeySpec[]`) describes the contract: `BeginSearch(index: 1)`, `FindKeys(keyStep: 1, lastKeyOrLimit: 0, isLimit: false)`. Allocated once at type load, so no per-request allocation is added.
- `csvi.readOnly` is derived from the parsed command's type (`currentCustomRawStringCommand.type` or `currentCustomObjectCommand.type == CommandType.Read`). `cmd.IsReadOnly()` cannot be used here because both custom enum values fall above `LastReadCommand`.
- The new arm runs before the existing `IsDataCommand()` bypass, so no other command's slot check is affected.

## Testing

Added `test/cluster/Garnet.test.cluster.migrate/RedirectTests/TestClusterCustomCommands.cs`, which registers four minimal custom commands so the existing slot-verification matrix covers both branches of the new code path:

- `CLUSTERTESTRAWCMD` and `CLUSTERTESTOBJCMD` exercise `readOnly=false` (`CommandType.ReadModifyWrite`).
- `CLUSTERTESTRAWREADCMD` and `CLUSTERTESTOBJREADCMD` exercise `readOnly=true` (`CommandType.Read`). The read-only stub throws from every write-path method so an accidental write-path dispatch becomes a hard test failure.

`ClusterSlotVerificationTests.OneTimeSetUp` registers all four via `Register.NewCommand` on each node and adds them to the `TestCommands` array, so the existing `CLUSTERDOWN`/`OK`/`MOVED`/`ASK`/`CROSSSLOT`/`TRYAGAIN` matrix automatically runs against the new commands.

Test runs on `net10.0` Debug:

- `Garnet.test.cluster.migrate`: 54/54
- `Garnet.test.cluster`: 137/137
- `Garnet.test.cluster.multilog`: 144/144
- `Garnet.test.cluster.replication`: 107/107
- `Garnet.test.cluster.replication.asyncreplay`: 105/105
- `Garnet.test.cluster.replication.disklesssync`: 29/29
- `Garnet.test.cluster.replication.tls`: 105/105
- `Garnet.test.cluster.vectorsets`: 16/16
- `Garnet.test`: 789/792 (3 pre-existing skips unrelated to this change)

`dotnet format Garnet.slnx --verify-no-changes` and `dotnet format Tsavorite.slnx --verify-no-changes` both clean. Full solution build: 0 warnings, 0 errors.