### PR TITLE
Set IsReplicating on APPENDLOG init handshake to prevent idle resync loop

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- VersionPrefix property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>2.0.0-beta.6</VersionPrefix>
+		<VersionPrefix>2.0.0-beta.7</VersionPrefix>
 	</PropertyGroup>
 </Project>

--- a/libs/cluster/Session/RespClusterReplicationCommands.cs
+++ b/libs/cluster/Session/RespClusterReplicationCommands.cs
@@ -205,25 +205,6 @@ namespace Garnet.cluster
 
             LogPrimaryStream(physicalSublogIdx, previousAddress, currentAddress, nextAddress, logger);
 
-            // Mark this session as the active replication stream so that
-            // EnsureReplication does not trigger spurious resyncs while the
-            // AOF stream is idle (no data APPENDLOG to set the flag later).
-            IsReplicating = true;
-
-            // This is an initialization message
-            if (previousAddress == -1 && currentAddress == -1 && nextAddress == -1)
-            {
-                if (clusterProvider.replicationManager.InitializeReplicaReplayDriver(physicalSublogIdx, networkSender))
-                    replicaReplayDriverStore = clusterProvider.replicationManager.ReplicaReplayDriverStore;
-                else
-                    throw new GarnetException($"Failed to process {nameof(NetworkClusterAppendLog)}: [physicalSublogIdx: {physicalSublogIdx}] Received initialization message but ReplicaReplayDriver is already initialized!", LogLevel.Error, clientResponse: false);
-
-                while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
-                    SendAndReset();
-                return true;
-            }
-
-            var sbRecord = parseState.GetArgSliceByRef(5);
             var currentConfig = clusterProvider.clusterManager.CurrentConfig;
             var localRole = currentConfig.LocalNodeRole;
             var primaryId = currentConfig.LocalNodePrimaryId;
@@ -237,6 +218,25 @@ namespace Garnet.cluster
             }
             else
             {
+                // Mark this session as the active replication stream so that
+                // EnsureReplication does not trigger spurious resyncs while the
+                // AOF stream is idle (no data APPENDLOG to set the flag later).
+                IsReplicating = true;
+
+                // This is an initialization message
+                if (previousAddress == -1 && currentAddress == -1 && nextAddress == -1)
+                {
+                    if (clusterProvider.replicationManager.InitializeReplicaReplayDriver(physicalSublogIdx, networkSender))
+                        replicaReplayDriverStore = clusterProvider.replicationManager.ReplicaReplayDriverStore;
+                    else
+                        throw new GarnetException($"Failed to process {nameof(NetworkClusterAppendLog)}: [physicalSublogIdx: {physicalSublogIdx}] Received initialization message but ReplicaReplayDriver is already initialized!", LogLevel.Error, clientResponse: false);
+
+                    while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
+                        SendAndReset();
+                    return true;
+                }
+
+                var sbRecord = parseState.GetArgSliceByRef(5);
                 ProcessPrimaryStream(physicalSublogIdx, sbRecord.ToPointer(), sbRecord.Length,
                     previousAddress, currentAddress, nextAddress);
             }

--- a/libs/cluster/Session/RespClusterReplicationCommands.cs
+++ b/libs/cluster/Session/RespClusterReplicationCommands.cs
@@ -205,6 +205,11 @@ namespace Garnet.cluster
 
             LogPrimaryStream(physicalSublogIdx, previousAddress, currentAddress, nextAddress, logger);
 
+            // Mark this session as the active replication stream so that
+            // EnsureReplication does not trigger spurious resyncs while the
+            // AOF stream is idle (no data APPENDLOG to set the flag later).
+            IsReplicating = true;
+
             // This is an initialization message
             if (previousAddress == -1 && currentAddress == -1 && nextAddress == -1)
             {
@@ -232,8 +237,6 @@ namespace Garnet.cluster
             }
             else
             {
-                IsReplicating = true;
-
                 ProcessPrimaryStream(physicalSublogIdx, sbRecord.ToPointer(), sbRecord.Length,
                     previousAddress, currentAddress, nextAddress);
             }

--- a/libs/server/Cluster/IClusterSession.cs
+++ b/libs/server/Cluster/IClusterSession.cs
@@ -23,7 +23,7 @@ namespace Garnet.server
         bool ReadWriteSession { get; }
 
         /// <summary>
-        /// If the current session has seen an APPENDLOG command.
+        /// If the current session is part of an active replication stream (set on first APPENDLOG, including the init handshake).
         /// </summary>
         bool IsReplicating { get; }
 


### PR DESCRIPTION
After a TCP disruption on an idle cluster, the replica's EnsureReplication
would trigger repeated resyncs because IsReplicating was only set when a
data APPENDLOG arrived, not on the init handshake (-1,-1,-1). On an idle
stream no data APPENDLOG follows, so the flag stayed false and
EnsureReplication fired every ClusterReplicationReestablishmentTimeout.

Move IsReplicating = true to the top of NetworkClusterAppendLog so it is
set on every APPENDLOG message including the init handshake. The flag is
cleared implicitly when the session is disposed on connection drop.