### PR TITLE
[V1] Fix Vector Set Creation Live Lock

### DIFF
--- a/libs/common/ReadOptimizedLock.cs
+++ b/libs/common/ReadOptimizedLock.cs
@@ -296,7 +296,7 @@ namespace Garnet.common
                     }
                 }
             }
-            else if(lockToken.type == LockType.Shared)
+            else if (lockToken.type == LockType.Shared)
             {
                 // lockToken.token is an index
                 ref var releaseRef = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(lockCounts), lockToken.token);
@@ -411,7 +411,7 @@ namespace Garnet.common
                 }
             }
 
-            lockToken =  LockToken.CreateAllExclusive();
+            lockToken = LockToken.CreateAllExclusive();
         }
 
         /// <summary>

--- a/libs/common/ReadOptimizedLock.cs
+++ b/libs/common/ReadOptimizedLock.cs
@@ -99,13 +99,13 @@ namespace Garnet.common
             => new(LockType.Shared, token);
 
             /// <summary>
-            /// Create a token for an exclusive lock acquistion of a single hash.
+            /// Create a token for an exclusive lock acquisition of a single hash.
             /// </summary>
             internal static LockToken CreateExclusive(int token)
             => new(LockType.Exclusive, token);
 
             /// <summary>
-            /// Create a token for an exclusive lock acquistion of all possible hashes.
+            /// Create a token for an exclusive lock acquisition of all possible hashes.
             /// </summary>
             internal static LockToken CreateAllExclusive()
             => new(LockType.AllExclusive, -1);
@@ -271,9 +271,8 @@ namespace Garnet.common
         }
 
         /// <summary>
-        /// Releaes a lock previously acquired with <see cref="TryAcquireSharedLock"/>, <see cref="AcquireSharedLock"/>, <see cref="TryAcquireExclusiveLock"/>, <see cref="AcquireExclusiveLock"/>, <see cref="TryPromoteSharedLock"/>, or <see cref="AcquireAllExclusiveLock"/>.
+        /// Releases a lock previously acquired with <see cref="TryAcquireSharedLock"/>, <see cref="AcquireSharedLock"/>, <see cref="TryAcquireExclusiveLock"/>, <see cref="AcquireExclusiveLock"/>, <see cref="TryPromoteSharedLock"/>, or <see cref="AcquireAllExclusiveLock"/>.
         /// </summary>
-        /// <param name="lockToken"></param>
         public readonly void ReleaseLock(LockToken lockToken)
         {
             if (lockToken.type == LockType.Exclusive)

--- a/libs/common/ReadOptimizedLock.cs
+++ b/libs/common/ReadOptimizedLock.cs
@@ -45,6 +45,76 @@ namespace Garnet.common
     /// </remarks>
     public struct ReadOptimizedLock
     {
+        /// <summary>
+        /// Type of lock held by a <see cref="LockToken"/>.
+        /// </summary>
+        internal enum LockType : byte
+        {
+            /// <summary>
+            /// Illegal value.
+            /// </summary>
+            Invalid = 0,
+
+            /// <summary>
+            /// Shared lock.
+            /// </summary>
+            Shared,
+
+            /// <summary>
+            /// Exclusive lock for a specific hash.
+            /// </summary>
+            Exclusive,
+
+            /// <summary>
+            /// Exclusive lock for _all_ hashes.
+            /// </summary>
+            AllExclusive,
+        }
+
+        /// <summary>
+        /// Represents an acquisition of a lock.
+        /// 
+        /// Used to release the lock, and upgrade shared to exclusive locks.
+        /// </summary>
+        public readonly struct LockToken
+        {
+            internal readonly LockType type;
+            internal readonly int token;
+
+            /// <summary>
+            /// True if lock is exclusive (either for one hash or all hashes).
+            /// </summary>
+            public readonly bool IsExclusive => type is LockType.Exclusive or LockType.AllExclusive;
+
+            private LockToken(LockType type, int token)
+            {
+                this.type = type;
+                this.token = token;
+            }
+
+            /// <summary>
+            /// Create a token for a shared lock acquisition of a single hash.
+            /// </summary>
+            internal static LockToken CreateShared(int token)
+            => new(LockType.Shared, token);
+
+            /// <summary>
+            /// Create a token for an exclusive lock acquistion of a single hash.
+            /// </summary>
+            internal static LockToken CreateExclusive(int token)
+            => new(LockType.Exclusive, token);
+
+            /// <summary>
+            /// Create a token for an exclusive lock acquistion of all possible hashes.
+            /// </summary>
+            internal static LockToken CreateAllExclusive()
+            => new(LockType.AllExclusive, -1);
+
+            /// <inheritdoc/>
+            public override string ToString()
+            => type.ToString();
+        }
+
         // Beyond 4K bytes per core we're well past "this is worth the tradeoff", so cut off then.
         //
         // Must be a power of 2.
@@ -151,7 +221,7 @@ namespace Garnet.common
         /// 
         /// Will block exclusive locks until released.
         /// </summary>
-        public readonly bool TryAcquireSharedLock(long hash, out int lockToken)
+        public readonly bool TryAcquireSharedLock(long hash, out LockToken lockToken)
         {
             var ix = CalculateIndex(hash, GetProcessorHint());
 
@@ -166,7 +236,7 @@ namespace Garnet.common
                 return false;
             }
 
-            lockToken = ix;
+            lockToken = LockToken.CreateShared(ix);
             return true;
         }
 
@@ -175,7 +245,7 @@ namespace Garnet.common
         /// 
         /// Will block exclusive locks until released.
         /// </summary>
-        public readonly void AcquireSharedLock(long hash, out int lockToken)
+        public readonly void AcquireSharedLock(long hash, out LockToken lockToken)
         {
             var ix = CalculateIndex(hash, GetProcessorHint());
 
@@ -194,22 +264,60 @@ namespace Garnet.common
                 }
                 else
                 {
-                    lockToken = ix;
+                    lockToken = LockToken.CreateShared(ix);
                     return;
                 }
             }
         }
 
         /// <summary>
-        /// Release a lock previously acquired with <see cref="TryAcquireSharedLock(long, out int)"/> or <see cref="AcquireSharedLock(long, out int)"/>.
+        /// Releaes a lock previously acquired with <see cref="TryAcquireSharedLock"/>, <see cref="AcquireSharedLock"/>, <see cref="TryAcquireExclusiveLock"/>, <see cref="AcquireExclusiveLock"/>, <see cref="TryPromoteSharedLock"/>, or <see cref="AcquireAllExclusiveLock"/>.
         /// </summary>
-        public readonly void ReleaseSharedLock(int lockToken)
+        /// <param name="lockToken"></param>
+        public readonly void ReleaseLock(LockToken lockToken)
         {
-            Debug.Assert(lockToken >= 0 && lockToken < lockCounts.Length, "Invalid lock token");
+            if (lockToken.type == LockType.Exclusive)
+            {
+                // lockToken.token is a hash
+                ref var countRef = ref MemoryMarshal.GetArrayDataReference(lockCounts);
 
-            ref var releaseRef = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(lockCounts), lockToken);
+                var hash = lockToken.token;
 
-            _ = Interlocked.Decrement(ref releaseRef);
+                var coreCount = coreSelectionMask + 1;
+                for (var i = 0; i < coreCount; i++)
+                {
+                    var releaseIx = CalculateIndex(hash, i);
+
+                    ref var releaseRef = ref Unsafe.Add(ref countRef, releaseIx);
+                    while (Interlocked.CompareExchange(ref releaseRef, 0, int.MinValue) != int.MinValue)
+                    {
+                        // Optimistic shared lock got us, back off and try again
+                        _ = Thread.Yield();
+                    }
+                }
+            }
+            else if(lockToken.type == LockType.Shared)
+            {
+                // lockToken.token is an index
+                ref var releaseRef = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(lockCounts), lockToken.token);
+
+                _ = Interlocked.Decrement(ref releaseRef);
+            }
+            else
+            {
+                // lockToken.token is ignored
+                Debug.Assert(lockToken.type == LockType.AllExclusive, "Unexpected lock type");
+
+                for (var i = 0; i < lockCounts.Length; i++)
+                {
+                    ref var releaseRef = ref lockCounts[i];
+                    while (Interlocked.CompareExchange(ref releaseRef, 0, int.MinValue) != int.MinValue)
+                    {
+                        // Optimistic shared lock got us, back off and try again
+                        _ = Thread.Yield();
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -217,7 +325,7 @@ namespace Garnet.common
         /// 
         /// Will block all other locks until released.
         /// </summary>
-        public readonly bool TryAcquireExclusiveLock(long hash, out int lockToken)
+        public readonly bool TryAcquireExclusiveLock(long hash, out LockToken lockToken)
         {
             ref var countRef = ref MemoryMarshal.GetArrayDataReference(lockCounts);
 
@@ -250,7 +358,7 @@ namespace Garnet.common
             // Successfully acquired all shards exclusively
 
             // Throwing away half the hash shouldn't affect correctness since we do the same thing when processing the full hash
-            lockToken = (int)hash;
+            lockToken = LockToken.CreateExclusive((int)hash);
 
             return true;
         }
@@ -260,7 +368,7 @@ namespace Garnet.common
         /// 
         /// Will block all other locks until released.
         /// </summary>
-        public readonly void AcquireExclusiveLock(long hash, out int lockToken)
+        public readonly void AcquireExclusiveLock(long hash, out LockToken lockToken)
         {
             ref var countRef = ref MemoryMarshal.GetArrayDataReference(lockCounts);
 
@@ -280,48 +388,45 @@ namespace Garnet.common
             }
 
             // Throwing away half the hash shouldn't affect correctness since we do the same thing when processing the full hash
-            lockToken = (int)hash;
+            lockToken = LockToken.CreateExclusive((int)hash);
         }
 
         /// <summary>
-        /// Release a lock previously acquired with <see cref="TryAcquireExclusiveLock(long, out int)"/>, <see cref="AcquireExclusiveLock(long, out int)"/>, or <see cref="TryPromoteSharedLock(long, int, out int)"/>.
+        /// Acquire an exclusive lock for all possible hashes, blocking until that succeeds.
+        /// 
+        /// Will block all other locks until released.
         /// </summary>
-        public readonly void ReleaseExclusiveLock(int lockToken)
+        public readonly void AcquireAllExclusiveLock(out LockToken lockToken)
         {
-            // The lockToken is a hash, so no range check here
-
-            ref var countRef = ref MemoryMarshal.GetArrayDataReference(lockCounts);
-
-            var hash = lockToken;
-
-            var coreCount = coreSelectionMask + 1;
-            for (var i = 0; i < coreCount; i++)
+            for (var i = 0; i < lockCounts.Length; i++)
             {
-                var releaseIx = CalculateIndex(hash, i);
+                ref var acquireRef = ref lockCounts[i];
 
-                ref var releaseRef = ref Unsafe.Add(ref countRef, releaseIx);
-                while (Interlocked.CompareExchange(ref releaseRef, 0, int.MinValue) != int.MinValue)
+                while (Interlocked.CompareExchange(ref acquireRef, int.MinValue, 0) != 0)
                 {
-                    // Optimistic shared lock got us, back off and try again
+                    // Optimistic shared lock got us, or conflict with some other excluive lock acquisition
+                    //
+                    // Backoff and try again
                     _ = Thread.Yield();
                 }
             }
+
+            lockToken =  LockToken.CreateAllExclusive();
         }
 
         /// <summary>
-        /// Attempt to promote a shared lock previously acquired via <see cref="TryAcquireSharedLock(long, out int)"/> or <see cref="AcquireSharedLock(long, out int)"/> to an exclusive lock.
+        /// Attempt to promote a shared lock previously acquired via <see cref="TryAcquireSharedLock"/> or <see cref="AcquireSharedLock"/> to an exclusive lock.
         /// 
         /// If successful, will block all other locks until released.
         /// 
-        /// If successful, must be released with <see cref="ReleaseExclusiveLock(int)"/>.
-        /// 
-        /// If unsuccessful, shared lock will still be held and must be released with <see cref="ReleaseSharedLock(int)"/>.
+        /// Upon return <paramref name="lockToken"/> is an active lock which must be <see cref="ReleaseLock"/>'d.
+        /// If true is returned, the lock is an exclusive lock.  If false, it remains a shared lock
         /// </summary>
-        public readonly bool TryPromoteSharedLock(long hash, int lockToken, out int newLockToken)
+        public readonly bool TryPromoteSharedLock(long hash, ref LockToken lockToken)
         {
-            Debug.Assert(Interlocked.CompareExchange(ref lockCounts[lockToken], 0, 0) > 0, "Illegal call when not holding shard lock");
-
-            Debug.Assert(lockToken >= 0 && lockToken < lockCounts.Length, "Invalid lock token");
+            Debug.Assert(lockToken.type == LockType.Shared, "Expected shared lock type");
+            Debug.Assert(lockToken.token >= 0 && lockToken.token < lockCounts.Length, "Invalid lock token");
+            Debug.Assert(Interlocked.CompareExchange(ref lockCounts[lockToken.token], 0, 0) > 0, "Illegal call when not holding shard lock");
 
             ref var countRef = ref MemoryMarshal.GetArrayDataReference(lockCounts);
 
@@ -331,7 +436,7 @@ namespace Garnet.common
                 var acquireIx = CalculateIndex(hash, i);
                 ref var acquireRef = ref Unsafe.Add(ref countRef, acquireIx);
 
-                if (acquireIx == lockToken)
+                if (acquireIx == lockToken.token)
                 {
                     // Do the promote
                     if (Interlocked.CompareExchange(ref acquireRef, int.MinValue, 1) != 1)
@@ -350,7 +455,6 @@ namespace Garnet.common
                         }
 
                         // Note we're still holding the shared lock here
-                        Unsafe.SkipInit(out newLockToken);
                         return false;
                     }
                 }
@@ -363,7 +467,7 @@ namespace Garnet.common
                         for (var j = 0; j < i; j++)
                         {
                             var releaseIx = CalculateIndex(hash, j);
-                            var releaseTargetValue = releaseIx == lockToken ? 1 : 0;
+                            var releaseTargetValue = releaseIx == lockToken.token ? 1 : 0;
 
                             ref var releaseRef = ref Unsafe.Add(ref countRef, releaseIx);
                             while (Interlocked.CompareExchange(ref releaseRef, releaseTargetValue, int.MinValue) != int.MinValue)
@@ -374,14 +478,13 @@ namespace Garnet.common
                         }
 
                         // Note we're still holding the shared lock here
-                        Unsafe.SkipInit(out newLockToken);
                         return false;
                     }
                 }
             }
 
             // Throwing away half the hash shouldn't affect correctness since we do the same thing when processing the full hash
-            newLockToken = (int)hash;
+            lockToken = LockToken.CreateExclusive((int)hash);
             return true;
         }
 

--- a/libs/server/Resp/Vector/VectorManager.Locking.cs
+++ b/libs/server/Resp/Vector/VectorManager.Locking.cs
@@ -334,7 +334,14 @@ namespace Garnet.server
                     }
                     catch
                     {
-                        vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+                        if (takeExclusiveLock)
+                        {
+                            vectorSetLocks.ReleaseExclusiveLock(sharedLockToken);
+                        }
+                        else
+                        {
+                            vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+                        }
 
                         throw;
                     }
@@ -501,7 +508,14 @@ namespace Garnet.server
                     }
                     else if (readRes != GarnetStatus.OK)
                     {
-                        vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+                        if (takeExclusiveLock)
+                        {
+                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+                        }
+                        else
+                        {
+                            vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+                        }
 
                         status = readRes;
                         return default;

--- a/libs/server/Resp/Vector/VectorManager.Locking.cs
+++ b/libs/server/Resp/Vector/VectorManager.Locking.cs
@@ -144,7 +144,7 @@ namespace Garnet.server
 
                     if (needsRecreate)
                     {
-                        if (!takeExclusiveLock)
+                        if (!lockToken.IsExclusive)
                         {
                             // Try to promote
                             if (!vectorSetLocks.TryPromoteSharedLock(keyHash, ref lockToken))
@@ -323,7 +323,7 @@ namespace Garnet.server
 
                     if (readRes == GarnetStatus.NOTFOUND || needsRecreate)
                     {
-                        if (!takeExclusiveLock)
+                        if (!lockToken.IsExclusive)
                         {
                             if (!vectorSetLocks.TryPromoteSharedLock(keyHash, ref lockToken))
                             {

--- a/libs/server/Resp/Vector/VectorManager.Locking.cs
+++ b/libs/server/Resp/Vector/VectorManager.Locking.cs
@@ -18,16 +18,16 @@ namespace Garnet.server
     public sealed partial class VectorManager
     {
         /// <summary>
-        /// Used to scope a shared lock related to a Vector Set operation.
+        /// Used to scope a lock (shared or exclusive) related to a Vector Set operation.
         /// 
         /// Disposing this releases the lock and exits the storage session context on the current thread.
         /// </summary>
-        internal readonly ref struct ReadVectorLock : IDisposable
+        internal readonly ref struct VectorSetLock : IDisposable
         {
             private readonly ref readonly ReadOptimizedLock lockableCtx;
-            private readonly int lockToken;
+            private readonly ReadOptimizedLock.LockToken lockToken;
 
-            internal ReadVectorLock(ref readonly ReadOptimizedLock lockableCtx, int lockToken)
+            internal VectorSetLock(ref readonly ReadOptimizedLock lockableCtx, ReadOptimizedLock.LockToken lockToken)
             {
                 this.lockToken = lockToken;
                 this.lockableCtx = ref lockableCtx;
@@ -44,38 +44,7 @@ namespace Garnet.server
                     return;
                 }
 
-                lockableCtx.ReleaseSharedLock(lockToken);
-            }
-        }
-
-        /// <summary>
-        /// Used to scope exclusive locks  to exclusive Vector Set operation (delete, migrate, etc.).
-        /// 
-        /// Disposing this releases the lock and exits the storage session context on the current thread.
-        /// </summary>
-        internal readonly ref struct ExclusiveVectorLock : IDisposable
-        {
-            private readonly ref readonly ReadOptimizedLock lockableCtx;
-            private readonly int lockToken;
-
-            internal ExclusiveVectorLock(ref readonly ReadOptimizedLock lockableCtx, int lockToken)
-            {
-                this.lockToken = lockToken;
-                this.lockableCtx = ref lockableCtx;
-            }
-
-            /// <inheritdoc/>
-            public void Dispose()
-            {
-                Debug.Assert(ActiveThreadSession != null, "Shouldn't exit context when not in one");
-                ActiveThreadSession = null;
-
-                if (Unsafe.IsNullRef(in lockableCtx))
-                {
-                    return;
-                }
-
-                lockableCtx.ReleaseExclusiveLock(lockToken);
+                lockableCtx.ReleaseLock(lockToken);
             }
         }
 
@@ -100,7 +69,7 @@ namespace Garnet.server
         /// 
         /// Returns a disposable that prevents the index from being deleted while undisposed.
         /// </summary>
-        internal ReadVectorLock ReadVectorIndex(StorageSession storageSession, ref SpanByte key, ref RawStringInput input, scoped Span<byte> indexSpan, out GarnetStatus status)
+        internal VectorSetLock ReadVectorIndex(StorageSession storageSession, ref SpanByte key, ref RawStringInput input, scoped Span<byte> indexSpan, out GarnetStatus status)
         {
             Debug.Assert(indexSpan.Length == IndexSizeBytes, "Insufficient space for index");
 
@@ -121,15 +90,17 @@ namespace Garnet.server
                     input.header.cmd = readCmd;
                     input.arg1 = 0;
 
-                    var exclusiveLockToken = 0;
-                    var sharedLockToken = 0;
+                    ReadOptimizedLock.LockToken lockToken;
                     if (takeExclusiveLock)
                     {
-                        vectorSetLocks.AcquireExclusiveLock(keyHash, out exclusiveLockToken);
+                        vectorSetLocks.AcquireExclusiveLock(keyHash, out lockToken);
+
+                        // If we pass through _again_, don't start with an exclusive lock
+                        takeExclusiveLock = false;
                     }
                     else
                     {
-                        vectorSetLocks.AcquireSharedLock(keyHash, out sharedLockToken);
+                        vectorSetLocks.AcquireSharedLock(keyHash, out lockToken);
                     }
 
                     GarnetStatus readRes;
@@ -140,14 +111,7 @@ namespace Garnet.server
                     }
                     catch
                     {
-                        if (takeExclusiveLock)
-                        {
-                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
-                        }
-                        else
-                        {
-                            vectorSetLocks.ReleaseSharedLock(sharedLockToken);
-                        }
+                        vectorSetLocks.ReleaseLock(lockToken);
 
                         throw;
                     }
@@ -159,7 +123,7 @@ namespace Garnet.server
                         {
                             status = GarnetStatus.BADSTATE;
 
-                            vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+                            vectorSetLocks.ReleaseLock(lockToken);
                             return default;
                         }
 
@@ -170,13 +134,10 @@ namespace Garnet.server
                         needsRecreate = false;
                     }
 
-                    if (takeExclusiveLock && !needsRecreate)
+                    if (lockToken.IsExclusive && !needsRecreate)
                     {
-                        // Raised to recreate, lower to shared and retry immediately
-                        vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
-
-                        sharedLockToken = exclusiveLockToken = 0;
-                        takeExclusiveLock = false;
+                        // Raised to recreate but don't need it, lower to shared and retry
+                        vectorSetLocks.ReleaseLock(lockToken);
 
                         continue;
                     }
@@ -186,12 +147,10 @@ namespace Garnet.server
                         if (!takeExclusiveLock)
                         {
                             // Try to promote
-                            if (!vectorSetLocks.TryPromoteSharedLock(keyHash, sharedLockToken, out exclusiveLockToken))
+                            if (!vectorSetLocks.TryPromoteSharedLock(keyHash, ref lockToken))
                             {
                                 // Release the SHARED lock if we can't promote and try again - but this time DEMAND an exclusive lock
-                                vectorSetLocks.ReleaseSharedLock(sharedLockToken);
-
-                                sharedLockToken = exclusiveLockToken = 0;
+                                vectorSetLocks.ReleaseLock(lockToken);
                                 takeExclusiveLock = true;
 
                                 continue;
@@ -239,7 +198,7 @@ namespace Garnet.server
                         }
                         catch
                         {
-                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+                            vectorSetLocks.ReleaseLock(lockToken);
 
                             throw;
                         }
@@ -247,17 +206,14 @@ namespace Garnet.server
                         if (writeRes == GarnetStatus.OK)
                         {
                             // Try again so we don't hold an exclusive lock while performing a search
-                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
-
-                            sharedLockToken = exclusiveLockToken = 0;
-                            takeExclusiveLock = false;
+                            vectorSetLocks.ReleaseLock(lockToken);
 
                             continue;
                         }
                         else
                         {
                             status = writeRes;
-                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+                            vectorSetLocks.ReleaseLock(lockToken);
 
                             return default;
                         }
@@ -265,13 +221,13 @@ namespace Garnet.server
                     else if (readRes != GarnetStatus.OK)
                     {
                         status = readRes;
-                        vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+                        vectorSetLocks.ReleaseLock(lockToken);
 
                         return default;
                     }
 
                     status = GarnetStatus.OK;
-                    return new(in vectorSetLocks, sharedLockToken);
+                    return new(in vectorSetLocks, lockToken);
                 }
             }
             catch
@@ -290,7 +246,7 @@ namespace Garnet.server
         /// 
         /// Returns a disposable that prevents the index from being deleted while undisposed.
         /// </summary>
-        internal ReadVectorLock ReadOrCreateVectorIndex(
+        internal VectorSetLock ReadOrCreateVectorIndex(
             StorageSession storageSession,
             ref SpanByte key,
             ref RawStringInput input,
@@ -314,16 +270,17 @@ namespace Garnet.server
                 {
                     input.arg1 = 0;
 
-                    var sharedLockToken = 0;
-                    var exclusiveLockToken = 0;
-
+                    ReadOptimizedLock.LockToken lockToken;
                     if (takeExclusiveLock)
                     {
-                        vectorSetLocks.AcquireExclusiveLock(keyHash, out exclusiveLockToken);
+                        vectorSetLocks.AcquireExclusiveLock(keyHash, out lockToken);
+
+                        // If we pass through _again_, don't start with an exclusive lock
+                        takeExclusiveLock = false;
                     }
                     else
                     {
-                        vectorSetLocks.AcquireSharedLock(keyHash, out sharedLockToken);
+                        vectorSetLocks.AcquireSharedLock(keyHash, out lockToken);
                     }
 
                     GarnetStatus readRes;
@@ -334,14 +291,7 @@ namespace Garnet.server
                     }
                     catch
                     {
-                        if (takeExclusiveLock)
-                        {
-                            vectorSetLocks.ReleaseExclusiveLock(sharedLockToken);
-                        }
-                        else
-                        {
-                            vectorSetLocks.ReleaseSharedLock(sharedLockToken);
-                        }
+                        vectorSetLocks.ReleaseLock(lockToken);
 
                         throw;
                     }
@@ -353,7 +303,7 @@ namespace Garnet.server
                         {
                             status = GarnetStatus.BADSTATE;
 
-                            vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+                            vectorSetLocks.ReleaseLock(lockToken);
                             return default;
                         }
 
@@ -365,12 +315,9 @@ namespace Garnet.server
                     }
 
                     // Don't need the exclusive lock, lower to shared immediately
-                    if (takeExclusiveLock && !(readRes == GarnetStatus.NOTFOUND || needsRecreate))
+                    if (lockToken.IsExclusive && !(readRes == GarnetStatus.NOTFOUND || needsRecreate))
                     {
-                        vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
-
-                        sharedLockToken = exclusiveLockToken = 0;
-                        takeExclusiveLock = false;
+                        vectorSetLocks.ReleaseLock(lockToken);
                         continue;
                     }
 
@@ -378,12 +325,10 @@ namespace Garnet.server
                     {
                         if (!takeExclusiveLock)
                         {
-                            if (!vectorSetLocks.TryPromoteSharedLock(keyHash, sharedLockToken, out exclusiveLockToken))
+                            if (!vectorSetLocks.TryPromoteSharedLock(keyHash, ref lockToken))
                             {
                                 // Release the SHARED lock if we can't promote and try again but DEMAND exclusive this time
-                                vectorSetLocks.ReleaseSharedLock(sharedLockToken);
-
-                                sharedLockToken = exclusiveLockToken = 0;
+                                vectorSetLocks.ReleaseLock(lockToken);
                                 takeExclusiveLock = true;
 
                                 continue;
@@ -485,7 +430,7 @@ namespace Garnet.server
                         }
                         catch
                         {
-                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+                            vectorSetLocks.ReleaseLock(lockToken);
 
                             throw;
                         }
@@ -493,36 +438,27 @@ namespace Garnet.server
                         if (writeRes == GarnetStatus.OK)
                         {
                             // Try again so we don't hold an exclusive lock while adding a vector (which might be time consuming)
-                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
-
-                            takeExclusiveLock = false;
+                            vectorSetLocks.ReleaseLock(lockToken);
                             continue;
                         }
                         else
                         {
                             status = writeRes;
-                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+                            vectorSetLocks.ReleaseLock(lockToken);
 
                             return default;
                         }
                     }
                     else if (readRes != GarnetStatus.OK)
                     {
-                        if (takeExclusiveLock)
-                        {
-                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
-                        }
-                        else
-                        {
-                            vectorSetLocks.ReleaseSharedLock(sharedLockToken);
-                        }
+                        vectorSetLocks.ReleaseLock(lockToken);
 
                         status = readRes;
                         return default;
                     }
 
                     status = GarnetStatus.OK;
-                    return new(in vectorSetLocks, sharedLockToken);
+                    return new(in vectorSetLocks, lockToken);
                 }
             }
             catch
@@ -539,7 +475,7 @@ namespace Garnet.server
         /// <summary>
         /// Acquire exclusive lock over a given key.
         /// </summary>
-        private ExclusiveVectorLock AcquireExclusiveLocks(StorageSession storageSession, ref SpanByte key)
+        private VectorSetLock AcquireExclusiveLocks(StorageSession storageSession, ref SpanByte key)
         {
             var keyHash = storageSession.lockableContext.GetKeyHash(key);
 
@@ -553,7 +489,7 @@ namespace Garnet.server
         /// 
         /// If the index is partially deleted, <paramref name="status"/> will be set to <see cref="GarnetStatus.BADSTATE"/> but the locks will be still acquired.
         /// </summary>
-        internal ExclusiveVectorLock ReadForDeleteVectorIndex(StorageSession storageSession, ref SpanByte key, ref RawStringInput input, scoped Span<byte> indexSpan, out GarnetStatus status)
+        internal VectorSetLock ReadForDeleteVectorIndex(StorageSession storageSession, ref SpanByte key, ref RawStringInput input, scoped Span<byte> indexSpan, out GarnetStatus status)
         {
             Debug.Assert(indexSpan.Length == IndexSizeBytes, "Insufficient space for index");
 

--- a/libs/server/Resp/Vector/VectorManager.Locking.cs
+++ b/libs/server/Resp/Vector/VectorManager.Locking.cs
@@ -114,12 +114,23 @@ namespace Garnet.server
 
                 var readCmd = input.header.cmd;
 
+                var takeExclusiveLock = false;
+
                 while (true)
                 {
                     input.header.cmd = readCmd;
                     input.arg1 = 0;
 
-                    vectorSetLocks.AcquireSharedLock(keyHash, out var sharedLockToken);
+                    var exclusiveLockToken = 0;
+                    var sharedLockToken = 0;
+                    if (takeExclusiveLock)
+                    {
+                        vectorSetLocks.AcquireExclusiveLock(keyHash, out exclusiveLockToken);
+                    }
+                    else
+                    {
+                        vectorSetLocks.AcquireSharedLock(keyHash, out sharedLockToken);
+                    }
 
                     GarnetStatus readRes;
                     try
@@ -129,7 +140,14 @@ namespace Garnet.server
                     }
                     catch
                     {
-                        vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+                        if (takeExclusiveLock)
+                        {
+                            vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+                        }
+                        else
+                        {
+                            vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+                        }
 
                         throw;
                     }
@@ -152,14 +170,32 @@ namespace Garnet.server
                         needsRecreate = false;
                     }
 
+                    if (takeExclusiveLock && !needsRecreate)
+                    {
+                        // Raised to recreate, lower to shared and retry immediately
+                        vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+
+                        sharedLockToken = exclusiveLockToken = 0;
+                        takeExclusiveLock = false;
+
+                        continue;
+                    }
+
                     if (needsRecreate)
                     {
-                        if (!vectorSetLocks.TryPromoteSharedLock(keyHash, sharedLockToken, out var exclusiveLockToken))
+                        if (!takeExclusiveLock)
                         {
-                            // Release the SHARED lock if we can't promote and try again
-                            vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+                            // Try to promote
+                            if (!vectorSetLocks.TryPromoteSharedLock(keyHash, sharedLockToken, out exclusiveLockToken))
+                            {
+                                // Release the SHARED lock if we can't promote and try again - but this time DEMAND an exclusive lock
+                                vectorSetLocks.ReleaseSharedLock(sharedLockToken);
 
-                            continue;
+                                sharedLockToken = exclusiveLockToken = 0;
+                                takeExclusiveLock = true;
+
+                                continue;
+                            }
                         }
 
                         ReadIndex(indexSpan, out var indexContext, out var dims, out var reduceDims, out var quantType, out var buildExplorationFactor, out var numLinks, out var distanceMetric, out _, out _);
@@ -212,6 +248,10 @@ namespace Garnet.server
                         {
                             // Try again so we don't hold an exclusive lock while performing a search
                             vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+
+                            sharedLockToken = exclusiveLockToken = 0;
+                            takeExclusiveLock = false;
+
                             continue;
                         }
                         else
@@ -268,11 +308,23 @@ namespace Garnet.server
 
                 var indexConfig = SpanByteAndMemory.FromPinnedSpan(indexSpan);
 
+                var takeExclusiveLock = false;
+
                 while (true)
                 {
                     input.arg1 = 0;
 
-                    vectorSetLocks.AcquireSharedLock(keyHash, out var sharedLockToken);
+                    var sharedLockToken = 0;
+                    var exclusiveLockToken = 0;
+
+                    if (takeExclusiveLock)
+                    {
+                        vectorSetLocks.AcquireExclusiveLock(keyHash, out exclusiveLockToken);
+                    }
+                    else
+                    {
+                        vectorSetLocks.AcquireSharedLock(keyHash, out sharedLockToken);
+                    }
 
                     GarnetStatus readRes;
                     try
@@ -305,14 +357,30 @@ namespace Garnet.server
                         needsRecreate = false;
                     }
 
+                    // Don't need the exclusive lock, lower to shared immediately
+                    if (takeExclusiveLock && !(readRes == GarnetStatus.NOTFOUND || needsRecreate))
+                    {
+                        vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+
+                        sharedLockToken = exclusiveLockToken = 0;
+                        takeExclusiveLock = false;
+                        continue;
+                    }
+
                     if (readRes == GarnetStatus.NOTFOUND || needsRecreate)
                     {
-                        if (!vectorSetLocks.TryPromoteSharedLock(keyHash, sharedLockToken, out var exclusiveLockToken))
+                        if (!takeExclusiveLock)
                         {
-                            // Release the SHARED lock if we can't promote and try again
-                            vectorSetLocks.ReleaseSharedLock(sharedLockToken);
+                            if (!vectorSetLocks.TryPromoteSharedLock(keyHash, sharedLockToken, out exclusiveLockToken))
+                            {
+                                // Release the SHARED lock if we can't promote and try again but DEMAND exclusive this time
+                                vectorSetLocks.ReleaseSharedLock(sharedLockToken);
 
-                            continue;
+                                sharedLockToken = exclusiveLockToken = 0;
+                                takeExclusiveLock = true;
+
+                                continue;
+                            }
                         }
 
                         ulong indexContext;
@@ -419,6 +487,8 @@ namespace Garnet.server
                         {
                             // Try again so we don't hold an exclusive lock while adding a vector (which might be time consuming)
                             vectorSetLocks.ReleaseExclusiveLock(exclusiveLockToken);
+
+                            takeExclusiveLock = false;
                             continue;
                         }
                         else

--- a/test/Garnet.test/ReadOptimizedLockTests.cs
+++ b/test/Garnet.test/ReadOptimizedLockTests.cs
@@ -35,8 +35,8 @@ namespace Garnet.test
             var gotExclusive = lockContext.TryAcquireExclusiveLock(hash, out _);
             ClassicAssert.IsFalse(gotExclusive);
 
-            lockContext.ReleaseSharedLock(sharedToken0);
-            lockContext.ReleaseSharedLock(sharedToken1);
+            lockContext.ReleaseLock(sharedToken0);
+            lockContext.ReleaseLock(sharedToken1);
 
             var gotExclusiveAgain = lockContext.TryAcquireExclusiveLock(hash, out var exclusiveToken);
             ClassicAssert.IsTrue(gotExclusiveAgain);
@@ -44,7 +44,7 @@ namespace Garnet.test
             var gotSharedAgain = lockContext.TryAcquireSharedLock(hash, out _);
             ClassicAssert.IsFalse(gotSharedAgain);
 
-            lockContext.ReleaseExclusiveLock(exclusiveToken);
+            lockContext.ReleaseLock(exclusiveToken);
         }
 
         [Test]
@@ -153,7 +153,7 @@ namespace Garnet.test
                                                     ClassicAssert.AreEqual(sub[0], sub[k]);
                                                 }
 
-                                                lockContext.ReleaseSharedLock(sharedLockToken);
+                                                lockContext.ReleaseLock(sharedLockToken);
                                             }
                                             else
                                             {
@@ -174,7 +174,7 @@ namespace Garnet.test
                                                     sub[k] = newValue;
                                                 }
 
-                                                lockContext.ReleaseExclusiveLock(exclusiveLockToken);
+                                                lockContext.ReleaseLock(exclusiveLockToken);
                                             }
                                             else
                                             {
@@ -193,7 +193,7 @@ namespace Garnet.test
                                                 ClassicAssert.AreEqual(sub[0], sub[k]);
                                             }
 
-                                            lockContext.ReleaseSharedLock(sharedLockToken);
+                                            lockContext.ReleaseLock(sharedLockToken);
                                         }
 
                                         break;
@@ -209,7 +209,7 @@ namespace Garnet.test
                                                 sub[k] = newValue;
                                             }
 
-                                            lockContext.ReleaseExclusiveLock(exclusiveLockToken);
+                                            lockContext.ReleaseLock(exclusiveLockToken);
                                         }
 
                                         break;
@@ -217,7 +217,7 @@ namespace Garnet.test
                                     // Try: Read, verify, promote, modify
                                     case 4:
                                         {
-                                            if (lockContext.TryAcquireSharedLock(hash, out var sharedLockToken))
+                                            if (lockContext.TryAcquireSharedLock(hash, out var lockToken))
                                             {
                                                 var sub = values[hashIx];
                                                 for (var k = 1; k < sub.Length; k++)
@@ -225,7 +225,7 @@ namespace Garnet.test
                                                     ClassicAssert.AreEqual(sub[0], sub[k]);
                                                 }
 
-                                                if (lockContext.TryPromoteSharedLock(hash, sharedLockToken, out var exclusiveLockToken))
+                                                if (lockContext.TryPromoteSharedLock(hash, ref lockToken))
                                                 {
                                                     var newValue = threadRandom.NextInt64();
                                                     for (var k = 0; k < sub.Length; k++)
@@ -233,11 +233,11 @@ namespace Garnet.test
                                                         sub[k] = newValue;
                                                     }
 
-                                                    lockContext.ReleaseExclusiveLock(exclusiveLockToken);
+                                                    lockContext.ReleaseLock(lockToken);
                                                 }
                                                 else
                                                 {
-                                                    lockContext.ReleaseSharedLock(sharedLockToken);
+                                                    lockContext.ReleaseLock(lockToken);
 
                                                     j--;
                                                 }


### PR DESCRIPTION
Cherry-picking #1846 onto v1 to keep Vector Set parity.

We're getting pretty close to stopping backports to V1, but since #1726 will land against v1 I'd like to keep parity for a bit longer.