### PR TITLE
Fix VSIM COUNT when FILTER is set

### DIFF
--- a/libs/server/Resp/Vector/RespServerSessionVectors.cs
+++ b/libs/server/Resp/Vector/RespServerSessionVectors.cs
@@ -892,7 +892,10 @@ namespace Garnet.server
                                 while (!RespWriteUtils.TryWriteArrayLength(arrayItemCount, ref dcurr, dend))
                                     SendAndReset();
 
-                                for (var resultIndex = 0; resultIndex < outputCount; resultIndex++)
+                                var writtenCount = 0;
+                                var resultIndex = 0;
+
+                                while (writtenCount < outputCount)
                                 {
                                     ReadOnlySpan<byte> elementData;
 
@@ -937,6 +940,9 @@ namespace Garnet.server
                                             var skipAttrLen = BinaryPrimitives.ReadInt32LittleEndian(remaininingAttributes);
                                             remaininingAttributes = remaininingAttributes[(sizeof(int) + skipAttrLen)..];
                                         }
+
+                                        resultIndex++;
+                                        continue;
                                     }
 
                                     while (!RespWriteUtils.TryWriteBulkString(elementData, ref dcurr, dend))
@@ -970,6 +976,9 @@ namespace Garnet.server
                                         var attrLen = BinaryPrimitives.ReadInt32LittleEndian(remaininingAttributes);
                                         remaininingAttributes = remaininingAttributes[(sizeof(int) + attrLen)..];
                                     }
+
+                                    resultIndex++;
+                                    writtenCount++;
                                 }
                             }
                         }

--- a/libs/server/Resp/Vector/RespServerSessionVectors.cs
+++ b/libs/server/Resp/Vector/RespServerSessionVectors.cs
@@ -862,7 +862,7 @@ namespace Garnet.server
 
                                 var totalFound = distancesSpan.Length;
 
-                                // Compute output count: if bitmap is present, popcount it; otherwise all results
+                                // Compute max output count: if bitmap is present, popcount it; otherwise all results
                                 int outputCount;
                                 if (hasFilter)
                                 {
@@ -875,6 +875,10 @@ namespace Garnet.server
                                     outputCount = totalFound;
                                 }
 
+                                // Limit to what is actually asked for
+                                outputCount = Math.Min(count.Value, outputCount);
+
+                                // Each flag doubles output
                                 var arrayItemCount = outputCount;
                                 if (withScores.Value)
                                 {
@@ -888,7 +892,7 @@ namespace Garnet.server
                                 while (!RespWriteUtils.TryWriteArrayLength(arrayItemCount, ref dcurr, dend))
                                     SendAndReset();
 
-                                for (var resultIndex = 0; resultIndex < totalFound; resultIndex++)
+                                for (var resultIndex = 0; resultIndex < outputCount; resultIndex++)
                                 {
                                     ReadOnlySpan<byte> elementData;
 
@@ -933,7 +937,6 @@ namespace Garnet.server
                                             var skipAttrLen = BinaryPrimitives.ReadInt32LittleEndian(remaininingAttributes);
                                             remaininingAttributes = remaininingAttributes[(sizeof(int) + skipAttrLen)..];
                                         }
-                                        continue;
                                     }
 
                                     while (!RespWriteUtils.TryWriteBulkString(elementData, ref dcurr, dend))

--- a/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
+++ b/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -715,6 +716,47 @@ namespace Garnet.test
 
             ClassicAssert.AreEqual(0, res4.Length,
                 "Should return 0 results since no vectors have year > 1990");
+        }
+
+        [Test]
+        public void VSIMCount()
+        {
+            const string VectorSet = "foo";
+            const int VectorCount = 100;
+            const int Select = 10;
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            _ = db.KeyDelete(VectorSet);
+
+            // Add first vector with year=1980
+            for (var i = 0; i < VectorCount; i++)
+            {
+                var elementId = new byte[sizeof(int)];
+                BinaryPrimitives.WriteInt32LittleEndian(elementId, i);
+
+                var res = (int)db.Execute("VADD", [VectorSet, "VALUES", "3", "1.0", "2.0", "3.0", elementId, "NOQUANT", "SETATTR", $"{{\"field\": {100 + i}}}"]);
+                ClassicAssert.AreEqual(1, res);
+            }
+
+            var vsimNoFilter = (byte[][])db.Execute("VSIM", [VectorSet, "VALUES", "3", "1.0", "2.0", "3.0", "COUNT", Select]);
+            ClassicAssert.AreEqual(Select, vsimNoFilter.Length);
+
+            var vsimNoFilterWithAttribs = (byte[][])db.Execute("VSIM", [VectorSet, "VALUES", "3", "1.0", "2.0", "3.0", "COUNT", Select, "WITHATTRIBS"]);
+            ClassicAssert.AreEqual(Select * 2, vsimNoFilterWithAttribs.Length);
+
+            var vsimNoFilterWithAttribsWithScores = (byte[][])db.Execute("VSIM", [VectorSet, "VALUES", "3", "1.0", "2.0", "3.0", "COUNT", Select, "WITHATTRIBS", "WITHSCORES"]);
+            ClassicAssert.AreEqual(Select * 3, vsimNoFilterWithAttribsWithScores.Length);
+
+            var vsimWithFilter = (byte[][])db.Execute("VSIM", [VectorSet, "VALUES", "3", "1.0", "2.0", "3.0", "COUNT", Select, "FILTER", $".field >= 100 and .field <= {100 + (2 * Select)}"]);
+            ClassicAssert.AreEqual(Select, vsimWithFilter.Length);
+
+            var vsimWithFilterWithAttribs = (byte[][])db.Execute("VSIM", [VectorSet, "VALUES", "3", "1.0", "2.0", "3.0", "COUNT", Select, "FILTER", $".field >= 100 and .field <= {100 + (2 * Select)}", "WITHATTRIBS"]);
+            ClassicAssert.AreEqual(Select * 2, vsimWithFilterWithAttribs.Length);
+
+            var vsimWithFilterWithAttribsWithScores = (byte[][])db.Execute("VSIM", [VectorSet, "VALUES", "3", "1.0", "2.0", "3.0", "COUNT", Select, "FILTER", $".field >= 100 and .field <= {100 + (2 * Select)}", "WITHATTRIBS", "WITHSCORES"]);
+            ClassicAssert.AreEqual(Select * 3, vsimWithFilterWithAttribsWithScores.Length);
         }
 
         [Test]

--- a/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
+++ b/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
@@ -730,7 +730,6 @@ namespace Garnet.test
 
             _ = db.KeyDelete(VectorSet);
 
-            // Add first vector with year=1980
             for (var i = 0; i < VectorCount; i++)
             {
                 var elementId = new byte[sizeof(int)];


### PR DESCRIPTION
When `FILTER` is set on `VSIM` we over select to do post-filtering.

We were not correctly limiting the number of result returned, instead returning whatever matched from the over select.

This fixes that.