### PR TITLE
Add server-side RESP protocol restrictions

### DIFF
--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -189,6 +189,9 @@ namespace Garnet
         [Option("acl-strict-custom-commands", Required = false, HelpText = "If true (default), the server refuses to start when an ACL rule references a custom (extension) command name that no loaded module has registered. Set to false to load unresolved names as-is and log warnings.")]
         public bool? AclStrictCustomCommands { get; set; }
 
+        [Option("allowed-protocols", Required = false, HelpText = "RESP protocol versions accepted by client sessions. Value options: Both, Resp2, Resp3")]
+        public RespProtocolMode? AllowedProtocols { get; set; }
+
         [Option("aad-authority", Required = false, HelpText = "The authority of AAD authentication.")]
         public string AadAuthority { get; set; }
 
@@ -918,6 +921,7 @@ namespace Garnet
                 FastMigrate = FastMigrate.GetValueOrDefault(),
                 AuthSettings = GetAuthenticationSettings(logger),
                 AclStrictCustomCommands = AclStrictCustomCommands.GetValueOrDefault(true),
+                AllowedProtocols = AllowedProtocols.GetValueOrDefault(RespProtocolMode.Both),
                 EnableAOF = EnableAOF.GetValueOrDefault(),
                 EnableLua = EnableLua.GetValueOrDefault(),
                 LuaTransactionMode = LuaTransactionMode.GetValueOrDefault(),

--- a/libs/host/Configuration/Options.cs
+++ b/libs/host/Configuration/Options.cs
@@ -189,6 +189,9 @@ namespace Garnet
         [Option("acl-strict-custom-commands", Required = false, HelpText = "If true (default), the server refuses to start when an ACL rule references a custom (extension) command name that no loaded module has registered. Set to false to load unresolved names as-is and log warnings.")]
         public bool? AclStrictCustomCommands { get; set; }
 
+        [Option("allowed-protocols", Required = false, HelpText = "RESP protocol versions accepted by client sessions. Value options: Both, Resp2, Resp3")]
+        public RespProtocolMode? AllowedProtocols { get; set; }
+
         [Option("aad-authority", Required = false, HelpText = "The authority of AAD authentication.")]
         public string AadAuthority { get; set; }
 
@@ -899,6 +902,7 @@ namespace Garnet
                 FastMigrate = FastMigrate.GetValueOrDefault(),
                 AuthSettings = GetAuthenticationSettings(logger),
                 AclStrictCustomCommands = AclStrictCustomCommands.GetValueOrDefault(true),
+                AllowedProtocols = AllowedProtocols.GetValueOrDefault(RespProtocolMode.Both),
                 EnableAOF = EnableAOF.GetValueOrDefault(),
                 EnableLua = EnableLua.GetValueOrDefault(),
                 LuaTransactionMode = LuaTransactionMode.GetValueOrDefault(),

--- a/libs/host/defaults.conf
+++ b/libs/host/defaults.conf
@@ -129,6 +129,9 @@
 	/* Refuse to start when an ACL rule references a custom (extension) command name that no loaded module has registered. Default true (strict). Set to false to load unresolved names as-is and log warnings. */
 	"AclStrictCustomCommands" : true,
 
+	/* RESP protocol versions accepted by client sessions. Value options: Both, Resp2, Resp3 */
+	"AllowedProtocols" : "Both",
+
 	/* The authority of AAD authentication. */
 	"AadAuthority" : "https://login.microsoftonline.com",
 

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -1475,6 +1475,11 @@ namespace Garnet.server
                 return true;
             }
 
+            if (!storeWrapper.serverOptions.IsRespProtocolVersionAllowed(tmpRespProtocolVersion ?? respProtocolVersion))
+            {
+                return AbortWithErrorMessage(CmdStrings.RESP_ERR_PROTOCOL_VERSION_NOT_ALLOWED);
+            }
+
             ProcessHelloCommand(tmpRespProtocolVersion, authUsername, authPassword, tmpClientName);
             return true;
         }

--- a/libs/server/Resp/BasicCommands.cs
+++ b/libs/server/Resp/BasicCommands.cs
@@ -1438,6 +1438,11 @@ namespace Garnet.server
                 return true;
             }
 
+            if (!storeWrapper.serverOptions.IsRespProtocolVersionAllowed(tmpRespProtocolVersion ?? respProtocolVersion))
+            {
+                return AbortWithErrorMessage(CmdStrings.RESP_ERR_PROTOCOL_VERSION_NOT_ALLOWED);
+            }
+
             ProcessHelloCommand(tmpRespProtocolVersion, authUsername, authPassword, tmpClientName);
             return true;
         }

--- a/libs/server/Resp/CmdStrings.cs
+++ b/libs/server/Resp/CmdStrings.cs
@@ -262,6 +262,7 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> RESP_ERR_NO_TRANSACTION_PROCEDURE => "ERR Could not get transaction procedure"u8;
         public static ReadOnlySpan<byte> RESP_ERR_WRONG_NUMBER_OF_ARGUMENTS => "ERR wrong number of arguments for command"u8;
         public static ReadOnlySpan<byte> RESP_ERR_UNSUPPORTED_PROTOCOL_VERSION => "ERR Unsupported protocol version"u8;
+        public static ReadOnlySpan<byte> RESP_ERR_PROTOCOL_VERSION_NOT_ALLOWED => "ERR Protocol version not allowed by server configuration"u8;
         public static ReadOnlySpan<byte> RESP_ERR_ASYNC_PROTOCOL_CHANGE => "ERR protocol change is not allowed with pending async operations"u8;
         public static ReadOnlySpan<byte> RESP_ERR_NOT_VALID_FLOAT => "ERR value is not a valid float"u8;
         public static ReadOnlySpan<byte> RESP_ERR_MIN_MAX_NOT_VALID_FLOAT => "ERR min or max is not a float"u8;

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -652,7 +652,7 @@ namespace Garnet.server
 
                     if (CheckACLPermissions(cmd) && (noScriptPassed = CheckScriptPermissions(cmd)))
                     {
-                        if (!IsCommandAllowedByRespProtocolPolicy(cmd))
+                        if (cmd != RespCommand.HELLO && !storeWrapper.serverOptions.IsRespProtocolVersionAllowed(respProtocolVersion))
                         {
                             WriteError(CmdStrings.RESP_ERR_PROTOCOL_VERSION_NOT_ALLOWED);
                             commandStats?.IncrementRejected(cmd);
@@ -750,20 +750,6 @@ namespace Garnet.server
                     networkSender.DisposeNetworkSender(true);
                 }
             }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool IsCommandAllowedByRespProtocolPolicy(RespCommand cmd)
-        {
-            if (cmd == RespCommand.HELLO)
-                return true;
-
-            return storeWrapper.serverOptions.AllowedProtocols switch
-            {
-                RespProtocolMode.Resp2 => respProtocolVersion == 2,
-                RespProtocolMode.Resp3 => respProtocolVersion == 3,
-                _ => respProtocolVersion is 2 or 3,
-            };
         }
 
         // Make first command in string as uppercase

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -758,7 +758,12 @@ namespace Garnet.server
             if (cmd == RespCommand.HELLO)
                 return true;
 
-            return storeWrapper.serverOptions.IsRespProtocolVersionAllowed(respProtocolVersion);
+            return storeWrapper.serverOptions.AllowedProtocols switch
+            {
+                RespProtocolMode.Resp2 => respProtocolVersion == 2,
+                RespProtocolMode.Resp3 => respProtocolVersion == 3,
+                _ => respProtocolVersion is 2 or 3,
+            };
         }
 
         // Make first command in string as uppercase

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -755,7 +755,7 @@ namespace Garnet.server
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool IsCommandAllowedByRespProtocolPolicy(RespCommand cmd)
         {
-            if (storeWrapper.serverOptions.AllowedProtocols == RespProtocolMode.Both || cmd == RespCommand.HELLO)
+            if (cmd == RespCommand.HELLO)
                 return true;
 
             return storeWrapper.serverOptions.IsRespProtocolVersionAllowed(respProtocolVersion);

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -652,9 +652,14 @@ namespace Garnet.server
 
                     if (CheckACLPermissions(cmd) && (noScriptPassed = CheckScriptPermissions(cmd)))
                     {
+                        if (!IsCommandAllowedByRespProtocolPolicy(cmd))
+                        {
+                            WriteError(CmdStrings.RESP_ERR_PROTOCOL_VERSION_NOT_ALLOWED);
+                            commandStats?.IncrementRejected(cmd);
+                        }
                         // In RESP2, only a small set of commands are allowed while in subscription mode.
                         // RESP3 uses distinct push types for subscription messages, so all commands are valid.
-                        if (isSubscriptionSession && respProtocolVersion == 2 && !cmd.IsAllowedInSubscriptionMode())
+                        else if (isSubscriptionSession && respProtocolVersion == 2 && !cmd.IsAllowedInSubscriptionMode())
                         {
                             while (!RespWriteUtils.TryWriteError(string.Format(CmdStrings.GenericPubSubCommandNotAllowed, cmd.ToString()), ref dcurr, dend))
                                 SendAndReset();
@@ -745,6 +750,15 @@ namespace Garnet.server
                     networkSender.DisposeNetworkSender(true);
                 }
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool IsCommandAllowedByRespProtocolPolicy(RespCommand cmd)
+        {
+            if (storeWrapper.serverOptions.AllowedProtocols == RespProtocolMode.Both || cmd == RespCommand.HELLO)
+                return true;
+
+            return storeWrapper.serverOptions.IsRespProtocolVersionAllowed(respProtocolVersion);
         }
 
         // Make first command in string as uppercase

--- a/libs/server/Servers/GarnetServerOptions.cs
+++ b/libs/server/Servers/GarnetServerOptions.cs
@@ -81,6 +81,11 @@ namespace Garnet.server
         public bool AclStrictCustomCommands = true;
 
         /// <summary>
+        /// RESP protocol versions accepted by client sessions.
+        /// </summary>
+        public RespProtocolMode AllowedProtocols = RespProtocolMode.Both;
+
+        /// <summary>
         /// Enable append-only file (write ahead log)
         /// </summary>
         public bool EnableAOF = false;
@@ -719,6 +724,16 @@ namespace Garnet.server
         {
             this.logger = logger;
         }
+
+        /// <summary>
+        /// Check whether a RESP protocol version is allowed by server configuration.
+        /// </summary>
+        public bool IsRespProtocolVersionAllowed(byte version) => AllowedProtocols switch
+        {
+            RespProtocolMode.Resp2 => version == 2,
+            RespProtocolMode.Resp3 => version == 3,
+            _ => version is 2 or 3,
+        };
 
         /// <summary>
         /// Initialize Garnet server options

--- a/libs/server/Servers/GarnetServerOptions.cs
+++ b/libs/server/Servers/GarnetServerOptions.cs
@@ -81,6 +81,11 @@ namespace Garnet.server
         public bool AclStrictCustomCommands = true;
 
         /// <summary>
+        /// RESP protocol versions accepted by client sessions.
+        /// </summary>
+        public RespProtocolMode AllowedProtocols = RespProtocolMode.Both;
+
+        /// <summary>
         /// Enable append-only file (write ahead log)
         /// </summary>
         public bool EnableAOF = false;
@@ -673,6 +678,16 @@ namespace Garnet.server
         {
             this.logger = logger;
         }
+
+        /// <summary>
+        /// Check whether a RESP protocol version is allowed by server configuration.
+        /// </summary>
+        public bool IsRespProtocolVersionAllowed(byte version) => AllowedProtocols switch
+        {
+            RespProtocolMode.Resp2 => version == 2,
+            RespProtocolMode.Resp3 => version == 3,
+            _ => version is 2 or 3,
+        };
 
         /// <summary>
         /// Initialize Garnet server options

--- a/libs/server/Servers/RespProtocolMode.cs
+++ b/libs/server/Servers/RespProtocolMode.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace Garnet.server
+{
+    /// <summary>
+    /// RESP protocol versions accepted by the server.
+    /// </summary>
+    public enum RespProtocolMode
+    {
+        /// <summary>
+        /// Accept both RESP2 and RESP3 clients.
+        /// </summary>
+        Both,
+
+        /// <summary>
+        /// Accept RESP2 clients only.
+        /// </summary>
+        Resp2,
+
+        /// <summary>
+        /// Accept RESP3 clients only.
+        /// </summary>
+        Resp3,
+    }
+}

--- a/test/standalone/Garnet.test/GarnetServerConfigTests.cs
+++ b/test/standalone/Garnet.test/GarnetServerConfigTests.cs
@@ -1759,6 +1759,158 @@ namespace Garnet.test
         }
 
         [Test]
+        public void AllowedProtocols()
+        {
+            {
+                var args = Array.Empty<string>();
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out _, out _, out _);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(RespProtocolMode.Both, options.GetServerOptions().AllowedProtocols);
+            }
+
+            {
+                var args = new[] { "--allowed-protocols", "RESP3" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                ClassicAssert.AreEqual(RespProtocolMode.Resp3, options.GetServerOptions().AllowedProtocols);
+            }
+
+            {
+                var args = new[] { "--allowed-protocols", "resp2" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                ClassicAssert.AreEqual(RespProtocolMode.Resp2, options.GetServerOptions().AllowedProtocols);
+            }
+
+            {
+                const string JSON = @"{ ""AllowedProtocols"": ""Resp3"" }";
+                var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out var invalidOptions, out _);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                ClassicAssert.AreEqual(RespProtocolMode.Resp3, options.GetServerOptions().AllowedProtocols);
+            }
+        }
+
+        [Test]
+        public void EnableVectorSetPreview()
+        {
+            // Command line args
+            {
+                // Default accepted
+                {
+                    var args = Array.Empty<string>();
+                    var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out _, out _, out _);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsFalse(options.EnableVectorSetPreview);
+                }
+
+                // Switch is accepted
+                {
+                    var args = new[] { "--enable-vector-set-preview" };
+                    var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out _, out _, out _);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsTrue(options.EnableVectorSetPreview);
+                }
+            }
+
+            // JSON args
+            {
+                // Default accepted
+                {
+                    const string JSON = @"{ }";
+                    var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out var invalidOptions, out var exitGracefully);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsFalse(options.EnableVectorSetPreview);
+                }
+
+                // False is accepted
+                {
+                    const string JSON = @"{ ""EnableVectorSetPreview"": false }";
+                    var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out var invalidOptions, out var exitGracefully);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsFalse(options.EnableVectorSetPreview);
+                }
+
+                // True is accepted
+                {
+                    const string JSON = @"{ ""EnableVectorSetPreview"": true }";
+                    var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out var invalidOptions, out var exitGracefully);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsTrue(options.EnableVectorSetPreview);
+                }
+
+                // Invalid rejected
+                {
+                    const string JSON = @"{ ""EnableVectorSetPreview"": ""foo"" }";
+                    var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out var invalidOptions, out var exitGracefully);
+                    ClassicAssert.IsFalse(parseSuccessful);
+                }
+            }
+        }
+
+        [Test]
+        public void MinimumPageSizeWithVectorSetPreview()
+        {
+            // Command line args
+            {
+                // Allow exactly minimum
+                {
+                    var args = new[] { "--enable-vector-set-preview", "--page", "16k" };
+                    var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out _, out _, out _);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsTrue(options.EnableVectorSetPreview);
+                    ClassicAssert.AreEqual("16k", options.PageSize);
+                }
+
+                // Allow lower than minimum if preview not enabled
+                {
+                    var args = new[] { "--page", "1k" };
+                    var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out _, out _, out _);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsFalse(options.EnableVectorSetPreview);
+                    ClassicAssert.AreEqual("1k", options.PageSize);
+                }
+
+                // Reject too small
+                {
+                    var args = new[] { "--enable-vector-set-preview", "--page", "4k" };
+                    var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out _, out _, out _, out _);
+                    ClassicAssert.IsFalse(parseSuccessful);
+                }
+            }
+
+            // JSON args
+            {
+                // Allow exactly minimum
+                {
+                    const string JSON = @"{ ""EnableVectorSetPreview"": true, ""PageSize"": ""16k"" }";
+                    var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out _, out _);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsTrue(options.EnableVectorSetPreview);
+                    ClassicAssert.AreEqual("16k", options.PageSize);
+                }
+
+                // Allow lower than minimum if preview not enabled
+                {
+                    const string JSON = @"{ ""EnableVectorSetPreview"": false, ""PageSize"": ""1k"" }";
+                    var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out _, out _);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsFalse(options.EnableVectorSetPreview);
+                    ClassicAssert.AreEqual("1k", options.PageSize);
+                }
+
+                // Reject too small
+                {
+                    const string JSON = @"{ ""EnableVectorSetPreview"": true, ""PageSize"": ""4k"" }";
+                    var parseSuccessful = TryParseGarnetConfOptions(JSON, out _, out _, out _);
+                    ClassicAssert.IsFalse(parseSuccessful);
+                }
+            }
+        }
+
+        [Test]
         public void AofSizeLimitWithoutAofEnabled()
         {
             // Setting --aof-size-limit without --aof should throw

--- a/test/standalone/Garnet.test/GarnetServerConfigTests.cs
+++ b/test/standalone/Garnet.test/GarnetServerConfigTests.cs
@@ -1658,6 +1658,158 @@ namespace Garnet.test
         }
 
         [Test]
+        public void AllowedProtocols()
+        {
+            {
+                var args = Array.Empty<string>();
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out _, out _, out _);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(RespProtocolMode.Both, options.GetServerOptions().AllowedProtocols);
+            }
+
+            {
+                var args = new[] { "--allowed-protocols", "RESP3" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                ClassicAssert.AreEqual(RespProtocolMode.Resp3, options.GetServerOptions().AllowedProtocols);
+            }
+
+            {
+                var args = new[] { "--allowed-protocols", "resp2" };
+                var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out var invalidOptions, out _, out _, silentMode: true);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                ClassicAssert.AreEqual(RespProtocolMode.Resp2, options.GetServerOptions().AllowedProtocols);
+            }
+
+            {
+                const string JSON = @"{ ""AllowedProtocols"": ""Resp3"" }";
+                var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out var invalidOptions, out _);
+                ClassicAssert.IsTrue(parseSuccessful);
+                ClassicAssert.AreEqual(0, invalidOptions.Count);
+                ClassicAssert.AreEqual(RespProtocolMode.Resp3, options.GetServerOptions().AllowedProtocols);
+            }
+        }
+
+        [Test]
+        public void EnableVectorSetPreview()
+        {
+            // Command line args
+            {
+                // Default accepted
+                {
+                    var args = Array.Empty<string>();
+                    var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out _, out _, out _);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsFalse(options.EnableVectorSetPreview);
+                }
+
+                // Switch is accepted
+                {
+                    var args = new[] { "--enable-vector-set-preview" };
+                    var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out _, out _, out _);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsTrue(options.EnableVectorSetPreview);
+                }
+            }
+
+            // JSON args
+            {
+                // Default accepted
+                {
+                    const string JSON = @"{ }";
+                    var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out var invalidOptions, out var exitGracefully);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsFalse(options.EnableVectorSetPreview);
+                }
+
+                // False is accepted
+                {
+                    const string JSON = @"{ ""EnableVectorSetPreview"": false }";
+                    var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out var invalidOptions, out var exitGracefully);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsFalse(options.EnableVectorSetPreview);
+                }
+
+                // True is accepted
+                {
+                    const string JSON = @"{ ""EnableVectorSetPreview"": true }";
+                    var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out var invalidOptions, out var exitGracefully);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsTrue(options.EnableVectorSetPreview);
+                }
+
+                // Invalid rejected
+                {
+                    const string JSON = @"{ ""EnableVectorSetPreview"": ""foo"" }";
+                    var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out var invalidOptions, out var exitGracefully);
+                    ClassicAssert.IsFalse(parseSuccessful);
+                }
+            }
+        }
+
+        [Test]
+        public void MinimumPageSizeWithVectorSetPreview()
+        {
+            // Command line args
+            {
+                // Allow exactly minimum
+                {
+                    var args = new[] { "--enable-vector-set-preview", "--page", "16k" };
+                    var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out _, out _, out _);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsTrue(options.EnableVectorSetPreview);
+                    ClassicAssert.AreEqual("16k", options.PageSize);
+                }
+
+                // Allow lower than minimum if preview not enabled
+                {
+                    var args = new[] { "--page", "1k" };
+                    var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out var options, out _, out _, out _);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsFalse(options.EnableVectorSetPreview);
+                    ClassicAssert.AreEqual("1k", options.PageSize);
+                }
+
+                // Reject too small
+                {
+                    var args = new[] { "--enable-vector-set-preview", "--page", "4k" };
+                    var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out _, out _, out _, out _);
+                    ClassicAssert.IsFalse(parseSuccessful);
+                }
+            }
+
+            // JSON args
+            {
+                // Allow exactly minimum
+                {
+                    const string JSON = @"{ ""EnableVectorSetPreview"": true, ""PageSize"": ""16k"" }";
+                    var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out _, out _);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsTrue(options.EnableVectorSetPreview);
+                    ClassicAssert.AreEqual("16k", options.PageSize);
+                }
+
+                // Allow lower than minimum if preview not enabled
+                {
+                    const string JSON = @"{ ""EnableVectorSetPreview"": false, ""PageSize"": ""1k"" }";
+                    var parseSuccessful = TryParseGarnetConfOptions(JSON, out var options, out _, out _);
+                    ClassicAssert.IsTrue(parseSuccessful);
+                    ClassicAssert.IsFalse(options.EnableVectorSetPreview);
+                    ClassicAssert.AreEqual("1k", options.PageSize);
+                }
+
+                // Reject too small
+                {
+                    const string JSON = @"{ ""EnableVectorSetPreview"": true, ""PageSize"": ""4k"" }";
+                    var parseSuccessful = TryParseGarnetConfOptions(JSON, out _, out _, out _);
+                    ClassicAssert.IsFalse(parseSuccessful);
+                }
+            }
+        }
+
+        [Test]
         public void AofSizeLimitWithoutAofEnabled()
         {
             // Setting --aof-size-limit without --aof should throw

--- a/test/standalone/Garnet.test/RespTests.cs
+++ b/test/standalone/Garnet.test/RespTests.cs
@@ -4123,6 +4123,54 @@ namespace Garnet.test
         }
 
         [Test]
+        public async Task HelloRespectsResp2OnlyPolicy()
+        {
+            TearDown();
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, disablePubSub: false, allowedProtocols: RespProtocolMode.Resp2);
+            server.Start();
+
+            using var c = TestUtils.GetGarnetClientSession(raw: true);
+            c.Connect();
+
+            var response = await c.ExecuteAsync("PING").ConfigureAwait(false);
+            ClassicAssert.AreEqual("+PONG\r\n", response);
+
+            response = await c.ExecuteAsync("HELLO", "3").ConfigureAwait(false);
+            ClassicAssert.AreEqual($"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_PROTOCOL_VERSION_NOT_ALLOWED)}\r\n", response);
+
+            response = await c.ExecuteAsync("HELLO", "2").ConfigureAwait(false);
+            ClassicAssert.IsTrue(response.Contains("$5\r\nproto\r\n:2\r\n"), response);
+        }
+
+        [Test]
+        public async Task HelloRespectsResp3OnlyPolicy()
+        {
+            TearDown();
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, disablePubSub: false, allowedProtocols: RespProtocolMode.Resp3);
+            server.Start();
+
+            using var c = TestUtils.GetGarnetClientSession(raw: true);
+            c.Connect();
+
+            var response = await c.ExecuteAsync("PING").ConfigureAwait(false);
+            ClassicAssert.AreEqual($"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_PROTOCOL_VERSION_NOT_ALLOWED)}\r\n", response);
+
+            response = await c.ExecuteAsync("HELLO").ConfigureAwait(false);
+            ClassicAssert.AreEqual($"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_PROTOCOL_VERSION_NOT_ALLOWED)}\r\n", response);
+
+            response = await c.ExecuteAsync("HELLO", "2").ConfigureAwait(false);
+            ClassicAssert.AreEqual($"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_PROTOCOL_VERSION_NOT_ALLOWED)}\r\n", response);
+
+            response = await c.ExecuteAsync("HELLO", "3").ConfigureAwait(false);
+            ClassicAssert.IsTrue(response.Contains("$5\r\nproto\r\n:3\r\n"), response);
+
+            response = await c.ExecuteAsync("PING").ConfigureAwait(false);
+            ClassicAssert.AreEqual("+PONG\r\n", response);
+        }
+
+        [Test]
         [TestCase([2, "$-1\r\n", "$1\r\n", "*4", '*'], Description = "RESP2 output")]
         [TestCase([3, "_\r\n", ",", "%2", '~'], Description = "RESP3 output")]
         public async Task RespOutputTests(byte respVersion, string expectedResponse, string doublePrefix, string mapPrefix, char setPrefix)

--- a/test/standalone/Garnet.test/RespTests.cs
+++ b/test/standalone/Garnet.test/RespTests.cs
@@ -4052,6 +4052,54 @@ namespace Garnet.test
         }
 
         [Test]
+        public async Task HelloRespectsResp2OnlyPolicy()
+        {
+            TearDown();
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, disablePubSub: false, allowedProtocols: RespProtocolMode.Resp2);
+            server.Start();
+
+            using var c = TestUtils.GetGarnetClientSession(raw: true);
+            c.Connect();
+
+            var response = await c.ExecuteAsync("PING").ConfigureAwait(false);
+            ClassicAssert.AreEqual("+PONG\r\n", response);
+
+            response = await c.ExecuteAsync("HELLO", "3").ConfigureAwait(false);
+            ClassicAssert.AreEqual($"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_PROTOCOL_VERSION_NOT_ALLOWED)}\r\n", response);
+
+            response = await c.ExecuteAsync("HELLO", "2").ConfigureAwait(false);
+            ClassicAssert.IsTrue(response.Contains("$5\r\nproto\r\n:2\r\n"), response);
+        }
+
+        [Test]
+        public async Task HelloRespectsResp3OnlyPolicy()
+        {
+            TearDown();
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, disablePubSub: false, allowedProtocols: RespProtocolMode.Resp3);
+            server.Start();
+
+            using var c = TestUtils.GetGarnetClientSession(raw: true);
+            c.Connect();
+
+            var response = await c.ExecuteAsync("PING").ConfigureAwait(false);
+            ClassicAssert.AreEqual($"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_PROTOCOL_VERSION_NOT_ALLOWED)}\r\n", response);
+
+            response = await c.ExecuteAsync("HELLO").ConfigureAwait(false);
+            ClassicAssert.AreEqual($"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_PROTOCOL_VERSION_NOT_ALLOWED)}\r\n", response);
+
+            response = await c.ExecuteAsync("HELLO", "2").ConfigureAwait(false);
+            ClassicAssert.AreEqual($"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_PROTOCOL_VERSION_NOT_ALLOWED)}\r\n", response);
+
+            response = await c.ExecuteAsync("HELLO", "3").ConfigureAwait(false);
+            ClassicAssert.IsTrue(response.Contains("$5\r\nproto\r\n:3\r\n"), response);
+
+            response = await c.ExecuteAsync("PING").ConfigureAwait(false);
+            ClassicAssert.AreEqual("+PONG\r\n", response);
+        }
+
+        [Test]
         [TestCase([2, "$-1\r\n", "$1\r\n", "*4", '*'], Description = "RESP2 output")]
         [TestCase([3, "_\r\n", ",", "%2", '~'], Description = "RESP3 output")]
         public async Task RespOutputTests(byte respVersion, string expectedResponse, string doublePrefix, string mapPrefix, char setPrefix)

--- a/test/standalone/Garnet.test/TestUtils.cs
+++ b/test/standalone/Garnet.test/TestUtils.cs
@@ -350,7 +350,8 @@ namespace Garnet.test
             int compactionMaxSegments = 32,
             string segmentSize = "1g",
             bool? nativeAllocator = null,
-            string bufferPoolMemoryBudget = null
+            string bufferPoolMemoryBudget = null,
+            RespProtocolMode allowedProtocols = RespProtocolMode.Both
         )
         {
             if (useAzureStorage)
@@ -404,6 +405,7 @@ namespace Garnet.test
                 CommitFrequencyMs = commitFrequencyMs,
                 WaitForCommit = commitWait,
                 AclStrictCustomCommands = aclStrictCustomCommands,
+                AllowedProtocols = allowedProtocols,
                 TlsOptions = enableTLS ? new GarnetTlsOptions(
                     certFileName: tlsCertFileName ?? certFile,
                     certPassword: tlsCertPassword ?? certPassword,

--- a/test/standalone/Garnet.test/TestUtils.cs
+++ b/test/standalone/Garnet.test/TestUtils.cs
@@ -351,7 +351,8 @@ namespace Garnet.test
             int compactionMaxSegments = 32,
             string segmentSize = "1g",
             bool? nativeAllocator = null,
-            string bufferPoolMemoryBudget = null
+            string bufferPoolMemoryBudget = null,
+            RespProtocolMode allowedProtocols = RespProtocolMode.Both
         )
         {
             if (useAzureStorage)
@@ -405,6 +406,7 @@ namespace Garnet.test
                 CommitFrequencyMs = commitFrequencyMs,
                 WaitForCommit = commitWait,
                 AclStrictCustomCommands = aclStrictCustomCommands,
+                AllowedProtocols = allowedProtocols,
                 TlsOptions = enableTLS ? new GarnetTlsOptions(
                     certFileName: tlsCertFileName ?? certFile,
                     certPassword: tlsCertPassword ?? certPassword,


### PR DESCRIPTION
### Summary

- add `--allowed-protocols` with `Both`, `Resp2`, and `Resp3` modes
- reject `HELLO` protocol switches that are disallowed by server configuration
- in RESP3-only mode, reject commands before the session has negotiated `HELLO 3`

### Details

`Both` remains the default behavior. `Resp2` keeps existing RESP2 clients working
and rejects `HELLO 3`. `Resp3` allows `HELLO 3` as the negotiation entry point,
then permits normal commands after the session protocol switches to RESP3. A
client in RESP3-only mode that sends ordinary commands before `HELLO 3` receives:

```text
ERR Protocol version not allowed by server configuration
```

For authenticated deployments, clients should use `HELLO 3 AUTH <user> <pass>`
as the first command.

### Tests

```bash
/Users/haihan/.dotnet/dotnet test test/standalone/Garnet.test/Garnet.test.csproj --no-restore --framework net8.0 --filter 'FullyQualifiedName~GarnetServerConfigTests.AllowedProtocols' -v:minimal
/Users/haihan/.dotnet/dotnet test test/standalone/Garnet.test/Garnet.test.csproj --no-restore --framework net8.0 --filter 'FullyQualifiedName~RespTests.HelloRespectsResp' -v:minimal
/Users/haihan/.dotnet/dotnet test test/standalone/Garnet.test/Garnet.test.csproj --no-restore --framework net8.0 --filter 'FullyQualifiedName~RespTests.HelloTest1|FullyQualifiedName~RespTests.HelloAuthErrorTest' -v:minimal
/Users/haihan/.dotnet/dotnet test test/standalone/Garnet.test/Garnet.test.csproj --no-restore --framework net8.0 --filter 'FullyQualifiedName~RespTests.RespOutputTests' -v:minimal
git diff --check -- libs/host/Configuration/Options.cs libs/host/defaults.conf libs/server/Resp/BasicCommands.cs libs/server/Resp/CmdStrings.cs libs/server/Resp/RespServerSession.cs libs/server/Servers/GarnetServerOptions.cs test/standalone/Garnet.test/GarnetServerConfigTests.cs test/standalone/Garnet.test/RespTests.cs test/standalone/Garnet.test/TestUtils.cs
git diff --no-index --check /dev/null libs/server/Servers/RespProtocolMode.cs; test $? -eq 1
```

Latest local validation result, 2026-06-13 07:24 PDT / 14:24 UTC: all four
targeted `dotnet test` invocations passed, covering 7 tests total. Both
tracked-file `git diff --check` and the untracked `RespProtocolMode.cs`
no-index whitespace check passed.

Addresses #1755.
