### PR TITLE
[RangeIndex] Handle crashes and recovery

### DIFF
--- a/test/cluster/Garnet.test.cluster.migrate.rangeindex/ClusterRangeIndexMigrateTests.Crashes.cs
+++ b/test/cluster/Garnet.test.cluster.migrate.rangeindex/ClusterRangeIndexMigrateTests.Crashes.cs
@@ -1,0 +1,501 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+#if DEBUG
+using Garnet.common;
+#endif
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using StackExchange.Redis;
+
+namespace Garnet.test.cluster
+{
+    /// <summary>
+    /// Cluster-migration tests that currently crash the test host via a native bf-tree panic
+    /// (mini_page_op / circular_buffer assertion). They are split into this partial-class file
+    /// and marked [Explicit] so they do not run in CI until the underlying RangeIndex
+    /// crash/recovery issues are fixed, at which point they become passing regression tests.
+    /// </summary>
+    public partial class ClusterRangeIndexMigrateTests
+    {
+        /// <summary>
+        /// Client writes RI.SET continuously while migration happens, following MOVED redirects.
+        /// </summary>
+        [Test]
+        [Category("CLUSTER")]
+        [Explicit("Reproduces a BfTree native crash (mini_page_op/circular_buffer panic) during cluster migration; crashes the test host. Tracked for RangeIndex crash/recovery.")]
+        public async Task ClusterMigrateRangeIndexWhileModifyingAsync()
+        {
+            const int shards = 2;
+
+            context.CreateInstances(shards, enableRangeIndexPreview: true);
+            context.CreateConnection();
+
+            _ = context.clusterTestUtils.SimpleSetupCluster(logger: context.logger);
+
+            var primary0 = (IPEndPoint)context.clusterTestUtils.GetEndPoint(0);
+            var primary1 = (IPEndPoint)context.clusterTestUtils.GetEndPoint(1);
+            var primary0Id = context.clusterTestUtils.ClusterMyId(primary0);
+            var slots = context.clusterTestUtils.ClusterSlots(primary0);
+
+            var riKey = FindKeyOnNode(nameof(ClusterMigrateRangeIndexWhileModifyingAsync), primary0Id, slots);
+            var slot = context.clusterTestUtils.HashSlot(riKey);
+
+            // Create RI key
+            var createResult = (string)context.clusterTestUtils.Execute(
+                primary0, "RI.CREATE",
+                [riKey, "DISK", "CACHESIZE", "65536", "MINRECORD", "8"],
+                flags: CommandFlags.NoRedirect);
+            ClassicAssert.AreEqual("OK", createResult);
+
+            // Start background writer
+            using var cts = new CancellationTokenSource();
+            var written = new ConcurrentBag<(string Field, string Value)>();
+
+            var writeTask = Task.Run(async () =>
+            {
+                await Task.Yield();
+
+                using var con = ConnectionMultiplexer.Connect(context.clusterTestUtils.GetRedisConfig(context.endpoints));
+                var db = con.GetDatabase();
+                var ix = 0;
+
+                while (!cts.IsCancellationRequested)
+                {
+                    var field = $"field_{ix}";
+                    var value = $"value_{ix}";
+
+                    try
+                    {
+                        var result = (string)db.Execute("RI.SET", [new RedisKey(riKey), field, value]);
+                        if (result == "OK")
+                            written.Add((field, value));
+                    }
+                    catch (Exception exc) when (
+                        exc is RedisTimeoutException
+                        || exc is RedisConnectionException
+                        || (exc is RedisServerException rse && (
+                            rse.Message.StartsWith("MOVED ")
+                            || rse.Message.StartsWith("Key has MOVED to "))))
+                    {
+                        continue;
+                    }
+
+                    ix++;
+                }
+            });
+
+            await Task.Delay(1_000).ConfigureAwait(false);
+
+            var countPreMigration = written.Count;
+            ClassicAssert.IsTrue(countPreMigration > 0, "Should have some writes before migration");
+
+            // Migrate
+            using (var migrateToken = new CancellationTokenSource())
+            {
+                migrateToken.CancelAfter(30_000);
+
+                context.clusterTestUtils.MigrateSlots(primary0, primary1, [slot]);
+                context.clusterTestUtils.WaitForMigrationCleanup(0, cancellationToken: migrateToken.Token);
+                context.clusterTestUtils.WaitForMigrationCleanup(1, cancellationToken: migrateToken.Token);
+            }
+
+            WaitForSlotOwnership(primary0, primary1, slot);
+
+            // Wait for more writes after migration
+            var countPostMigration = written.Count;
+            await Task.Delay(2_000).ConfigureAwait(false);
+            var countAfterPause = written.Count;
+
+            ClassicAssert.IsTrue(countAfterPause > countPostMigration, "Writes should resume after migration");
+
+            cts.Cancel();
+            await writeTask.ConfigureAwait(false);
+
+            // Write directly to the target after migration completes and verify readback
+            for (var i = 0; i < 5; i++)
+            {
+                var field = $"verify_field_{i}";
+                var value = $"verify_value_{i}";
+                var setRes = (string)context.clusterTestUtils.Execute(
+                    primary1, "RI.SET", [riKey, field, value],
+                    flags: CommandFlags.NoRedirect);
+                ClassicAssert.AreEqual("OK", setRes, $"RI.SET {field} should succeed on target after migration");
+
+                var getRes = (string)context.clusterTestUtils.Execute(
+                    primary1, "RI.GET", [riKey, field],
+                    flags: CommandFlags.NoRedirect);
+                ClassicAssert.AreEqual(value, getRes, $"RI.GET {field} should return correct value on target");
+            }
+        }
+
+        /// <summary>
+        /// Large RangeIndex migration that generates enough data to span multiple chunks
+        /// even at the default 256 KB chunk size. Verifies all data survives.
+        /// </summary>
+        [Test]
+        [Category("CLUSTER")]
+        [TestCase(1024)]          // 1 KB chunks — many chunks for large tree
+        [TestCase(256 * 1024)]    // default — still multiple chunks with enough data
+        [Explicit("Reproduces a BfTree native crash (mini_page_op/circular_buffer panic) during cluster migration; crashes the test host. Tracked for RangeIndex crash/recovery.")]
+        public void ClusterMigrateRangeIndexLargeTree(int chunkSize)
+        {
+            const int shards = 2;
+            const int fieldCount = 500;
+
+            context.CreateInstances(shards, enableRangeIndexPreview: true);
+            context.CreateConnection();
+
+            _ = context.clusterTestUtils.SimpleSetupCluster(logger: context.logger);
+
+            var primary0 = (IPEndPoint)context.clusterTestUtils.GetEndPoint(0);
+            var primary1 = (IPEndPoint)context.clusterTestUtils.GetEndPoint(1);
+            var primary0Id = context.clusterTestUtils.ClusterMyId(primary0);
+            var slots = context.clusterTestUtils.ClusterSlots(primary0);
+
+            var riKey = FindKeyOnNode($"{nameof(ClusterMigrateRangeIndexLargeTree)}_{chunkSize}", primary0Id, slots);
+            var slot = context.clusterTestUtils.HashSlot(riKey);
+
+            // Create RI with large data — 500 fields × ~1 KB values ≈ 500 KB of data
+            var rand = new Random(42);
+            var fields = new List<(string Field, string Value)>();
+            for (var i = 0; i < fieldCount; i++)
+            {
+                var valueBytes = new byte[512];
+                rand.NextBytes(valueBytes);
+                var value = Convert.ToBase64String(valueBytes);
+                fields.Add(($"field_{i:D5}", value));
+            }
+
+            // Use a larger max record size to accommodate the ~700-byte base64 values
+            var createResult = (string)context.clusterTestUtils.Execute(
+                primary0, "RI.CREATE",
+                [riKey, "DISK", "CACHESIZE", "65536", "MINRECORD", "8", "MAXRECORD", "1024"],
+                flags: CommandFlags.NoRedirect);
+            ClassicAssert.AreEqual("OK", createResult, "RI.CREATE should succeed");
+
+            foreach (var (field, value) in fields)
+            {
+                var setResult = (string)context.clusterTestUtils.Execute(
+                    primary0, "RI.SET", [riKey, field, value],
+                    flags: CommandFlags.NoRedirect);
+                ClassicAssert.AreEqual("OK", setResult, $"RI.SET should succeed for {field}");
+            }
+
+            // Verify a sample before migration
+            VerifyFieldsOnEndpoint(primary0, riKey, fields.Take(10));
+
+            // Migrate
+            context.clusterTestUtils.MigrateSlots(primary0, primary1, [slot]);
+            context.clusterTestUtils.WaitForMigrationCleanup(0);
+            context.clusterTestUtils.WaitForMigrationCleanup(1);
+
+            WaitForSlotOwnership(primary0, primary1, slot);
+
+            // Verify ALL fields on target — every single one must survive
+            VerifyFieldsOnEndpoint(primary1, riKey, fields);
+
+            // Verify source returns MOVED
+            var movedResult = (string)context.clusterTestUtils.Execute(
+                primary0, "RI.GET", [riKey, "field_00000"],
+                flags: CommandFlags.NoRedirect);
+            ClassicAssert.IsTrue(movedResult.StartsWith("Key has MOVED to "),
+                $"Expected MOVED from source, got: {movedResult}");
+        }
+
+        /// <summary>
+        /// Test concurrent RI.SET writes and RI.GET reads simultaneously during migration.
+        /// </summary>
+        [Test]
+        [Category("CLUSTER")]
+        [Explicit("Reproduces a BfTree native crash (mini_page_op/circular_buffer panic) during cluster migration; crashes the test host. Tracked for RangeIndex crash/recovery.")]
+        public async Task ClusterMigrateRangeIndexWhileReadingAndWritingAsync()
+        {
+            const int shards = 2;
+
+            context.CreateInstances(shards, enableRangeIndexPreview: true);
+            context.CreateConnection();
+
+            _ = context.clusterTestUtils.SimpleSetupCluster(logger: context.logger);
+
+            var primary0 = (IPEndPoint)context.clusterTestUtils.GetEndPoint(0);
+            var primary1 = (IPEndPoint)context.clusterTestUtils.GetEndPoint(1);
+            var primary0Id = context.clusterTestUtils.ClusterMyId(primary0);
+            var slots = context.clusterTestUtils.ClusterSlots(primary0);
+
+            var riKey = FindKeyOnNode(nameof(ClusterMigrateRangeIndexWhileReadingAndWritingAsync), primary0Id, slots);
+            var slot = context.clusterTestUtils.HashSlot(riKey);
+
+            // Create RI key and seed with initial data
+            var initialFields = Enumerable.Range(0, 50).Select(i => ($"field_{i}", $"value_{i}")).ToList();
+            CreateRangeIndexWithFields(primary0, riKey, initialFields);
+
+            using var cts = new CancellationTokenSource();
+            var written = new ConcurrentBag<(string Field, string Value)>();
+            var readErrors = new ConcurrentBag<string>();
+
+            // Background writer
+            var writeTask = Task.Run(async () =>
+            {
+                await Task.Yield();
+
+                using var con = ConnectionMultiplexer.Connect(context.clusterTestUtils.GetRedisConfig(context.endpoints));
+                var db = con.GetDatabase();
+                var ix = 1000;
+
+                while (!cts.IsCancellationRequested)
+                {
+                    var field = $"w_field_{ix}";
+                    var value = $"w_value_{ix}";
+
+                    try
+                    {
+                        var result = (string)db.Execute("RI.SET", [new RedisKey(riKey), field, value]);
+                        if (result == "OK")
+                            written.Add((field, value));
+                    }
+                    catch (Exception exc) when (
+                        exc is RedisTimeoutException
+                        || exc is RedisConnectionException
+                        || (exc is RedisServerException rse && (
+                            rse.Message.StartsWith("MOVED ")
+                            || rse.Message.StartsWith("Key has MOVED to "))))
+                    {
+                        continue;
+                    }
+
+                    ix++;
+                }
+            });
+
+            // Background reader (reads initial fields)
+            var readTask = Task.Run(async () =>
+            {
+                await Task.Yield();
+
+                using var con = ConnectionMultiplexer.Connect(context.clusterTestUtils.GetRedisConfig(context.endpoints));
+                var db = con.GetDatabase();
+
+                while (!cts.IsCancellationRequested)
+                {
+                    var ix = Random.Shared.Next(initialFields.Count);
+                    var (field, expectedValue) = initialFields[ix];
+
+                    try
+                    {
+                        var result = (string)db.Execute("RI.GET", [new RedisKey(riKey), field]);
+                        if (result != null && result != expectedValue)
+                            readErrors.Add($"RI.GET {field}: expected '{expectedValue}', got '{result}'");
+                    }
+                    catch (Exception exc) when (
+                        exc is RedisTimeoutException
+                        || exc is RedisConnectionException
+                        || (exc is RedisServerException rse && (
+                            rse.Message.StartsWith("MOVED ")
+                            || rse.Message.StartsWith("Key has MOVED to "))))
+                    {
+                        // Expected during migration
+                    }
+                }
+            });
+
+            await Task.Delay(1_000).ConfigureAwait(false);
+            ClassicAssert.IsTrue(written.Count > 0, "Should have some writes before migration");
+
+            // Migrate
+            using (var migrateToken = new CancellationTokenSource())
+            {
+                migrateToken.CancelAfter(30_000);
+                context.clusterTestUtils.MigrateSlots(primary0, primary1, [slot]);
+                context.clusterTestUtils.WaitForMigrationCleanup(0, cancellationToken: migrateToken.Token);
+                context.clusterTestUtils.WaitForMigrationCleanup(1, cancellationToken: migrateToken.Token);
+            }
+
+            WaitForSlotOwnership(primary0, primary1, slot);
+
+            // Let reads + writes continue post-migration
+            await Task.Delay(2_000).ConfigureAwait(false);
+
+            cts.Cancel();
+            await Task.WhenAll(writeTask, readTask).ConfigureAwait(false);
+
+            ClassicAssert.IsEmpty(readErrors, $"Read value mismatches: {string.Join("; ", readErrors.Take(5))}");
+
+            // Verify initial fields on target
+            VerifyFieldsOnEndpoint(primary1, riKey, initialFields);
+
+            // Verify we can still write on target after migration
+            for (var i = 0; i < 5; i++)
+            {
+                var field = $"post_migrate_{i}";
+                var value = $"post_value_{i}";
+                var setRes = (string)context.clusterTestUtils.Execute(
+                    primary1, "RI.SET", [riKey, field, value],
+                    flags: CommandFlags.NoRedirect);
+                ClassicAssert.AreEqual("OK", setRes);
+
+                var getRes = (string)context.clusterTestUtils.Execute(
+                    primary1, "RI.GET", [riKey, field],
+                    flags: CommandFlags.NoRedirect);
+                ClassicAssert.AreEqual(value, getRes);
+            }
+        }
+
+#if DEBUG
+        /// <summary>
+        /// Slow-transmit test: pause before each transmit to widen the race window,
+        /// while concurrent readers and writers are active.
+        /// Verifies no deadlocks and data integrity.
+        /// </summary>
+        [Test]
+        [Category("CLUSTER")]
+        [Explicit("Reproduces a BfTree native crash (mini_page_op/circular_buffer panic) during cluster migration; crashes the test host. Tracked for RangeIndex crash/recovery.")]
+        public async Task ClusterMigrateRangeIndexSlowTransmitWithConcurrentOpsAsync()
+        {
+            const int shards = 2;
+
+            context.CreateInstances(shards, enableRangeIndexPreview: true);
+            context.CreateConnection();
+
+            _ = context.clusterTestUtils.SimpleSetupCluster(logger: context.logger);
+
+            var primary0 = (IPEndPoint)context.clusterTestUtils.GetEndPoint(0);
+            var primary1 = (IPEndPoint)context.clusterTestUtils.GetEndPoint(1);
+            var primary0Id = context.clusterTestUtils.ClusterMyId(primary0);
+            var slots = context.clusterTestUtils.ClusterSlots(primary0);
+
+            var riKey = FindKeyOnNode(nameof(ClusterMigrateRangeIndexSlowTransmitWithConcurrentOpsAsync), primary0Id, slots);
+            var slot = context.clusterTestUtils.HashSlot(riKey);
+
+            // Create RI key with data
+            var fields = Enumerable.Range(0, 50).Select(i => ($"field_{i}", $"value_{i}")).ToList();
+            CreateRangeIndexWithFields(primary0, riKey, fields);
+
+            using var cts = new CancellationTokenSource();
+            var written = new ConcurrentBag<(string Field, string Value)>();
+            var readErrors = new ConcurrentBag<string>();
+
+            // Background writer
+            var writeTask = Task.Run(async () =>
+            {
+                await Task.Yield();
+
+                using var con = ConnectionMultiplexer.Connect(context.clusterTestUtils.GetRedisConfig(context.endpoints));
+                var db = con.GetDatabase();
+                var ix = 5000;
+
+                while (!cts.IsCancellationRequested)
+                {
+                    try
+                    {
+                        var field = $"slow_w_{ix}";
+                        var value = $"slow_v_{ix}";
+                        var result = (string)db.Execute("RI.SET", [new RedisKey(riKey), field, value]);
+                        if (result == "OK")
+                            written.Add((field, value));
+                    }
+                    catch (Exception exc) when (
+                        exc is RedisTimeoutException
+                        || exc is RedisConnectionException
+                        || (exc is RedisServerException rse && (
+                            rse.Message.StartsWith("MOVED ")
+                            || rse.Message.StartsWith("Key has MOVED to "))))
+                    {
+                        continue;
+                    }
+
+                    ix++;
+                }
+            });
+
+            // Background reader
+            var readTask = Task.Run(async () =>
+            {
+                await Task.Yield();
+
+                using var con = ConnectionMultiplexer.Connect(context.clusterTestUtils.GetRedisConfig(context.endpoints));
+                var db = con.GetDatabase();
+
+                while (!cts.IsCancellationRequested)
+                {
+                    var ix = Random.Shared.Next(fields.Count);
+                    var (field, expectedValue) = fields[ix];
+
+                    try
+                    {
+                        var result = (string)db.Execute("RI.GET", [new RedisKey(riKey), field]);
+                        if (result != null && result != expectedValue)
+                            readErrors.Add($"RI.GET {field}: expected '{expectedValue}', got '{result}'");
+                    }
+                    catch (Exception exc) when (
+                        exc is RedisTimeoutException
+                        || exc is RedisConnectionException
+                        || (exc is RedisServerException rse && (
+                            rse.Message.StartsWith("MOVED ")
+                            || rse.Message.StartsWith("Key has MOVED to "))))
+                    {
+                        // Expected during migration
+                    }
+                }
+            });
+
+            // Let readers + writers start up
+            await Task.Delay(500).ConfigureAwait(false);
+
+            // Arm pause hook to slow down the transmit phase
+            ExceptionInjectionHelper.EnableException(ExceptionInjectionType.RangeIndex_Migration_After_Transmitting);
+
+            try
+            {
+                var migrateTask = Task.Run(async () =>
+                {
+                    context.clusterTestUtils.MigrateSlots(primary0, primary1, [slot]);
+                    await Task.CompletedTask;
+                });
+
+                // Wait for migration to hit the pause point
+                var deadline = Stopwatch.GetTimestamp();
+                while (ExceptionInjectionHelper.IsEnabled(ExceptionInjectionType.RangeIndex_Migration_After_Transmitting)
+                       && Stopwatch.GetElapsedTime(deadline) < TimeSpan.FromSeconds(15))
+                {
+                    await Task.Delay(100).ConfigureAwait(false);
+                }
+
+                // Paused in TRANSMITTING — let concurrent ops run for a bit
+                await Task.Delay(2_000).ConfigureAwait(false);
+
+                // Resume
+                ExceptionInjectionHelper.EnableException(ExceptionInjectionType.RangeIndex_Migration_After_Transmitting);
+
+                await migrateTask.WaitAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+                context.clusterTestUtils.WaitForMigrationCleanup(logger: context.logger);
+
+                WaitForSlotOwnership(primary0, primary1, slot);
+
+                // Let ops run post-migration
+                await Task.Delay(1_000).ConfigureAwait(false);
+
+                cts.Cancel();
+                await Task.WhenAll(writeTask, readTask).ConfigureAwait(false);
+
+                ClassicAssert.IsEmpty(readErrors, $"Read mismatches: {string.Join("; ", readErrors.Take(5))}");
+
+                // Verify initial fields on target
+                VerifyFieldsOnEndpoint(primary1, riKey, fields);
+            }
+            finally
+            {
+                ExceptionInjectionHelper.DisableException(ExceptionInjectionType.RangeIndex_Migration_After_Transmitting);
+            }
+        }
+#endif
+    }
+}

--- a/test/cluster/Garnet.test.cluster.migrate.rangeindex/ClusterRangeIndexMigrateTests.cs
+++ b/test/cluster/Garnet.test.cluster.migrate.rangeindex/ClusterRangeIndexMigrateTests.cs
@@ -22,7 +22,7 @@ using StackExchange.Redis;
 namespace Garnet.test.cluster
 {
     [TestFixture, NonParallelizable]
-    public class ClusterRangeIndexMigrateTests : TestBase
+    public partial class ClusterRangeIndexMigrateTests : TestBase
     {
         ClusterTestContext context;
         readonly int defaultShards = 3;

--- a/test/standalone/Garnet.test.rangeindex/RangeIndexConcurrentDeleteRepro.cs
+++ b/test/standalone/Garnet.test.rangeindex/RangeIndexConcurrentDeleteRepro.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using StackExchange.Redis;
+
+namespace Garnet.test
+{
+    /// <summary>
+    /// Repros for BfTree lifecycle-vs-data-op concurrency bugs that are NOT migration-specific:
+    /// a whole-key <c>DEL</c> drives the exact same <c>DisposeTreeUnderLock</c> path as
+    /// <c>MigrateOperation.DeleteRangeIndex</c>, so concurrent <c>RI.SET</c> + whole-key <c>DEL</c>
+    /// exercises the same drop/insert interaction discovered during cluster-migration testing.
+    ///
+    /// <para>Both tests are <see cref="ExplicitAttribute"/>: they currently crash or hang by
+    /// design (they reproduce open bugs) and must not run in CI until the underlying issues are
+    /// fixed. They are intended to become passing regression tests once the fixes land.</para>
+    /// </summary>
+    [TestFixture]
+    public class RangeIndexConcurrentDeleteRepro : TestBase
+    {
+        GarnetServer server;
+
+        [SetUp]
+        public void Setup()
+        {
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableRangeIndexPreview: true);
+            server.Start();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            server.Dispose();
+            TestUtils.OnTearDown();
+        }
+
+        /// <summary>
+        /// Race repro: concurrent <c>RI.SET</c> while another client repeatedly does a whole-key
+        /// <c>DEL</c> (which drops the native BfTree via a deferred epoch dispose) + <c>RI.CREATE</c>.
+        /// The deferred <c>bftree_drop</c> can race a concurrent <c>InsertByPtr</c> that runs under
+        /// the shared lock but OUTSIDE epoch protection — a native use-after-free
+        /// (bf-tree panic: <c>mini_page_op.rs</c> / <c>circular_buffer/mod.rs</c> assertion).
+        /// </summary>
+        [Test]
+        [Explicit("Repro for the BfTree drop-vs-insert use-after-free; crashes the process by design.")]
+        public async Task ConcurrentSetAndWholeKeyDeleteRepro()
+        {
+            const string key = "myindex";
+            const int writerCount = 4;
+            var runFor = TimeSpan.FromSeconds(5);
+
+            using var seed = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            seed.GetDatabase(0).Execute("RI.CREATE", key, "DISK", "CACHESIZE", "65536", "MINRECORD", "8");
+
+            using var cts = new CancellationTokenSource(runFor);
+
+            // Writers: RI.SET in a loop with a tiny pause so the deleter's exclusive lock is not
+            // starved. A "no such range index" error is expected right after a DEL — treat benign.
+            var writers = new Task[writerCount];
+            for (var w = 0; w < writerCount; w++)
+            {
+                var id = w;
+                writers[w] = Task.Run(() =>
+                {
+                    using var conn = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+                    var db = conn.GetDatabase(0);
+                    var i = 0;
+                    while (!cts.IsCancellationRequested)
+                    {
+                        try
+                        {
+                            db.Execute("RI.SET", key, $"field_{id}_{i:D6}", $"value_{id}_{i:D6}");
+                        }
+                        catch (RedisServerException)
+                        {
+                            // index missing (deleter ran) or size error — benign for this repro
+                        }
+                        i++;
+                        if ((i & 0x3F) == 0)
+                            Thread.Sleep(1);
+                    }
+                });
+            }
+
+            // Deleter: continuously DEL the whole key (drops the tree) then recreate it.
+            var deleter = Task.Run(() =>
+            {
+                using var conn = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+                var db = conn.GetDatabase(0);
+                while (!cts.IsCancellationRequested)
+                {
+                    try
+                    {
+                        db.KeyDelete(key);
+                        db.Execute("RI.CREATE", key, "DISK", "CACHESIZE", "65536", "MINRECORD", "8");
+                    }
+                    catch (RedisServerException)
+                    {
+                        // RI.CREATE may race another recreate — benign
+                    }
+                    Thread.Sleep(2);
+                }
+            });
+
+            await Task.WhenAll(writers).ConfigureAwait(false);
+            await deleter.ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Livelock repro: many writers continuously hold the per-key SHARED RangeIndex lock
+        /// (RI.SET) with no pause, while a deleter needs the per-key EXCLUSIVE lock (whole-key
+        /// <c>DEL</c> → <c>DisposeTreeUnderLock</c>). The read-optimized lock's exclusive
+        /// acquisition spins per-core CAS waiting for all shared holders to drain; under sustained
+        /// shared traffic the exclusive acquisition is starved and the <c>DEL</c> never makes
+        /// progress, hanging the operation. A livelock under normal client traffic is not an
+        /// acceptable signal and should be guarded against.
+        /// </summary>
+        [Test]
+        [Explicit("Repro for exclusive-lock starvation under sustained RI.SET traffic; hangs by design.")]
+        public async Task ConcurrentSetStarvesWholeKeyDeleteRepro()
+        {
+            const string key = "myindex";
+            const int writerCount = 8;
+            var runFor = TimeSpan.FromSeconds(8);
+
+            using var seed = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            seed.GetDatabase(0).Execute("RI.CREATE", key, "DISK", "CACHESIZE", "65536", "MINRECORD", "8");
+
+            using var cts = new CancellationTokenSource(runFor);
+
+            // Writers: hammer RI.SET with zero pause to keep the shared lock continuously busy.
+            var writers = new Task[writerCount];
+            for (var w = 0; w < writerCount; w++)
+            {
+                var id = w;
+                writers[w] = Task.Run(() =>
+                {
+                    using var conn = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+                    var db = conn.GetDatabase(0);
+                    var i = 0;
+                    while (!cts.IsCancellationRequested)
+                    {
+                        try
+                        {
+                            db.Execute("RI.SET", key, $"field_{id}_{i:D6}", $"value_{id}_{i:D6}");
+                        }
+                        catch (RedisServerException)
+                        {
+                            // index missing (deleter ran) or size error — benign for this repro
+                        }
+                        i++;
+                    }
+                });
+            }
+
+            // Deleter: whole-key DEL that should complete promptly but can be starved by the
+            // continuous shared-lock traffic above.
+            var deleter = Task.Run(() =>
+            {
+                using var conn = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+                var db = conn.GetDatabase(0);
+                while (!cts.IsCancellationRequested)
+                {
+                    try
+                    {
+                        db.KeyDelete(key);
+                        db.Execute("RI.CREATE", key, "DISK", "CACHESIZE", "65536", "MINRECORD", "8");
+                    }
+                    catch (RedisServerException)
+                    {
+                        // RI.CREATE may race another recreate — benign
+                    }
+                }
+            });
+
+            await Task.WhenAll(writers).ConfigureAwait(false);
+            await deleter.ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
## What

Collects the RangeIndex (BfTree) crash/recovery repro tests in one place, **all marked `[Explicit]`** so they don't run in CI (they crash/hang by design). They become passing regression tests once the underlying issues are fixed. Base is `tiagonapoli/bftree-migration` because the cluster repros need the migration feature.

## Cluster-migration crash repros
New partial-class file `ClusterRangeIndexMigrateTests.Crashes.cs` (split out so the main migration suite stays crash-free and green). The main test class is made `partial` to host it.

- **`WhileModifyingAsync` / `WhileReadingAndWritingAsync` / `SlowTransmitWithConcurrentOpsAsync`** — drop-vs-insert **use-after-free**. The deferred `bftree_drop` (queued by `DisposeTreeUnderLock` and run via `BumpCurrentEpoch` *outside* the per-key exclusive lock) races a concurrent `InsertByPtr` that runs under the **shared** lock but *outside* store-epoch protection. Native panic (`mini_page_op.rs` / `circular_buffer/mod.rs` assertion) aborts the process.
- **`LargeTree`** — **concurrency-independent** crash: a single-threaded migration of a large multi-page tree crashes during snapshot/drop. Distinct, arguably more serious root cause.

## Standalone repros (migration-independent)
`RangeIndexConcurrentDeleteRepro.cs` proves these are not migration-specific — a whole-key `DEL` drives the same `DisposeTreeUnderLock` → deferred `bftree_drop` path as `MigrateOperation.DeleteRangeIndex`.

- **`ConcurrentSetAndWholeKeyDeleteRepro`** — the drop-vs-insert use-after-free.
- **`ConcurrentSetStarvesWholeKeyDeleteRepro`** — exclusive-lock starvation / livelock (sustained `RI.SET` shared-lock traffic starves the whole-key `DEL`'s exclusive-lock acquisition).

## Notes
- These 4 cluster tests were removed from `bftree-migration` (the feature branch) in its own commit; that suite now runs green (19/19). They live here for tracking.
- Root cause is structural: the per-key lock and the store epoch each only half-cover the native BfTree calls, and `DEL` / eviction / migration-delete all share that path.

🤖 Generated with [GitHub Copilot CLI](https://gh.io/copilot-cli)
