### PR TITLE
Remove EnableFastCommit option (always enabled)

### DIFF
--- a/benchmark/Resp.benchmark/OfflineBench/AOFBench/AofGen.cs
+++ b/benchmark/Resp.benchmark/OfflineBench/AOFBench/AofGen.cs
@@ -231,7 +231,6 @@ namespace Resp.benchmark
                 AofMemorySize = options.AofMemorySize,
                 AofPageSize = options.AofPageSize,
                 UseAofNullDevice = true,
-                EnableFastCommit = true,
                 CommitFrequencyMs = -1,
                 FastAofTruncate = true,
                 EnableCluster = true,

--- a/libs/cluster/Server/ClusterProvider.cs
+++ b/libs/cluster/Server/ClusterProvider.cs
@@ -183,7 +183,6 @@ namespace Garnet.cluster
                 else
                 {
                     storeWrapper.appendOnlyFile?.Log.TruncateUntil(truncateUntil);
-                    if (!serverOptions.EnableFastCommit) storeWrapper.appendOnlyFile?.Log.Commit();
                 }
             }
         }

--- a/libs/cluster/Server/Replication/ReplicaOps/AOFReplay/ReplicaReplayDriver.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/AOFReplay/ReplicaReplayDriver.cs
@@ -172,10 +172,6 @@ namespace Garnet.cluster
                 }
                 else if (payloadLength < 0)
                 {
-                    if (!serverOptions.EnableFastCommit)
-                    {
-                        throw new GarnetException("Received FastCommit request at replica AOF processor, but FastCommit is not enabled", clientResponse: false);
-                    }
                     TsavoriteLogRecoveryInfo info = new();
                     info.Initialize(new ReadOnlySpan<byte>(ptr + entryLength, -payloadLength));
                     physicalSublog.UnsafeCommitMetadataOnly(info, isProtected);
@@ -245,10 +241,6 @@ namespace Garnet.cluster
                     }
                     else if (payloadLength < 0)
                     {
-                        if (!serverOptions.EnableFastCommit)
-                        {
-                            throw new GarnetException("Received FastCommit request at replica AOF processor, but FastCommit is not enabled", clientResponse: false);
-                        }
                         TsavoriteLogRecoveryInfo info = new();
                         info.Initialize(new ReadOnlySpan<byte>(ptr + entryLength, -payloadLength));
                         physicalSublog.UnsafeCommitMetadataOnly(info, isProtected);

--- a/libs/cluster/Server/Replication/ReplicaOps/AOFReplay/ReplicaReplaySession.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/AOFReplay/ReplicaReplaySession.cs
@@ -100,7 +100,7 @@ namespace Garnet.cluster
                 physicalSublog ??= clusterProvider.storeWrapper.appendOnlyFile.Log.GetSubLog(physicalSublogIdx);
 
                 // Enqueue to AOF
-                _ = physicalSublog.UnsafeEnqueueRaw(new Span<byte>(record, recordLength), noCommit: clusterProvider.serverOptions.EnableFastCommit);
+                _ = physicalSublog.UnsafeEnqueueRaw(new Span<byte>(record, recordLength), noCommit: true);
 
                 if (clusterProvider.storeWrapper.serverOptions.ReplicationOffsetMaxLag == 0)
                 {

--- a/libs/cluster/Server/Replication/ReplicaOps/AOFReplay/ReplicaReplayTask.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/AOFReplay/ReplicaReplayTask.cs
@@ -113,9 +113,6 @@ namespace Garnet.cluster
                             }
                             else if (payloadLength < 0)
                             {
-                                if (!clusterProvider.serverOptions.EnableFastCommit)
-                                    ExceptionUtils.ThrowException(new GarnetException("Received FastCommit request at replica AOF processor, but FastCommit is not enabled", clientResponse: false));
-
                                 // Only a single thread should commit metadata
                                 if (replayTaskIdx == 0)
                                 {

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaDiskbasedSync.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaDiskbasedSync.cs
@@ -115,14 +115,6 @@ namespace Garnet.cluster
                         clientName: nameof(TryReplicateDiskbasedSyncAsync));
                     await gcs.ConnectAsync((int)clusterProvider.serverOptions.ReplicaSyncTimeout.TotalMilliseconds, linkedCts.Token).ConfigureAwait(false);
 
-                    // Wait for Commit of AOF (data received from old primary) if FastCommit is not enabled
-                    // If FastCommit is enabled, we commit during AOF stream processing
-                    if (!clusterProvider.serverOptions.EnableFastCommit && storeWrapper.appendOnlyFile != null)
-                    {
-                        await storeWrapper.appendOnlyFile.Log.CommitAsync().ConfigureAwait(false);
-                        await storeWrapper.appendOnlyFile.Log.WaitForCommitAsync().ConfigureAwait(false);
-                    }
-
                     // Reset background replay iterator if this node was a replica
                     clusterProvider.replicationManager.ResetReplicaReplayDriverStore();
 

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaDisklessSync.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaDisklessSync.cs
@@ -82,11 +82,6 @@ namespace Garnet.cluster
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ctsRepManager.Token, resetHandler.Token);
                 try
                 {
-                    if (!clusterProvider.serverOptions.EnableFastCommit && storeWrapper.appendOnlyFile != null)
-                    {
-                        await storeWrapper.appendOnlyFile.Log.CommitAsync().ConfigureAwait(false);
-                        await storeWrapper.appendOnlyFile.Log.WaitForCommitAsync().ConfigureAwait(false);
-                    }
 
                     // Reset background replay tasks if this node was a replica
                     clusterProvider.replicationManager.ResetReplicaReplayDriverStore();

--- a/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
+++ b/libs/cluster/Server/Replication/ReplicationHistoryManager.cs
@@ -147,11 +147,6 @@ namespace Garnet.cluster
         /// </summary>
         public void TryUpdateForFailover()
         {
-            if (!clusterProvider.serverOptions.EnableFastCommit)
-            {
-                storeWrapper.appendOnlyFile?.Log.Commit();
-                storeWrapper.appendOnlyFile?.Log.WaitForCommit();
-            }
             while (true)
             {
                 var replicationOffset2 = storeWrapper.appendOnlyFile.Log.CommittedUntilAddress;

--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -389,9 +389,6 @@ namespace Garnet
         [Option("checkpoint-throttle-delay", Required = false, HelpText = "Whether and by how much should we throttle the disk IO for checkpoints: -1 - disable throttling; >= 0 - run checkpoint flush in separate task, sleep for specified time after each WriteAsync")]
         public int CheckpointThrottleFlushDelayMs { get; set; }
 
-        [OptionValidation]
-        [Option("fast-commit", Required = false, HelpText = "Use FastCommit when writing AOF.")]
-        public bool? EnableFastCommit { get; set; }
 
         [IntRangeValidation(0, int.MaxValue)]
         [Option("fast-commit-throttle", Required = false, HelpText = "Throttle FastCommit to write metadata once every K commits.")]
@@ -794,8 +791,6 @@ namespace Garnet
                     throw new Exception("SlowLogThreshold must be at least 100 microseconds.");
             }
 
-            if (AofPhysicalSublogCount > 1 && !EnableFastCommit.GetValueOrDefault())
-                throw new Exception("Cannot use sharded-log without FastCommit!");
 
             if (!EnableAOF.GetValueOrDefault())
             {
@@ -869,7 +864,6 @@ namespace Garnet
                 GossipDelay = GossipDelay,
                 ClusterTimeout = ClusterTimeout,
                 ClusterConfigFlushFrequencyMs = ClusterConfigFlushFrequencyMs,
-                EnableFastCommit = EnableFastCommit.GetValueOrDefault(),
                 FastCommitThrottleFreq = FastCommitThrottleFreq,
                 NetworkSendThrottleMax = NetworkSendThrottleMax,
                 TlsOptions = EnableTLS.GetValueOrDefault() ? new GarnetTlsOptions(

--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -284,9 +284,6 @@
 	/* Whether and by how much should we throttle the disk IO for checkpoints: -1 - disable throttling; >= 0 - run checkpoint flush in separate task, sleep for specified time after each WriteAsync */
 	"CheckpointThrottleFlushDelayMs" : 0,
 
-	/* Use FastCommit when writing AOF. */
-	"EnableFastCommit" : true,
-
 	/* Throttle FastCommit to write metadata once every K commits. */
 	"FastCommitThrottleFreq" : 1000,
 

--- a/libs/server/AOF/GarnetLog.cs
+++ b/libs/server/AOF/GarnetLog.cs
@@ -47,7 +47,6 @@ namespace Garnet.server
         /// <param name="logger">Optional logger for recording events.</param>
         public GarnetLog(GarnetAppendOnlyFile appendOnlyFile, GarnetServerOptions serverOptions, TsavoriteLogSettings[] logSettings, ILogger logger = null)
         {
-            Debug.Assert(serverOptions.EnableFastCommit || serverOptions.AofPhysicalSublogCount == 1, "Cannot use sharded-log without FastCommit!");
             this.appendOnlyFile = appendOnlyFile;
             this.cookieGeneratorCallback = () =>
             {

--- a/libs/server/AOF/Recover/RecoverLogDriver.cs
+++ b/libs/server/AOF/Recover/RecoverLogDriver.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Garnet.common;
 using Microsoft.Extensions.Logging;
 using Tsavorite.core;
 
@@ -100,11 +99,6 @@ namespace Garnet.server
                     }
                     else if (payloadLength < 0)
                     {
-                        if (!serverOptions.EnableFastCommit)
-                        {
-                            throw new GarnetException("Received FastCommit request at replica AOF processor, but FastCommit is not enabled", clientResponse: false);
-                        }
-
                         TsavoriteLogRecoveryInfo info = new();
                         info.Initialize(new ReadOnlySpan<byte>(ptr + entryLength, -payloadLength));
                         physicalSublog.UnsafeCommitMetadataOnly(info, isProtected);
@@ -213,9 +207,6 @@ namespace Garnet.server
                             }
                             else if (payloadLength < 0)
                             {
-                                if (!serverOptions.EnableFastCommit)
-                                    throw new GarnetException("Received FastCommit request at replica AOF processor, but FastCommit is not enabled", clientResponse: false);
-
                                 // Only a single thread should commit metadata
                                 if (replayTaskIdx == 0)
                                 {

--- a/libs/server/Databases/DatabaseManagerBase.cs
+++ b/libs/server/Databases/DatabaseManagerBase.cs
@@ -475,17 +475,11 @@ namespace Garnet.server
         private ValueTask CompactionCommitAofAsync(GarnetDatabase db)
         {
             // If we are the primary, we commit the AOF.
-            // If we are the replica, we commit the AOF only if fast commit is disabled
-            // because we do not want to clobber AOF addresses.
             // TODO: replica should instead wait until the next AOF commit is done via primary
             if (StoreWrapper.serverOptions.EnableAOF)
             {
-                if (StoreWrapper.serverOptions.EnableCluster && StoreWrapper.clusterProvider.IsReplica())
-                {
-                    if (!StoreWrapper.serverOptions.EnableFastCommit && db.AppendOnlyFile != null)
-                        return db.AppendOnlyFile.Log.CommitAsync();
-                }
-                else
+                // Replica does not commit here because it would clobber AOF addresses.
+                if (!(StoreWrapper.serverOptions.EnableCluster && StoreWrapper.clusterProvider.IsReplica()))
                 {
                     if (db.AppendOnlyFile != null)
                         return db.AppendOnlyFile.Log.CommitAsync();

--- a/libs/server/Servers/GarnetServerOptions.cs
+++ b/libs/server/Servers/GarnetServerOptions.cs
@@ -289,10 +289,6 @@ namespace Garnet.server
         /// </summary>
         public int CheckpointThrottleFlushDelayMs = 0;
 
-        /// <summary>
-        /// Enable FastCommit mode for TsavoriteAof
-        /// </summary>
-        public bool EnableFastCommit = true;
 
         /// <summary>
         /// Throttle FastCommit to write metadata once every K commits
@@ -874,7 +870,7 @@ namespace Garnet.server
                     SegmentSizeBits = segmentSizeBits,
                     LogDevice = GetAofDevice(dbId, subLogIdx: AofPhysicalSublogCount == 1 ? -1 : i),
                     TryRecoverLatest = false,
-                    FastCommitMode = EnableFastCommit,
+                    FastCommitMode = true,
                     AutoCommit = AofAutoCommit && (AofPhysicalSublogCount == 1),
                     MutableFraction = 0.9,
                     Epoch = null
@@ -886,7 +882,7 @@ namespace Garnet.server
                     FastAofTruncate ? new NullNamedDeviceFactoryCreator() : DeviceFactoryCreator,
                         new DefaultCheckpointNamingScheme(aofDir, AofPhysicalSublogCount == 1 ? -1 : i),
                         removeOutdated: true,
-                        fastCommitThrottleFreq: EnableFastCommit ? FastCommitThrottleFreq : 0);
+                        fastCommitThrottleFreq: FastCommitThrottleFreq);
             }
         }
 

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -647,7 +647,7 @@ namespace Garnet.server
                 {
                     if (token.IsCancellationRequested) break;
 
-                    // if we are replica and in auto-commit - do not commit as it will clobber the AOF addresses
+                    // Replicas should never run the periodic commit task because it can clobber replicated AOF addresses.
                     if (clusterProvider?.IsReplica() ?? false)
                     {
                         await Task.Delay(commitFrequencyMs, token).ConfigureAwait(false);

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -648,7 +648,7 @@ namespace Garnet.server
                     if (token.IsCancellationRequested) break;
 
                     // if we are replica and in auto-commit - do not commit as it will clobber the AOF addresses
-                    if (serverOptions.EnableFastCommit && (clusterProvider?.IsReplica() ?? false))
+                    if (clusterProvider?.IsReplica() ?? false)
                     {
                         await Task.Delay(commitFrequencyMs, token).ConfigureAwait(false);
                     }

--- a/test/Garnet.fuzz/Targets/GarnetEndToEnd.cs
+++ b/test/Garnet.fuzz/Targets/GarnetEndToEnd.cs
@@ -375,7 +375,6 @@ namespace Garnet.fuzz.Targets
                 EnableAOF = true,
                 LogMemorySize = "1g",
                 GossipDelay = 5,
-                EnableFastCommit = true,
                 MetricsSamplingFrequency = 0,
                 TlsOptions = null,
                 DeviceFactoryCreator = new LocalStorageNamedDeviceFactoryCreator(),

--- a/test/cluster/Garnet.test.cluster.replication/ReplicationTests/ClusterReplicationBaseTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication/ReplicationTests/ClusterReplicationBaseTests.cs
@@ -814,7 +814,7 @@ namespace Garnet.test.cluster
         [Test, Order(16)]
         [Category("REPLICATION")]
         public void ClusterDivergentReplicasTest([Values] bool performRMW, [Values] bool disableObjects, [Values] bool ckptBeforeDivergence)
-            => ClusterDivergentReplicasTest(performRMW, disableObjects, ckptBeforeDivergence, false, false, fastCommit: false);
+            => ClusterDivergentReplicasTest(performRMW, disableObjects, ckptBeforeDivergence, false, false);
 
         [Test, Order(17)]
         [Category("REPLICATION")]
@@ -824,8 +824,7 @@ namespace Garnet.test.cluster
                 disableObjects,
                 ckptBeforeDivergence: true,
                 multiCheckpointAfterDivergence: true,
-                mainMemoryReplication: false,
-                fastCommit: false);
+                mainMemoryReplication: false);
 
         [Test, Order(18)]
         [Category("REPLICATION")]
@@ -835,8 +834,7 @@ namespace Garnet.test.cluster
                 disableObjects,
                 ckptBeforeDivergence,
                 multiCheckpointAfterDivergence: false,
-                mainMemoryReplication: true,
-                fastCommit: false);
+                mainMemoryReplication: true);
 
         [Test, Order(19)]
         [Category("REPLICATION")]
@@ -846,8 +844,7 @@ namespace Garnet.test.cluster
                 disableObjects,
                 ckptBeforeDivergence: true,
                 multiCheckpointAfterDivergence: true,
-                mainMemoryReplication: true,
-                fastCommit: false);
+                mainMemoryReplication: true);
 
         [Test, Order(20)]
         [Category("REPLICATION")]
@@ -857,24 +854,21 @@ namespace Garnet.test.cluster
                 disableObjects: disableObjects,
                 ckptBeforeDivergence: true,
                 multiCheckpointAfterDivergence: true,
-                mainMemoryReplication: mainMemoryReplication,
-                fastCommit: true);
+                mainMemoryReplication: mainMemoryReplication);
 
-        void ClusterDivergentReplicasTest(bool performRMW, bool disableObjects, bool ckptBeforeDivergence, bool multiCheckpointAfterDivergence, bool mainMemoryReplication, bool fastCommit)
+        void ClusterDivergentReplicasTest(bool performRMW, bool disableObjects, bool ckptBeforeDivergence, bool multiCheckpointAfterDivergence, bool mainMemoryReplication)
         {
             var set = false;
             var replica_count = 2;// Per primary
             var primary_count = 1;
             var nodes_count = primary_count + (primary_count * replica_count);
             ClassicAssert.IsTrue(primary_count > 0);
-            fastCommit = sublogCount > 1;
             context.CreateInstances(
                 nodes_count,
                 disableObjects: disableObjects,
                 FastAofTruncate: mainMemoryReplication,
                 CommitFrequencyMs: mainMemoryReplication ? -1 : 0,
                 OnDemandCheckpoint: mainMemoryReplication,
-                FastCommit: fastCommit,
                 enableAOF: true,
                 useTLS: useTLS,
                 asyncReplay: asyncReplay,

--- a/test/cluster/Garnet.test.cluster/ClusterManagementTests.cs
+++ b/test/cluster/Garnet.test.cluster/ClusterManagementTests.cs
@@ -1255,7 +1255,6 @@ namespace Garnet.test.cluster
                 metricsSamplingFrequency: 1,
                 loggingFrequencySecs: 10,
                 checkpointThrottleFlushDelayMs: 0,
-                FastCommit: true,
                 FastAofTruncate: true,
                 OnDemandCheckpoint: true,
                 useTLS: true,

--- a/test/cluster/Garnet.test.cluster/ClusterTestContext.cs
+++ b/test/cluster/Garnet.test.cluster/ClusterTestContext.cs
@@ -241,7 +241,6 @@ namespace Garnet.test.cluster
         /// <param name="CommitFrequencyMs"></param>
         /// <param name="useAofNullDevice"></param>
         /// <param name="DisableStorageTier"></param>
-        /// <param name="FastCommit"></param>
         /// <param name="timeout"></param>
         /// <param name="useTLS"></param>
         /// <param name="useAcl"></param>
@@ -292,7 +291,6 @@ namespace Garnet.test.cluster
             int CommitFrequencyMs = 0,
             bool useAofNullDevice = false,
             bool DisableStorageTier = false,
-            bool FastCommit = true,
             int timeout = -1,
             bool useTLS = false,
             bool useAcl = false,
@@ -354,7 +352,6 @@ namespace Garnet.test.cluster
                 useAofNullDevice: useAofNullDevice,
                 DisableStorageTier: DisableStorageTier,
                 OnDemandCheckpoint: OnDemandCheckpoint,
-                FastCommit: FastCommit,
                 useAcl: useAcl,
                 aclFile: credManager.aclFilePath,
                 authUsername: clusterCreds.user,
@@ -413,7 +410,6 @@ namespace Garnet.test.cluster
         /// <param name="AofMemorySize"></param>
         /// <param name="CommitFrequencyMs"></param>
         /// <param name="DisableStorageTier"></param>
-        /// <param name="FastCommit"></param>
         /// <param name="timeout"></param>
         /// <param name="gossipDelay"></param>
         /// <param name="useTLS"></param>
@@ -443,7 +439,6 @@ namespace Garnet.test.cluster
             string AofMemorySize = "64m",
             int CommitFrequencyMs = 0,
             bool DisableStorageTier = false,
-            bool FastCommit = true,
             int timeout = -1,
             int gossipDelay = 5,
             bool useTLS = false,
@@ -481,7 +476,6 @@ namespace Garnet.test.cluster
                 commitFrequencyMs: CommitFrequencyMs,
                 disableStorageTier: DisableStorageTier,
                 onDemandCheckpoint: OnDemandCheckpoint,
-                fastCommit: FastCommit,
                 useAcl: useAcl,
                 asyncReplay: asyncReplay,
                 sublogCount: sublogCount,

--- a/test/standalone/Garnet.test/TestUtils.cs
+++ b/test/standalone/Garnet.test/TestUtils.cs
@@ -532,7 +532,6 @@ namespace Garnet.test
             int CommitFrequencyMs = 0,
             bool useAofNullDevice = false,
             bool DisableStorageTier = false,
-            bool FastCommit = true,
             string authUsername = null,
             string authPassword = null,
             bool useAcl = false, // NOTE: Temporary until ACL is enforced as default
@@ -601,7 +600,6 @@ namespace Garnet.test
                     commitFrequencyMs: CommitFrequencyMs,
                     useAofNullDevice: useAofNullDevice,
                     disableStorageTier: DisableStorageTier,
-                    fastCommit: FastCommit,
                     authUsername: authUsername,
                     authPassword: authPassword,
                     useAcl: useAcl,
@@ -679,7 +677,6 @@ namespace Garnet.test
             int commitFrequencyMs = 0,
             bool useAofNullDevice = false,
             bool disableStorageTier = false,
-            bool fastCommit = true,
             string authUsername = null,
             string authPassword = null,
             bool useAcl = false, // NOTE: Temporary until ACL is enforced as default
@@ -785,7 +782,6 @@ namespace Garnet.test
                 EnableAOF = enableAOF,
                 LogMemorySize = "1g",
                 GossipDelay = gossipDelay,
-                EnableFastCommit = fastCommit,
                 MetricsSamplingFrequency = metricsSamplingFrequency,
                 TlsOptions = useTLS ? new GarnetTlsOptions(
                     certFileName: certFile,

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -149,7 +149,6 @@ For all available command line settings, run `GarnetServer.exe -h` or `GarnetSer
 | **AzureStorageServiceUri** | ```--storage-service-uri``` | ```string``` |  | The service URI to use when establishing connection to Azure Blobs Storage. |
 | **AzureStorageManagedIdentity** | ```--storage-managed-identity``` | ```string``` |  | The managed identity to use when establishing connection to Azure Blobs Storage. |
 | **CheckpointThrottleFlushDelayMs** | ```--checkpoint-throttle-delay``` | ```int``` | Integer in range:<br/>[-1, MaxValue] | Whether and by how much should we throttle the disk IO for checkpoints: -1 - disable throttling; >= 0 - run checkpoint flush in separate task, sleep for specified time after each WriteAsync |
-| **EnableFastCommit** | ```--fast-commit``` | ```bool``` |  | Use FastCommit when writing AOF. |
 | **FastCommitThrottleFreq** | ```--fast-commit-throttle``` | ```int``` | Integer in range:<br/>[0, MaxValue] | Throttle FastCommit to write metadata once every K commits. |
 | **NetworkSendThrottleMax** | ```--network-send-throttle``` | ```int``` | Integer in range:<br/>[0, MaxValue] | Throttle the maximum outstanding network sends per session. |
 | **EnableScatterGatherGet** | ```--sg-get``` | ```bool``` |  | Whether we use scatter gather IO for MGET or a batch of contiguous GET operations - useful to saturate disk random read IO. |


### PR DESCRIPTION
## Summary

Remove the `EnableFastCommit` server option and make the codebase always operate in FastCommit mode.

## Changes

- Remove `EnableFastCommit` field from `GarnetServerOptions`, `Options`, and `defaults.conf`
- Hardcode `FastCommitMode = true` in TsavoriteLog settings
- Remove all dead-code paths gated on `!EnableFastCommit` (manual commits in replica sync, failover, recovery, cluster truncation)
- Simplify commit task in `StoreWrapper` and `DatabaseManagerBase`
- Remove `fastCommit` parameter from test utilities and cluster test contexts
- Update website configuration documentation

## Motivation

`EnableFastCommit` has defaulted to `true` everywhere (server, tests, benchmarks) and the non-fast-commit path was effectively dead code. Removing it simplifies the AOF/replication logic and eliminates a configuration footgun.
