### PR TITLE
Bound replica AOF truncation by active replay offset

### DIFF
--- a/libs/cluster/Server/ClusterProvider.cs
+++ b/libs/cluster/Server/ClusterProvider.cs
@@ -174,8 +174,9 @@ namespace Garnet.cluster
         /// <inheritdoc />
         public void SafeTruncateAOF(in AofAddress truncateUntil)
         {
-            if (clusterManager.CurrentConfig.LocalNodeRole == NodeRole.PRIMARY)
-                replicationManager.AofSyncDriverStore.SafeTruncateAof(truncateUntil);
+            var role = clusterManager.CurrentConfig.LocalNodeRole;
+            if (role == NodeRole.PRIMARY)
+                replicationManager.AofSyncDriverStore.SafeTruncateAof(role, truncateUntil);
             else
             {
                 if (serverOptions.FastAofTruncate)

--- a/libs/cluster/Server/Replication/PrimaryOps/AofOperations/AofSyncDriverStore.cs
+++ b/libs/cluster/Server/Replication/PrimaryOps/AofOperations/AofSyncDriverStore.cs
@@ -90,6 +90,11 @@ namespace Garnet.cluster
                         TruncatedUntil = prevAddress;
                 }
 
+                // Bound truncation by replicationOffset to avoid truncating replica log beyond the point of active replay
+                var replicationUpperBound = clusterProvider.replicationManager.GetReplicationOffset(physicalSublogIdx);
+                if (replicationUpperBound < TruncatedUntil)
+                    TruncatedUntil = replicationUpperBound;
+
                 // Inform that we have logically truncatedUntil
                 this.TruncatedUntil.MonotonicUpdate(TruncatedUntil, physicalSublogIdx);
             }
@@ -115,9 +120,11 @@ namespace Garnet.cluster
         /// <summary>
         /// Safely truncate AOF until provided address by checking against active AofSyncDrivers
         /// </summary>
-        /// <param name="truncateUntil"></param>
-        public void SafeTruncateAof(in AofAddress truncateUntil)
+        /// <param name="role">Role of caller</param>
+        /// <param name="truncateUntil">TruncateUntil address</param>
+        public void SafeTruncateAof(NodeRole role, in AofAddress truncateUntil)
         {
+            Debug.Assert(role == NodeRole.PRIMARY, $"{nameof(SafeTruncateAof)} should be called only by a PRIMARY node!");
             _lock.WriteLock();
 
             if (_disposed)
@@ -140,6 +147,8 @@ namespace Garnet.cluster
                             TruncatedUntil[physicalSublogIdx] = previousAddress[physicalSublogIdx];
                     }
                 }
+
+                // NOTE: Do not need truncation based on replicationOffset because caller should always be a PRIMARY.
                 // Inform that we have logically truncatedUntil
                 this.TruncatedUntil.MonotonicUpdate(ref TruncatedUntil);
             }


### PR DESCRIPTION
## Summary
On a replica running with `FastAofTruncate`, the AOF tail-page-shift callback (`AofSyncDriverStore.LogShiftTailCallback`) computes its truncation target from the log's ReadOnly mark. That mark can advance ahead of the replica's own replay cursor (its replication offset), so the AOF begin-address could be shifted past records the replica had not yet replayed — silently dropping unreplayed data.

This PR bounds the per-sublog truncation in `SafeTruncateAof(long, int)` by `ReplicationManager.GetReplicationOffset(sublogIdx)`, guaranteeing the AOF begin-address never passes the replay cursor.

## Changes
- `AofSyncDriverStore.SafeTruncateAof(long, int)`: cap `TruncatedUntil` at the sublog replication offset before shifting the begin-address. On a primary this is a no-op (offset == tail address).
- `SafeTruncateAof(in AofAddress)` now takes the caller `NodeRole` and asserts `PRIMARY`, documenting why the replication-offset bound is unnecessary on that path. `ClusterProvider.SafeTruncateAOF` passes the role through.

## Notes
No test is included: reproducing the pre-fix behavior depends on replay lagging AOF ingestion, which is timing-dependent and cannot be triggered deterministically.