### PR TITLE
Fix AOF page/memory size defaults and validation (#1811)

### DIFF
--- a/benchmark/Resp.benchmark/Options.cs
+++ b/benchmark/Resp.benchmark/Options.cs
@@ -146,10 +146,10 @@ namespace Resp.benchmark
         [Option("aof-replay-task-count", Required = false, Default = 1, HelpText = "Number of replay tasks per physical sublog at the replica.")]
         public int AofReplayTaskCount { get; set; }
 
-        [Option("aof-memory-size", Required = false, Default = "64m", HelpText = "Total AOF memory buffer used in bytes (rounds down to power of 2) - spills to disk after this limit.")]
+        [Option("aof-memory-size", Required = false, Default = "128m", HelpText = "Total AOF memory buffer used in bytes (rounds down to power of 2) - spills to disk after this limit. Must be at least twice AofPageSize.")]
         public string AofMemorySize { get; set; }
 
-        [Option("aof-page-size", Required = false, Default = "4m", HelpText = "Size of each AOF page in bytes(rounds down to power of 2)")]
+        [Option("aof-page-size", Required = false, Default = "32m", HelpText = "Size of each AOF page in bytes (rounds down to power of 2). Must be at least twice the main-log PageSize.")]
         public string AofPageSize { get; set; }
 
         /// <summary>

--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -193,11 +193,11 @@ namespace Garnet
         public bool? EnableAOF { get; set; }
 
         [MemorySizeValidation]
-        [Option("aof-memory", Required = false, HelpText = "Total AOF memory buffer used in bytes (rounds down to power of 2) - spills to disk after this limit")]
+        [Option("aof-memory", Required = false, HelpText = "Total AOF memory buffer used in bytes (rounds down to power of 2) - spills to disk after this limit. Must be at least twice AofPageSize.")]
         public string AofMemorySize { get; set; }
 
         [MemorySizeValidation]
-        [Option("aof-page-size", Required = false, HelpText = "Size of each AOF page in bytes(rounds down to power of 2)")]
+        [Option("aof-page-size", Required = false, HelpText = "Size of each AOF page in bytes (rounds down to power of 2). Must be at least twice the main-log PageSize, since an AOF entry can be as large as the underlying main-log record being written; object commands like LPUSH/HSET can push this even higher. When you raise this, also raise --aof-memory to at least 2x this value.")]
         public string AofPageSize { get; set; }
 
         [MemorySizeValidation]

--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -126,11 +126,15 @@
 	/* Enable write ahead logging (append-only file). */
 	"EnableAOF" : false,
 
-	/* Total AOF memory buffer used in bytes (rounds down to power of 2) - spills to disk after this limit */
-	"AofMemorySize" : "64m",
+	/* Total AOF memory buffer used in bytes (rounds down to power of 2) - spills to disk after this limit. */
+	/* Must be at least twice AofPageSize. */
+	"AofMemorySize" : "128m",
 
-	/* Size of each AOF page in bytes(rounds down to power of 2) */
-	"AofPageSize" : "4m",
+	/* Size of each AOF page in bytes (rounds down to power of 2). */
+	/* Must be at least twice the main-log PageSize, since an AOF entry can be as large as the underlying main-log record being written. */
+	/* For object commands like LPUSH/HSET, the entry holds the full RESP input (key + members), which can be larger still. */
+	/* If you raise AofPageSize, also raise AofMemorySize to at least 2 x AofPageSize. */
+	"AofPageSize" : "32m",
 
 	/* Size of each AOF segment (file) in bytes on disk (rounds down to power of 2). This is the granularity at which AOF files are created and truncated. */
 	"AofSegmentSize" : "1g",

--- a/libs/server/Servers/GarnetServerOptions.cs
+++ b/libs/server/Servers/GarnetServerOptions.cs
@@ -64,12 +64,12 @@ namespace Garnet.server
         /// <summary>
         /// Total AOF memory buffer used in bytes (rounds down to power of 2) - spills to disk after this limit.
         /// </summary>
-        public string AofMemorySize = "64m";
+        public string AofMemorySize = "128m";
 
         /// <summary>
         /// Aof page size in bytes (rounds down to power of 2).
         /// </summary>
-        public string AofPageSize = "4m";
+        public string AofPageSize = "32m";
 
         /// <summary>
         /// Size of each AOF segment (file) in bytes on disk (rounds down to power of 2).
@@ -868,16 +868,52 @@ namespace Garnet.server
             var pageSizeBits = AofPageSizeBits();
             var segmentSizeBits = AofSegmentSizeBits();
 
-            if (pageSizeBits > memorySizeBits)
+            // Tsavorite requires MemorySize >= 2 * PageSize (so at least two pages fit in memory).
+            // With power-of-two rounded sizes this means memorySizeBits >= pageSizeBits + 1.
+            // Catch this here so we can produce a Garnet-specific error that names the actual
+            // AofMemorySize / AofPageSize config options, rather than the generic Tsavorite
+            // "MemorySize must be at least twice the page size" message which does not say AOF.
+            if (memorySizeBits <= pageSizeBits)
             {
-                logger?.LogError("AOF Page size cannot be more than the AOF memory size.");
-                throw new Exception("AOF Page size cannot be more than the AOF memory size.");
+                var effectiveMemory = PrettySize(1L << memorySizeBits);
+                var effectivePage = PrettySize(1L << pageSizeBits);
+                var minMemory = PrettySize(1L << (pageSizeBits + 1));
+                var msg = $"AofMemorySize (effective {effectiveMemory} after rounding down to a power of two) " +
+                          $"must be at least twice AofPageSize (effective {effectivePage}). " +
+                          $"Increase --aof-memory to at least {minMemory}, or reduce --aof-page-size.";
+                logger?.LogError("{msg}", msg);
+                throw new Exception(msg);
             }
 
             if (pageSizeBits > segmentSizeBits)
             {
-                logger?.LogError("AOF Page size cannot be more than the AOF segment size.");
-                throw new Exception("AOF Page size cannot be more than the AOF segment size.");
+                var effectivePage = PrettySize(1L << pageSizeBits);
+                var effectiveSegment = PrettySize(1L << segmentSizeBits);
+                var msg = $"AofPageSize (effective {effectivePage} after rounding down to a power of two) " +
+                          $"cannot be larger than AofSegmentSize (effective {effectiveSegment}). " +
+                          $"Increase --aof-segment-size to at least {effectivePage}, or reduce --aof-page-size.";
+                logger?.LogError("{msg}", msg);
+                throw new Exception(msg);
+            }
+
+            // AofPageSize must be at least twice the main-log PageSize. An AOF entry mirrors a single
+            // main-log write (key + value/input + small overhead); raw-string SETs can be as large as
+            // the main-log PageSize (values above MaxInlineValueSize overflow to the heap on the main
+            // store but are still written in full to the AOF), and object commands like LPUSH/HSET can
+            // push the AOF entry even higher. Throw a clear error here so users do not hit the runtime
+            // "Entry does not fit on page" path with a stalled session.
+            var mainPageSizeBits = PageSizeBits();
+            if (pageSizeBits < mainPageSizeBits + 1)
+            {
+                var effectiveAofPage = PrettySize(1L << pageSizeBits);
+                var effectiveMainPage = PrettySize(1L << mainPageSizeBits);
+                var minAofPage = PrettySize(1L << (mainPageSizeBits + 1));
+                var msg = $"AofPageSize (effective {effectiveAofPage} after rounding down to a power of two) " +
+                          $"must be at least twice the main-log PageSize (effective {effectiveMainPage}). " +
+                          $"Increase --aof-page-size to at least {minAofPage} (and --aof-memory to at least {PrettySize(1L << (mainPageSizeBits + 2))}), " +
+                          $"or reduce --page.";
+                logger?.LogError("{msg}", msg);
+                throw new Exception(msg);
             }
 
             tsavoriteLogSettings = new TsavoriteLogSettings[AofPhysicalSublogCount];

--- a/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
+++ b/libs/storage/Tsavorite/cs/src/core/TsavoriteLog/TsavoriteLog.cs
@@ -3413,7 +3413,9 @@ namespace Tsavorite.core
         private void ValidateAllocatedLength(int numSlots)
         {
             if (numSlots > allocator.PageSize)
-                throw new TsavoriteException("Entry does not fit on page");
+                throw new TsavoriteException(
+                    $"Entry does not fit on page: allocated entry size ({numSlots} bytes) exceeds log page size ({allocator.PageSize} bytes). " +
+                    "Increase the page size (and memory size to at least 2x page size) or split the entry into smaller writes.");
         }
     }
 }

--- a/test/standalone/Garnet.test.scripting/RespAofTests.cs
+++ b/test/standalone/Garnet.test.scripting/RespAofTests.cs
@@ -1166,7 +1166,9 @@ namespace Garnet.test
 
             server.Dispose(false);
             // 4 KB AOF page so we can trigger the oversize path with a small payload.
-            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableAOF: true, aofPageSize: "4k");
+            // Also shrink main-log PageSize to 1 KB so we satisfy the AofPageSize >= 2 * PageSize
+            // startup validation introduced for https://github.com/microsoft/garnet/issues/1811.
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableAOF: true, pageSize: "1k", aofPageSize: "4k");
             server.Start();
 
             // 1) SET with a value larger than the AOF page. The AOF Enqueue throws and StackExchange.Redis

--- a/test/standalone/Garnet.test/GarnetServerConfigTests.cs
+++ b/test/standalone/Garnet.test/GarnetServerConfigTests.cs
@@ -1379,13 +1379,85 @@ namespace Garnet.test
             }
 
             // AofPageSize > AofSegmentSize should throw.
-            args = ["--aof", "--aof-page-size", "8m", "--aof-segment-size", "4m"];
+            args = ["--aof", "--aof-page-size", "8m", "--aof-segment-size", "4m", "--aof-memory", "16m"];
             parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out options, out invalidOptions, out _, out _, silentMode: true);
             ClassicAssert.IsTrue(parseSuccessful);
             ClassicAssert.AreEqual(0, invalidOptions.Count);
             serverOptions = options.GetServerOptions();
             var ex = Assert.Throws<Exception>(() => serverOptions.GetAofSettings(0, out _));
-            ClassicAssert.IsTrue(ex.Message.Contains("AOF Page size cannot be more than the AOF segment size."));
+            ClassicAssert.IsTrue(ex.Message.Contains("AofPageSize"));
+            ClassicAssert.IsTrue(ex.Message.Contains("AofSegmentSize"));
+            ClassicAssert.IsTrue(ex.Message.Contains("--aof-segment-size"));
+
+            // AofMemorySize == AofPageSize should throw with a Garnet-specific message naming both
+            // AofMemorySize and AofPageSize (regression test for misleading
+            // "MemorySize must be at least twice the page size" error surfaced in issue #1811).
+            args = ["--aof", "--aof-page-size", "64m", "--aof-memory", "64m"];
+            parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out options, out invalidOptions, out _, out _, silentMode: true);
+            ClassicAssert.IsTrue(parseSuccessful);
+            ClassicAssert.AreEqual(0, invalidOptions.Count);
+            serverOptions = options.GetServerOptions();
+            ex = Assert.Throws<Exception>(() => serverOptions.GetAofSettings(0, out _));
+            ClassicAssert.IsTrue(ex.Message.Contains("AofMemorySize"), $"Expected message to mention AofMemorySize, got: {ex.Message}");
+            ClassicAssert.IsTrue(ex.Message.Contains("AofPageSize"), $"Expected message to mention AofPageSize, got: {ex.Message}");
+            ClassicAssert.IsTrue(ex.Message.Contains("--aof-memory"), $"Expected message to mention --aof-memory, got: {ex.Message}");
+
+            // AofMemorySize == 2 * AofPageSize should be the minimum that succeeds.
+            args = ["--aof", "--aof-page-size", "64m", "--aof-memory", "128m"];
+            parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out options, out invalidOptions, out _, out _, silentMode: true);
+            ClassicAssert.IsTrue(parseSuccessful);
+            ClassicAssert.AreEqual(0, invalidOptions.Count);
+            serverOptions = options.GetServerOptions();
+            serverOptions.GetAofSettings(0, out logSettings);
+            try
+            {
+                ClassicAssert.AreEqual(1, logSettings.Length);
+                ClassicAssert.AreEqual(1L << 26, logSettings[0].PageSize);
+                ClassicAssert.AreEqual(1L << 27, logSettings[0].MemorySize);
+            }
+            finally
+            {
+                foreach (var s in logSettings)
+                {
+                    s.LogDevice?.Dispose();
+                    s.LogCommitManager?.Dispose();
+                }
+            }
+
+            // AofPageSize < 2 * (main-log) PageSize should throw, because an AOF entry can be as
+            // large as the underlying main-log record. Regression test for the runtime
+            // "Entry does not fit on page" surfaced in issue #1811.
+            args = ["--aof", "--aof-page-size", "8m", "--aof-memory", "32m", "--page", "16m"];
+            parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out options, out invalidOptions, out _, out _, silentMode: true);
+            ClassicAssert.IsTrue(parseSuccessful);
+            ClassicAssert.AreEqual(0, invalidOptions.Count);
+            serverOptions = options.GetServerOptions();
+            ex = Assert.Throws<Exception>(() => serverOptions.GetAofSettings(0, out _));
+            ClassicAssert.IsTrue(ex.Message.Contains("AofPageSize"), $"Expected message to mention AofPageSize, got: {ex.Message}");
+            ClassicAssert.IsTrue(ex.Message.Contains("PageSize"), $"Expected message to mention PageSize, got: {ex.Message}");
+            ClassicAssert.IsTrue(ex.Message.Contains("--aof-page-size"), $"Expected message to mention --aof-page-size, got: {ex.Message}");
+
+            // AofPageSize == 2 * (main-log) PageSize should be the minimum that succeeds against the new rule.
+            args = ["--aof", "--aof-page-size", "32m", "--aof-memory", "64m", "--page", "16m"];
+            parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out options, out invalidOptions, out _, out _, silentMode: true);
+            ClassicAssert.IsTrue(parseSuccessful);
+            ClassicAssert.AreEqual(0, invalidOptions.Count);
+            serverOptions = options.GetServerOptions();
+            serverOptions.GetAofSettings(0, out logSettings);
+            try
+            {
+                ClassicAssert.AreEqual(1, logSettings.Length);
+                ClassicAssert.AreEqual(1L << 25, logSettings[0].PageSize);
+                ClassicAssert.AreEqual(1L << 26, logSettings[0].MemorySize);
+            }
+            finally
+            {
+                foreach (var s in logSettings)
+                {
+                    s.LogDevice?.Dispose();
+                    s.LogCommitManager?.Dispose();
+                }
+            }
         }
 
         [Test]

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -116,8 +116,8 @@ For all available command line settings, run `GarnetServer.exe -h` or `GarnetSer
 | **AadIssuers** | ```--aad-issuers``` | ```string``` |  | The issuers of AAD token for AAD authentication. Should be a comma separated string. |
 | **AuthorizedAadApplicationIds** | ```--aad-authorized-app-ids``` | ```string``` |  | The authorized client app Ids for AAD authentication. Should be a comma separated string. |
 | **EnableAOF** | ```--aof``` | ```bool``` |  | Enable write ahead logging (append-only file). |
-| **AofMemorySize** | ```--aof-memory``` | ```string``` | Memory size | Total AOF memory buffer used in bytes (rounds down to power of 2) - spills to disk after this limit |
-| **AofPageSize** | ```--aof-page-size``` | ```string``` | Memory size | Size of each AOF page in bytes(rounds down to power of 2) |
+| **AofMemorySize** | ```--aof-memory``` | ```string``` | Memory size | Total AOF memory buffer used in bytes (rounds down to power of 2) - spills to disk after this limit. Must be at least twice AofPageSize. |
+| **AofPageSize** | ```--aof-page-size``` | ```string``` | Memory size | Size of each AOF page in bytes (rounds down to power of 2). Must be at least twice the main-log PageSize, since an AOF entry can be as large as the underlying main-log record being written; object commands like LPUSH/HSET can push this even higher. When you raise this, also raise --aof-memory to at least 2x this value. |
 | **AofSegmentSize** | ```--aof-segment-size``` | ```string``` | Memory size | Size of each AOF segment (file) in bytes on disk (rounds down to power of 2). This is the granularity at which AOF files are created and truncated. |
 | **CommitFrequencyMs** | ```--aof-commit-freq``` | ```int``` | Integer in range:<br/>[-1, MaxValue] | Write ahead logging (append-only file) commit issue frequency in milliseconds. 0 = issue an immediate commit per operation, -1 = manually issue commits using COMMITAOF command |
 | **WaitForCommit** | ```--aof-commit-wait``` | ```bool``` |  | Wait for AOF to flush the commit before returning results to client. Warning: will greatly increase operation latency. |


### PR DESCRIPTION
Tighten startup validation in GetAofSettings to catch all three AOF sizing mistakes with Garnet-specific errors that name the actual option, the effective rounded sizes, and the value to set, instead of letting them reach the generic Tsavorite messages or the runtime 'Entry does not fit on page' failure:

  1. AofMemorySize <= AofPageSize (was '<', allowed equality) — root cause of the misleading 'MemorySize must be at least twice the page size' error reported in #1811.
  2. AofPageSize > AofSegmentSize — clearer message naming both options.
  3. New: AofPageSize < 2 * main-log PageSize. An AOF entry can be as large as the underlying main-log record (raw-string values up to PageSize, object commands like LPUSH/HSET can push it higher), so the prior default ratio (AofPageSize=4m vs PageSize=16m) made the runtime 'Entry does not fit on page' easy to hit on routine writes.

Improve the Tsavorite runtime error in ValidateAllocatedLength to also include the entry size and a fix hint, while preserving the 'Entry does not fit on page' prefix for backward compat with the OversizedAofEntryDoesNotHangServer regression test (#1749).

Bump defaults to comply with the new rule:
  - AofPageSize:   4m  -> 32m
  - AofMemorySize: 64m -> 128m
Applied in defaults.conf, GarnetServerOptions.cs, and the Resp.benchmark
CLI defaults so the AOF benchmark works out of the box.

Update CLI help text (--aof-memory, --aof-page-size) and the public website doc to explain the 2x rule.

Tests:
  - Added two regression tests in GarnetServerConfigTests covering the AofPageSize-vs-PageSize boundary (fails just below 2x, succeeds at exactly 2x).
  - Updated OversizedAofEntryDoesNotHangServer to pass pageSize: '1k' alongside aofPageSize: '4k' so it still triggers the runtime oversize-entry path under the new validation.

Fixes #1811
Fixes #1770 