### PR TITLE
[RangeIndex] Replace busy-spin snapshot claim with SemaphoreSlim to avoid CPU spikes

### DIFF
--- a/libs/common/Testing/ExceptionInjectionHelper.cs
+++ b/libs/common/Testing/ExceptionInjectionHelper.cs
@@ -150,8 +150,7 @@ namespace Garnet.common
         }
 
         /// <summary>
-        /// Blocks (not busy-spinning) until <paramref name="exceptionType"/> is disabled,
-        /// consuming negligible CPU.
+        /// Blocks until <paramref name="exceptionType"/> is disabled.
         /// </summary>
         /// <param name="exceptionType"></param>
         public static void WaitOnClearWithThreadSleep(ExceptionInjectionType exceptionType)

--- a/libs/common/Testing/ExceptionInjectionHelper.cs
+++ b/libs/common/Testing/ExceptionInjectionHelper.cs
@@ -150,6 +150,19 @@ namespace Garnet.common
         }
 
         /// <summary>
+        /// Block (without busy-spinning) while the given injection is enabled, returning once it
+        /// is disabled. Unlike <see cref="WaitOnClear"/> this consumes negligible CPU while
+        /// waiting (1 ms polling sleeps), so any significant CPU observed during the wait is
+        /// attributable to other (busy-spinning) threads.
+        /// </summary>
+        /// <param name="exceptionType"></param>
+        public static void WaitOnClearBlocking(ExceptionInjectionType exceptionType)
+        {
+            while (IsEnabled(exceptionType))
+                Thread.Sleep(1);
+        }
+
+        /// <summary>
         /// Wait on clear condition
         /// </summary>
         /// <param name="exceptionType"></param>

--- a/libs/common/Testing/ExceptionInjectionHelper.cs
+++ b/libs/common/Testing/ExceptionInjectionHelper.cs
@@ -151,12 +151,10 @@ namespace Garnet.common
 
         /// <summary>
         /// Blocks (not busy-spinning) until <paramref name="exceptionType"/> is disabled,
-        /// consuming negligible CPU. Test-only: lets a holder park so any CPU observed during the
-        /// wait is attributable to other (busy-spinning) threads. Polls with short sleeps, so the
-        /// disable is noticed within roughly one OS timer tick (~15 ms on Windows).
+        /// consuming negligible CPU.
         /// </summary>
         /// <param name="exceptionType"></param>
-        public static void WaitOnClearBlocking(ExceptionInjectionType exceptionType)
+        public static void WaitOnClearWithThreadSleep(ExceptionInjectionType exceptionType)
         {
             while (IsEnabled(exceptionType))
                 Thread.Sleep(1);

--- a/libs/common/Testing/ExceptionInjectionHelper.cs
+++ b/libs/common/Testing/ExceptionInjectionHelper.cs
@@ -150,10 +150,10 @@ namespace Garnet.common
         }
 
         /// <summary>
-        /// Block (without busy-spinning) while the given injection is enabled, returning once it
-        /// is disabled. Unlike <see cref="WaitOnClear"/> this consumes negligible CPU while
-        /// waiting (1 ms polling sleeps), so any significant CPU observed during the wait is
-        /// attributable to other (busy-spinning) threads.
+        /// Blocks (not busy-spinning) until <paramref name="exceptionType"/> is disabled,
+        /// consuming negligible CPU. Test-only: lets a holder park so any CPU observed during the
+        /// wait is attributable to other (busy-spinning) threads. Polls with short sleeps, so the
+        /// disable is noticed within roughly one OS timer tick (~15 ms on Windows).
         /// </summary>
         /// <param name="exceptionType"></param>
         public static void WaitOnClearBlocking(ExceptionInjectionType exceptionType)

--- a/libs/common/Testing/ExceptionInjectionType.cs
+++ b/libs/common/Testing/ExceptionInjectionType.cs
@@ -112,5 +112,11 @@ namespace Garnet.common
         /// in-flight ProcessRecord.
         /// </summary>
         RangeIndex_Migration_Receive_Pause_In_ProcessRecord,
+        /// <summary>
+        /// RangeIndex CPR snapshot: while enabled, the snapshot holds the per-tree snapshot claim
+        /// (blocking, no CPU) to emulate a slow <c>cpr_snapshot</c>. A concurrent snapshot on the
+        /// same tree (e.g. migration) busy-spins on the claim, reproducing the high-CPU spin.
+        /// </summary>
+        RangeIndex_Snapshot_Inject_Latency,
     }
 }

--- a/libs/common/Testing/ExceptionInjectionType.cs
+++ b/libs/common/Testing/ExceptionInjectionType.cs
@@ -113,9 +113,9 @@ namespace Garnet.common
         /// </summary>
         RangeIndex_Migration_Receive_Pause_In_ProcessRecord,
         /// <summary>
-        /// RangeIndex CPR snapshot: while enabled, the snapshot holds the per-tree snapshot claim
-        /// (blocking, no CPU) to emulate a slow <c>cpr_snapshot</c>. A concurrent snapshot on the
-        /// same tree (e.g. migration) busy-spins on the claim, reproducing the high-CPU spin.
+        /// RangeIndex CPR snapshot: while enabled, the snapshot holds the per-tree snapshot lock
+        /// (blocking, no CPU) to emulate a slow <c>cpr_snapshot</c>, so a test can observe how
+        /// concurrent snapshots on the same tree (e.g. migration) behave under contention.
         /// </summary>
         RangeIndex_Snapshot_Inject_Latency,
     }

--- a/libs/server/Resp/RangeIndex/RangeIndexManager.cs
+++ b/libs/server/Resp/RangeIndex/RangeIndexManager.cs
@@ -157,20 +157,14 @@ namespace Garnet.server
             public int SnapshotPending;
 
             /// <summary>
-            /// Per-tree snapshot serialization lock (binary semaphore). Held while a CPR snapshot
-            /// of this tree is in flight, so concurrent snapshot producers — <see cref="GarnetRecordTriggers.OnFlush"/>,
-            /// <see cref="SnapshotAllTreesForCheckpoint"/>, and migration — do not race for bftree's
-            /// internal <c>snapshot_in_progress</c> flag (which would silently no-op one of them).
-            ///
-            /// <para>A semaphore (not a spin/CAS) because the critical section is a full CPR
-            /// snapshot, which is multi-second — waiters must block, not busy-spin, to avoid
-            /// burning a core each. A <c>SemaphoreSlim</c> (rather than <c>lock</c>/Monitor) keeps
-            /// the door open to an async snapshot path (<c>WaitAsync</c>) in the future.</para>
-            ///
-            /// <para>Intentionally not disposed: <see cref="TreeEntry"/> has no disposal lifecycle,
-            /// and the semaphore holds no unmanaged handle (its <c>AvailableWaitHandle</c> is never
-            /// used), so the GC reclaims it. This also avoids a dispose-vs-in-flight-snapshot race.
-            /// Mirrors <c>CollectionItemObserver.ResultFoundSemaphore</c>.</para>
+            /// Per-tree snapshot serialization lock. Held while a CPR snapshot of this tree is in
+            /// flight so concurrent producers (<see cref="GarnetRecordTriggers.OnFlush"/>,
+            /// <see cref="SnapshotAllTreesForCheckpoint"/>, migration) don't race bftree's internal
+            /// <c>snapshot_in_progress</c> flag (which would silently no-op one). A blocking lock,
+            /// not a spin, because a CPR snapshot is multi-second; <c>SemaphoreSlim</c> (over
+            /// <c>lock</c>) leaves an async (<c>WaitAsync</c>) path open. Intentionally not disposed
+            /// (no unmanaged handle since <c>AvailableWaitHandle</c> is unused), mirroring
+            /// <c>CollectionItemObserver.ResultFoundSemaphore</c>.
             /// </summary>
             private readonly SemaphoreSlim snapshotLock = new(1, 1);
 

--- a/libs/server/Resp/RangeIndex/RangeIndexManager.cs
+++ b/libs/server/Resp/RangeIndex/RangeIndexManager.cs
@@ -157,14 +157,7 @@ namespace Garnet.server
             public int SnapshotPending;
 
             /// <summary>
-            /// Per-tree snapshot serialization lock. Held while a CPR snapshot of this tree is in
-            /// flight so concurrent producers (<see cref="GarnetRecordTriggers.OnFlush"/>,
-            /// <see cref="SnapshotAllTreesForCheckpoint"/>, migration) don't race bftree's internal
-            /// <c>snapshot_in_progress</c> flag (which would silently no-op one). A blocking lock,
-            /// not a spin, because a CPR snapshot is multi-second; <c>SemaphoreSlim</c> (over
-            /// <c>lock</c>) leaves an async (<c>WaitAsync</c>) path open. Intentionally not disposed
-            /// (no unmanaged handle since <c>AvailableWaitHandle</c> is unused), mirroring
-            /// <c>CollectionItemObserver.ResultFoundSemaphore</c>.
+            /// Serializes CPR snapshots of this tree; concurrent snapshots are not allowed.
             /// </summary>
             private readonly SemaphoreSlim snapshotLock = new(1, 1);
 

--- a/libs/server/Resp/RangeIndex/RangeIndexManager.cs
+++ b/libs/server/Resp/RangeIndex/RangeIndexManager.cs
@@ -186,11 +186,6 @@ namespace Garnet.server
                 snapshotLock.Wait();
                 try
                 {
-                    // Test-only latency injection: while enabled, hold the per-tree snapshot lock
-                    // (blocking, negligible CPU) to emulate a slow cpr_snapshot. Concurrent
-                    // SnapshotUnderClaim callers on the same tree (e.g. migration) block on the
-                    // semaphore above rather than busy-spinning. No-op in Release and whenever the
-                    // injection is disabled.
                     ExceptionInjectionHelper.WaitOnClearBlocking(ExceptionInjectionType.RangeIndex_Snapshot_Inject_Latency);
                     BfTreeService.CprSnapshotByPtr(Tree.NativePtr, destinationPath);
                 }

--- a/libs/server/Resp/RangeIndex/RangeIndexManager.cs
+++ b/libs/server/Resp/RangeIndex/RangeIndexManager.cs
@@ -168,11 +168,8 @@ namespace Garnet.server
             internal bool IsSnapshotInProgressForTest => snapshotLock.CurrentCount == 0;
 
             /// <summary>
-            /// Under the per-tree snapshot lock, take a CPR snapshot of the live tree straight into
-            /// <paramref name="destinationPath"/>. The lock serializes concurrent flush / checkpoint
-            /// / migration snapshots so they don't race bftree's internal <c>snapshot_in_progress</c>
-            /// flag (which would silently no-op one). bftree writes a fresh self-contained file at
-            /// the given path.
+            /// Under the per-tree snapshot lock (which serializes concurrent snapshots), take a CPR
+            /// snapshot of the live tree straight into <paramref name="destinationPath"/>.
             /// </summary>
             public void SnapshotUnderClaim(string destinationPath)
             {

--- a/libs/server/Resp/RangeIndex/RangeIndexManager.cs
+++ b/libs/server/Resp/RangeIndex/RangeIndexManager.cs
@@ -175,14 +175,11 @@ namespace Garnet.server
             internal bool IsSnapshotInProgressForTest => snapshotLock.CurrentCount == 0;
 
             /// <summary>
-            /// Acquire the per-tree snapshot lock (blocking — no busy-spin), take a CPR snapshot of
-            /// the live tree directly into <paramref name="destinationPath"/>, then release the
-            /// lock. The lock serializes against concurrent flush / checkpoint / migration snapshots
-            /// on the same tree — bftree silently no-ops a <c>cpr_snapshot</c> that races its
-            /// internal <c>snapshot_in_progress</c> flag, so each caller must hold the lock while it
-            /// snapshots. bftree takes the destination path as a <c>cpr_snapshot</c> argument and
-            /// writes a fresh self-contained file, so we snapshot straight to
-            /// <paramref name="destinationPath"/>.
+            /// Under the per-tree snapshot lock (blocking, no busy-spin), take a CPR snapshot of the
+            /// live tree straight into <paramref name="destinationPath"/>. The lock serializes
+            /// concurrent flush / checkpoint / migration snapshots so they don't race bftree's
+            /// internal <c>snapshot_in_progress</c> flag (which would silently no-op one). bftree
+            /// writes a fresh self-contained file at the given path.
             /// </summary>
             public void SnapshotUnderClaim(string destinationPath)
             {

--- a/libs/server/Resp/RangeIndex/RangeIndexManager.cs
+++ b/libs/server/Resp/RangeIndex/RangeIndexManager.cs
@@ -66,6 +66,14 @@ namespace Garnet.server
         /// <summary>Gets the number of live (registered) BfTree indexes (activated + pending).</summary>
         internal int LiveIndexCount => liveIndexes.Count;
 
+        /// <summary>
+        /// Test-only: returns the live <see cref="TreeEntry"/> for the given key, or <c>null</c>
+        /// if no live (activated) tree exists for it. Used by tests that need to drive the
+        /// per-tree snapshot claim directly.
+        /// </summary>
+        internal TreeEntry GetLiveTreeEntryForTest(ReadOnlySpan<byte> keyBytes)
+            => liveIndexes.TryGetValue(KeyId(keyBytes), out var entry) && entry?.Tree != null ? entry : null;
+
         /// <summary>Gets the log-tied root directory for RI files. Used by the cluster replication layer
         /// to determine the target directory for received flush files on the replica side.</summary>
         public string RiLogRoot => riLogRoot;
@@ -149,45 +157,55 @@ namespace Garnet.server
             public int SnapshotPending;
 
             /// <summary>
-            /// Per-tree snapshot serialization atomic. 0 = idle; 1 = a snapshot is in flight.
-            /// Both <see cref="GarnetRecordTriggers.OnFlush"/> and
-            /// <see cref="SnapshotAllTreesForCheckpoint"/> claim this before calling
-            /// <c>cpr_snapshot</c> so the two callers do not race for bftree's internal
-            /// <c>snapshot_in_progress</c> flag (which would no-op one of them silently).
+            /// Per-tree snapshot serialization lock (binary semaphore). Held while a CPR snapshot
+            /// of this tree is in flight, so concurrent snapshot producers — <see cref="GarnetRecordTriggers.OnFlush"/>,
+            /// <see cref="SnapshotAllTreesForCheckpoint"/>, and migration — do not race for bftree's
+            /// internal <c>snapshot_in_progress</c> flag (which would silently no-op one of them).
+            ///
+            /// <para>A semaphore (not a spin/CAS) because the critical section is a full CPR
+            /// snapshot, which is multi-second — waiters must block, not busy-spin, to avoid
+            /// burning a core each. A <c>SemaphoreSlim</c> (rather than <c>lock</c>/Monitor) keeps
+            /// the door open to an async snapshot path (<c>WaitAsync</c>) in the future.</para>
+            ///
+            /// <para>Intentionally not disposed: <see cref="TreeEntry"/> has no disposal lifecycle,
+            /// and the semaphore holds no unmanaged handle (its <c>AvailableWaitHandle</c> is never
+            /// used), so the GC reclaims it. This also avoids a dispose-vs-in-flight-snapshot race.
+            /// Mirrors <c>CollectionItemObserver.ResultFoundSemaphore</c>.</para>
             /// </summary>
-            public int SnapshotInProgress;
-
-            /// <summary>Try to claim the per-tree snapshot atomic. Returns true if claimed.</summary>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public bool TryClaimSnapshot()
-                => Interlocked.CompareExchange(ref SnapshotInProgress, 1, 0) == 0;
-
-            /// <summary>Release the per-tree snapshot atomic.</summary>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public void ReleaseSnapshot()
-                => Volatile.Write(ref SnapshotInProgress, 0);
+            private readonly SemaphoreSlim snapshotLock = new(1, 1);
 
             /// <summary>
-            /// Spin to claim the per-tree snapshot atomic, take a CPR snapshot of the live tree
-            /// directly into <paramref name="destinationPath"/>, then release the claim. The
-            /// claim serializes against concurrent flush / checkpoint / migration snapshots on
-            /// the same tree — bftree silently no-ops a <c>cpr_snapshot</c> that races its
-            /// internal <c>snapshot_in_progress</c> flag, so each caller must hold the claim
-            /// while it snapshots. bftree takes the destination path as a <c>cpr_snapshot</c>
-            /// argument and writes a fresh self-contained file, so we snapshot straight to
+            /// Test-only: <c>true</c> while a snapshot holds <see cref="snapshotLock"/>. Lets a test
+            /// detect that the holder has entered the critical section.
+            /// </summary>
+            internal bool IsSnapshotInProgressForTest => snapshotLock.CurrentCount == 0;
+
+            /// <summary>
+            /// Acquire the per-tree snapshot lock (blocking — no busy-spin), take a CPR snapshot of
+            /// the live tree directly into <paramref name="destinationPath"/>, then release the
+            /// lock. The lock serializes against concurrent flush / checkpoint / migration snapshots
+            /// on the same tree — bftree silently no-ops a <c>cpr_snapshot</c> that races its
+            /// internal <c>snapshot_in_progress</c> flag, so each caller must hold the lock while it
+            /// snapshots. bftree takes the destination path as a <c>cpr_snapshot</c> argument and
+            /// writes a fresh self-contained file, so we snapshot straight to
             /// <paramref name="destinationPath"/>.
             /// </summary>
             public void SnapshotUnderClaim(string destinationPath)
             {
-                while (!TryClaimSnapshot())
-                    Thread.Yield();
+                snapshotLock.Wait();
                 try
                 {
+                    // Test-only latency injection: while enabled, hold the per-tree snapshot lock
+                    // (blocking, negligible CPU) to emulate a slow cpr_snapshot. Concurrent
+                    // SnapshotUnderClaim callers on the same tree (e.g. migration) block on the
+                    // semaphore above rather than busy-spinning. No-op in Release and whenever the
+                    // injection is disabled.
+                    ExceptionInjectionHelper.WaitOnClearBlocking(ExceptionInjectionType.RangeIndex_Snapshot_Inject_Latency);
                     BfTreeService.CprSnapshotByPtr(Tree.NativePtr, destinationPath);
                 }
                 finally
                 {
-                    ReleaseSnapshot();
+                    snapshotLock.Release();
                 }
             }
 
@@ -648,7 +666,7 @@ namespace Garnet.server
         ///
         /// <para><b>Live case</b> (<c>stub.TreeHandle != 0</c>): take a CPR snapshot via the
         /// native handle. CPR is concurrent-safe with workers (no per-key X-lock needed).
-        /// Per-tree atomic <see cref="TreeEntry.SnapshotInProgress"/> serializes against
+        /// Per-tree lock <see cref="TreeEntry.SnapshotUnderClaim"/> serializes against
         /// concurrent <see cref="SnapshotAllTreesForCheckpoint"/> for the same tree (otherwise
         /// bftree's internal <c>snapshot_in_progress</c> would no-op one of them).</para>
         ///
@@ -784,7 +802,7 @@ namespace Garnet.server
         /// to snapshot from; data.bftree was pre-staged by PreStage).</item>
         /// </list></para>
         ///
-        /// <para>Uses the per-tree atomic <see cref="TreeEntry.SnapshotInProgress"/> to serialize
+        /// <para>Uses the per-tree lock <see cref="TreeEntry.SnapshotUnderClaim"/> to serialize
         /// against concurrent <see cref="SnapshotTreeForFlush"/> for the same tree. Per-key
         /// X-lock is NOT taken here — that lock would deadlock if any deferred OnFlush fired
         /// on the checkpoint thread while it held S-locks on hot-path readers' shards.</para>

--- a/libs/server/Resp/RangeIndex/RangeIndexManager.cs
+++ b/libs/server/Resp/RangeIndex/RangeIndexManager.cs
@@ -168,11 +168,11 @@ namespace Garnet.server
             internal bool IsSnapshotInProgressForTest => snapshotLock.CurrentCount == 0;
 
             /// <summary>
-            /// Under the per-tree snapshot lock (blocking, no busy-spin), take a CPR snapshot of the
-            /// live tree straight into <paramref name="destinationPath"/>. The lock serializes
-            /// concurrent flush / checkpoint / migration snapshots so they don't race bftree's
-            /// internal <c>snapshot_in_progress</c> flag (which would silently no-op one). bftree
-            /// writes a fresh self-contained file at the given path.
+            /// Under the per-tree snapshot lock, take a CPR snapshot of the live tree straight into
+            /// <paramref name="destinationPath"/>. The lock serializes concurrent flush / checkpoint
+            /// / migration snapshots so they don't race bftree's internal <c>snapshot_in_progress</c>
+            /// flag (which would silently no-op one). bftree writes a fresh self-contained file at
+            /// the given path.
             /// </summary>
             public void SnapshotUnderClaim(string destinationPath)
             {

--- a/libs/server/Resp/RangeIndex/RangeIndexManager.cs
+++ b/libs/server/Resp/RangeIndex/RangeIndexManager.cs
@@ -186,7 +186,7 @@ namespace Garnet.server
                 snapshotLock.Wait();
                 try
                 {
-                    ExceptionInjectionHelper.WaitOnClearBlocking(ExceptionInjectionType.RangeIndex_Snapshot_Inject_Latency);
+                    ExceptionInjectionHelper.WaitOnClearWithThreadSleep(ExceptionInjectionType.RangeIndex_Snapshot_Inject_Latency);
                     BfTreeService.CprSnapshotByPtr(Tree.NativePtr, destinationPath);
                 }
                 finally

--- a/test/standalone/Garnet.test.rangeindex/RespRangeIndexTests.cs
+++ b/test/standalone/Garnet.test.rangeindex/RespRangeIndexTests.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 #if DEBUG
-using System.Diagnostics;
 using Garnet.common;
 #endif
 using Garnet.server;
@@ -2504,9 +2503,7 @@ namespace Garnet.test
         /// <c>TreeEntry.SnapshotUnderClaim</c>) park instead of burning a core each.
         ///
         /// <para>Deterministic: no waiter completes while the holder holds the lock; all complete
-        /// once latency clears. CPU during the wait is logged only (not asserted) to avoid CI
-        /// flakiness — ~0 cores with the semaphore vs ~waiterCount with the old <c>Thread.Yield()</c>
-        /// spin.</para>
+        /// once the latency clears.</para>
         /// </summary>
         [Test]
         public void RIConcurrentSnapshotsTest()
@@ -2534,16 +2531,11 @@ namespace Garnet.test
                 ClassicAssert.IsTrue(SpinWait.SpinUntil(() => entry.IsSnapshotInProgressForTest, TimeSpan.FromSeconds(10)), "holder failed to acquire the snapshot lock");
 
                 // Waiters contend on the SAME tree; they block on the semaphore (no busy-spin).
-                var cpu0 = Process.GetCurrentProcess().TotalProcessorTime;
-                var sw = Stopwatch.StartNew();
                 var waiters = Enumerable.Range(0, waiterCount).Select(i => Task.Run(() => entry.SnapshotUnderClaim(SnapPath($"waiter{i}")))).ToArray();
 
                 // #1: while the holder holds the lock, no waiter can complete.
                 Thread.Sleep(500);
-                var cpuMs = (Process.GetCurrentProcess().TotalProcessorTime - cpu0).TotalMilliseconds;
-                var wallMs = sw.Elapsed.TotalMilliseconds;
                 ClassicAssert.IsFalse(waiters.Any(t => t.IsCompletedSuccessfully), "a waiter completed while the holder held the snapshot lock");
-                TestContext.Progress.WriteLine($"[snapshot-wait] waiters={waiterCount} window={wallMs:F0}ms cpu={cpuMs:F0}ms (~{cpuMs / Math.Max(1, wallMs):F2} cores)");
 
                 // Release the latency; holder + waiters each run a real (~3s) snapshot serially.
                 ExceptionInjectionHelper.DisableException(ExceptionInjectionType.RangeIndex_Snapshot_Inject_Latency);

--- a/test/standalone/Garnet.test.rangeindex/RespRangeIndexTests.cs
+++ b/test/standalone/Garnet.test.rangeindex/RespRangeIndexTests.cs
@@ -2531,32 +2531,25 @@ namespace Garnet.test
             try
             {
                 var holder = Task.Run(() => entry.SnapshotUnderClaim(SnapPath("holder")));
-                ClassicAssert.IsTrue(
-                    SpinWait.SpinUntil(() => entry.IsSnapshotInProgressForTest, TimeSpan.FromSeconds(10)),
-                    "holder failed to acquire the snapshot lock");
+                ClassicAssert.IsTrue(SpinWait.SpinUntil(() => entry.IsSnapshotInProgressForTest, TimeSpan.FromSeconds(10)), "holder failed to acquire the snapshot lock");
 
                 // Waiters contend on the SAME tree; they block on the semaphore (no busy-spin).
                 var cpu0 = Process.GetCurrentProcess().TotalProcessorTime;
                 var sw = Stopwatch.StartNew();
-                var waiters = Enumerable.Range(0, waiterCount)
-                    .Select(i => Task.Run(() => entry.SnapshotUnderClaim(SnapPath($"waiter{i}"))))
-                    .ToArray();
+                var waiters = Enumerable.Range(0, waiterCount).Select(i => Task.Run(() => entry.SnapshotUnderClaim(SnapPath($"waiter{i}")))).ToArray();
 
                 // #1: while the holder holds the lock, no waiter can complete.
                 Thread.Sleep(500);
                 var cpuMs = (Process.GetCurrentProcess().TotalProcessorTime - cpu0).TotalMilliseconds;
                 var wallMs = sw.Elapsed.TotalMilliseconds;
-                ClassicAssert.IsFalse(waiters.Any(t => t.IsCompletedSuccessfully),
-                    "a waiter completed while the holder held the snapshot lock");
-                TestContext.Progress.WriteLine(
-                    $"[snapshot-wait] waiters={waiterCount} window={wallMs:F0}ms cpu={cpuMs:F0}ms (~{cpuMs / Math.Max(1, wallMs):F2} cores)");
+                ClassicAssert.IsFalse(waiters.Any(t => t.IsCompletedSuccessfully), "a waiter completed while the holder held the snapshot lock");
+                TestContext.Progress.WriteLine($"[snapshot-wait] waiters={waiterCount} window={wallMs:F0}ms cpu={cpuMs:F0}ms (~{cpuMs / Math.Max(1, wallMs):F2} cores)");
 
                 // Release the latency; holder + waiters each run a real (~3s) snapshot serially.
                 ExceptionInjectionHelper.DisableException(ExceptionInjectionType.RangeIndex_Snapshot_Inject_Latency);
 
                 // #2: everything completes (and any fault surfaces) once the lock is released.
-                ClassicAssert.IsTrue(Task.WaitAll(waiters.Append(holder).ToArray(), TimeSpan.FromSeconds(90)),
-                    "snapshots did not all complete after the lock was released");
+                ClassicAssert.IsTrue(Task.WaitAll(waiters.Append(holder).ToArray(), TimeSpan.FromSeconds(90)), "snapshots did not all complete after the lock was released");
             }
             finally
             {

--- a/test/standalone/Garnet.test.rangeindex/RespRangeIndexTests.cs
+++ b/test/standalone/Garnet.test.rangeindex/RespRangeIndexTests.cs
@@ -6,6 +6,10 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+#if DEBUG
+using System.Diagnostics;
+using Garnet.common;
+#endif
 using Garnet.server;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
@@ -2491,5 +2495,141 @@ namespace Garnet.test
             ClassicAssert.IsTrue(rangeIndexManager.KeyExists(System.Text.Encoding.ASCII.GetBytes("str-key"), ref ctx));
             ClassicAssert.IsFalse(rangeIndexManager.KeyExists(System.Text.Encoding.ASCII.GetBytes("nope"), ref ctx));
         }
+
+#if DEBUG
+        /// <summary>
+        /// Verifies that concurrent CPR snapshots of the same tree serialize by <b>blocking</b>
+        /// (not busy-spinning). When one snapshot is slow (here, artificial latency injected while
+        /// holding the per-tree snapshot lock), concurrent snapshots on the same tree — exactly
+        /// what the migration snapshot path does (<c>SnapshotForMigration</c> →
+        /// <c>TreeEntry.SnapshotUnderClaim</c>) — park on the <c>SemaphoreSlim</c> rather than
+        /// burning a core each.
+        ///
+        /// <para>The assertions are deterministic: no waiter can complete while the holder holds
+        /// the lock, and all complete once the injected latency is cleared. The CPU consumed during
+        /// the wait window is measured and logged only (not asserted) to avoid CI flakiness — with
+        /// the semaphore it should read ~0 cores; with the previous <c>Thread.Yield()</c> spin it
+        /// read ~<c>waiterCount</c> cores.</para>
+        /// </summary>
+        [Test]
+        public void RIConcurrentSnapshotsBlockWithoutBusySpinTest()
+        {
+            const int waiterCount = 10;
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            // DISK-backed RI so it mirrors migration (which requires a disk-backed tree) and
+            // SnapshotUnderClaim writes a real snapshot file to riLogRoot.
+            db.Execute("RI.CREATE", "snapidx", "DISK", "CACHESIZE", "65536", "MINRECORD", "8");
+            db.Execute("RI.SET", "snapidx", "field1", "value1");
+
+            var rangeIndexManager = server.Provider.StoreWrapper.rangeIndexManager;
+            var entry = rangeIndexManager.GetLiveTreeEntryForTest("snapidx"u8);
+            ClassicAssert.IsNotNull(entry, "expected a live BfTree for 'snapidx'");
+
+            var logRoot = rangeIndexManager.RiLogRoot;
+            var holderPath = Path.Combine(logRoot, "holder.snapshot.bftree");
+
+            Exception holderEx = null;
+            var waiterEx = new Exception[waiterCount];
+            var waitersDone = new CountdownEvent(waiterCount);
+            var waitersCompleted = 0;
+
+            // Arm the latency injection BEFORE the holder acquires, so the holder blocks (negligible
+            // CPU) while holding the per-tree snapshot lock.
+            ExceptionInjectionHelper.EnableException(ExceptionInjectionType.RangeIndex_Snapshot_Inject_Latency);
+
+            var holder = new Thread(() =>
+            {
+                try { entry.SnapshotUnderClaim(holderPath); }
+                catch (Exception ex) { holderEx = ex; }
+            })
+            { IsBackground = true, Name = "ri-snapshot-holder" };
+
+            // Multiple waiters — each emulating the migration snapshot path on the SAME tree. All
+            // block on the per-tree SemaphoreSlim because the holder owns the lock (no busy-spin).
+            var waiters = new Thread[waiterCount];
+            for (var i = 0; i < waiterCount; i++)
+            {
+                var idx = i;
+                var waiterPath = Path.Combine(logRoot, $"waiter{idx}.snapshot.bftree");
+                waiters[idx] = new Thread(() =>
+                {
+                    try { entry.SnapshotUnderClaim(waiterPath); }
+                    catch (Exception ex) { waiterEx[idx] = ex; }
+                    finally
+                    {
+                        Interlocked.Increment(ref waitersCompleted);
+                        waitersDone.Signal();
+                    }
+                })
+                { IsBackground = true, Name = $"ri-snapshot-waiter-{idx}" };
+            }
+
+            try
+            {
+                holder.Start();
+
+                // Wait until the holder has actually acquired the snapshot lock and is parked in
+                // the injected latency wait.
+                var deadline = Stopwatch.GetTimestamp();
+                while (!entry.IsSnapshotInProgressForTest
+                       && Stopwatch.GetElapsedTime(deadline) < TimeSpan.FromSeconds(10))
+                    Thread.Yield();
+                ClassicAssert.IsTrue(entry.IsSnapshotInProgressForTest,
+                    "holder failed to acquire the snapshot lock");
+
+                // Start all waiters.
+                var cpuBefore = Process.GetCurrentProcess().TotalProcessorTime;
+                var wallBefore = Stopwatch.GetTimestamp();
+                foreach (var w in waiters)
+                    w.Start();
+
+                // Deterministic assertion #1: while the holder holds the lock, NO waiter can
+                // complete (they are all blocked). The 500ms window is enough to observe in
+                // Task Manager / dotnet-counters that the waiters consume ~no CPU (unlike the
+                // previous Thread.Yield() spin, which burned a core each).
+                var allCompletedWhileBlocked = waitersDone.Wait(TimeSpan.FromMilliseconds(500));
+
+                var cpuDuringWait = Process.GetCurrentProcess().TotalProcessorTime - cpuBefore;
+                var wallDuringWait = Stopwatch.GetElapsedTime(wallBefore);
+
+                ClassicAssert.IsFalse(allCompletedWhileBlocked,
+                    "waiters unexpectedly completed while the holder held the snapshot lock");
+                ClassicAssert.AreEqual(0, Volatile.Read(ref waitersCompleted),
+                    "no waiter should complete while the holder holds the lock");
+
+                // Log (do NOT assert) the CPU consumed during the wait window. With the SemaphoreSlim
+                // this should read ~0 cores; with the previous Thread.Yield() spin it read
+                // ~waiterCount cores.
+                TestContext.Progress.WriteLine(
+                    $"[snapshot-wait] waiters={waiterCount} window={wallDuringWait.TotalMilliseconds:F0}ms " +
+                    $"cpu={cpuDuringWait.TotalMilliseconds:F0}ms " +
+                    $"(~{cpuDuringWait.TotalMilliseconds / Math.Max(1, wallDuringWait.TotalMilliseconds):F2} cores)");
+
+                // Release the injected latency: the holder finishes its real snapshot and releases
+                // the lock; the waiters then acquire one-by-one and complete.
+                ExceptionInjectionHelper.DisableException(ExceptionInjectionType.RangeIndex_Snapshot_Inject_Latency);
+
+                // Deterministic assertion #2: all waiters complete once the lock is released.
+                // Each does a real (~3s) CPR snapshot serially, so allow a generous timeout.
+                ClassicAssert.IsTrue(waitersDone.Wait(TimeSpan.FromSeconds(60)),
+                    "waiters did not all complete after the snapshot lock was released");
+            }
+            finally
+            {
+                // Always clear the injection so a mid-test failure cannot wedge other tests.
+                ExceptionInjectionHelper.DisableException(ExceptionInjectionType.RangeIndex_Snapshot_Inject_Latency);
+                holder.Join(TimeSpan.FromSeconds(60));
+                foreach (var w in waiters)
+                    w.Join(TimeSpan.FromSeconds(60));
+            }
+
+            ClassicAssert.IsNull(holderEx, $"holder threw: {holderEx}");
+            for (var i = 0; i < waiterCount; i++)
+                ClassicAssert.IsNull(waiterEx[i], $"waiter {i} threw: {waiterEx[i]}");
+        }
+#endif
     }
 }

--- a/test/standalone/Garnet.test.rangeindex/RespRangeIndexTests.cs
+++ b/test/standalone/Garnet.test.rangeindex/RespRangeIndexTests.cs
@@ -2498,137 +2498,70 @@ namespace Garnet.test
 
 #if DEBUG
         /// <summary>
-        /// Verifies that concurrent CPR snapshots of the same tree serialize by <b>blocking</b>
-        /// (not busy-spinning). When one snapshot is slow (here, artificial latency injected while
-        /// holding the per-tree snapshot lock), concurrent snapshots on the same tree — exactly
-        /// what the migration snapshot path does (<c>SnapshotForMigration</c> →
-        /// <c>TreeEntry.SnapshotUnderClaim</c>) — park on the <c>SemaphoreSlim</c> rather than
-        /// burning a core each.
+        /// Concurrent CPR snapshots of the same tree serialize by <b>blocking</b> on the per-tree
+        /// <c>SemaphoreSlim</c>, not busy-spinning. A holder takes the snapshot lock with injected
+        /// latency; concurrent snapshots (the migration path: <c>SnapshotForMigration</c> →
+        /// <c>TreeEntry.SnapshotUnderClaim</c>) park instead of burning a core each.
         ///
-        /// <para>The assertions are deterministic: no waiter can complete while the holder holds
-        /// the lock, and all complete once the injected latency is cleared. The CPU consumed during
-        /// the wait window is measured and logged only (not asserted) to avoid CI flakiness — with
-        /// the semaphore it should read ~0 cores; with the previous <c>Thread.Yield()</c> spin it
-        /// read ~<c>waiterCount</c> cores.</para>
+        /// <para>Deterministic: no waiter completes while the holder holds the lock; all complete
+        /// once latency clears. CPU during the wait is logged only (not asserted) to avoid CI
+        /// flakiness — ~0 cores with the semaphore vs ~waiterCount with the old <c>Thread.Yield()</c>
+        /// spin.</para>
         /// </summary>
         [Test]
-        public void RIConcurrentSnapshotsBlockWithoutBusySpinTest()
+        public void RIConcurrentSnapshotsTest()
         {
             const int waiterCount = 10;
 
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = redis.GetDatabase(0);
 
-            // DISK-backed RI so it mirrors migration (which requires a disk-backed tree) and
-            // SnapshotUnderClaim writes a real snapshot file to riLogRoot.
+            // DISK-backed RI mirrors migration and writes a real snapshot file to riLogRoot.
             db.Execute("RI.CREATE", "snapidx", "DISK", "CACHESIZE", "65536", "MINRECORD", "8");
             db.Execute("RI.SET", "snapidx", "field1", "value1");
 
-            var rangeIndexManager = server.Provider.StoreWrapper.rangeIndexManager;
-            var entry = rangeIndexManager.GetLiveTreeEntryForTest("snapidx"u8);
+            var manager = server.Provider.StoreWrapper.rangeIndexManager;
+            var entry = manager.GetLiveTreeEntryForTest("snapidx"u8);
             ClassicAssert.IsNotNull(entry, "expected a live BfTree for 'snapidx'");
 
-            var logRoot = rangeIndexManager.RiLogRoot;
-            var holderPath = Path.Combine(logRoot, "holder.snapshot.bftree");
+            string SnapPath(string name) => Path.Combine(manager.RiLogRoot, $"{name}.snapshot.bftree");
 
-            Exception holderEx = null;
-            var waiterEx = new Exception[waiterCount];
-            var waitersDone = new CountdownEvent(waiterCount);
-            var waitersCompleted = 0;
-
-            // Arm the latency injection BEFORE the holder acquires, so the holder blocks (negligible
-            // CPU) while holding the per-tree snapshot lock.
+            // Arm the latency injection so the holder parks (negligible CPU) while holding the lock.
             ExceptionInjectionHelper.EnableException(ExceptionInjectionType.RangeIndex_Snapshot_Inject_Latency);
-
-            var holder = new Thread(() =>
-            {
-                try { entry.SnapshotUnderClaim(holderPath); }
-                catch (Exception ex) { holderEx = ex; }
-            })
-            { IsBackground = true, Name = "ri-snapshot-holder" };
-
-            // Multiple waiters — each emulating the migration snapshot path on the SAME tree. All
-            // block on the per-tree SemaphoreSlim because the holder owns the lock (no busy-spin).
-            var waiters = new Thread[waiterCount];
-            for (var i = 0; i < waiterCount; i++)
-            {
-                var idx = i;
-                var waiterPath = Path.Combine(logRoot, $"waiter{idx}.snapshot.bftree");
-                waiters[idx] = new Thread(() =>
-                {
-                    try { entry.SnapshotUnderClaim(waiterPath); }
-                    catch (Exception ex) { waiterEx[idx] = ex; }
-                    finally
-                    {
-                        Interlocked.Increment(ref waitersCompleted);
-                        waitersDone.Signal();
-                    }
-                })
-                { IsBackground = true, Name = $"ri-snapshot-waiter-{idx}" };
-            }
-
             try
             {
-                holder.Start();
-
-                // Wait until the holder has actually acquired the snapshot lock and is parked in
-                // the injected latency wait.
-                var deadline = Stopwatch.GetTimestamp();
-                while (!entry.IsSnapshotInProgressForTest
-                       && Stopwatch.GetElapsedTime(deadline) < TimeSpan.FromSeconds(10))
-                    Thread.Yield();
-                ClassicAssert.IsTrue(entry.IsSnapshotInProgressForTest,
+                var holder = Task.Run(() => entry.SnapshotUnderClaim(SnapPath("holder")));
+                ClassicAssert.IsTrue(
+                    SpinWait.SpinUntil(() => entry.IsSnapshotInProgressForTest, TimeSpan.FromSeconds(10)),
                     "holder failed to acquire the snapshot lock");
 
-                // Start all waiters.
-                var cpuBefore = Process.GetCurrentProcess().TotalProcessorTime;
-                var wallBefore = Stopwatch.GetTimestamp();
-                foreach (var w in waiters)
-                    w.Start();
+                // Waiters contend on the SAME tree; they block on the semaphore (no busy-spin).
+                var cpu0 = Process.GetCurrentProcess().TotalProcessorTime;
+                var sw = Stopwatch.StartNew();
+                var waiters = Enumerable.Range(0, waiterCount)
+                    .Select(i => Task.Run(() => entry.SnapshotUnderClaim(SnapPath($"waiter{i}"))))
+                    .ToArray();
 
-                // Deterministic assertion #1: while the holder holds the lock, NO waiter can
-                // complete (they are all blocked). The 500ms window is enough to observe in
-                // Task Manager / dotnet-counters that the waiters consume ~no CPU (unlike the
-                // previous Thread.Yield() spin, which burned a core each).
-                var allCompletedWhileBlocked = waitersDone.Wait(TimeSpan.FromMilliseconds(500));
-
-                var cpuDuringWait = Process.GetCurrentProcess().TotalProcessorTime - cpuBefore;
-                var wallDuringWait = Stopwatch.GetElapsedTime(wallBefore);
-
-                ClassicAssert.IsFalse(allCompletedWhileBlocked,
-                    "waiters unexpectedly completed while the holder held the snapshot lock");
-                ClassicAssert.AreEqual(0, Volatile.Read(ref waitersCompleted),
-                    "no waiter should complete while the holder holds the lock");
-
-                // Log (do NOT assert) the CPU consumed during the wait window. With the SemaphoreSlim
-                // this should read ~0 cores; with the previous Thread.Yield() spin it read
-                // ~waiterCount cores.
+                // #1: while the holder holds the lock, no waiter can complete.
+                Thread.Sleep(500);
+                var cpuMs = (Process.GetCurrentProcess().TotalProcessorTime - cpu0).TotalMilliseconds;
+                var wallMs = sw.Elapsed.TotalMilliseconds;
+                ClassicAssert.IsFalse(waiters.Any(t => t.IsCompletedSuccessfully),
+                    "a waiter completed while the holder held the snapshot lock");
                 TestContext.Progress.WriteLine(
-                    $"[snapshot-wait] waiters={waiterCount} window={wallDuringWait.TotalMilliseconds:F0}ms " +
-                    $"cpu={cpuDuringWait.TotalMilliseconds:F0}ms " +
-                    $"(~{cpuDuringWait.TotalMilliseconds / Math.Max(1, wallDuringWait.TotalMilliseconds):F2} cores)");
+                    $"[snapshot-wait] waiters={waiterCount} window={wallMs:F0}ms cpu={cpuMs:F0}ms (~{cpuMs / Math.Max(1, wallMs):F2} cores)");
 
-                // Release the injected latency: the holder finishes its real snapshot and releases
-                // the lock; the waiters then acquire one-by-one and complete.
+                // Release the latency; holder + waiters each run a real (~3s) snapshot serially.
                 ExceptionInjectionHelper.DisableException(ExceptionInjectionType.RangeIndex_Snapshot_Inject_Latency);
 
-                // Deterministic assertion #2: all waiters complete once the lock is released.
-                // Each does a real (~3s) CPR snapshot serially, so allow a generous timeout.
-                ClassicAssert.IsTrue(waitersDone.Wait(TimeSpan.FromSeconds(60)),
-                    "waiters did not all complete after the snapshot lock was released");
+                // #2: everything completes (and any fault surfaces) once the lock is released.
+                ClassicAssert.IsTrue(Task.WaitAll(waiters.Append(holder).ToArray(), TimeSpan.FromSeconds(90)),
+                    "snapshots did not all complete after the lock was released");
             }
             finally
             {
-                // Always clear the injection so a mid-test failure cannot wedge other tests.
                 ExceptionInjectionHelper.DisableException(ExceptionInjectionType.RangeIndex_Snapshot_Inject_Latency);
-                holder.Join(TimeSpan.FromSeconds(60));
-                foreach (var w in waiters)
-                    w.Join(TimeSpan.FromSeconds(60));
             }
-
-            ClassicAssert.IsNull(holderEx, $"holder threw: {holderEx}");
-            for (var i = 0; i < waiterCount; i++)
-                ClassicAssert.IsNull(waiterEx[i], $"waiter {i} threw: {waiterEx[i]}");
         }
 #endif
     }

--- a/website/docs/commands/range-index.md
+++ b/website/docs/commands/range-index.md
@@ -44,6 +44,41 @@ Range Index is fully integrated with Garnet's checkpoint and AOF mechanisms:
 - **Eviction and lazy restore:** When memory pressure causes the stub to be evicted from the log,
   the BfTree data file is preserved. On next access, the tree is lazily restored from its snapshot.
 
+#### Snapshot performance
+
+A BfTree checkpoint takes a CPR (Concurrent Prefix Recovery) snapshot, which is synchronous and
+non-blocking to concurrent readers/writers. It has a **fixed floor of ~3 seconds** (the snapshot
+state machine advances through several phases, each with a short barrier) plus a component that
+grows roughly **linearly with the tree's data size**. The snapshot is dominated by total data
+**size**, not the number of keys.
+
+Measured on a single disk-backed tree (local NVMe, 1 KB values, cache large enough to keep the
+tree resident; times are approximate and hardware-dependent):
+
+| Tree data | Keys | Snapshot file | Snapshot time |
+|-----------|------|---------------|---------------|
+| 32 MB     | 32 K | 39 MB         | ~3.0 s        |
+| 64 MB     | 65 K | 78 MB         | ~3.1 s        |
+| 128 MB    | 129 K| 145 MB        | ~3.2 s        |
+| 512 MB    | 516 K| 594 MB        | ~4.0 s        |
+| 1 GB      | 1.0 M| 1.16 GB       | ~5.1 s        |
+| 2 GB      | 2.1 M| 2.44 GB       | ~6.3 s        |
+| 4 GB      | 4.1 M| 4.90 GB       | ~8.6 s        |
+
+Holding the data size roughly constant (~500 MB) while varying the value size — and therefore the
+key count — shows snapshot time is **independent of key count**:
+
+| Value size | Keys  | Snapshot time |
+|------------|-------|---------------|
+| 64 B       | 6.7 M | ~4.2 s        |
+| 256 B      | 2.0 M | ~4.0 s        |
+| 1 KB       | 516 K | ~4.1 s        |
+| 4 KB       | 131 K | ~4.0 s        |
+
+> **Note:** Each live tree is snapshotted independently during a checkpoint, and snapshots of the
+> same tree are serialized. A checkpoint of many large indexes therefore scales with the sum of
+> their sizes.
+
 ---
 
 ## Lifecycle Commands


### PR DESCRIPTION
## Problem

The per-tree snapshot claim in `TreeEntry` serialized concurrent CPR snapshots — `OnFlush` (flush), `SnapshotAllTreesForCheckpoint` (checkpoint), and `SnapshotForMigration` (cluster migration) — using a CAS + busy-spin:

```csharp
while (!TryClaimSnapshot())   // Interlocked.CompareExchange on an int
    Thread.Yield();
```

However, in case of pretty big BFTree, and since we may be writing multi-gigabyte files, snapshot may take more time, so any waiter will burn CPU for the entire wait. If migration happens during a checkpoint, or flushes happen with migration/checkpoint, we might burn CPU unnecessarily.

## Fix

Replace the CAS + spin with a per-tree `SemaphoreSlim` so waiters block instead of spinning:

```csharp
snapshotLock.Wait();
try { /* injected latency hook */ CprSnapshotByPtr(...); }
finally { snapshotLock.Release(); }
```
