### PR TITLE
Implement RESP3 for `VSIM` (and `VEMB`) and `RAW` for `VEMB`

### DIFF
--- a/libs/server/API/GarnetApi.cs
+++ b/libs/server/API/GarnetApi.cs
@@ -393,6 +393,10 @@ namespace Garnet.server
         => storageSession.VectorSetEmbedding(key, element.ReadOnlySpan, ref outputDistances);
 
         /// <inheritdoc/>
+        public GarnetStatus VectorSetRawEmbedding(PinnedSpanByte key, PinnedSpanByte element, ref SpanByteAndMemory quantizedValues, out VectorQuantType quantType, out double norm, out double? range)
+        => storageSession.VectorSetRawEmbedding(key, element.ReadOnlySpan, ref quantizedValues, out quantType, out norm, out range);
+
+        /// <inheritdoc/>
         public unsafe GarnetStatus VectorSetDimensions(PinnedSpanByte key, out int dimensions)
         => storageSession.VectorSetDimensions(key, out dimensions);
 

--- a/libs/server/API/GarnetWatchApi.cs
+++ b/libs/server/API/GarnetWatchApi.cs
@@ -644,6 +644,13 @@ namespace Garnet.server
         }
 
         /// <inheritdoc/>
+        public GarnetStatus VectorSetRawEmbedding(PinnedSpanByte key, PinnedSpanByte element, ref SpanByteAndMemory quantizedValues, out VectorQuantType quantType, out double norm, out double? range)
+        {
+            garnetApi.WATCH(key, StoreType.Main);
+            return garnetApi.VectorSetRawEmbedding(key, element, ref quantizedValues, out quantType, out norm, out range);
+        }
+
+        /// <inheritdoc/>
         public GarnetStatus VectorSetDimensions(PinnedSpanByte key, out int dimensions)
         {
             garnetApi.WATCH(key, StoreType.Main);

--- a/libs/server/API/IGarnetApi.cs
+++ b/libs/server/API/IGarnetApi.cs
@@ -2128,6 +2128,11 @@ namespace Garnet.server
         GarnetStatus VectorSetEmbedding(PinnedSpanByte key, PinnedSpanByte element, ref SpanByteAndMemory outputDistances);
 
         /// <summary>
+        /// Fetch RAW embedding of a given element in a Vector Set.
+        /// </summary>
+        GarnetStatus VectorSetRawEmbedding(PinnedSpanByte key, PinnedSpanByte element, ref SpanByteAndMemory quantizedValues, out VectorQuantType quantType, out double norm, out double? range);
+
+        /// <summary>
         /// Fetch the dimensionality of the given Vector Set.
         /// 
         /// If the Vector Set was created with reduced dimensions, reports the reduced dimensions.

--- a/libs/server/Resp/Vector/RespServerSessionVectors.cs
+++ b/libs/server/Resp/Vector/RespServerSessionVectors.cs
@@ -920,137 +920,11 @@ namespace Garnet.server
                         {
                             if (respProtocolVersion == 3)
                             {
-                                // TODO: this is rather complicated, so punt for now
-                                throw new NotImplementedException();
+                                WriteRESP3Result(this, count.Value, idResult, distanceResult, filterBitmapResult, withAttributes.Value, withScores.Value, idFormat, attributeResult);
                             }
                             else
                             {
-                                var remainingIds = idResult.ReadOnlySpan;
-                                var distancesSpan = MemoryMarshal.Cast<byte, float>(distanceResult.ReadOnlySpan);
-                                var hasFilter = filterBitmapResult.Length > 0;
-                                var filterBitmap = hasFilter ? filterBitmapResult.ReadOnlySpan : default;
-                                var remaininingAttributes = (withAttributes.Value || hasFilter) ? attributeResult.ReadOnlySpan : default;
-
-                                var totalFound = distancesSpan.Length;
-
-                                // Compute max output count: if bitmap is present, popcount it; otherwise all results
-                                int outputCount;
-                                if (hasFilter)
-                                {
-                                    outputCount = 0;
-                                    for (var b = 0; b < filterBitmap.Length; b++)
-                                        outputCount += System.Numerics.BitOperations.PopCount(filterBitmap[b]);
-                                }
-                                else
-                                {
-                                    outputCount = totalFound;
-                                }
-
-                                // Limit to what is actually asked for
-                                outputCount = Math.Min(count.Value, outputCount);
-
-                                // Each flag doubles output
-                                var arrayItemCount = outputCount;
-                                if (withScores.Value)
-                                {
-                                    arrayItemCount += outputCount;
-                                }
-                                if (withAttributes.Value)
-                                {
-                                    arrayItemCount += outputCount;
-                                }
-
-                                while (!RespWriteUtils.TryWriteArrayLength(arrayItemCount, ref dcurr, dend))
-                                    SendAndReset();
-
-                                var writtenCount = 0;
-                                var resultIndex = 0;
-
-                                while (writtenCount < outputCount)
-                                {
-                                    ReadOnlySpan<byte> elementData;
-
-                                    if (idFormat == VectorIdFormat.I32LengthPrefixed)
-                                    {
-                                        if (remainingIds.Length < sizeof(int))
-                                        {
-                                            throw new GarnetException($"Insufficient bytes for result id length at resultIndex={resultIndex}: {Convert.ToHexString(distanceResult.ReadOnlySpan)}");
-                                        }
-
-                                        var elementLen = BinaryPrimitives.ReadInt32LittleEndian(remainingIds);
-
-                                        if (remainingIds.Length < sizeof(int) + elementLen)
-                                        {
-                                            throw new GarnetException($"Insufficient bytes for result of length={elementLen} at resultIndex={resultIndex}: {Convert.ToHexString(distanceResult.ReadOnlySpan)}");
-                                        }
-
-                                        elementData = remainingIds.Slice(sizeof(int), elementLen);
-                                        remainingIds = remainingIds[(sizeof(int) + elementLen)..];
-                                    }
-                                    else if (idFormat == VectorIdFormat.FixedI32)
-                                    {
-                                        if (remainingIds.Length < sizeof(int))
-                                        {
-                                            throw new GarnetException($"Insufficient bytes for result id length at resultIndex={resultIndex}: {Convert.ToHexString(distanceResult.ReadOnlySpan)}");
-                                        }
-
-                                        elementData = remainingIds[..sizeof(int)];
-                                        remainingIds = remainingIds[sizeof(int)..];
-                                    }
-                                    else
-                                    {
-                                        throw new GarnetException($"Unexpected id format: {idFormat}");
-                                    }
-
-                                    // Check filter bitmap — skip results that didn't pass the filter
-                                    if (hasFilter && (filterBitmap[resultIndex >> 3] & (1 << (resultIndex & 7))) == 0)
-                                    {
-                                        // Advance attribute reader for skipped results (attributes are always present when bitmap exists)
-                                        if (!remaininingAttributes.IsEmpty)
-                                        {
-                                            var skipAttrLen = BinaryPrimitives.ReadInt32LittleEndian(remaininingAttributes);
-                                            remaininingAttributes = remaininingAttributes[(sizeof(int) + skipAttrLen)..];
-                                        }
-
-                                        resultIndex++;
-                                        continue;
-                                    }
-
-                                    while (!RespWriteUtils.TryWriteBulkString(elementData, ref dcurr, dend))
-                                        SendAndReset();
-
-                                    if (withScores.Value)
-                                    {
-                                        var distance = distancesSpan[resultIndex];
-
-                                        while (!RespWriteUtils.TryWriteDoubleBulkString(distance, ref dcurr, dend))
-                                            SendAndReset();
-                                    }
-
-                                    if (withAttributes.Value)
-                                    {
-                                        if (remaininingAttributes.Length < sizeof(int))
-                                        {
-                                            throw new GarnetException($"Insufficient bytes for attribute length at resultIndex={resultIndex}: {Convert.ToHexString(attributeResult.ReadOnlySpan)}");
-                                        }
-
-                                        var attrLen = BinaryPrimitives.ReadInt32LittleEndian(remaininingAttributes);
-                                        var attr = remaininingAttributes.Slice(sizeof(int), attrLen);
-                                        remaininingAttributes = remaininingAttributes[(sizeof(int) + attrLen)..];
-
-                                        while (!RespWriteUtils.TryWriteBulkString(attr, ref dcurr, dend))
-                                            SendAndReset();
-                                    }
-                                    else if (!remaininingAttributes.IsEmpty)
-                                    {
-                                        // Attributes fetched for filtering but not requested — advance reader
-                                        var attrLen = BinaryPrimitives.ReadInt32LittleEndian(remaininingAttributes);
-                                        remaininingAttributes = remaininingAttributes[(sizeof(int) + attrLen)..];
-                                    }
-
-                                    resultIndex++;
-                                    writtenCount++;
-                                }
+                                WriteRESP2Result(this, count.Value, idResult, distanceResult, filterBitmapResult, withAttributes.Value, withScores.Value, idFormat, attributeResult);
                             }
                         }
                         else if (vectorRes == VectorManagerResult.BadParams)
@@ -1091,6 +965,282 @@ namespace Garnet.server
                 if (rentedValues != null)
                 {
                     ArrayPool<byte>.Shared.Return(rentedValues);
+                }
+            }
+
+            // Write VSIM RESP2 result
+            //
+            // If not withScores and not withAttributes this is an array of matching elements in ascending order by distance
+            // If withScores (and not withAttributes) this is a map where keys are bulk string elements and values are double distances
+            // If withAttributes (and not withScores) this is a map where keys are bulk string elements and values are bulk string attributes
+            // If both withScores and withAttributes this is a map where keys are bulk string elements and values are 2 element arrays with double distances and bulk string attributes (in that order)
+            static void WriteRESP3Result(RespServerSession self, int count, SpanByteAndMemory idResult, SpanByteAndMemory distanceResult, SpanByteAndMemory filterBitmapResult, bool withAttributes, bool withScores, VectorIdFormat idFormat, SpanByteAndMemory attributeResult)
+            {
+                var remainingIds = idResult.ReadOnlySpan;
+                var distancesSpan = MemoryMarshal.Cast<byte, float>(distanceResult.ReadOnlySpan);
+                var hasFilter = filterBitmapResult.Length > 0;
+                var filterBitmap = hasFilter ? filterBitmapResult.ReadOnlySpan : default;
+                var remaininingAttributes = (withAttributes || hasFilter) ? attributeResult.ReadOnlySpan : default;
+
+                var totalFound = distancesSpan.Length;
+
+                // Compute max output count: if bitmap is present, popcount it; otherwise all results
+                int outputCount;
+                if (hasFilter)
+                {
+                    outputCount = 0;
+                    for (var b = 0; b < filterBitmap.Length; b++)
+                        outputCount += System.Numerics.BitOperations.PopCount(filterBitmap[b]);
+                }
+                else
+                {
+                    outputCount = totalFound;
+                }
+
+                // Limit to what is actually asked for
+                outputCount = Math.Min(count, outputCount);
+
+                if (!withAttributes && !withScores)
+                {
+                    // No score or attributes, simple array
+                    self.WriteArrayLength(outputCount);
+                }
+                else
+                {
+                    // At least one of scores or attributes, so a map is needed
+                    self.WriteMapLength(outputCount);
+                }
+
+                var writtenCount = 0;
+                var resultIndex = 0;
+
+                while (writtenCount < outputCount)
+                {
+                    ReadOnlySpan<byte> elementData;
+
+                    if (idFormat == VectorIdFormat.I32LengthPrefixed)
+                    {
+                        if (remainingIds.Length < sizeof(int))
+                        {
+                            throw new GarnetException($"Insufficient bytes for result id length at resultIndex={resultIndex}: {Convert.ToHexString(distanceResult.ReadOnlySpan)}");
+                        }
+
+                        var elementLen = BinaryPrimitives.ReadInt32LittleEndian(remainingIds);
+
+                        if (remainingIds.Length < sizeof(int) + elementLen)
+                        {
+                            throw new GarnetException($"Insufficient bytes for result of length={elementLen} at resultIndex={resultIndex}: {Convert.ToHexString(distanceResult.ReadOnlySpan)}");
+                        }
+
+                        elementData = remainingIds.Slice(sizeof(int), elementLen);
+                        remainingIds = remainingIds[(sizeof(int) + elementLen)..];
+                    }
+                    else if (idFormat == VectorIdFormat.FixedI32)
+                    {
+                        if (remainingIds.Length < sizeof(int))
+                        {
+                            throw new GarnetException($"Insufficient bytes for result id length at resultIndex={resultIndex}: {Convert.ToHexString(distanceResult.ReadOnlySpan)}");
+                        }
+
+                        elementData = remainingIds[..sizeof(int)];
+                        remainingIds = remainingIds[sizeof(int)..];
+                    }
+                    else
+                    {
+                        throw new GarnetException($"Unexpected id format: {idFormat}");
+                    }
+
+                    // Check filter bitmap — skip results that didn't pass the filter
+                    if (hasFilter && (filterBitmap[resultIndex >> 3] & (1 << (resultIndex & 7))) == 0)
+                    {
+                        // Advance attribute reader for skipped results (attributes are always present when bitmap exists)
+                        if (!remaininingAttributes.IsEmpty)
+                        {
+                            var skipAttrLen = BinaryPrimitives.ReadInt32LittleEndian(remaininingAttributes);
+                            remaininingAttributes = remaininingAttributes[(sizeof(int) + skipAttrLen)..];
+                        }
+
+                        resultIndex++;
+                        continue;
+                    }
+
+                    // Write the element
+                    self.WriteBulkString(elementData);
+
+                    if (withScores && withAttributes)
+                    {
+                        // Writing both, so need wrapping array
+                        self.WriteArrayLength(2);
+                    }
+
+                    if (withScores)
+                    {
+                        // Write score if requested
+                        var distance = distancesSpan[resultIndex];
+
+                        self.WriteDoubleNumeric(distance);
+                    }
+
+                    if (withAttributes)
+                    {
+                        // Write attribute if requested
+                        if (remaininingAttributes.Length < sizeof(int))
+                        {
+                            throw new GarnetException($"Insufficient bytes for attribute length at resultIndex={resultIndex}: {Convert.ToHexString(attributeResult.ReadOnlySpan)}");
+                        }
+
+                        var attrLen = BinaryPrimitives.ReadInt32LittleEndian(remaininingAttributes);
+                        var attr = remaininingAttributes.Slice(sizeof(int), attrLen);
+                        remaininingAttributes = remaininingAttributes[(sizeof(int) + attrLen)..];
+
+                        if (attr.IsEmpty)
+                        {
+                            self.WriteNull();
+                        }
+                        else
+                        {
+                            self.WriteBulkString(attr);
+                        }
+                    }
+
+                    resultIndex++;
+                    writtenCount++;
+                }
+            }
+
+            // Write VSIM RESP2 result
+            //
+            // This is an array with matching elements in ascending order by distance
+            // If withScores (and not withAttributes) then the array size is doubled and every 2nd element is a bulk string of the distance
+            // If withAttributes (and not withScores) then the array size is doubled and every 2nd element is a bulk string of the vector's attribute (if any)
+            // If both withScores and withAttributes the array size is tripled and every 2nd element is a bulk string of the distance, and every 3rd element is a bulk string of the vector's attribute (if any)
+            static void WriteRESP2Result(RespServerSession self, int count, SpanByteAndMemory idResult, SpanByteAndMemory distanceResult, SpanByteAndMemory filterBitmapResult, bool withAttributes, bool withScores, VectorIdFormat idFormat, SpanByteAndMemory attributeResult)
+            {
+                var remainingIds = idResult.ReadOnlySpan;
+                var distancesSpan = MemoryMarshal.Cast<byte, float>(distanceResult.ReadOnlySpan);
+                var hasFilter = filterBitmapResult.Length > 0;
+                var filterBitmap = hasFilter ? filterBitmapResult.ReadOnlySpan : default;
+                var remaininingAttributes = (withAttributes || hasFilter) ? attributeResult.ReadOnlySpan : default;
+
+                var totalFound = distancesSpan.Length;
+
+                // Compute max output count: if bitmap is present, popcount it; otherwise all results
+                int outputCount;
+                if (hasFilter)
+                {
+                    outputCount = 0;
+                    for (var b = 0; b < filterBitmap.Length; b++)
+                        outputCount += System.Numerics.BitOperations.PopCount(filterBitmap[b]);
+                }
+                else
+                {
+                    outputCount = totalFound;
+                }
+
+                // Limit to what is actually asked for
+                outputCount = Math.Min(count, outputCount);
+
+                // Each flag doubles output
+                var arrayItemCount = outputCount;
+                if (withScores)
+                {
+                    arrayItemCount += outputCount;
+                }
+                if (withAttributes)
+                {
+                    arrayItemCount += outputCount;
+                }
+
+                while (!RespWriteUtils.TryWriteArrayLength(arrayItemCount, ref self.dcurr, self.dend))
+                    self.SendAndReset();
+
+                var writtenCount = 0;
+                var resultIndex = 0;
+
+                while (writtenCount < outputCount)
+                {
+                    ReadOnlySpan<byte> elementData;
+
+                    if (idFormat == VectorIdFormat.I32LengthPrefixed)
+                    {
+                        if (remainingIds.Length < sizeof(int))
+                        {
+                            throw new GarnetException($"Insufficient bytes for result id length at resultIndex={resultIndex}: {Convert.ToHexString(distanceResult.ReadOnlySpan)}");
+                        }
+
+                        var elementLen = BinaryPrimitives.ReadInt32LittleEndian(remainingIds);
+
+                        if (remainingIds.Length < sizeof(int) + elementLen)
+                        {
+                            throw new GarnetException($"Insufficient bytes for result of length={elementLen} at resultIndex={resultIndex}: {Convert.ToHexString(distanceResult.ReadOnlySpan)}");
+                        }
+
+                        elementData = remainingIds.Slice(sizeof(int), elementLen);
+                        remainingIds = remainingIds[(sizeof(int) + elementLen)..];
+                    }
+                    else if (idFormat == VectorIdFormat.FixedI32)
+                    {
+                        if (remainingIds.Length < sizeof(int))
+                        {
+                            throw new GarnetException($"Insufficient bytes for result id length at resultIndex={resultIndex}: {Convert.ToHexString(distanceResult.ReadOnlySpan)}");
+                        }
+
+                        elementData = remainingIds[..sizeof(int)];
+                        remainingIds = remainingIds[sizeof(int)..];
+                    }
+                    else
+                    {
+                        throw new GarnetException($"Unexpected id format: {idFormat}");
+                    }
+
+                    // Check filter bitmap — skip results that didn't pass the filter
+                    if (hasFilter && (filterBitmap[resultIndex >> 3] & (1 << (resultIndex & 7))) == 0)
+                    {
+                        // Advance attribute reader for skipped results (attributes are always present when bitmap exists)
+                        if (!remaininingAttributes.IsEmpty)
+                        {
+                            var skipAttrLen = BinaryPrimitives.ReadInt32LittleEndian(remaininingAttributes);
+                            remaininingAttributes = remaininingAttributes[(sizeof(int) + skipAttrLen)..];
+                        }
+
+                        resultIndex++;
+                        continue;
+                    }
+
+                    while (!RespWriteUtils.TryWriteBulkString(elementData, ref self.dcurr, self.dend))
+                        self.SendAndReset();
+
+                    if (withScores)
+                    {
+                        var distance = distancesSpan[resultIndex];
+
+                        while (!RespWriteUtils.TryWriteDoubleBulkString(distance, ref self.dcurr, self.dend))
+                            self.SendAndReset();
+                    }
+
+                    if (withAttributes)
+                    {
+                        if (remaininingAttributes.Length < sizeof(int))
+                        {
+                            throw new GarnetException($"Insufficient bytes for attribute length at resultIndex={resultIndex}: {Convert.ToHexString(attributeResult.ReadOnlySpan)}");
+                        }
+
+                        var attrLen = BinaryPrimitives.ReadInt32LittleEndian(remaininingAttributes);
+                        var attr = remaininingAttributes.Slice(sizeof(int), attrLen);
+                        remaininingAttributes = remaininingAttributes[(sizeof(int) + attrLen)..];
+
+                        while (!RespWriteUtils.TryWriteBulkString(attr, ref self.dcurr, self.dend))
+                            self.SendAndReset();
+                    }
+                    else if (!remaininingAttributes.IsEmpty)
+                    {
+                        // Attributes fetched for filtering but not requested — advance reader
+                        var attrLen = BinaryPrimitives.ReadInt32LittleEndian(remaininingAttributes);
+                        remaininingAttributes = remaininingAttributes[(sizeof(int) + attrLen)..];
+                    }
+
+                    resultIndex++;
+                    writtenCount++;
                 }
             }
         }

--- a/libs/server/Resp/Vector/RespServerSessionVectors.cs
+++ b/libs/server/Resp/Vector/RespServerSessionVectors.cs
@@ -1276,50 +1276,157 @@ namespace Garnet.server
                 raw = true;
             }
 
-            // TODO: what do we do here?
             if (raw)
             {
-                throw new NotImplementedException();
-            }
+                // Write out the vector's quantized elements
+                //
+                // The quantization map (which is written as first element) is as:
+                //  BIN, XBIN_I8, XBIN_U8  -> bin
+                //  Q8, XNOQUANT_I8, XNOQUANT_U8 -> q8
+                //  NOQUANT -> fp32
+                //
+                // The data string (written as second element) is whatever DiskANN stored
+                // under the quantized vector context, EXCEPT for the *NOQUANT* quantizers in which
+                // case it's the original vector.
+                //
+                // L2 norm (third element) and quantization range (fourth element for Q8) are dummy values
+                // for now.
 
-            Span<float> distanceSpace = stackalloc float[DefaultResultSetSize];
+                Span<float> quantizedSpace = stackalloc float[DefaultResultSetSize];
+                var quantizedResult = SpanByteAndMemory.FromPinnedSpan(MemoryMarshal.Cast<float, byte>(quantizedSpace));
 
-            var distanceResult = SpanByteAndMemory.FromPinnedSpan(MemoryMarshal.Cast<float, byte>(distanceSpace));
-
-            try
-            {
-                var res = storageApi.VectorSetEmbedding(key, elem, ref distanceResult);
-
-                if (res == GarnetStatus.OK)
+                try
                 {
-                    var distanceSpan = MemoryMarshal.Cast<byte, float>(distanceResult.ReadOnlySpan);
+                    var res = storageApi.VectorSetRawEmbedding(key, elem, ref quantizedResult, out var quantType, out var norm, out var range);
 
-                    while (!RespWriteUtils.TryWriteArrayLength(distanceSpan.Length, ref dcurr, dend))
-                        SendAndReset();
-
-                    for (var i = 0; i < distanceSpan.Length; i++)
+                    if (res == GarnetStatus.OK)
                     {
-                        while (!RespWriteUtils.TryWriteDoubleBulkString(distanceSpan[i], ref dcurr, dend))
+                        // Start array
+                        if (quantType == VectorQuantType.Q8)
+                        {
+                            WriteArrayLength(4);
+                        }
+                        else
+                        {
+                            WriteArrayLength(3);
+                        }
+
+                        // Write quant type
+                        if (quantType is VectorQuantType.Bin or VectorQuantType.XBin_I8 or VectorQuantType.XBin_U8)
+                        {
+                            WriteSimpleString("bin"u8);
+                        }
+                        else if (quantType is VectorQuantType.Q8 or VectorQuantType.XNoQuant_U8 or VectorQuantType.XNoQuant_I8)
+                        {
+                            WriteSimpleString("q8"u8);
+                        }
+                        else if (quantType == VectorQuantType.NoQuant)
+                        {
+                            WriteSimpleString("fp32");
+                        }
+                        else
+                        {
+                            throw new GarnetException($"Unexpected quantization type: {quantType}");
+                        }
+
+                        // Write raw data
+                        WriteBulkString(quantizedResult.ReadOnlySpan);
+
+                        // Write norm
+                        if (respProtocolVersion == 3)
+                        {
+                            WriteDoubleNumeric(norm);
+                        }
+                        else
+                        {
+                            while (!RespWriteUtils.TryWriteDoubleBulkString(norm, ref dcurr, dend))
+                                SendAndReset();
+                        }
+
+                        // For Q8 only write quantization range
+                        if (quantType == VectorQuantType.Q8)
+                        {
+                            if (respProtocolVersion == 3)
+                            {
+                                WriteDoubleNumeric(range.Value);
+                            }
+                            else
+                            {
+                                while (!RespWriteUtils.TryWriteDoubleBulkString(norm, ref dcurr, dend))
+                                    SendAndReset();
+                            }
+                        }
+                    }
+                    else if (res == GarnetStatus.WRONGTYPE)
+                    {
+                        return AbortVectorSetWrongType();
+                    }
+                    else
+                    {
+                        while (!RespWriteUtils.TryWriteEmptyArray(ref dcurr, dend))
                             SendAndReset();
                     }
-                }
-                else if (res == GarnetStatus.WRONGTYPE)
-                {
-                    return AbortVectorSetWrongType();
-                }
-                else
-                {
-                    while (!RespWriteUtils.TryWriteEmptyArray(ref dcurr, dend))
-                        SendAndReset();
-                }
 
-                return true;
-            }
-            finally
-            {
-                if (!distanceResult.IsSpanByte)
+                    return true;
+                }
+                finally
                 {
-                    distanceResult.Memory.Dispose();
+                    quantizedResult.Dispose();
+                }
+            }
+            else
+            {
+                // Write out the vector's elements
+                //
+                // In Redis this is reconstructed from quantized data, but with DiskANN we just have the real original values
+
+                Span<float> distanceSpace = stackalloc float[DefaultResultSetSize];
+
+                var distanceResult = SpanByteAndMemory.FromPinnedSpan(MemoryMarshal.Cast<float, byte>(distanceSpace));
+
+                try
+                {
+                    var res = storageApi.VectorSetEmbedding(key, elem, ref distanceResult);
+
+                    if (res == GarnetStatus.OK)
+                    {
+                        var distanceSpan = MemoryMarshal.Cast<byte, float>(distanceResult.ReadOnlySpan);
+
+                        while (!RespWriteUtils.TryWriteArrayLength(distanceSpan.Length, ref dcurr, dend))
+                            SendAndReset();
+
+                        if (respProtocolVersion == 3)
+                        {
+                            for (var i = 0; i < distanceSpan.Length; i++)
+                            {
+                                while (!RespWriteUtils.TryWriteDoubleNumeric(distanceSpan[i], ref dcurr, dend))
+                                    SendAndReset();
+                            }
+                        }
+                        else
+                        {
+                            for (var i = 0; i < distanceSpan.Length; i++)
+                            {
+                                while (!RespWriteUtils.TryWriteDoubleBulkString(distanceSpan[i], ref dcurr, dend))
+                                    SendAndReset();
+                            }
+                        }
+                    }
+                    else if (res == GarnetStatus.WRONGTYPE)
+                    {
+                        return AbortVectorSetWrongType();
+                    }
+                    else
+                    {
+                        while (!RespWriteUtils.TryWriteEmptyArray(ref dcurr, dend))
+                            SendAndReset();
+                    }
+
+                    return true;
+                }
+                finally
+                {
+                    distanceResult.Dispose();
                 }
             }
         }

--- a/libs/server/Resp/Vector/RespServerSessionVectors.cs
+++ b/libs/server/Resp/Vector/RespServerSessionVectors.cs
@@ -968,7 +968,7 @@ namespace Garnet.server
                 }
             }
 
-            // Write VSIM RESP2 result
+            // Write VSIM RESP3 result
             //
             // If not withScores and not withAttributes this is an array of matching elements in ascending order by distance
             // If withScores (and not withAttributes) this is a map where keys are bulk string elements and values are double distances
@@ -1352,7 +1352,7 @@ namespace Garnet.server
                             }
                             else
                             {
-                                while (!RespWriteUtils.TryWriteDoubleBulkString(norm, ref dcurr, dend))
+                                while (!RespWriteUtils.TryWriteDoubleBulkString(range.Value, ref dcurr, dend))
                                     SendAndReset();
                             }
                         }

--- a/libs/server/Resp/Vector/VectorManager.cs
+++ b/libs/server/Resp/Vector/VectorManager.cs
@@ -1257,6 +1257,72 @@ namespace Garnet.server
             }
         }
 
+        /// <summary>
+        /// Try to read the associated raw quantization data for an element out of a Vector Set.
+        /// </summary>
+        internal bool TryGetRawEmbedding(ReadOnlySpan<byte> indexValue, ReadOnlySpan<byte> element, ref SpanByteAndMemory quantizedValues, out VectorQuantType quantType, out double norm, out double? range)
+        {
+            AssertHaveStorageSession();
+
+            ReadIndex(indexValue, out var context, out _, out _, out quantType, out _, out _, out _, out _);
+
+            // Get internal id for the given element
+            Span<byte> internalId = stackalloc byte[sizeof(int)];
+            var internalIdBytes = SpanByteAndMemory.FromPinnedSpan(internalId);
+            try
+            {
+                if (!ReadSizeUnknown(context | DiskANNService.InternalIdMap, forceAlignment: true, element, ref internalIdBytes))
+                {
+                    norm = double.NaN;
+                    range = null;
+                    return false;
+                }
+
+                Debug.Assert(internalIdBytes.IsSpanByte, "Internal Id should always be of known size");
+            }
+            finally
+            {
+                internalIdBytes.Memory?.Dispose();
+            }
+
+            // NoQuant-ish quantizers won't have a quantized vector in the steady state
+            var readContext = context;
+            if (quantType is VectorQuantType.NoQuant or VectorQuantType.XNoQuant_U8 or VectorQuantType.XNoQuant_I8)
+            {
+                readContext |= DiskANNService.FullVector;
+            }
+            else
+            {
+                readContext |= DiskANNService.QuantizedVector;
+            }
+
+            // Get the RAW view - we're leaking DiskANN internal details here but that's _kind of_ the point
+            while (true)
+            {
+                if (ReadSizeUnknown(readContext, forceAlignment: true, internalId, ref quantizedValues))
+                {
+                    break;
+                }
+
+                // If read fails, that _might_ mean that quantization hasn't happened yet, so try and fetch the full vector
+                if (readContext == (context | DiskANNService.QuantizedVector))
+                {
+                    readContext = context | DiskANNService.FullVector;
+                    continue;
+                }
+
+                norm = double.NaN;
+                range = null;
+                return false;
+            }
+
+            // TODO: These values are nonsense, but is there an equivalent we can pull out for DiskANN?
+            norm = 1.0;
+            range = quantType == VectorQuantType.Q8 ? 1.0 : null;
+
+            return true;
+        }
+
         [Conditional("DEBUG")]
         private static void AssertHaveStorageSession()
         {

--- a/libs/server/Resp/Vector/VectorManager.cs
+++ b/libs/server/Resp/Vector/VectorManager.cs
@@ -1282,7 +1282,7 @@ namespace Garnet.server
         {
             AssertHaveStorageSession();
 
-            ReadIndex(indexValue, out var context, out _, out _, out quantType, out _, out _, out _, out _);
+            ReadIndex(indexValue, out var context, out _, out _, out quantType, out _, out _, out _, out _, out _);
 
             // Get internal id for the given element
             Span<byte> internalId = stackalloc byte[sizeof(int)];

--- a/libs/server/Storage/Session/MainStore/VectorStoreOps.cs
+++ b/libs/server/Storage/Session/MainStore/VectorStoreOps.cs
@@ -331,7 +331,7 @@ namespace Garnet.server
         }
 
         /// <summary>
-        /// Get a RAW view of a quantized vector associated with an element, after (approximately) reversing any transformation.
+        /// Get a RAW view of a quantized (or full, if no quantized version is available) vector associated with an element.
         /// </summary>
         [SkipLocalsInit]
         public GarnetStatus VectorSetRawEmbedding(PinnedSpanByte key, ReadOnlySpan<byte> element, ref SpanByteAndMemory quantizedValues, out VectorQuantType quantType, out double norm, out double? range)

--- a/libs/server/Storage/Session/MainStore/VectorStoreOps.cs
+++ b/libs/server/Storage/Session/MainStore/VectorStoreOps.cs
@@ -287,10 +287,10 @@ namespace Garnet.server
         }
 
         /// <summary>
-        /// Get the approximate vector associated with an element, after (approximately) reversing any transformation.
+        /// Get the vector associated with an element.
         /// </summary>
         [SkipLocalsInit]
-        public unsafe GarnetStatus VectorSetEmbedding(PinnedSpanByte key, ReadOnlySpan<byte> element, ref SpanByteAndMemory outputDistances)
+        public GarnetStatus VectorSetEmbedding(PinnedSpanByte key, ReadOnlySpan<byte> element, ref SpanByteAndMemory outputDistances)
         {
             parseState.InitializeWithArgument(key);
 
@@ -306,6 +306,37 @@ namespace Garnet.server
                 }
 
                 if (!vectorManager.TryGetEmbedding(indexSpan, element, ref outputDistances))
+                {
+                    return GarnetStatus.NOTFOUND;
+                }
+
+                return GarnetStatus.OK;
+            }
+        }
+
+        /// <summary>
+        /// Get a RAW view of a quantized vector associated with an element, after (approximately) reversing any transformation.
+        /// </summary>
+        [SkipLocalsInit]
+        public GarnetStatus VectorSetRawEmbedding(PinnedSpanByte key, ReadOnlySpan<byte> element, ref SpanByteAndMemory quantizedValues, out VectorQuantType quantType, out double norm, out double? range)
+        {
+            parseState.InitializeWithArgument(key);
+
+            var input = new StringInput(RespCommand.VEMB, ref parseState);
+
+            Span<byte> indexSpan = stackalloc byte[VectorManager.IndexSizeBytes];
+
+            using (vectorManager.ReadVectorIndex(this, key, ref input, indexSpan, out var status))
+            {
+                if (status != GarnetStatus.OK)
+                {
+                    quantType = VectorQuantType.Invalid;
+                    norm = double.NaN;
+                    range = null;
+                    return status;
+                }
+
+                if (!vectorManager.TryGetRawEmbedding(indexSpan, element, ref quantizedValues, out quantType, out norm, out range))
                 {
                     return GarnetStatus.NOTFOUND;
                 }

--- a/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
+++ b/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
@@ -3314,6 +3314,87 @@ namespace Garnet.test
             }
         }
 
+        [Test]
+        [CancelAfter(30_000)]
+        public async Task VEMBRawAsync([Values("NOQUANT", "Q8", "BIN", "XNOQUANT_U8", "XNOQUANT_I8", "XBIN_I8", "XBIN_U8")] string quantizer, CancellationToken cancellation)
+        {
+            const string VectorSetName = nameof(VEMBRawAsync);
+            const string ElementName = nameof(ElementName);
+            const int VectorsForQuantization = 2_000;
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            var quantizationNeeded = !(quantizer.Contains("NOQUANT", StringComparison.OrdinalIgnoreCase) || quantizer == "Q8");
+
+            var addRes = (int)await db.ExecuteAsync("VADD", [VectorSetName, "VALUES", "3", "1.0", "2.0", "3.0", ElementName, quantizer]).ConfigureAwait(false);
+            ClassicAssert.AreEqual(1, addRes);
+
+            await CheckRAWAsync(db, quantizer).ConfigureAwait(false);
+
+            if (quantizationNeeded)
+            {
+                // Trigger quantization if it's possible
+                var vectorManager = server.Provider.StoreWrapper.DefaultDatabase.VectorManager;
+
+                var quantTableStart = vectorManager.QuantizationRequestsProcessed;
+                var quantBackfillStart = vectorManager.QuantizationBackfillsProcessed;
+
+                var addsTriggeringQuantization = new Task<RedisResult>[VectorsForQuantization];
+
+                for (var i = 0; i < addsTriggeringQuantization.Length; i++)
+                {
+                    addsTriggeringQuantization[i] = db.ExecuteAsync("VADD", [VectorSetName, "VALUES", "3", "4.0", "5.0", "6.0", $"{ElementName}_{i}", quantizer]);
+                }
+
+                _ = await Task.WhenAll(addsTriggeringQuantization).ConfigureAwait(false);
+                foreach (var t in addsTriggeringQuantization)
+                {
+                    ClassicAssert.AreEqual(1, (int)await t.ConfigureAwait(false));
+                }
+
+                // We expect 1 _succesful_ table build
+                while (vectorManager.QuantizationRequestsProcessed != (quantTableStart + 1))
+                {
+                    await Task.Delay(1_000, cancellation).ConfigureAwait(false);
+                }
+
+                // No explicit config is set, so we expect Environment.ProcessorCount _successful_ backfills after the table build
+                while (vectorManager.QuantizationBackfillsProcessed != (quantBackfillStart + Environment.ProcessorCount))
+                {
+                    await Task.Delay(1_000, cancellation).ConfigureAwait(false);
+                }
+
+                await CheckRAWAsync(db, quantizer).ConfigureAwait(false);
+            }
+
+            static async Task CheckRAWAsync(IDatabase db, string quantizer)
+            {
+                var preQuantVEMBRaw = (byte[][])await db.ExecuteAsync("VEMB", [VectorSetName, ElementName, "RAW"]).ConfigureAwait(false);
+                var expectedLength = quantizer == "Q8" ? 4 : 3;
+
+                ClassicAssert.AreEqual(expectedLength, preQuantVEMBRaw.Length);
+
+                var expectedQType =
+                    quantizer switch
+                    {
+                        "NOQUANT" => "fp32",
+                        "Q8" or "XNOQUANT_I8" or "XNOQUANT_U8" => "q8",
+                        "BIN" or "XBIN_I8" or "XBIN_U8" => "bin",
+                        _ => throw new InvalidOperationException($"Unexpected quantizer: {quantizer}"),
+                    };
+                ClassicAssert.AreEqual(expectedQType, Encoding.ASCII.GetString(preQuantVEMBRaw[0]));
+
+                ClassicAssert.AreNotEqual(0, preQuantVEMBRaw[1].Length);
+                ClassicAssert.IsFalse(double.IsNaN(double.Parse(Encoding.ASCII.GetString(preQuantVEMBRaw[2]))));
+
+                if (expectedLength > 3)
+                {
+                    ClassicAssert.IsFalse(double.IsNaN(double.Parse(Encoding.ASCII.GetString(preQuantVEMBRaw[3]))));
+                }
+            }
+        }
+
         /// <summary>
         /// Create a new GarnetServer instance with common parameters.
         /// </summary>

--- a/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
+++ b/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
@@ -554,6 +554,132 @@ namespace Garnet.test
         }
 
         [Test]
+        public void VSIMResp3()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: RedisProtocol.Resp3));
+            var db = redis.GetDatabase();
+
+            var res1 = db.Execute("VADD", ["foo", "REDUCE", "50", "VALUES", "75", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "fizz", "CAS", "NOQUANT", "EF", "16", "M", "32", "SETATTR", "{\"id\": 123}"]);
+            ClassicAssert.AreEqual(1, (int)res1);
+
+            var res2 = db.Execute("VADD", ["foo", "REDUCE", "50", "VALUES", "75", "100.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "buzz", "CAS", "NOQUANT", "EF", "16", "M", "32", "SETATTR", "{\"id\": 456}"]);
+            ClassicAssert.AreEqual(1, (int)res2);
+
+            var res3 = (string[])db.Execute("VSIM", ["foo", "VALUES", "75", "110.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "COUNT", "5", "EPSILON", "1.0", "EF", "40"]);
+            ClassicAssert.AreEqual(2, res3.Length);
+            ClassicAssert.IsTrue(res3.Contains("fizz"));
+            ClassicAssert.IsTrue(res3.Contains("buzz"));
+
+            var res4 = (string[])db.Execute("VSIM", ["foo", "ELE", "fizz", "COUNT", "5", "EPSILON", "1.0", "EF", "40"]);
+            ClassicAssert.AreEqual(2, res4.Length);
+            ClassicAssert.IsTrue(res4.Contains("fizz"));
+            ClassicAssert.IsTrue(res4.Contains("buzz"));
+
+            // FP32
+            var float5 = new float[75];
+            float5[0] = 3;
+            for (var i = 1; i < float5.Length; i++)
+            {
+                float5[i] = float5[i - 1] + 0.1f;
+            }
+            var res5 = (string[])db.Execute("VSIM", ["foo", "FP32", MemoryMarshal.Cast<float, byte>(float5).ToArray(), "COUNT", "5", "EPSILON", "1.0", "EF", "40"]);
+            ClassicAssert.AreEqual(2, res5.Length);
+            ClassicAssert.IsTrue(res5.Contains("fizz"));
+            ClassicAssert.IsTrue(res5.Contains("buzz"));
+
+            // XB8
+            var byte6 = new byte[75];
+            byte6[0] = 10;
+            for (var i = 1; i < byte6.Length; i++)
+            {
+                byte6[i] = (byte)(byte6[i - 1] + 1);
+            }
+            var res6 = (string[])db.Execute("VSIM", ["foo", "XB8", byte6, "COUNT", "5", "EPSILON", "1.0", "EF", "40"]);
+            ClassicAssert.AreEqual(2, res6.Length);
+            ClassicAssert.IsTrue(res6.Contains("fizz"));
+            ClassicAssert.IsTrue(res6.Contains("buzz"));
+
+            // COUNT > EF
+            var byte7 = new byte[75];
+            byte7[0] = 20;
+            for (var i = 1; i < byte7.Length; i++)
+            {
+                byte7[i] = (byte)(byte7[i - 1] + 1);
+            }
+            var res7 = (string[])db.Execute("VSIM", ["foo", "XB8", byte7, "COUNT", "100", "EPSILON", "1.0", "EF", "40"]);
+            ClassicAssert.AreEqual(2, res7.Length);
+            ClassicAssert.IsTrue(res7.Contains("fizz"));
+            ClassicAssert.IsTrue(res7.Contains("buzz"));
+
+            // WITHSCORES (a MAP in Resp3)
+            var res8Raw = db.Execute("VSIM", ["foo", "XB8", byte7, "COUNT", "100", "EPSILON", "1.0", "EF", "40", "WITHSCORES"]);
+            ClassicAssert.AreEqual(ResultType.Map, res8Raw.Resp3Type);
+
+            var res8 = res8Raw.ToDictionary();
+            ClassicAssert.IsTrue(res8.Values.All(static v => ResultType.Double == v.Resp3Type));
+
+            ClassicAssert.AreEqual(2, res8.Count);
+            ClassicAssert.IsTrue(res8.ContainsKey("fizz"));
+            ClassicAssert.IsTrue(res8.ContainsKey("buzz"));
+            ClassicAssert.IsFalse(res8.Values.Any(static x => double.IsNaN((double)x)));
+
+            // WITHATTRIBS (a MAP in Resp3)
+            var res9Raw = db.Execute("VSIM", ["foo", "XB8", byte7, "COUNT", "100", "EPSILON", "1.0", "EF", "40", "WITHATTRIBS"]);
+            ClassicAssert.AreEqual(ResultType.Map, res9Raw.Resp3Type);
+
+            var res9 = res9Raw.ToDictionary();
+            ClassicAssert.IsTrue(res9.Values.All(static v => ResultType.BulkString == v.Resp3Type));
+
+            ClassicAssert.AreEqual(2, res9.Count);
+            ClassicAssert.IsTrue(res9.ContainsKey("fizz"));
+            ClassicAssert.IsTrue(res9.ContainsKey("buzz"));
+            ClassicAssert.AreEqual("{\"id\": 123}", (string)res9["fizz"]);
+            ClassicAssert.AreEqual("{\"id\": 456}", (string)res9["buzz"]);
+
+            // WITHSCORES and WITHATTRIBS (a MAP in Resp3)
+            var res10Raw = db.Execute("VSIM", ["foo", "XB8", byte7, "COUNT", "100", "EPSILON", "1.0", "EF", "40", "WITHATTRIBS", "WITHSCORES"]);
+            ClassicAssert.AreEqual(ResultType.Map, res10Raw.Resp3Type);
+
+            var res10 = res10Raw.ToDictionary();
+            ClassicAssert.IsTrue(res10.Values.All(static v => ResultType.Array == v.Resp3Type));
+
+            ClassicAssert.AreEqual(2, res10.Count);
+            ClassicAssert.IsTrue(res10.ContainsKey("fizz"));
+            ClassicAssert.IsTrue(res10.ContainsKey("buzz"));
+
+            var res10Fizz = (RedisResult[])res10["fizz"];
+            var res10Buzz = (RedisResult[])res10["buzz"];
+            ClassicAssert.AreEqual(2, res10Fizz.Length);
+            ClassicAssert.AreEqual(ResultType.Double, res10Fizz[0].Resp3Type);
+            ClassicAssert.AreEqual(ResultType.BulkString, res10Fizz[1].Resp3Type);
+            ClassicAssert.AreEqual(2, res10Buzz.Length);
+            ClassicAssert.AreEqual(ResultType.Double, res10Buzz[0].Resp3Type);
+            ClassicAssert.AreEqual(ResultType.BulkString, res10Buzz[1].Resp3Type);
+
+            ClassicAssert.IsFalse(double.IsNaN((double)res10Fizz[0]));
+            ClassicAssert.AreEqual("{\"id\": 123}", (string)res10Fizz[1]);
+
+            ClassicAssert.IsFalse(double.IsNaN((double)res10Buzz[0]));
+            ClassicAssert.AreEqual("{\"id\": 456}", (string)res10Buzz[1]);
+
+            // WITHSCORES and WITHATTRIBS (a MAP in Resp3)
+            var res11Raw = db.Execute("VSIM", ["foo", "XB8", byte7, "COUNT", "100", "EPSILON", "1.0", "EF", "40", "WITHATTRIBS", "WITHSCORES", "FILTER", ".id > 200"]);
+            ClassicAssert.AreEqual(ResultType.Map, res11Raw.Resp3Type);
+
+            var res11 = res11Raw.ToDictionary();
+            ClassicAssert.AreEqual(1, res11.Count);
+
+            var res11Buzz = res11["buzz"];
+            ClassicAssert.AreEqual(ResultType.Array, res11Buzz.Resp3Type);
+            ClassicAssert.AreEqual(2, res11Buzz.Length);
+            ClassicAssert.AreEqual(ResultType.Double, res11Buzz[0].Resp3Type);
+            ClassicAssert.AreEqual(ResultType.BulkString, res11Buzz[1].Resp3Type);
+
+            ClassicAssert.IsFalse(double.IsNaN((double)res11Buzz[0]));
+            ClassicAssert.AreEqual("{\"id\": 456}", (string)res11Buzz[1]);
+        }
+
+        [Test]
         public void VSIMWithAttribs()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());


### PR DESCRIPTION
Knocking a couple more TODOs out on Vector Sets.

 - RESP3 response for [`VSIM`](https://redis.io/docs/latest/commands/vsim/)
 - `RAW` option for [`VEMB`](https://redis.io/docs/latest/commands/vemb/), as well as some RESP3 fixes
 
 `RAW` intentionally exposes implementation details in Redis - rather than try and fake those for Garnet, I fit the expected shape and expose some of our own internal details.

Concretely that means:
 - We return the quantized vector data stored by DiskANN if available, with no formatting or other changes
 - If no quantized vector data is available, we return the full vector (also with no formatting or other changes)
 - We map our quantizer extensions to `bin|q8|fp32` 
   * `BIN`, `XBIN_I8`, `XBIN_U8` -> `bin`
   * `Q8`, `XNOQUANT_U8`, `XNOQUANT_I8` -> `q8`
   * `NOQUANT` -> `fp32`
 - L2 norm and quantization range (if applicable) are given non-zero dummy values of `1.0`
   * We may choose to put something real here later, but the only guidance for them in Redis docs is to multiply dimension data by range, so `1.0` works
   * Arguably `RAW` should never be used in applications, only during debugging, so we can leave these dummied out forever
