### PR TITLE
Bump version to 2.0.1-beta.2

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- VersionPrefix property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>2.0.1-beta.1</VersionPrefix>
+		<VersionPrefix>2.0.1-beta.2</VersionPrefix>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Bumps `VersionPrefix` in `Version.props` from `2.0.1-beta.1` to `2.0.1-beta.2` for the next beta release.