### PR TITLE
Fix casts in bftree FFI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         os: [ ubuntu-latest, windows-latest ]
         framework: [ 'net8.0' , 'net10.0']
         configuration: [ 'Debug', 'Release' ]
-        test: [ 'Garnet.test', 'Garnet.test.collections', 'Garnet.test.acl', 'Garnet.test.scripting', 'Garnet.test.complexstring', 'Garnet.test.vectorset', 'Garnet.test.rangeindex', 'Garnet.test.extensions' ]
+        test: [ 'Garnet.test', 'Garnet.test.collections', 'Garnet.test.acl', 'Garnet.test.scripting', 'Garnet.test.complexstring', 'Garnet.test.vectorset', 'Garnet.test.rangeindex', 'Garnet.test.extensions', 'BfTreeInterop.test' ]
     if: needs.changes.outputs.garnet == 'true'
     steps:
       - name: Check out code
@@ -138,6 +138,9 @@ jobs:
           restore-keys: nuget-${{ runner.os }}-
       - name: Install dependencies
         run: dotnet restore
+      - name: Build native BfTree library
+        if: ${{ matrix.test == 'BfTreeInterop.test' }}
+        run: cargo build --release --locked --manifest-path libs/native/bftree-garnet/Cargo.toml
       - name: Run tests ${{ matrix.test }}
         run: dotnet test test/standalone/${{ matrix.test }} -f ${{ matrix.framework }} --configuration ${{ matrix.configuration }} --logger "console;verbosity=detailed" --logger trx --results-directory "GarnetTestResults-${{ matrix.os }}-${{ matrix.framework }}-${{ matrix.configuration }}-${{ matrix.test }}" -- NUnit.DisplayName=FullName
         timeout-minutes: 45 

--- a/Garnet.slnx
+++ b/Garnet.slnx
@@ -77,6 +77,7 @@
   </Folder>
   <Folder Name="/test/">
     <Project Path="test/Garnet.fuzz/Garnet.fuzz.csproj" />
+    <Project Path="test/standalone/BfTreeInterop.test/BfTreeInterop.test.csproj" />
     <Project Path="test/standalone/Garnet.test/Garnet.test.csproj" />
     <Project Path="test/standalone/Garnet.test.acl/Garnet.test.acl.csproj" />
     <Project Path="test/standalone/Garnet.test.collections/Garnet.test.collections.csproj" />

--- a/libs/native/bftree-garnet/BfTreeService.cs
+++ b/libs/native/bftree-garnet/BfTreeService.cs
@@ -23,6 +23,8 @@ namespace Garnet.server.BfTreeInterop
         Deleted = -2,
         /// <summary>The key is invalid (e.g. too long).</summary>
         InvalidKey = -3,
+        /// <summary>Invalid arguments (null pointer or negative length).</summary>
+        InvalidArguments = -4,
     }
 
     /// <summary>
@@ -34,6 +36,19 @@ namespace Garnet.server.BfTreeInterop
         Success = 0,
         /// <summary>Key or value is invalid (e.g. exceeds configured limits).</summary>
         InvalidKV = 1,
+        /// <summary>Invalid arguments (null pointer or negative length).</summary>
+        InvalidArguments = -1,
+    }
+
+    /// <summary>
+    /// Result codes for BfTree delete operations.
+    /// </summary>
+    public enum BfTreeDeleteResult
+    {
+        /// <summary>Delete succeeded.</summary>
+        Success = 0,
+        /// <summary>Invalid arguments (null pointer or negative length).</summary>
+        InvalidArguments = -1,
     }
 
     /// <summary>
@@ -201,9 +216,9 @@ namespace Garnet.server.BfTreeInterop
         /// Delete a key. Zero-overhead.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Delete(PinnedSpanByte key)
+        public BfTreeDeleteResult Delete(PinnedSpanByte key)
         {
-            NativeBfTreeMethods.bftree_delete(_tree, key.ToPointer(), key.Length);
+            return (BfTreeDeleteResult)NativeBfTreeMethods.bftree_delete(_tree, key.ToPointer(), key.Length);
         }
 
         /// <summary>
@@ -270,9 +285,9 @@ namespace Garnet.server.BfTreeInterop
         /// Delete via native pointer.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void DeleteByPtr(nint treePtr, PinnedSpanByte key)
+        public static BfTreeDeleteResult DeleteByPtr(nint treePtr, PinnedSpanByte key)
         {
-            NativeBfTreeMethods.bftree_delete(treePtr, key.ToPointer(), key.Length);
+            return (BfTreeDeleteResult)NativeBfTreeMethods.bftree_delete(treePtr, key.ToPointer(), key.Length);
         }
 
         /// <summary>
@@ -287,6 +302,10 @@ namespace Garnet.server.BfTreeInterop
                 handle = NativeBfTreeMethods.bftree_scan_with_count(
                     treePtr, skp, startKey.Length, count, (byte)returnField);
             }
+
+            if (handle == nint.Zero)
+                throw new InvalidOperationException("bftree_scan_with_count returned a null handle.");
+
             try
             {
                 Span<byte> buffer = stackalloc byte[8192];
@@ -310,6 +329,10 @@ namespace Garnet.server.BfTreeInterop
                 handle = NativeBfTreeMethods.bftree_scan_with_end_key(
                     treePtr, skp, startKey.Length, ekp, endKey.Length, (byte)returnField);
             }
+
+            if (handle == nint.Zero)
+                throw new InvalidOperationException("bftree_scan_with_end_key returned a null handle.");
+
             try
             {
                 Span<byte> buffer = stackalloc byte[8192];
@@ -367,11 +390,11 @@ namespace Garnet.server.BfTreeInterop
         /// <summary>
         /// Delete a key from the BfTree.
         /// </summary>
-        public void Delete(ReadOnlySpan<byte> key)
+        public BfTreeDeleteResult Delete(ReadOnlySpan<byte> key)
         {
             ObjectDisposedException.ThrowIf(_disposed != 0, this);
             fixed (byte* kp = key)
-                Delete(PinnedSpanByte.FromPinnedPointer(kp, key.Length));
+                return Delete(PinnedSpanByte.FromPinnedPointer(kp, key.Length));
         }
 
         /// <summary>
@@ -398,6 +421,10 @@ namespace Garnet.server.BfTreeInterop
                 handle = NativeBfTreeMethods.bftree_scan_with_count(
                     _tree, skp, startKey.Length, count, (byte)returnField);
             }
+
+            if (handle == nint.Zero)
+                throw new InvalidOperationException("bftree_scan_with_count returned a null handle.");
+
             try
             {
                 return DrainScanIteratorWithCallback(handle, scanBuffer, returnField, onRecord);
@@ -424,6 +451,10 @@ namespace Garnet.server.BfTreeInterop
                 handle = NativeBfTreeMethods.bftree_scan_with_count(
                     _tree, skp, startKey.Length, count, (byte)returnField);
             }
+
+            if (handle == nint.Zero)
+                throw new InvalidOperationException("bftree_scan_with_count returned a null handle.");
+
             try
             {
                 return DrainScanIteratorToList(handle, returnField);
@@ -448,6 +479,10 @@ namespace Garnet.server.BfTreeInterop
                 handle = NativeBfTreeMethods.bftree_scan_with_end_key(
                     _tree, skp, startKey.Length, ekp, endKey.Length, (byte)returnField);
             }
+
+            if (handle == nint.Zero)
+                throw new InvalidOperationException("bftree_scan_with_end_key returned a null handle.");
+
             try
             {
                 return DrainScanIteratorToList(handle, returnField);

--- a/libs/native/bftree-garnet/NativeBfTreeMethods.cs
+++ b/libs/native/bftree-garnet/NativeBfTreeMethods.cs
@@ -49,7 +49,8 @@ namespace Garnet.server.BfTreeInterop
         // ---------------------------------------------------------------
 
         /// <summary>
-        /// Insert a key-value pair. Returns 0 on success, 1 on invalid KV.
+        /// Insert a key-value pair. Returns 0 on success, 1 on invalid KV (size limits),
+        /// -1 on invalid arguments (null pointer or negative length).
         /// </summary>
         [LibraryImport(LibName)]
         internal static partial int bftree_insert(
@@ -59,7 +60,8 @@ namespace Garnet.server.BfTreeInterop
 
         /// <summary>
         /// Read the value for a key into out_buffer.
-        /// Returns 0 (found), -1 (not found), -2 (deleted), -3 (invalid key).
+        /// Returns 0 (found), -1 (not found), -2 (deleted), -3 (invalid key),
+        /// -4 (invalid arguments: null pointer or negative length).
         /// On success, out_value_len is set to the number of bytes written.
         /// </summary>
         [LibraryImport(LibName)]
@@ -70,10 +72,11 @@ namespace Garnet.server.BfTreeInterop
             int* out_value_len);
 
         /// <summary>
-        /// Delete a key from the tree.
+        /// Delete a key from the tree. Returns 0 on success, -1 on invalid arguments
+        /// (null pointer or negative length).
         /// </summary>
         [LibraryImport(LibName)]
-        internal static partial void bftree_delete(
+        internal static partial int bftree_delete(
             nint tree,
             byte* key, int key_len);
 

--- a/libs/native/bftree-garnet/Properties/AssemblyInfo.cs
+++ b/libs/native/bftree-garnet/Properties/AssemblyInfo.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("BfTreeInterop.test" + BfTreeAssemblyRef.GarnetPublicKey)]
+
+/// <summary>
+/// Sets public key string for friend assemblies.
+/// </summary>
+static class BfTreeAssemblyRef
+{
+    internal const string GarnetPublicKey = ", PublicKey=0024000004800000940000000602000000240000525341310004000001000100011b1661238d3d3c76232193c8aa2de8c05b8930d6dfe8cd88797a8f5624fdf14a1643141f31da05c0f67961b0e3a64c7120001d2f8579f01ac788b0ff545790d44854abe02f42bfe36a056166a75c6a694db8c5b6609cff8a2dbb429855a1d9f79d4d8ec3e145c74bfdd903274b7344beea93eab86b422652f8dd8eecf530d2";
+}

--- a/libs/native/bftree-garnet/src/lib.rs
+++ b/libs/native/bftree-garnet/src/lib.rs
@@ -19,9 +19,14 @@ const READ_FOUND: i32 = 0; // Actual byte count is in `out_value_len`.
 const READ_NOT_FOUND: i32 = -1;
 const READ_DELETED: i32 = -2;
 const READ_INVALID_KEY: i32 = -3;
+const READ_INVALID_ARGS: i32 = -4;
 
 const INSERT_SUCCESS: i32 = 0;
 const INSERT_INVALID_KV: i32 = 1;
+const INSERT_INVALID_ARGS: i32 = -1;
+
+const DELETE_SUCCESS: i32 = 0;
+const DELETE_INVALID_ARGS: i32 = -1;
 
 // ---------------------------------------------------------------------------
 // Storage backend constants (matches C# StorageBackendType enum)
@@ -140,7 +145,9 @@ pub unsafe extern "C" fn bftree_drop(tree: *mut BfTree) {
 // Point operations
 // ---------------------------------------------------------------------------
 
-/// Insert a key-value pair. Returns INSERT_SUCCESS (0) or INSERT_INVALID_KV (1).
+/// Insert a key-value pair. Returns INSERT_SUCCESS (0), INSERT_INVALID_KV (1) when
+/// the key/value violates the tree's configured size limits, or INSERT_INVALID_ARGS
+/// (-1) when the arguments are invalid (null pointers or a negative length).
 ///
 /// # Safety
 /// `tree` must be a valid BfTree pointer. `key`/`value` must point to valid
@@ -153,6 +160,10 @@ pub unsafe extern "C" fn bftree_insert(
     value: *const u8,
     value_len: i32,
 ) -> i32 {
+    if tree.is_null() || key.is_null() || value.is_null() || key_len < 0 || value_len < 0 {
+        return INSERT_INVALID_ARGS;
+    }
+
     let tree = &*tree;
     let key = slice::from_raw_parts(key, key_len as usize);
     let value = slice::from_raw_parts(value, value_len as usize);
@@ -167,8 +178,9 @@ pub unsafe extern "C" fn bftree_insert(
 /// On success, writes the value bytes into `out_buffer` and sets
 /// `*out_value_len` to the number of bytes written. Returns READ_FOUND (0).
 ///
-/// On failure, returns READ_NOT_FOUND (-1), READ_DELETED (-2), or
-/// READ_INVALID_KEY (-3).
+/// On failure, returns READ_NOT_FOUND (-1), READ_DELETED (-2),
+/// READ_INVALID_KEY (-3), or READ_INVALID_ARGS (-4) when the arguments are invalid
+/// (null pointers or a negative length).
 ///
 /// # Safety
 /// All pointer arguments must be valid. `out_buffer` must have at least
@@ -182,6 +194,10 @@ pub unsafe extern "C" fn bftree_read(
     out_buffer_len: i32,
     out_value_len: *mut i32,
 ) -> i32 {
+    if tree.is_null() || key.is_null() || key_len < 0 || out_buffer.is_null() || out_buffer_len < 0 {
+        return READ_INVALID_ARGS;
+    }
+
     let tree = &*tree;
     let key = slice::from_raw_parts(key, key_len as usize);
     let buffer = slice::from_raw_parts_mut(out_buffer, out_buffer_len as usize);
@@ -198,7 +214,8 @@ pub unsafe extern "C" fn bftree_read(
     }
 }
 
-/// Delete a key from the tree.
+/// Delete a key from the tree. Returns DELETE_SUCCESS (0), or DELETE_INVALID_ARGS (-1)
+/// when the arguments are invalid (null pointers or a negative length).
 ///
 /// # Safety
 /// `tree` must be a valid BfTree pointer. `key` must point to valid memory.
@@ -207,10 +224,15 @@ pub unsafe extern "C" fn bftree_delete(
     tree: *mut BfTree,
     key: *const u8,
     key_len: i32,
-) {
+) -> i32 {
+    if tree.is_null() || key.is_null() || key_len < 0 {
+        return DELETE_INVALID_ARGS;
+    }
+
     let tree = &*tree;
     let key = slice::from_raw_parts(key, key_len as usize);
     tree.delete(key);
+    DELETE_SUCCESS
 }
 
 // ---------------------------------------------------------------------------
@@ -243,6 +265,10 @@ pub unsafe extern "C" fn bftree_scan_with_count(
     count: i32,
     return_field: u8,
 ) -> *mut ScanHandle<'static> {
+    if tree.is_null() || start_key.is_null() || start_key_len < 0 || count < 0 {
+        return std::ptr::null_mut();
+    }
+
     let tree = &*tree;
     let start = slice::from_raw_parts(start_key, start_key_len as usize);
     let rf = match return_field {
@@ -272,6 +298,10 @@ pub unsafe extern "C" fn bftree_scan_with_end_key(
     end_key_len: i32,
     return_field: u8,
 ) -> *mut ScanHandle<'static> {
+    if tree.is_null() || start_key.is_null() || start_key_len < 0 || end_key.is_null() || end_key_len < 0 {
+        return std::ptr::null_mut();
+    }
+
     let tree = &*tree;
     let start = slice::from_raw_parts(start_key, start_key_len as usize);
     let end = slice::from_raw_parts(end_key, end_key_len as usize);
@@ -311,6 +341,10 @@ pub unsafe extern "C" fn bftree_scan_next(
     out_key_len: *mut i32,
     out_value_len: *mut i32,
 ) -> i32 {
+    if handle.is_null() || out_buffer.is_null() || out_buffer_len < 0 {
+        return 0;
+    }
+
     let handle = &mut *handle;
     let buffer = slice::from_raw_parts_mut(out_buffer, out_buffer_len as usize);
     match handle.iter.next(buffer) {

--- a/libs/server/Resp/RangeIndex/RangeIndexManager.Replication.cs
+++ b/libs/server/Resp/RangeIndex/RangeIndexManager.Replication.cs
@@ -149,7 +149,13 @@ namespace Garnet.server
                 if (status != GarnetStatus.OK) return;
                 var treePtr = ReadIndex(stubSpan).TreeHandle;
                 if (treePtr == nint.Zero) return;
-                BfTreeService.InsertByPtr(treePtr, field, value);
+
+                var insertResult = BfTreeService.InsertByPtr(treePtr, field, value);
+                if (insertResult != BfTreeInsertResult.Success)
+                {
+                    logger?.LogError("RI.SET AOF replay: native insert rejected ({result}) for a {keyLen}-byte key with field {fieldLen}B and value {valueLen}B; primary/replica divergence.", insertResult, key.Length, field.Length, value.Length);
+                    throw new GarnetException($"RI.SET AOF replay failed: native insert returned {insertResult}");
+                }
             }
         }
 
@@ -174,7 +180,13 @@ namespace Garnet.server
                 if (status != GarnetStatus.OK) return;
                 var treePtr = ReadIndex(stubSpan).TreeHandle;
                 if (treePtr == nint.Zero) return;
-                BfTreeService.DeleteByPtr(treePtr, field);
+
+                var deleteResult = BfTreeService.DeleteByPtr(treePtr, field);
+                if (deleteResult != BfTreeDeleteResult.Success)
+                {
+                    logger?.LogError("RI.DEL AOF replay: native delete rejected ({result}) for a {keyLen}-byte key with field {fieldLen}B; primary/replica divergence.", deleteResult, key.Length, field.Length);
+                    throw new GarnetException($"RI.DEL AOF replay failed: native delete returned {deleteResult}");
+                }
             }
         }
     }

--- a/libs/server/Storage/Session/MainStore/RangeIndexOps.cs
+++ b/libs/server/Storage/Session/MainStore/RangeIndexOps.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Garnet.common;
 using Garnet.server.BfTreeInterop;
+using Microsoft.Extensions.Logging;
 using Tsavorite.core;
 
 namespace Garnet.server
@@ -221,6 +222,12 @@ namespace Garnet.server
                 }
 
                 var insertResult = BfTreeService.InsertByPtr(treePtr, field, value);
+                if (insertResult == BfTreeInsertResult.InvalidArguments)
+                {
+                    logger?.LogError("RI.SET: invalid arguments for a {keyLen}-byte field and {valueLen}-byte value.", field.Length, value.Length);
+                    throw new GarnetException("RI.SET: invalid arguments.");
+                }
+
                 if (insertResult == BfTreeInsertResult.InvalidKV)
                 {
                     ref readonly var stub = ref RangeIndexManager.ReadIndex(stubSpan);
@@ -302,6 +309,12 @@ namespace Garnet.server
                     var valueStart = bufStart + optimisticHeaderSize;
                     var readResult = BfTreeService.ReadByPtrInto(stub.TreeHandle, field, valueStart, maxValueSize, out var bytesWritten);
 
+                    if (readResult == BfTreeReadResult.InvalidArguments)
+                    {
+                        logger?.LogError("RI.GET: invalid arguments for a {fieldLen}-byte field.", field.Length);
+                        throw new GarnetException("RI.GET: invalid arguments.");
+                    }
+
                     if (readResult != BfTreeReadResult.Found || bytesWritten < 0)
                     {
                         result = RangeIndexResult.NotFound;
@@ -340,6 +353,13 @@ namespace Garnet.server
                     {
                         var valueStart = bufStart + optimisticHeaderSize;
                         var readResult = BfTreeService.ReadByPtrInto(stub.TreeHandle, field, valueStart, maxValueSize, out var bytesWritten);
+
+                        if (readResult == BfTreeReadResult.InvalidArguments)
+                        {
+                            heapMemory.Dispose();
+                            logger?.LogError("RI.GET: invalid arguments for a {fieldLen}-byte field.", field.Length);
+                            throw new GarnetException("RI.GET: invalid arguments.");
+                        }
 
                         if (readResult != BfTreeReadResult.Found || bytesWritten < 0)
                         {
@@ -411,7 +431,13 @@ namespace Garnet.server
                     return GarnetStatus.OK;
                 }
 
-                BfTreeService.DeleteByPtr(treePtr, field);
+                var deleteResult = BfTreeService.DeleteByPtr(treePtr, field);
+                if (deleteResult != BfTreeDeleteResult.Success)
+                {
+                    logger?.LogError("RI.DEL: invalid arguments for a {fieldLen}-byte field.", field.Length);
+                    throw new GarnetException("RI.DEL: invalid arguments.");
+                }
+
                 result = RangeIndexResult.OK;
 
                 functionsState.rangeIndexManager.ReplicateRangeIndexDel(

--- a/test/standalone/BfTreeInterop.test/BfTreeInterop.test.csproj
+++ b/test/standalone/BfTreeInterop.test/BfTreeInterop.test.csproj
@@ -5,6 +5,9 @@
     <NoWarn>1701;1702;1591</NoWarn>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../../../Garnet.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../libs/native/bftree-garnet/BfTreeInterop.csproj" />
+    <ProjectReference Include="../../../libs/native/bftree-garnet/BfTreeInterop.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/standalone/BfTreeInterop.test/BfTreeInteropNativeTests.cs
+++ b/test/standalone/BfTreeInterop.test/BfTreeInteropNativeTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.IO;
+using System.Text;
+using Garnet.server.BfTreeInterop;
+using NUnit.Framework;
+
+namespace BfTreeInterop.test
+{
+    /// <summary>
+    /// Tests that call the native P/Invoke layer (<see cref="NativeBfTreeMethods"/>) directly with
+    /// invalid arguments — negative lengths, null data pointers, and a null tree handle — bypassing
+    /// the managed <c>PinnedSpanByte</c> / <c>BfTreeService</c> wrappers. These exercise the
+    /// FFI-boundary guards at the exact point where a signed length would be cast to an unsigned
+    /// size, verifying they return a sentinel instead of constructing an invalid slice.
+    /// </summary>
+    [TestFixture]
+    public unsafe class BfTreeInteropNativeTests
+    {
+        private const byte StorageDisk = 0;
+        private const byte StorageMemory = 1;
+
+        // Native result codes (mirror the Rust constants in lib.rs).
+        private const int InsertInvalidArgs = -1;
+        private const int ReadInvalidArgs = -4;
+        private const int DeleteInvalidArgs = -1;
+
+        private nint tree;
+
+        [SetUp]
+        public void Setup()
+        {
+            tree = NativeBfTreeMethods.bftree_create(0, 0, 0, 0, 0, StorageMemory, null, 0, 0);
+            Assert.That(tree, Is.Not.EqualTo(nint.Zero), "failed to create memory-backed tree");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (tree != nint.Zero)
+                NativeBfTreeMethods.bftree_drop(tree);
+            tree = nint.Zero;
+        }
+
+        [Test]
+        public void Insert_InvalidArgs_ReturnsInvalidArgs()
+        {
+            byte k = 0, v = 0;
+            Assert.That(NativeBfTreeMethods.bftree_insert(nint.Zero, &k, 1, &v, 1), Is.EqualTo(InsertInvalidArgs), "null tree");
+            Assert.That(NativeBfTreeMethods.bftree_insert(tree, null, 1, &v, 1), Is.EqualTo(InsertInvalidArgs), "null key");
+            Assert.That(NativeBfTreeMethods.bftree_insert(tree, &k, 1, null, 1), Is.EqualTo(InsertInvalidArgs), "null value");
+            Assert.That(NativeBfTreeMethods.bftree_insert(tree, &k, -1, &v, 1), Is.EqualTo(InsertInvalidArgs), "negative key length");
+            Assert.That(NativeBfTreeMethods.bftree_insert(tree, &k, 1, &v, -1), Is.EqualTo(InsertInvalidArgs), "negative value length");
+        }
+
+        [Test]
+        public void Read_InvalidArgs_ReturnsInvalidArgs()
+        {
+            byte k = 0;
+            byte* buf = stackalloc byte[16];
+            int outLen = 0;
+            Assert.That(NativeBfTreeMethods.bftree_read(nint.Zero, &k, 1, buf, 16, &outLen), Is.EqualTo(ReadInvalidArgs), "null tree");
+            Assert.That(NativeBfTreeMethods.bftree_read(tree, null, 1, buf, 16, &outLen), Is.EqualTo(ReadInvalidArgs), "null key");
+            Assert.That(NativeBfTreeMethods.bftree_read(tree, &k, -1, buf, 16, &outLen), Is.EqualTo(ReadInvalidArgs), "negative key length");
+            Assert.That(NativeBfTreeMethods.bftree_read(tree, &k, 1, null, 16, &outLen), Is.EqualTo(ReadInvalidArgs), "null out buffer");
+            Assert.That(NativeBfTreeMethods.bftree_read(tree, &k, 1, buf, -1, &outLen), Is.EqualTo(ReadInvalidArgs), "negative out buffer length");
+        }
+
+        [Test]
+        public void Delete_InvalidArgs_ReturnsInvalidArgs()
+        {
+            byte k = 0;
+            Assert.That(NativeBfTreeMethods.bftree_delete(nint.Zero, &k, 1), Is.EqualTo(DeleteInvalidArgs), "null tree");
+            Assert.That(NativeBfTreeMethods.bftree_delete(tree, null, 1), Is.EqualTo(DeleteInvalidArgs), "null key");
+            Assert.That(NativeBfTreeMethods.bftree_delete(tree, &k, -1), Is.EqualTo(DeleteInvalidArgs), "negative key length");
+        }
+
+        [Test]
+        public void ScanWithCount_InvalidArgs_ReturnsNullHandle()
+        {
+            byte start = 0;
+            Assert.That(NativeBfTreeMethods.bftree_scan_with_count(nint.Zero, &start, 1, 10, 2), Is.EqualTo(nint.Zero), "null tree");
+            Assert.That(NativeBfTreeMethods.bftree_scan_with_count(tree, null, 1, 10, 2), Is.EqualTo(nint.Zero), "null start key");
+            Assert.That(NativeBfTreeMethods.bftree_scan_with_count(tree, &start, -1, 10, 2), Is.EqualTo(nint.Zero), "negative start key length");
+            Assert.That(NativeBfTreeMethods.bftree_scan_with_count(tree, &start, 1, -1, 2), Is.EqualTo(nint.Zero), "negative count");
+        }
+
+        [Test]
+        public void ScanWithEndKey_InvalidArgs_ReturnsNullHandle()
+        {
+            byte start = 0, end = 0xff;
+            Assert.That(NativeBfTreeMethods.bftree_scan_with_end_key(nint.Zero, &start, 1, &end, 1, 2), Is.EqualTo(nint.Zero), "null tree");
+            Assert.That(NativeBfTreeMethods.bftree_scan_with_end_key(tree, null, 1, &end, 1, 2), Is.EqualTo(nint.Zero), "null start key");
+            Assert.That(NativeBfTreeMethods.bftree_scan_with_end_key(tree, &start, -1, &end, 1, 2), Is.EqualTo(nint.Zero), "negative start key length");
+            Assert.That(NativeBfTreeMethods.bftree_scan_with_end_key(tree, &start, 1, null, 1, 2), Is.EqualTo(nint.Zero), "null end key");
+            Assert.That(NativeBfTreeMethods.bftree_scan_with_end_key(tree, &start, 1, &end, -1, 2), Is.EqualTo(nint.Zero), "negative end key length");
+        }
+
+        [Test]
+        public void ScanNext_InvalidArgs_ReturnsZero()
+        {
+            byte* buf = stackalloc byte[16];
+            int keyLen = 0, valueLen = 0;
+
+            // A null handle short-circuits to 0 regardless of the other arguments.
+            Assert.That(NativeBfTreeMethods.bftree_scan_next(nint.Zero, buf, 16, &keyLen, &valueLen), Is.EqualTo(0), "null handle");
+
+            // Isolating the out-buffer guards needs a valid handle. Scanning is only supported on
+            // disk-backed trees (a memory/cache_only tree aborts natively), so build one here.
+            var path = Path.Combine(Path.GetTempPath(), $"bftree_native_{Guid.NewGuid():N}.bftree");
+            var pathBytes = Encoding.UTF8.GetBytes(path);
+            nint diskTree;
+            fixed (byte* pp = pathBytes)
+                diskTree = NativeBfTreeMethods.bftree_create(0, 4, 0, 0, 0, StorageDisk, pp, pathBytes.Length, 0);
+            Assert.That(diskTree, Is.Not.EqualTo(nint.Zero), "failed to create disk-backed tree");
+
+            nint handle = nint.Zero;
+            try
+            {
+                byte start = 0;
+                handle = NativeBfTreeMethods.bftree_scan_with_count(diskTree, &start, 1, 10, 2);
+                Assert.That(handle, Is.Not.EqualTo(nint.Zero), "expected a valid scan handle");
+                Assert.That(NativeBfTreeMethods.bftree_scan_next(handle, null, 16, &keyLen, &valueLen), Is.EqualTo(0), "null out buffer");
+                Assert.That(NativeBfTreeMethods.bftree_scan_next(handle, buf, -1, &keyLen, &valueLen), Is.EqualTo(0), "negative out buffer length");
+            }
+            finally
+            {
+                if (handle != nint.Zero)
+                    NativeBfTreeMethods.bftree_scan_drop(handle);
+                NativeBfTreeMethods.bftree_drop(diskTree);
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+        }
+    }
+}

--- a/test/standalone/BfTreeInterop.test/BfTreeInteropTests.cs
+++ b/test/standalone/BfTreeInterop.test/BfTreeInteropTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using Garnet.server.BfTreeInterop;
 using NUnit.Framework;
+using Tsavorite.core;
 
 namespace BfTreeInterop.test
 {
@@ -18,25 +19,22 @@ namespace BfTreeInterop.test
     [TestFixture]
     public class BfTreeInteropTests
     {
-        private BfTreeService _tree;
-        private string _treePath;
+        private BfTreeService tree;
+        private string treePath;
 
         [SetUp]
         public void Setup()
         {
-            _treePath = Path.Combine(
-                Path.GetTempPath(), $"bftree_test_{Guid.NewGuid():N}.bftree");
-            _tree = new BfTreeService(
-                filePath: _treePath,
-                cbMinRecordSize: 4);
+            treePath = Path.Combine(Path.GetTempPath(), $"bftree_test_{Guid.NewGuid():N}.bftree");
+            tree = new BfTreeService(filePath: treePath, cbMinRecordSize: 4);
         }
 
         [TearDown]
         public void TearDown()
         {
-            _tree?.Dispose();
-            if (_treePath != null && File.Exists(_treePath))
-                File.Delete(_treePath);
+            tree?.Dispose();
+            if (treePath != null && File.Exists(treePath))
+                File.Delete(treePath);
         }
 
         // ---------------------------------------------------------------
@@ -52,7 +50,11 @@ namespace BfTreeInterop.test
                 using var tree = new BfTreeService(filePath: path, cbMinRecordSize: 4);
                 Assert.Pass();
             }
-            finally { if (File.Exists(path)) File.Delete(path); }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
         }
 
         [Test]
@@ -61,24 +63,20 @@ namespace BfTreeInterop.test
             var path = Path.Combine(Path.GetTempPath(), $"bftree_t_{Guid.NewGuid():N}.bftree");
             try
             {
-                using var tree = new BfTreeService(
-                    filePath: path,
-                    cbSizeByte: 16 * 1024 * 1024,
-                    cbMinRecordSize: 8,
-                    cbMaxRecordSize: 4096,
-                    cbMaxKeyLen: 128,
-                    leafPageSize: 16384);
+                using var tree = new BfTreeService(filePath: path, cbSizeByte: 16 * 1024 * 1024, cbMinRecordSize: 8, cbMaxRecordSize: 4096, cbMaxKeyLen: 128, leafPageSize: 16384);
                 Assert.Pass();
             }
-            finally { if (File.Exists(path)) File.Delete(path); }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
         }
 
         [Test]
         public void CreateMemoryOnly()
         {
-            using var tree = new BfTreeService(
-                storageBackend: StorageBackendType.Memory,
-                cbMinRecordSize: 4);
+            using var tree = new BfTreeService(storageBackend: StorageBackendType.Memory, cbMinRecordSize: 4);
             var insertResult = tree.Insert("testkey"u8, "testval"u8);
             Assert.That(insertResult, Is.EqualTo(BfTreeInsertResult.Success));
         }
@@ -99,7 +97,11 @@ namespace BfTreeInterop.test
                 tree.Dispose();
                 Assert.DoesNotThrow(() => tree.Dispose());
             }
-            finally { if (File.Exists(path)) File.Delete(path); }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
         }
 
         // ---------------------------------------------------------------
@@ -112,10 +114,10 @@ namespace BfTreeInterop.test
             var key = "user:1001"u8;
             var value = "Alice"u8;
 
-            var insertResult = _tree.Insert(key, value);
+            var insertResult = tree.Insert(key, value);
             Assert.That(insertResult, Is.EqualTo(BfTreeInsertResult.Success));
 
-            var readResult = _tree.Read(key, out var readValue);
+            var readResult = tree.Read(key, out var readValue);
             Assert.That(readResult, Is.EqualTo(BfTreeReadResult.Found));
             Assert.That(readValue, Is.EqualTo(value.ToArray()));
         }
@@ -125,10 +127,10 @@ namespace BfTreeInterop.test
         {
             var key = "mykey"u8;
 
-            _tree.Insert(key, "value1"u8);
-            _tree.Insert(key, "value2"u8);
+            tree.Insert(key, "value1"u8);
+            tree.Insert(key, "value2"u8);
 
-            var readResult = _tree.Read(key, out var value);
+            var readResult = tree.Read(key, out var value);
             Assert.That(readResult, Is.EqualTo(BfTreeReadResult.Found));
             Assert.That(value, Is.EqualTo("value2"u8.ToArray()));
         }
@@ -140,7 +142,7 @@ namespace BfTreeInterop.test
             {
                 var key = Encoding.UTF8.GetBytes($"key:{i:D4}");
                 var value = Encoding.UTF8.GetBytes($"value:{i}");
-                var result = _tree.Insert(key, value);
+                var result = tree.Insert(key, value);
                 Assert.That(result, Is.EqualTo(BfTreeInsertResult.Success));
             }
 
@@ -148,7 +150,7 @@ namespace BfTreeInterop.test
             {
                 var key = Encoding.UTF8.GetBytes($"key:{i:D4}");
                 var expectedValue = Encoding.UTF8.GetBytes($"value:{i}");
-                var readResult = _tree.Read(key, out var readValue);
+                var readResult = tree.Read(key, out var readValue);
                 Assert.That(readResult, Is.EqualTo(BfTreeReadResult.Found));
                 Assert.That(readValue, Is.EqualTo(expectedValue));
             }
@@ -161,7 +163,7 @@ namespace BfTreeInterop.test
         [Test]
         public void ReadNotFound()
         {
-            var readResult = _tree.Read("nonexistent"u8, out var value);
+            var readResult = tree.Read("nonexistent"u8, out var value);
             Assert.That(readResult, Is.EqualTo(BfTreeReadResult.NotFound));
             Assert.That(value, Is.Empty);
         }
@@ -170,10 +172,10 @@ namespace BfTreeInterop.test
         public void ReadAfterDelete_ReturnsDeleted()
         {
             var key = "deleteme"u8;
-            _tree.Insert(key, "value"u8);
-            _tree.Delete(key);
+            tree.Insert(key, "value"u8);
+            tree.Delete(key);
 
-            var readResult = _tree.Read(key, out var value);
+            var readResult = tree.Read(key, out var value);
             Assert.That(readResult, Is.EqualTo(BfTreeReadResult.Deleted));
             Assert.That(value, Is.Empty);
         }
@@ -183,10 +185,10 @@ namespace BfTreeInterop.test
         {
             var key = "spankey"u8;
             var expected = "spanvalue"u8;
-            _tree.Insert(key, expected);
+            tree.Insert(key, expected);
 
             Span<byte> buffer = stackalloc byte[256];
-            var result = _tree.Read(key, buffer, out int bytesWritten);
+            var result = tree.Read(key, buffer, out int bytesWritten);
             Assert.That(result, Is.EqualTo(BfTreeReadResult.Found));
             Assert.That(bytesWritten, Is.EqualTo(expected.Length));
             Assert.That(buffer[..bytesWritten].SequenceEqual(expected), Is.True);
@@ -196,7 +198,7 @@ namespace BfTreeInterop.test
         public void ReadIntoSpan_NotFound()
         {
             Span<byte> buffer = stackalloc byte[256];
-            var result = _tree.Read("nope"u8, buffer, out int bytesWritten);
+            var result = tree.Read("nope"u8, buffer, out int bytesWritten);
             Assert.That(result, Is.EqualTo(BfTreeReadResult.NotFound));
             Assert.That(bytesWritten, Is.EqualTo(0));
         }
@@ -209,17 +211,17 @@ namespace BfTreeInterop.test
         public void DeleteExistingKey()
         {
             var key = "toremove"u8;
-            _tree.Insert(key, "data"u8);
-            _tree.Delete(key);
+            tree.Insert(key, "data"u8);
+            Assert.That(tree.Delete(key), Is.EqualTo(BfTreeDeleteResult.Success));
 
-            var readResult = _tree.Read(key, out _);
+            var readResult = tree.Read(key, out _);
             Assert.That(readResult, Is.EqualTo(BfTreeReadResult.Deleted));
         }
 
         [Test]
-        public void DeleteNonExistentKey_DoesNotThrow()
+        public void DeleteNonExistentKey_ReturnsSuccess()
         {
-            Assert.DoesNotThrow(() => _tree.Delete("ghost"u8));
+            Assert.That(tree.Delete("ghost"u8), Is.EqualTo(BfTreeDeleteResult.Success));
         }
 
         // ---------------------------------------------------------------
@@ -231,7 +233,7 @@ namespace BfTreeInterop.test
         {
             InsertTestData(10);
 
-            var results = _tree.ScanWithCount("key:"u8, 5);
+            var results = tree.ScanWithCount("key:"u8, 5);
             Assert.That(results, Has.Count.EqualTo(5));
         }
 
@@ -240,7 +242,7 @@ namespace BfTreeInterop.test
         {
             InsertTestData(5);
 
-            var results = _tree.ScanWithCount("key:"u8, 10, ScanReturnField.KeyAndValue);
+            var results = tree.ScanWithCount("key:"u8, 10, ScanReturnField.KeyAndValue);
             Assert.That(results, Has.Count.EqualTo(5));
 
             foreach (var r in results)
@@ -255,7 +257,7 @@ namespace BfTreeInterop.test
         {
             InsertTestData(5);
 
-            var results = _tree.ScanWithCount("key:"u8, 10, ScanReturnField.Key);
+            var results = tree.ScanWithCount("key:"u8, 10, ScanReturnField.Key);
             Assert.That(results, Has.Count.EqualTo(5));
 
             foreach (var r in results)
@@ -270,7 +272,7 @@ namespace BfTreeInterop.test
         {
             InsertTestData(5);
 
-            var results = _tree.ScanWithCount("key:"u8, 10, ScanReturnField.Value);
+            var results = tree.ScanWithCount("key:"u8, 10, ScanReturnField.Value);
             Assert.That(results, Has.Count.EqualTo(5));
 
             foreach (var r in results)
@@ -284,15 +286,16 @@ namespace BfTreeInterop.test
         public void ScanWithCount_Ordering()
         {
             // Insert keys out of order, verify scan returns them sorted
-            _tree.Insert("key:C"u8, "3"u8);
-            _tree.Insert("key:A"u8, "1"u8);
-            _tree.Insert("key:B"u8, "2"u8);
+            tree.Insert("key:C"u8, "3"u8);
+            tree.Insert("key:A"u8, "1"u8);
+            tree.Insert("key:B"u8, "2"u8);
 
-            var results = _tree.ScanWithCount("key:"u8, 10, ScanReturnField.Key);
+            var results = tree.ScanWithCount("key:"u8, 10, ScanReturnField.Key);
             Assert.That(results, Has.Count.EqualTo(3));
 
             var keys = results.Select(r => Encoding.UTF8.GetString(r.Key.Span)).ToList();
-            Assert.That(keys, Is.EqualTo(new[] { "key:A", "key:B", "key:C" }));
+            string[] expectedKeys = ["key:A", "key:B", "key:C"];
+            Assert.That(keys, Is.EqualTo(expectedKeys));
         }
 
         [Test]
@@ -301,8 +304,7 @@ namespace BfTreeInterop.test
             InsertTestData(10); // key:0000 through key:0009
 
             // Start from key:0005, should get key:0005 through key:0009
-            var results = _tree.ScanWithCount(
-                Encoding.UTF8.GetBytes("key:0005"), 10, ScanReturnField.Key);
+            var results = tree.ScanWithCount(Encoding.UTF8.GetBytes("key:0005"), 10, ScanReturnField.Key);
             Assert.That(results, Has.Count.EqualTo(5));
 
             var firstKey = Encoding.UTF8.GetString(results[0].Key.Span);
@@ -312,7 +314,7 @@ namespace BfTreeInterop.test
         [Test]
         public void ScanWithCount_EmptyTree()
         {
-            var results = _tree.ScanWithCount("key:"u8, 10);
+            var results = tree.ScanWithCount("key:"u8, 10);
             Assert.That(results, Is.Empty);
         }
 
@@ -325,10 +327,7 @@ namespace BfTreeInterop.test
         {
             InsertTestData(10); // key:0000 through key:0009
 
-            var results = _tree.ScanWithEndKey(
-                Encoding.UTF8.GetBytes("key:0002"),
-                Encoding.UTF8.GetBytes("key:0005"),
-                ScanReturnField.Key);
+            var results = tree.ScanWithEndKey(Encoding.UTF8.GetBytes("key:0002"), Encoding.UTF8.GetBytes("key:0005"), ScanReturnField.Key);
 
             var keys = results.Select(r => Encoding.UTF8.GetString(r.Key.Span)).ToList();
             Assert.That(keys, Has.Count.GreaterThanOrEqualTo(3));
@@ -340,10 +339,7 @@ namespace BfTreeInterop.test
         {
             InsertTestData(5);
 
-            var results = _tree.ScanWithEndKey(
-                "key:0000"u8.ToArray(),
-                "key:9999"u8.ToArray(),
-                ScanReturnField.KeyAndValue);
+            var results = tree.ScanWithEndKey("key:0000"u8.ToArray(), "key:9999"u8.ToArray(), ScanReturnField.KeyAndValue);
             Assert.That(results, Has.Count.EqualTo(5));
         }
 
@@ -352,9 +348,7 @@ namespace BfTreeInterop.test
         {
             InsertTestData(5); // key:0000 through key:0004
 
-            var results = _tree.ScanWithEndKey(
-                "zzz:0000"u8.ToArray(),
-                "zzz:9999"u8.ToArray());
+            var results = tree.ScanWithEndKey("zzz:0000"u8.ToArray(), "zzz:9999"u8.ToArray());
             Assert.That(results, Is.Empty);
         }
 
@@ -367,7 +361,7 @@ namespace BfTreeInterop.test
         {
             InsertTestData(20);
 
-            var results = _tree.ScanAll();
+            var results = tree.ScanAll();
             Assert.That(results, Has.Count.EqualTo(20));
 
             // Verify ordering
@@ -379,7 +373,7 @@ namespace BfTreeInterop.test
         [Test]
         public void ScanAll_EmptyTree()
         {
-            var results = _tree.ScanAll();
+            var results = tree.ScanAll();
             Assert.That(results, Is.Empty);
         }
 
@@ -388,7 +382,7 @@ namespace BfTreeInterop.test
         {
             InsertTestData(5);
 
-            var results = _tree.ScanAll(ScanReturnField.Key);
+            var results = tree.ScanAll(ScanReturnField.Key);
             Assert.That(results, Has.Count.EqualTo(5));
 
             foreach (var r in results)
@@ -409,8 +403,7 @@ namespace BfTreeInterop.test
 
             var keys = new List<string>();
             Span<byte> scanBuf = stackalloc byte[8192];
-            int count = _tree.ScanWithCount("key:"u8, 100, scanBuf,
-                (key, value) =>
+            int count = tree.ScanWithCount("key:"u8, 100, scanBuf, (key, value) =>
                 {
                     keys.Add(Encoding.UTF8.GetString(key));
                     return true;
@@ -428,8 +421,7 @@ namespace BfTreeInterop.test
 
             int seen = 0;
             Span<byte> scanBuf = stackalloc byte[8192];
-            int count = _tree.ScanWithCount("key:"u8, 100, scanBuf,
-                (key, value) =>
+            int count = tree.ScanWithCount("key:"u8, 100, scanBuf, (key, value) =>
                 {
                     seen++;
                     return seen < 3; // stop after 3 records
@@ -445,74 +437,94 @@ namespace BfTreeInterop.test
         [Test]
         public void SnapshotAndRecover_RoundTrip()
         {
-            InsertTestData(20);
-            _tree.Snapshot();
-            _tree.Dispose();
-
-            // Recover from the same file
-            _tree = BfTreeService.RecoverFromSnapshot(_treePath, cbMinRecordSize: 4);
-
-            for (int i = 0; i < 20; i++)
+            var snapshotPath = Path.Combine(Path.GetTempPath(), $"bftree_snap_{Guid.NewGuid():N}.bftree");
+            try
             {
-                var key = Encoding.UTF8.GetBytes($"key:{i:D4}");
-                var expectedValue = Encoding.UTF8.GetBytes($"val:{i}");
-                var readResult = _tree.Read(key, out var readValue);
-                Assert.That(readResult, Is.EqualTo(BfTreeReadResult.Found),
-                    $"Key key:{i:D4} not found after recovery");
-                Assert.That(readValue, Is.EqualTo(expectedValue));
+                tree.Dispose();
+                tree = new BfTreeService(filePath: treePath, enableSnapshots: true, cbMinRecordSize: 4);
+                InsertTestData(20);
+                BfTreeService.CprSnapshotByPtr(tree.NativePtr, snapshotPath);
+                tree.Dispose();
+
+                // Recover from the snapshot file
+                tree = BfTreeService.RecoverFromCprSnapshot(snapshotPath, false, StorageBackendType.Disk);
+
+                for (int i = 0; i < 20; i++)
+                {
+                    var key = Encoding.UTF8.GetBytes($"key:{i:D4}");
+                    var expectedValue = Encoding.UTF8.GetBytes($"val:{i}");
+                    var readResult = tree.Read(key, out var readValue);
+                    Assert.That(readResult, Is.EqualTo(BfTreeReadResult.Found), $"Key key:{i:D4} not found after recovery");
+                    Assert.That(readValue, Is.EqualTo(expectedValue));
+                }
+            }
+            finally
+            {
+                if (File.Exists(snapshotPath))
+                    File.Delete(snapshotPath);
             }
         }
 
         [Test]
         public void SnapshotAndRecover_ScanAfterRestore()
         {
-            InsertTestData(10);
-            _tree.Snapshot();
-            _tree.Dispose();
-
-            _tree = BfTreeService.RecoverFromSnapshot(_treePath, cbMinRecordSize: 4);
-
-            var results = _tree.ScanWithCount("key:"u8, 100, ScanReturnField.Key);
-            Assert.That(results, Has.Count.EqualTo(10));
-        }
-
-        [Test]
-        public void RecoverNonExistentFile_CreatesEmpty()
-        {
-            var path = Path.Combine(
-                Path.GetTempPath(), $"bftree_noexist_{Guid.NewGuid():N}.bftree");
+            var snapshotPath = Path.Combine(Path.GetTempPath(), $"bftree_snap_{Guid.NewGuid():N}.bftree");
             try
             {
-                using var tree = BfTreeService.RecoverFromSnapshot(path, cbMinRecordSize: 4);
-                var readResult = tree.Read("anything"u8, out _);
-                Assert.That(readResult, Is.EqualTo(BfTreeReadResult.NotFound));
+                tree.Dispose();
+                tree = new BfTreeService(filePath: treePath, enableSnapshots: true, cbMinRecordSize: 4);
+                InsertTestData(10);
+                BfTreeService.CprSnapshotByPtr(tree.NativePtr, snapshotPath);
+                tree.Dispose();
+
+                tree = BfTreeService.RecoverFromCprSnapshot(snapshotPath, false, StorageBackendType.Disk);
+
+                var results = tree.ScanWithCount("key:"u8, 100, ScanReturnField.Key);
+                Assert.That(results, Has.Count.EqualTo(10));
             }
-            finally { if (File.Exists(path)) File.Delete(path); }
+            finally
+            {
+                if (File.Exists(snapshotPath))
+                    File.Delete(snapshotPath);
+            }
         }
 
         [Test]
-        public void MemoryOnly_SnapshotThrows_PendingBfTreeSupport()
+        public void RecoverNonExistentFile_Throws()
         {
-            using var memTree = new BfTreeService(
-                storageBackend: StorageBackendType.Memory,
-                cbMinRecordSize: 4);
-            memTree.Insert("testkey"u8, "testval"u8);
-
-            var snapshotPath = Path.Combine(
-                Path.GetTempPath(), $"bftree_memsnap_{Guid.NewGuid():N}.bftree");
-            // FFI stub returns -1, C# surfaces as NotSupportedException
-            Assert.Throws<NotSupportedException>(() => memTree.Snapshot(snapshotPath));
+            var path = Path.Combine(Path.GetTempPath(), $"bftree_noexist_{Guid.NewGuid():N}.bftree");
+            Assert.Throws<InvalidOperationException>(() => BfTreeService.RecoverFromCprSnapshot(path, false, StorageBackendType.Disk));
         }
 
         [Test]
-        public void MemoryOnly_RecoverThrows_PendingBfTreeSupport()
+        public void MemoryOnly_SnapshotAndRecover_RoundTrip()
         {
-            // FFI stub returns null, C# surfaces as NotSupportedException
-            Assert.Throws<NotSupportedException>(() =>
-                BfTreeService.RecoverFromSnapshot(
-                    "/tmp/nonexistent.bftree",
-                    storageBackend: StorageBackendType.Memory,
-                    cbMinRecordSize: 4));
+            var snapshotPath = Path.Combine(Path.GetTempPath(), $"bftree_memsnap_{Guid.NewGuid():N}.bftree");
+            try
+            {
+                using (var memTree = new BfTreeService(storageBackend: StorageBackendType.Memory, enableSnapshots: true, cbMinRecordSize: 4))
+                {
+                    memTree.Insert("testkey"u8, "testval"u8);
+                    // bftree supports CPR snapshot for memory-backed trees uniformly with disk-backed.
+                    Assert.DoesNotThrow(() => BfTreeService.CprSnapshotByPtr(memTree.NativePtr, snapshotPath));
+                }
+
+                using var recovered = BfTreeService.RecoverFromCprSnapshot(snapshotPath, false, StorageBackendType.Memory);
+                Assert.That(recovered.Read("testkey"u8, out var value), Is.EqualTo(BfTreeReadResult.Found));
+                Assert.That(value, Is.EqualTo("testval"u8.ToArray()));
+            }
+            finally
+            {
+                if (File.Exists(snapshotPath))
+                    File.Delete(snapshotPath);
+            }
+        }
+
+        [Test]
+        public void MemoryOnly_RecoverFromNonExistentFile_Throws()
+        {
+            // Recovering a memory-backed tree from a missing snapshot file fails (null handle → throw).
+            Assert.Throws<InvalidOperationException>(() => BfTreeService.RecoverFromCprSnapshot("/tmp/nonexistent.bftree", false, StorageBackendType.Memory));
         }
 
         // ---------------------------------------------------------------
@@ -533,9 +545,12 @@ namespace BfTreeInterop.test
                 Assert.Throws<ObjectDisposedException>(() => tree.Delete("k"u8));
                 Assert.Throws<ObjectDisposedException>(() => tree.ScanWithCount("k"u8, 1));
                 Assert.Throws<ObjectDisposedException>(() => tree.ScanWithEndKey("a"u8, "z"u8));
-                Assert.Throws<ObjectDisposedException>(() => tree.Snapshot());
             }
-            finally { if (File.Exists(path)) File.Delete(path); }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
         }
 
         // ---------------------------------------------------------------
@@ -550,11 +565,79 @@ namespace BfTreeInterop.test
             {
                 var key = Encoding.UTF8.GetBytes($"large:{i:D6}");
                 var value = Encoding.UTF8.GetBytes($"payload_{i}_{new string('x', 100)}");
-                _tree.Insert(key, value);
+                tree.Insert(key, value);
             }
 
-            var results = _tree.ScanWithCount("large:"u8, count + 1, ScanReturnField.Key);
+            var results = tree.ScanWithCount("large:"u8, count + 1, ScanReturnField.Key);
             Assert.That(results, Has.Count.EqualTo(count));
+        }
+
+        [Test]
+        public unsafe void Insert_InvalidArguments_ReturnsInvalidArguments()
+        {
+            var keyBytes = "k"u8.ToArray();
+            var valueBytes = "v"u8.ToArray();
+            fixed (byte* kp = keyBytes)
+            fixed (byte* vp = valueBytes)
+            {
+                var validKey = PinnedSpanByte.FromPinnedPointer(kp, keyBytes.Length);
+                var validValue = PinnedSpanByte.FromPinnedPointer(vp, valueBytes.Length);
+                Assert.That(tree.Insert(PinnedSpanByte.FromPinnedPointer(kp, -1), validValue), Is.EqualTo(BfTreeInsertResult.InvalidArguments), "negative key length");
+                Assert.That(tree.Insert(validKey, PinnedSpanByte.FromPinnedPointer(vp, -1)), Is.EqualTo(BfTreeInsertResult.InvalidArguments), "negative value length");
+            }
+
+            // Tree must still be functional after rejecting the invalid input.
+            Assert.That(tree.Insert("healthy"u8, "value"u8), Is.EqualTo(BfTreeInsertResult.Success));
+        }
+
+        [Test]
+        public unsafe void Read_InvalidArguments_ReturnsInvalidArguments()
+        {
+            var keyBytes = "k"u8.ToArray();
+            Span<byte> outputBuffer = stackalloc byte[16];
+            fixed (byte* kp = keyBytes)
+            fixed (byte* op = outputBuffer)
+            {
+                var validKey = PinnedSpanByte.FromPinnedPointer(kp, keyBytes.Length);
+
+                var negKeyResult = tree.Read(PinnedSpanByte.FromPinnedPointer(kp, -1), op, outputBuffer.Length, out var negKeyBytesWritten);
+                Assert.That(negKeyResult, Is.EqualTo(BfTreeReadResult.InvalidArguments), "negative key length");
+                Assert.That(negKeyBytesWritten, Is.EqualTo(0), "negative key length bytesWritten");
+
+                var negBufResult = tree.Read(validKey, op, -1, out var negBufBytesWritten);
+                Assert.That(negBufResult, Is.EqualTo(BfTreeReadResult.InvalidArguments), "negative output buffer length");
+                Assert.That(negBufBytesWritten, Is.EqualTo(0), "negative output buffer length bytesWritten");
+            }
+        }
+
+        [Test]
+        public unsafe void Delete_InvalidArguments_DoesNotCorruptTree()
+        {
+            tree.Insert("keep"u8, "value"u8);
+
+            var keyBytes = "k"u8.ToArray();
+            fixed (byte* kp = keyBytes)
+            {
+                var key = PinnedSpanByte.FromPinnedPointer(kp, -1);
+                Assert.That(tree.Delete(key), Is.EqualTo(BfTreeDeleteResult.InvalidArguments), "negative key length");
+            }
+
+            // The pre-existing key must be untouched by the rejected delete.
+            Assert.That(tree.Read("keep"u8, out var value), Is.EqualTo(BfTreeReadResult.Found));
+            Assert.That(value, Is.EqualTo("value"u8.ToArray()));
+        }
+
+        [Test]
+        public void ScanWithCount_NegativeCount_Throws()
+        {
+            InsertTestData(10);
+
+            // A negative count makes the native scan-create reject with a null handle,
+            // which the wrapper surfaces as a bug rather than a silent empty result.
+            Assert.Throws<InvalidOperationException>(() => tree.ScanWithCount("key:"u8, -1, ScanReturnField.Key));
+
+            // A subsequent valid scan must still work.
+            Assert.That(tree.ScanWithCount("key:"u8, 10, ScanReturnField.Key), Is.Not.Empty);
         }
 
         // ---------------------------------------------------------------
@@ -563,7 +646,7 @@ namespace BfTreeInterop.test
 
         private void InsertTestData(int count)
         {
-            InsertTestDataInto(_tree, count);
+            InsertTestDataInto(tree, count);
         }
 
         private static void InsertTestDataInto(BfTreeService tree, int count)


### PR DESCRIPTION
## Summary

Adds missing length/pointer validation in the `bftree-garnet` Rust FFI layer. Six core FFI data functions accepted `i32` length parameters from C# and cast them straight to `usize` before calling `slice::from_raw_parts`, without checking for negative values. A negative `i32` (e.g. `-1`) sign-extends to a huge `usize`, which violates `slice::from_raw_parts` preconditions and produces an invalid slice (a hard abort in debug builds; out-of-bounds access in release).

The affected functions are: `bftree_insert`, `bftree_read`, `bftree_delete`, `bftree_scan_with_count`, `bftree_scan_with_end_key`, `bftree_scan_next`. 
