### PR TITLE
Fix large string handling in CLUSTER|NODES and CLUSTER|SHARDS

### DIFF
--- a/libs/cluster/Session/RespClusterBasicCommands.cs
+++ b/libs/cluster/Session/RespClusterBasicCommands.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Text;
 using Garnet.common;
@@ -274,8 +275,8 @@ namespace Garnet.cluster
             }
 
             var nodes = clusterProvider.clusterManager.CurrentConfig.GetClusterInfo(clusterProvider);
-            while (!RespWriteUtils.TryWriteAsciiBulkString(nodes, ref dcurr, dend))
-                SendAndReset();
+
+            WriteAsciiLargeRespString(nodes);
 
             return true;
         }
@@ -343,8 +344,8 @@ namespace Garnet.cluster
 
             var preferredType = clusterProvider.serverOptions.ClusterPreferredEndpointType;
             var shardsInfo = clusterProvider.clusterManager.CurrentConfig.GetShardsInfo(clusterProvider.clusterManager.clusterConnectionStore, preferredType);
-            while (!RespWriteUtils.TryWriteAsciiDirect(shardsInfo, ref dcurr, dend))
-                SendAndReset();
+
+            WriteAsciiLargeRespString(shardsInfo);
 
             return true;
         }
@@ -522,6 +523,44 @@ namespace Garnet.cluster
 
             clusterProvider.storeWrapper.subscribeBroker.Publish(parseState.GetArgSliceByRef(0), parseState.GetArgSliceByRef(1));
             return true;
+        }
+
+        /// <summary>
+        /// Handle a potentially quite large string by breaking it into pieces if necessary.
+        /// </summary>
+        private void WriteAsciiLargeRespString(ReadOnlySpan<char> message)
+        {
+            while (!RespWriteUtils.TryWriteBulkStringLength(message.Length, ref dcurr, dend))
+                SendAndReset();
+
+            // Attempt to write w/o any buffering
+            if (RespWriteUtils.TryWriteAsciiDirect(message, ref dcurr, dend))
+            {
+                return;
+            }
+
+            var buffer = ArrayPool<byte>.Shared.Rent(message.Length);
+            try
+            {
+                var len = Encoding.ASCII.GetBytes(message, buffer);
+                var remaining = buffer.AsSpan()[..len];
+
+                while (!remaining.IsEmpty)
+                {
+                    var space = (int)(dend - dcurr);
+                    var res = RespWriteUtils.TryWriteDirect(remaining[..space], ref dcurr, dend);
+                    Debug.Assert(res, "Should never fail to fit in output buffer");
+
+                    SendAndReset();
+                }
+
+                while (!RespWriteUtils.TryWriteNewLine(ref dcurr, dend))
+                    SendAndReset();
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
         }
     }
 }

--- a/libs/cluster/Session/RespClusterBasicCommands.cs
+++ b/libs/cluster/Session/RespClusterBasicCommands.cs
@@ -345,7 +345,7 @@ namespace Garnet.cluster
             var preferredType = clusterProvider.serverOptions.ClusterPreferredEndpointType;
             var shardsInfo = clusterProvider.clusterManager.CurrentConfig.GetShardsInfo(clusterProvider.clusterManager.clusterConnectionStore, preferredType);
 
-            WriteAsciiLargeRespString(shardsInfo);
+            WriteLargeAsciiDirectString(shardsInfo);
 
             return true;
         }
@@ -525,8 +525,43 @@ namespace Garnet.cluster
             return true;
         }
 
+
         /// <summary>
-        /// Handle a potentially quite large string by breaking it into pieces if necessary.
+        /// Handle a potentially large already encoded RESP response, breaking it into pieces if necessary.
+        /// </summary>
+        private void WriteLargeAsciiDirectString(ReadOnlySpan<char> message)
+        {
+            // Attempt to write w/o any buffering
+            if (RespWriteUtils.TryWriteAsciiDirect(message, ref dcurr, dend))
+            {
+                return;
+            }
+
+            var buffer = ArrayPool<byte>.Shared.Rent(message.Length);
+            try
+            {
+                var len = Encoding.ASCII.GetBytes(message, buffer);
+                var remaining = buffer.AsSpan()[..len];
+
+                while (!remaining.IsEmpty)
+                {
+                    var space = (int)(dend - dcurr);
+                    var res = RespWriteUtils.TryWriteDirect(remaining[..space], ref dcurr, dend);
+                    Debug.Assert(res, "Should never fail to fit in output buffer");
+
+                    SendAndReset();
+
+                    remaining = remaining[space..];
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+
+        /// <summary>
+        /// Handle a potentially large bulk string by breaking it into pieces if necessary.
         /// </summary>
         private void WriteAsciiLargeRespString(ReadOnlySpan<char> message)
         {

--- a/libs/cluster/Session/RespClusterBasicCommands.cs
+++ b/libs/cluster/Session/RespClusterBasicCommands.cs
@@ -536,6 +536,9 @@ namespace Garnet.cluster
             // Attempt to write w/o any buffering
             if (RespWriteUtils.TryWriteAsciiDirect(message, ref dcurr, dend))
             {
+                while (!RespWriteUtils.TryWriteNewLine(ref dcurr, dend))
+                    SendAndReset();
+
                 return;
             }
 
@@ -552,6 +555,8 @@ namespace Garnet.cluster
                     Debug.Assert(res, "Should never fail to fit in output buffer");
 
                     SendAndReset();
+
+                    remaining = remaining[space..];
                 }
 
                 while (!RespWriteUtils.TryWriteNewLine(ref dcurr, dend))

--- a/libs/cluster/Session/RespClusterBasicCommands.cs
+++ b/libs/cluster/Session/RespClusterBasicCommands.cs
@@ -545,9 +545,8 @@ namespace Garnet.cluster
 
                 while (!remaining.IsEmpty)
                 {
-                    var space = (int)(dend - dcurr);
-                    var res = RespWriteUtils.TryWriteDirect(remaining[..space], ref dcurr, dend);
-                    Debug.Assert(res, "Should never fail to fit in output buffer");
+                    var space = Math.Min((int)(dend - dcurr), remaining.Length);
+                    _ = RespWriteUtils.TryWriteDirect(remaining[..space], ref dcurr, dend);
 
                     SendAndReset();
 
@@ -585,9 +584,8 @@ namespace Garnet.cluster
 
                 while (!remaining.IsEmpty)
                 {
-                    var space = (int)(dend - dcurr);
-                    var res = RespWriteUtils.TryWriteDirect(remaining[..space], ref dcurr, dend);
-                    Debug.Assert(res, "Should never fail to fit in output buffer");
+                    var space = Math.Min((int)(dend - dcurr), remaining.Length);
+                    _ = RespWriteUtils.TryWriteDirect(remaining[..space], ref dcurr, dend);
 
                     SendAndReset();
 

--- a/libs/common/RespWriteUtils.cs
+++ b/libs/common/RespWriteUtils.cs
@@ -321,14 +321,20 @@ namespace Garnet.common
         /// Write length header of bulk string
         /// </summary>
         public static bool TryWriteBulkStringLength(ReadOnlySpan<byte> item, ref byte* curr, byte* end)
+        => TryWriteBulkStringLength(item.Length, ref curr, end);
+
+        /// <summary>
+        /// Write length header of bulk string
+        /// </summary>
+        public static bool TryWriteBulkStringLength(int len, ref byte* curr, byte* end)
         {
-            var itemDigits = NumUtils.CountDigits(item.Length);
+            var itemDigits = NumUtils.CountDigits(len);
             var totalLen = 1 + itemDigits + 2;
             if (totalLen > (int)(end - curr))
                 return false;
 
             *curr++ = (byte)'$';
-            NumUtils.WriteInt32(item.Length, itemDigits, ref curr);
+            NumUtils.WriteInt32(len, itemDigits, ref curr);
             WriteNewline(ref curr);
             return true;
         }


### PR DESCRIPTION
Same issue experimentally identified in #1781 and fixed for INFO in #1776.