### PR TITLE
Impose 512M maximum on RESP elements in RespReadUtils

### DIFF
--- a/libs/client/RespReadResponseUtils.cs
+++ b/libs/client/RespReadResponseUtils.cs
@@ -120,7 +120,7 @@ namespace Garnet.client
         static bool TryReadPtrWithSignedLengthHeader(ref byte* keyPtr, ref int length, ref byte* ptr, byte* end)
         {
             // Parse RESP string header
-            if (!RespReadUtils.TryReadSignedLengthHeader(out length, ref ptr, end))
+            if (!RespReadUtils.TryReadSignedLengthHeader(out length, ref ptr, end) || length > RespReadUtils.MaxArgumentLengthBytes)
             {
                 return false;
             }

--- a/libs/common/RespReadUtils.cs
+++ b/libs/common/RespReadUtils.cs
@@ -17,6 +17,13 @@ namespace Garnet.common
     public static unsafe class RespReadUtils
     {
         /// <summary>
+        /// Maximum size a single RESP element can be.
+        /// 
+        /// This matches the default Redis max string size of 512MB.
+        /// </summary>
+        public const int MaxArgumentLengthBytes = 512 * 1_024 * 1_024;
+
+        /// <summary>
         /// Tries to read the leading sign of the given ASCII-encoded number.
         /// </summary>
         /// <param name="ptr">String to try reading sign from.</param>
@@ -690,7 +697,7 @@ namespace Garnet.common
         public static bool TrySkipByteArrayWithLengthHeader(ref byte* ptr, byte* end)
         {
             // Parse RESP string header
-            if (!TryReadUnsignedLengthHeader(out var length, ref ptr, end))
+            if (!TryReadUnsignedLengthHeader(out var length, ref ptr, end) || length > RespReadUtils.MaxArgumentLengthBytes)
                 return false;
 
             // Advance read pointer to the end of the array (including terminator)
@@ -753,7 +760,7 @@ namespace Garnet.common
             result = default;
 
             // Parse RESP string header
-            if (!TryReadUnsignedLengthHeader(out var length, ref ptr, end))
+            if (!TryReadUnsignedLengthHeader(out var length, ref ptr, end) || length > RespReadUtils.MaxArgumentLengthBytes)
                 return false;
 
             // Advance read pointer to the end of the array (including terminator)
@@ -860,7 +867,7 @@ namespace Garnet.common
                 return false;
 
             // Parse RESP string header
-            if (!TryReadUnsignedLengthHeader(out var length, ref ptr, end))
+            if (!TryReadUnsignedLengthHeader(out var length, ref ptr, end) || length > RespReadUtils.MaxArgumentLengthBytes)
                 return false;
 
             // Extract string content + '\r\n' terminator
@@ -925,7 +932,7 @@ namespace Garnet.common
         public static bool TryReadPtrWithSignedLengthHeader(ref byte* stringPtr, ref int length, ref byte* ptr, byte* end)
         {
             // Parse RESP string header
-            if (!TryReadSignedLengthHeader(out length, ref ptr, end))
+            if (!TryReadSignedLengthHeader(out length, ref ptr, end) || length > RespReadUtils.MaxArgumentLengthBytes)
             {
                 return false;
             }
@@ -1148,7 +1155,7 @@ namespace Garnet.common
         public static bool TryReadPtrWithLengthHeader(ref byte* result, ref int len, ref byte* ptr, byte* end)
         {
             // Parse RESP string header
-            if (!TryReadUnsignedLengthHeader(out len, ref ptr, end))
+            if (!TryReadUnsignedLengthHeader(out len, ref ptr, end) || len > RespReadUtils.MaxArgumentLengthBytes)
             {
                 return false;
             }

--- a/libs/server/Resp/Parser/SessionParseState.cs
+++ b/libs/server/Resp/Parser/SessionParseState.cs
@@ -347,7 +347,7 @@ namespace Garnet.server
             ref var slice = ref Unsafe.AsRef<PinnedSpanByte>(bufferPtr + i);
 
             // Parse RESP string header
-            if (!RespReadUtils.TryReadUnsignedLengthHeader(out var length, ref ptr, end))
+            if (!RespReadUtils.TryReadUnsignedLengthHeader(out var length, ref ptr, end) || length > RespReadUtils.MaxArgumentLengthBytes)
                 return false;
             slice.Set(ptr, length);
 

--- a/test/standalone/Garnet.test/Resp/RespReadUtilsTests.cs
+++ b/test/standalone/Garnet.test/Resp/RespReadUtilsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Text;
 using Garnet.common;
 using Garnet.common.Parsing;
@@ -378,6 +379,111 @@ namespace Garnet.test.Resp
 
                 ClassicAssert.IsFalse(success);
                 ClassicAssert.AreEqual(0, recordSpan.Length);
+            }
+        }
+
+        [Test]
+        public static unsafe void RejectOversizedLengths()
+        {
+            var bigBuffer = GC.AllocateUninitializedArray<byte>(RespReadUtils.MaxArgumentLengthBytes + 1, pinned: true);
+
+            var smallToCopy = Encoding.ASCII.GetBytes("$1234\r\n" + new string('a', 1234) + "\r\n");
+            var bigToCopy = "$536870913\r\n"u8;
+
+            fixed (byte* startPtr = bigBuffer)
+            {
+                var endPtr = startPtr + bigBuffer.Length;
+
+                // TryReadPtrWithSignedLengthHeader
+                {
+                    // Pass in bounds
+                    var ptr = startPtr;
+                    smallToCopy.CopyTo(new Span<byte>(startPtr, bigBuffer.Length));
+
+                    var len = 0;
+                    byte* outPtr = null;
+                    ClassicAssert.True(RespReadUtils.TryReadPtrWithSignedLengthHeader(ref outPtr, ref len, ref ptr, endPtr));
+                    ClassicAssert.True(outPtr == (startPtr + 7));
+                    ClassicAssert.AreEqual(1234, len);
+                    ClassicAssert.True(ptr == (outPtr + len + 2));
+
+                    // Fail too big
+                    ptr = startPtr;
+
+                    len = 0;
+                    outPtr = null;
+                    bigToCopy.CopyTo(new Span<byte>(startPtr, bigBuffer.Length));
+                    ClassicAssert.False(RespReadUtils.TryReadPtrWithSignedLengthHeader(ref outPtr, ref len, ref ptr, endPtr));
+                }
+
+                // TrySkipByteArrayWithLengthHeader
+                {
+                    // Pass in bounds
+                    var ptr = startPtr;
+                    smallToCopy.CopyTo(new Span<byte>(startPtr, bigBuffer.Length));
+
+                    ClassicAssert.True(RespReadUtils.TrySkipByteArrayWithLengthHeader(ref ptr, endPtr));
+                    ClassicAssert.True(ptr == (startPtr + 7 + 1234 + 2));
+
+                    // Fail too big
+                    ptr = startPtr;
+                    bigToCopy.CopyTo(new Span<byte>(startPtr, bigBuffer.Length));
+                    ClassicAssert.False(RespReadUtils.TrySkipByteArrayWithLengthHeader(ref ptr, endPtr));
+                }
+
+                // TrySliceWithLengthHeader
+                {
+                    // Pass in bounds
+                    var ptr = startPtr;
+                    smallToCopy.CopyTo(new Span<byte>(startPtr, bigBuffer.Length));
+
+                    ClassicAssert.True(RespReadUtils.TrySliceWithLengthHeader(out var slice, ref ptr, endPtr));
+                    ClassicAssert.AreEqual(1234, slice.Length);
+                    ClassicAssert.True(ptr == (startPtr + 7 + slice.Length + 2));
+
+                    // Fail too big
+                    ptr = startPtr;
+                    bigToCopy.CopyTo(new Span<byte>(startPtr, bigBuffer.Length));
+                    ClassicAssert.False(RespReadUtils.TrySliceWithLengthHeader(out slice, ref ptr, endPtr));
+                }
+
+                // TryReadSpanWithLengthHeader
+                {
+                    // Pass in bounds
+                    var ptr = startPtr;
+                    smallToCopy.CopyTo(new Span<byte>(startPtr, bigBuffer.Length));
+
+                    ClassicAssert.True(RespReadUtils.TryReadSpanWithLengthHeader(out var slice, ref ptr, endPtr));
+                    ClassicAssert.AreEqual(1234, slice.Length);
+                    ClassicAssert.True(ptr == (startPtr + 7 + slice.Length + 2));
+
+                    // Fail too big
+                    ptr = startPtr;
+                    bigToCopy.CopyTo(new Span<byte>(startPtr, bigBuffer.Length));
+                    ClassicAssert.False(RespReadUtils.TryReadSpanWithLengthHeader(out slice, ref ptr, endPtr));
+                }
+
+                // TryReadPtrWithLengthHeader
+                {
+                    // Pass in bounds
+                    var ptr = startPtr;
+                    smallToCopy.CopyTo(new Span<byte>(startPtr, bigBuffer.Length));
+
+                    var len = 0;
+                    byte* resultPtr = null;
+                    ClassicAssert.True(RespReadUtils.TryReadPtrWithLengthHeader(ref resultPtr, ref len, ref ptr, endPtr));
+                    ClassicAssert.True(resultPtr == (startPtr + 7));
+                    ClassicAssert.AreEqual(1234, len);
+                    ClassicAssert.True(ptr == (startPtr + 7 + len + 2));
+
+                    // Fail too big
+                    ptr = startPtr;
+                    
+                    len = 0;
+                    resultPtr = null;
+                    bigToCopy.CopyTo(new Span<byte>(startPtr, bigBuffer.Length));
+                    ClassicAssert.False(RespReadUtils.TryReadPtrWithLengthHeader(ref resultPtr, ref len, ref ptr, endPtr));
+                }
             }
         }
     }

--- a/test/standalone/Garnet.test/Resp/RespReadUtilsTests.cs
+++ b/test/standalone/Garnet.test/Resp/RespReadUtilsTests.cs
@@ -478,7 +478,7 @@ namespace Garnet.test.Resp
 
                     // Fail too big
                     ptr = startPtr;
-                    
+
                     len = 0;
                     resultPtr = null;
                     bigToCopy.CopyTo(new Span<byte>(startPtr, bigBuffer.Length));


### PR DESCRIPTION
There are a number of places where we parse a length and then slam it into a pointer.

Generally this gets dicey with large numbers, and we don't actually expect requests where single elements are hundreds of megabytes to succeed.  A reasonable limit is the Redis string max length, or 512 megabytes.

We may want to revisit this later to fail requests streams more gracefully, but for now this just blanket "returns false" if we're about to get in trouble.