### PR TITLE
Fix `ObjectOutput.result1` corruption in RMW retries

### DIFF
--- a/libs/server/Objects/Hash/HashObjectImpl.cs
+++ b/libs/server/Objects/Hash/HashObjectImpl.cs
@@ -33,7 +33,7 @@ namespace Garnet.server
             else
                 writer.WriteNull();
 
-            output.result1++;
+            output.result1 = 1;
         }
 
         private void HashMultipleGet(ref ObjectInput input, ref ObjectOutput output, byte respProtocolVersion)
@@ -53,9 +53,9 @@ namespace Garnet.server
                 {
                     writer.WriteNull();
                 }
-
-                output.result1++;
             }
+
+            output.result1 = input.parseState.Count;
         }
 
         private void HashGetAll(ref ObjectOutput output, byte respProtocolVersion)
@@ -80,12 +80,16 @@ namespace Garnet.server
 
         private void HashDelete(ref ObjectInput input, ref ObjectOutput output)
         {
+            var removed = 0;
+
             for (var i = 0; i < input.parseState.Count; i++)
             {
                 var key = GetByteSpanFromInput(ref input, i);
                 if (Remove(key, out _))
-                    output.result1++;
+                    removed++;
             }
+
+            output.result1 = removed;
         }
 
         private void HashLength(ref ObjectOutput output)
@@ -182,6 +186,8 @@ namespace Garnet.server
         {
             DeleteExpiredItems();
 
+            var set = 0;
+
             var hashOp = input.header.HashOp;
             for (var i = 0; i < input.parseState.Count; i += 2)
             {
@@ -202,7 +208,7 @@ namespace Garnet.server
                     hashValueRef = value.ToArray();
                     UpdateSize(key, value, add: true);
 
-                    output.result1++;
+                    set++;
                 }
                 else if (exists && (hashOp is HashOperation.HSET or HashOperation.HMSET))
                 {
@@ -230,6 +236,8 @@ namespace Garnet.server
                     }
                 }
             }
+
+            output.result1 = set;
         }
 
         private void HashCollect(ref ObjectInput input, ref ObjectOutput output)
@@ -249,6 +257,8 @@ namespace Garnet.server
 
             var isExpirable = HasExpirableItems;
 
+            var written = 0;
+
             foreach (var item in hash)
             {
                 if (isExpirable && IsExpired(item.Key))
@@ -265,8 +275,10 @@ namespace Garnet.server
                     writer.WriteBulkString(item.Value);
                 }
 
-                output.result1++;
+                written++;
             }
+
+            output.result1 = written;
         }
 
         [SkipLocalsInit] // avoid zeroing the stackalloc buffer
@@ -437,8 +449,9 @@ namespace Garnet.server
                 var result = SetExpiration(item.ToArray(), expirationWithOption.ExpirationTimeInTicks, expirationWithOption.ExpireOption);
 #endif
                 writer.WriteInt32((int)result);
-                output.result1++;
             }
+
+            output.result1 = input.parseState.Count;
         }
 
         private void HashTimeToLive(ref ObjectInput input, ref ObjectOutput output, byte respProtocolVersion)
@@ -482,8 +495,9 @@ namespace Garnet.server
                 }
 
                 writer.WriteInt64(result);
-                output.result1++;
             }
+
+            output.result1 = input.parseState.Count;
         }
 
         private void HashPersist(ref ObjectInput input, ref ObjectOutput output, byte respProtocolVersion)
@@ -504,8 +518,9 @@ namespace Garnet.server
                 var result = Persist(item.ToArray());
 #endif
                 writer.WriteInt32(result);
-                output.result1++;
             }
+
+            output.result1 = input.parseState.Count;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/libs/server/Objects/List/ListObjectImpl.cs
+++ b/libs/server/Objects/List/ListObjectImpl.cs
@@ -261,6 +261,8 @@ namespace Garnet.server
                 writer.WriteArrayLength(count);
             }
 
+            var removed = 0;
+
             while (count > 0 && list.Any())
             {
                 LinkedListNode<byte[]> node = null;
@@ -279,8 +281,11 @@ namespace Garnet.server
                 writer.WriteBulkString(node.Value);
 
                 count--;
-                output.result1++;
+
+                removed++;
             }
+
+            output.result1 = removed;
         }
 
         private void ListSet(ref ObjectInput input, ref ObjectOutput output, byte respProtocolVersion)

--- a/libs/server/Objects/Set/SetObjectImpl.cs
+++ b/libs/server/Objects/Set/SetObjectImpl.cs
@@ -15,6 +15,8 @@ namespace Garnet.server
     {
         private void SetAdd(ref ObjectInput input, ref ObjectOutput output)
         {
+            var added = 0;
+
             for (var i = 0; i < input.parseState.Count; i++)
             {
                 var member = input.parseState.GetArgSliceByRef(i).ReadOnlySpan;
@@ -25,10 +27,12 @@ namespace Garnet.server
                 if (Set.Add(member.ToArray()))
 #endif
                 {
-                    output.result1++;
+                    added++;
                     UpdateSize(member);
                 }
             }
+
+            output.result1 = added;
         }
 
         private void SetMembers(ref ObjectInput input, ref ObjectOutput output, byte respProtocolVersion)
@@ -37,11 +41,15 @@ namespace Garnet.server
 
             writer.WriteSetLength(Set.Count);
 
+            var written = 0;
+
             foreach (var item in Set)
             {
                 writer.WriteBulkString(item);
-                output.result1++;
+                written++;
             }
+
+            output.result1 = written;
         }
 
         private void SetIsMember(ref ObjectInput input, ref ObjectOutput output, byte respProtocolVersion)
@@ -80,6 +88,8 @@ namespace Garnet.server
 
         private void SetRemove(ref ObjectInput input, ref ObjectOutput output)
         {
+            var removed = 0;
+
             for (var i = 0; i < input.parseState.Count; i++)
             {
                 var field = input.parseState.GetArgSliceByRef(i).ReadOnlySpan;
@@ -90,10 +100,12 @@ namespace Garnet.server
                 if (Set.Remove(field.ToArray()))
 #endif
                 {
-                    output.result1++;
+                    removed++;
                     UpdateSize(field, false);
                 }
             }
+
+            output.result1 = removed;
         }
 
         private void SetLength(ref ObjectOutput output)

--- a/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
@@ -212,6 +212,8 @@ namespace Garnet.server
         {
             DeleteExpiredItems();
 
+            var removed = 0;
+
             for (var i = 0; i < input.parseState.Count; i++)
             {
                 var value = input.parseState.GetArgSliceByRef(i).ReadOnlySpan;
@@ -220,12 +222,14 @@ namespace Garnet.server
                 if (!sortedSetDict.Remove(valueArray, out var key))
                     continue;
 
-                output.result1++;
+                removed++;
                 sortedSet.Remove((key, valueArray));
                 _ = TryRemoveExpiration(valueArray);
 
                 this.UpdateSize(value, false);
             }
+
+            output.result1 = removed;
         }
 
         private void SortedSetLength(ref ObjectOutput output)
@@ -852,8 +856,9 @@ namespace Garnet.server
             {
                 var result = Persist(item.ToArray());
                 writer.WriteInt32(result);
-                output.result1++;
             }
+
+            output.result1 = input.parseState.Count;
         }
 
         private void SortedSetTimeToLive(ref ObjectInput input, ref ObjectOutput output, byte respProtocolVersion)
@@ -898,8 +903,9 @@ namespace Garnet.server
                 }
 
                 writer.WriteInt64(result);
-                output.result1++;
             }
+
+            output.result1 = numFields;
         }
 
         private void SortedSetExpire(ref ObjectInput input, ref ObjectOutput output, byte respProtocolVersion)
@@ -915,8 +921,9 @@ namespace Garnet.server
             {
                 var result = SetExpiration(item.ToArray(), expirationWithOption.ExpirationTimeInTicks, expirationWithOption.ExpireOption);
                 writer.WriteInt32(result);
-                output.result1++;
             }
+
+            output.result1 = input.parseState.Count;
         }
 
         private void SortedSetCollect(ref ObjectInput input, ref ObjectOutput output)


### PR DESCRIPTION
A number of "object" commands mutate `ObjectOutput.result1` in response to a `InitialUpdater` call.

However these calls can be retried under contention, so any mutation that assumes an initial value (typically 0) will produce incorrect results.  I've audited uses of `result1` and fixed all the places where this can happen.

This fixes #1833

I did a separate pass through `StringOutput` and `UnifiedOutput`, and I think we're all fine there.