### PR TITLE
Clean TearDown failure behavior

### DIFF
--- a/test/cluster/Garnet.test.cluster/ClusterTestContext.cs
+++ b/test/cluster/Garnet.test.cluster/ClusterTestContext.cs
@@ -211,7 +211,7 @@ namespace Garnet.test.cluster
             }
 
             // Phase 4: Always runs — resets LightEpoch instances to prevent cross-test contamination
-            TestUtils.OnTearDown();
+            TestUtils.OnTearDown(logger: logger, suppressFailure: testAlreadyFailed || failureReason != null);
 
             // Fail the test at the end, after all cleanup is done
             if (failureReason != null)

--- a/test/standalone/Garnet.test/TestUtils.cs
+++ b/test/standalone/Garnet.test/TestUtils.cs
@@ -1312,9 +1312,9 @@ using System.Threading.Tasks;
             return RandomNumberGenerator.GetString(chars, len);
         }
 
-        internal static void OnTearDown(bool waitForDelete = false, ILogger logger = null)
+        internal static void OnTearDown(bool waitForDelete = false, ILogger logger = null, bool suppressFailure = false)
         {
-            var failTestOnLeak = TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Passed;
+            var failTestOnLeak = !suppressFailure && TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Passed;
 
             DeleteDirectory(MethodTestDir, wait: waitForDelete);
             var count = Tsavorite.core.LightEpoch.ActiveInstanceCount();
@@ -1346,6 +1346,11 @@ using System.Threading.Tasks;
             if (failTestOnLeak && !string.IsNullOrEmpty(failMsg))
             {
                 Assert.Fail(failMsg);
+            }
+            else if (logger is null && !string.IsNullOrEmpty(failMsg))
+            {
+                // Guarantee the leak message goes _somewhere_ if it doesn't fail the test
+                TestContext.Out.WriteLine(failMsg);
             }
         }
     }

--- a/test/standalone/Garnet.test/TestUtils.cs
+++ b/test/standalone/Garnet.test/TestUtils.cs
@@ -1314,14 +1314,18 @@ using System.Threading.Tasks;
 
         internal static void OnTearDown(bool waitForDelete = false, ILogger logger = null)
         {
+            var failTestOnLeak = TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Passed;
+
             DeleteDirectory(MethodTestDir, wait: waitForDelete);
             var count = Tsavorite.core.LightEpoch.ActiveInstanceCount();
+            var failMsg = "";
+
             if (count != 0)
             {
                 // Reset all instances to avoid impacting other tests
                 Tsavorite.core.LightEpoch.ResetAllInstances();
                 logger?.LogError("Tsavorite.core.LightEpoch instances still active: {count}", count);
-                Assert.Fail($"Tsavorite.core.LightEpoch instances still active: {count}");
+                failMsg += $"Tsavorite.core.LightEpoch instances still active: {count}";
             }
 
             var count2 = client.LightEpoch.ActiveInstanceCount();
@@ -1330,7 +1334,18 @@ using System.Threading.Tasks;
                 // Reset all instances to avoid impacting other tests
                 client.LightEpoch.ResetAllInstances();
                 logger?.LogError("Garnet.client.LightEpoch instances still active: {count2}", count2);
-                Assert.Fail($"Garnet.client.LightEpoch instances still active: {count2}");
+
+                if (!string.IsNullOrEmpty(failMsg))
+                {
+                    failMsg += Environment.NewLine;
+                }
+
+                failMsg += $"Garnet.client.LightEpoch instances still active: {count2}";
+            }
+
+            if (failTestOnLeak && !string.IsNullOrEmpty(failMsg))
+            {
+                Assert.Fail(failMsg);
             }
         }
     }


### PR DESCRIPTION
In `TestUtils.OnTearDown` we check for `LightEpoch` leaks, and fail if any occurred.

This is a good sanity check, but can make it harder to see the cause of a real test failure.

Additionally, if `Tsavorite.core.LightEpoch` epochs are leaked, we will not cleanup any leaked `Garnet.client.LightEpoch`s.

PR changes `TestUtils.OnTearDown` to:
 - always log leaked epochs
 - always reset both kinds of `LightEpoch` if they are leaked
 - only `Assert.Fail(...)` on a leaked epoch if the test would pass otherwise