### PR TITLE
Support INFO KEYSPACE command (#1668)

### DIFF
--- a/libs/server/Databases/DatabaseManagerBase.cs
+++ b/libs/server/Databases/DatabaseManagerBase.cs
@@ -598,6 +598,31 @@ namespace Garnet.server
         }
 
         /// <inheritdoc/>
+        public abstract (int keyCount, int expireCount) GetKeyspaceStats(int dbId);
+
+        /// <summary>
+        /// Count live keys and live keys with an expiration set for the given database via a full store scan.
+        /// Uses a dedicated per-database storage session guarded by <see cref="GarnetDatabase.KeyspaceScanLock"/>,
+        /// since INFO can be issued concurrently by multiple sessions.
+        /// </summary>
+        /// <param name="db">Database to scan.</param>
+        /// <returns>A tuple of (live keys, live keys with an expiration set).</returns>
+        protected (int keyCount, int expireCount) GetDatabaseKeyspaceStats(GarnetDatabase db)
+        {
+            lock (db.KeyspaceScanLock)
+            {
+                if (db.KeyspaceScanStorageSession == null)
+                {
+                    var scratchBufferBuilder = new ScratchBufferBuilder();
+                    var scratchBufferAllocator = new ScratchBufferAllocator();
+                    db.KeyspaceScanStorageSession = new StorageSession(StoreWrapper, scratchBufferBuilder, scratchBufferAllocator, null, null, db.Id, readSessionState: null, db.VectorManager, Logger);
+                }
+
+                return db.KeyspaceScanStorageSession.KeyspaceStats();
+            }
+        }
+
+        /// <inheritdoc/>
         public abstract (HybridLogScanMetrics mainStore, HybridLogScanMetrics objectStore)[] CollectHybridLogStats();
 
         protected (HybridLogScanMetrics mainStore, HybridLogScanMetrics objectStore) CollectHybridLogStatsForDb(GarnetDatabase db)

--- a/libs/server/Databases/DatabaseManagerBase.cs
+++ b/libs/server/Databases/DatabaseManagerBase.cs
@@ -598,7 +598,7 @@ namespace Garnet.server
         }
 
         /// <inheritdoc/>
-        public abstract (int keyCount, int expireCount) GetKeyspaceStats(int dbId);
+        public abstract (long keyCount, long expireCount) GetKeyspaceStats(int dbId);
 
         /// <summary>
         /// Count live keys and live keys with an expiration set for the given database via a full store scan.
@@ -607,7 +607,7 @@ namespace Garnet.server
         /// </summary>
         /// <param name="db">Database to scan.</param>
         /// <returns>A tuple of (live keys, live keys with an expiration set).</returns>
-        protected (int keyCount, int expireCount) GetDatabaseKeyspaceStats(GarnetDatabase db)
+        protected (long keyCount, long expireCount) GetDatabaseKeyspaceStats(GarnetDatabase db)
         {
             lock (db.KeyspaceScanLock)
             {

--- a/libs/server/Databases/IDatabaseManager.cs
+++ b/libs/server/Databases/IDatabaseManager.cs
@@ -248,6 +248,14 @@ namespace Garnet.server
         public (long numExpiredKeysFound, long totalRecordsScanned) ExpiredKeyDeletionScan(int dbId);
 
         /// <summary>
+        /// Count live keys and live keys with an expiration set for a database given its ID.
+        /// Used to populate the <c>INFO KEYSPACE</c> section.
+        /// </summary>
+        /// <param name="dbId">Database ID</param>
+        /// <returns>A tuple of (live keys, live keys with an expiration set).</returns>
+        public (int keyCount, int expireCount) GetKeyspaceStats(int dbId);
+
+        /// <summary>
         /// Collect and return an array mapping db Id to its stats
         /// </summary>
         /// <returns></returns>

--- a/libs/server/Databases/IDatabaseManager.cs
+++ b/libs/server/Databases/IDatabaseManager.cs
@@ -253,7 +253,7 @@ namespace Garnet.server
         /// </summary>
         /// <param name="dbId">Database ID</param>
         /// <returns>A tuple of (live keys, live keys with an expiration set).</returns>
-        public (int keyCount, int expireCount) GetKeyspaceStats(int dbId);
+        public (long keyCount, long expireCount) GetKeyspaceStats(int dbId);
 
         /// <summary>
         /// Collect and return an array mapping db Id to its stats

--- a/libs/server/Databases/MultiDatabaseManager.cs
+++ b/libs/server/Databases/MultiDatabaseManager.cs
@@ -1091,6 +1091,9 @@ namespace Garnet.server
         public override (long numExpiredKeysFound, long totalRecordsScanned) ExpiredKeyDeletionScan(int dbId)
             => StoreExpiredKeyDeletionScan(GetDbById(dbId));
 
+        public override (int keyCount, int expireCount) GetKeyspaceStats(int dbId)
+            => GetDatabaseKeyspaceStats(GetDbById(dbId));
+
         private GarnetDatabase GetDbById(int dbId)
         {
             var databasesMapSize = databases.ActualSize;

--- a/libs/server/Databases/MultiDatabaseManager.cs
+++ b/libs/server/Databases/MultiDatabaseManager.cs
@@ -1091,7 +1091,7 @@ namespace Garnet.server
         public override (long numExpiredKeysFound, long totalRecordsScanned) ExpiredKeyDeletionScan(int dbId)
             => StoreExpiredKeyDeletionScan(GetDbById(dbId));
 
-        public override (int keyCount, int expireCount) GetKeyspaceStats(int dbId)
+        public override (long keyCount, long expireCount) GetKeyspaceStats(int dbId)
             => GetDatabaseKeyspaceStats(GetDbById(dbId));
 
         private GarnetDatabase GetDbById(int dbId)

--- a/libs/server/Databases/SingleDatabaseManager.cs
+++ b/libs/server/Databases/SingleDatabaseManager.cs
@@ -375,7 +375,7 @@ namespace Garnet.server
             return StoreExpiredKeyDeletionScan(DefaultDatabase);
         }
 
-        public override (int keyCount, int expireCount) GetKeyspaceStats(int dbId)
+        public override (long keyCount, long expireCount) GetKeyspaceStats(int dbId)
         {
             ArgumentOutOfRangeException.ThrowIfNotEqual(dbId, 0);
             return GetDatabaseKeyspaceStats(DefaultDatabase);

--- a/libs/server/Databases/SingleDatabaseManager.cs
+++ b/libs/server/Databases/SingleDatabaseManager.cs
@@ -375,6 +375,12 @@ namespace Garnet.server
             return StoreExpiredKeyDeletionScan(DefaultDatabase);
         }
 
+        public override (int keyCount, int expireCount) GetKeyspaceStats(int dbId)
+        {
+            ArgumentOutOfRangeException.ThrowIfNotEqual(dbId, 0);
+            return GetDatabaseKeyspaceStats(DefaultDatabase);
+        }
+
         public override (HybridLogScanMetrics mainStore, HybridLogScanMetrics objectStore)[] CollectHybridLogStats() => [CollectHybridLogStatsForDb(defaultDatabase)];
 
         private unsafe void SafeFlushAOF(AofEntryType entryType, bool unsafeTruncateLog)

--- a/libs/server/GarnetDatabase.cs
+++ b/libs/server/GarnetDatabase.cs
@@ -98,6 +98,17 @@ namespace Garnet.server
         /// </summary>
         internal StorageSession StoreExpiredKeyDeletionDbStorageSession;
 
+        /// <summary>
+        /// Storage session intended for INFO KEYSPACE scans.
+        /// Shared across concurrent INFO callers, so all access must be guarded by <see cref="KeyspaceScanLock"/>.
+        /// </summary>
+        internal StorageSession KeyspaceScanStorageSession;
+
+        /// <summary>
+        /// Guards <see cref="KeyspaceScanStorageSession"/> since INFO can be issued concurrently by multiple sessions.
+        /// </summary>
+        internal readonly object KeyspaceScanLock = new();
+
         internal StorageSession HybridLogStatScanStorageSession;
 
         private KVSettings KvSettings;
@@ -169,6 +180,7 @@ namespace Garnet.server
             AppendOnlyFile?.Dispose();
             StoreCollectionDbStorageSession?.Dispose();
             StoreExpiredKeyDeletionDbStorageSession?.Dispose();
+            KeyspaceScanStorageSession?.Dispose();
 
             SizeTracker?.Stop();
         }

--- a/libs/server/Metrics/Info/GarnetInfoMetrics.cs
+++ b/libs/server/Metrics/Info/GarnetInfoMetrics.cs
@@ -22,6 +22,10 @@ namespace Garnet.server
                 InfoMetricsType.STOREREVIV => false,
                 InfoMetricsType.HLOGSCAN => false,
                 InfoMetricsType.COMMANDSTATS => false,
+                // KEYSPACE requires a full per-database log scan to count keys (Garnet has no O(1)
+                // key counter). Exclude it from the default/ALL/EVERYTHING sets so plain INFO stays
+                // cheap; it is still populated on an explicit `INFO KEYSPACE` request.
+                InfoMetricsType.KEYSPACE => false,
                 _ => true
             })];
 
@@ -380,9 +384,24 @@ namespace Garnet.server
             clientsInfo = [new("connected_clients", metricsDisabled ? "0" : (globalMetrics.total_connections_received - globalMetrics.total_connections_disposed).ToString())];
         }
 
-        private void PopulateKeyspaceInfo()
+        private void PopulateKeyspaceInfo(StoreWrapper storeWrapper)
         {
-            keyspaceInfo = null;
+            var databases = storeWrapper.GetDatabasesSnapshot();
+
+            List<MetricsItem> items = null;
+            foreach (var db in databases.OrderBy(db => db.Id))
+            {
+                var (keyCount, expireCount) = storeWrapper.GetKeyspaceStats(db.Id);
+
+                // Redis lists only databases that currently hold at least one key.
+                if (keyCount == 0)
+                    continue;
+
+                items ??= [];
+                items.Add(new($"db{db.Id}", $"keys={keyCount},expires={expireCount},avg_ttl=0"));
+            }
+
+            keyspaceInfo = items?.ToArray();
         }
 
         private void PopulateClusterBufferPoolStats(StoreWrapper storeWrapper)
@@ -514,7 +533,7 @@ namespace Garnet.server
                     GetSectionRespInfo(header, clientsInfo, sbResponse);
                     return;
                 case InfoMetricsType.KEYSPACE:
-                    PopulateKeyspaceInfo();
+                    PopulateKeyspaceInfo(storeWrapper);
                     GetSectionRespInfo(header, keyspaceInfo, sbResponse);
                     return;
                 case InfoMetricsType.MODULES:
@@ -592,7 +611,7 @@ namespace Garnet.server
                     PopulateClientsInfo(storeWrapper);
                     return clientsInfo;
                 case InfoMetricsType.KEYSPACE:
-                    PopulateKeyspaceInfo();
+                    PopulateKeyspaceInfo(storeWrapper);
                     return keyspaceInfo;
                 case InfoMetricsType.MODULES:
                     return null;

--- a/libs/server/Storage/Session/Common/ArrayKeyIterationFunctions.cs
+++ b/libs/server/Storage/Session/Common/ArrayKeyIterationFunctions.cs
@@ -17,6 +17,9 @@ namespace Garnet.server
         // These contain classes so instantiate once and re-initialize
         private ArrayKeyIterationFunctions.UnifiedStoreGetDBSize unifiedStoreDbSizeFuncs;
 
+        // Iterator for INFO KEYSPACE (counts live keys and live keys with an expiration set)
+        private ArrayKeyIterationFunctions.UnifiedStoreGetKeyspaceStats unifiedStoreKeyspaceStatsFuncs;
+
         // Iterator for SCAN command
         private ArrayKeyIterationFunctions.UnifiedStoreGetDBKeys unifiedStoreDbScanFuncs;
 
@@ -174,6 +177,22 @@ namespace Garnet.server
             unifiedBasicContext.Session.ScanCursor(ref cursor, long.MaxValue, unifiedStoreDbSizeFuncs);
 
             return unifiedStoreDbSizeFuncs.Count;
+        }
+
+        /// <summary>
+        /// Count the number of live keys and the number of live keys that have an expiration set,
+        /// in a single scan over the store. Used by the <c>INFO KEYSPACE</c> section.
+        /// The key count uses the same non-expired predicate as <see cref="DbSize"/>, so the two are consistent.
+        /// </summary>
+        /// <returns>A tuple of (total live keys, live keys with an expiration set).</returns>
+        internal (int keyCount, int expireCount) KeyspaceStats()
+        {
+            unifiedStoreKeyspaceStatsFuncs ??= new();
+            unifiedStoreKeyspaceStatsFuncs.Initialize();
+            long cursor = 0;
+            unifiedBasicContext.Session.ScanCursor(ref cursor, long.MaxValue, unifiedStoreKeyspaceStatsFuncs);
+
+            return (unifiedStoreKeyspaceStatsFuncs.KeyCount, unifiedStoreKeyspaceStatsFuncs.ExpireCount);
         }
 
         internal static unsafe class ArrayKeyIterationFunctions
@@ -334,6 +353,54 @@ namespace Garnet.server
                     cursorRecordResult = CursorRecordResult.Skip;
                     if (!CheckExpiry(in logRecord))
                         ++info.count;
+                    return true;
+                }
+
+                public bool OnStart(long beginAddress, long endAddress) => true;
+                public void OnStop(bool completed, long numberOfRecords) { }
+                public void OnException(Exception exception, long numberOfRecords) { }
+            }
+
+            internal class GetKeyspaceStatsInfo
+            {
+                // This must be a class as it is passed through pending IO operations, so it is wrapped by higher structures for inlining as a generic type arg.
+                internal int keyCount;
+                internal int expireCount;
+
+                internal void Initialize()
+                {
+                    keyCount = 0;
+                    expireCount = 0;
+                }
+            }
+
+            /// <summary>
+            /// Scan callback for the <c>INFO KEYSPACE</c> section. Counts live (non-expired) keys and,
+            /// among those, how many have an expiration set. The live-key predicate matches
+            /// <see cref="UnifiedStoreGetDBSize"/> so the reported key count is consistent with <c>DBSIZE</c>.
+            /// </summary>
+            internal sealed class UnifiedStoreGetKeyspaceStats : IScanIteratorFunctions
+            {
+                private readonly GetKeyspaceStatsInfo info;
+
+                internal int KeyCount => info.keyCount;
+
+                internal int ExpireCount => info.expireCount;
+
+                internal UnifiedStoreGetKeyspaceStats() => info = new();
+
+                internal void Initialize() => info.Initialize();
+
+                public bool Reader<TSourceLogRecord>(in TSourceLogRecord logRecord, RecordMetadata recordMetadata, long numberOfRecords, out CursorRecordResult cursorRecordResult)
+                    where TSourceLogRecord : ISourceLogRecord
+                {
+                    cursorRecordResult = CursorRecordResult.Skip;
+                    if (!CheckExpiry(in logRecord))
+                    {
+                        ++info.keyCount;
+                        if (logRecord.DataHeader.HasExpiration)
+                            ++info.expireCount;
+                    }
                     return true;
                 }
 

--- a/libs/server/Storage/Session/Common/ArrayKeyIterationFunctions.cs
+++ b/libs/server/Storage/Session/Common/ArrayKeyIterationFunctions.cs
@@ -185,7 +185,7 @@ namespace Garnet.server
         /// The key count uses the same non-expired predicate as <see cref="DbSize"/>, so the two are consistent.
         /// </summary>
         /// <returns>A tuple of (total live keys, live keys with an expiration set).</returns>
-        internal (int keyCount, int expireCount) KeyspaceStats()
+        internal (long keyCount, long expireCount) KeyspaceStats()
         {
             unifiedStoreKeyspaceStatsFuncs ??= new();
             unifiedStoreKeyspaceStatsFuncs.Initialize();
@@ -364,8 +364,8 @@ namespace Garnet.server
             internal class GetKeyspaceStatsInfo
             {
                 // This must be a class as it is passed through pending IO operations, so it is wrapped by higher structures for inlining as a generic type arg.
-                internal int keyCount;
-                internal int expireCount;
+                internal long keyCount;
+                internal long expireCount;
 
                 internal void Initialize()
                 {
@@ -383,9 +383,9 @@ namespace Garnet.server
             {
                 private readonly GetKeyspaceStatsInfo info;
 
-                internal int KeyCount => info.keyCount;
+                internal long KeyCount => info.keyCount;
 
-                internal int ExpireCount => info.expireCount;
+                internal long ExpireCount => info.expireCount;
 
                 internal UnifiedStoreGetKeyspaceStats() => info = new();
 

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -754,6 +754,15 @@ namespace Garnet.server
             => databaseManager.ExpiredKeyDeletionScan(dbId);
 
         /// <summary>
+        /// Count live keys and live keys with an expiration set for a specific database ID.
+        /// Used to populate the <c>INFO KEYSPACE</c> section.
+        /// </summary>
+        /// <param name="dbId">Database ID</param>
+        /// <returns>A tuple of (live keys, live keys with an expiration set).</returns>
+        public (int keyCount, int expireCount) GetKeyspaceStats(int dbId)
+            => databaseManager.GetKeyspaceStats(dbId);
+
+        /// <summary>
         /// Grows indexes of both main store and object store if current size is too small.
         /// </summary>
         /// <param name="token"></param>

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -759,7 +759,7 @@ namespace Garnet.server
         /// </summary>
         /// <param name="dbId">Database ID</param>
         /// <returns>A tuple of (live keys, live keys with an expiration set).</returns>
-        public (int keyCount, int expireCount) GetKeyspaceStats(int dbId)
+        public (long keyCount, long expireCount) GetKeyspaceStats(int dbId)
             => databaseManager.GetKeyspaceStats(dbId);
 
         /// <summary>

--- a/test/standalone/Garnet.test/RespInfoTests.cs
+++ b/test/standalone/Garnet.test/RespInfoTests.cs
@@ -112,7 +112,10 @@ namespace Garnet.test
             ClassicAssert.IsTrue(infoResult.Contains("# Memory"), $"INFO {option} should contain Memory section");
             ClassicAssert.IsTrue(infoResult.Contains("# Stats"), $"INFO {option} should contain Stats section");
             ClassicAssert.IsTrue(infoResult.Contains("# Clients"), $"INFO {option} should contain Clients section");
-            ClassicAssert.IsTrue(infoResult.Contains("# Keyspace"), $"INFO {option} should contain Keyspace section");
+
+            // KEYSPACE is scan-based and therefore excluded from the default/ALL/EVERYTHING sets
+            // (like HLOGSCAN); it is only produced on an explicit `INFO KEYSPACE` request.
+            ClassicAssert.IsFalse(infoResult.Contains("# Keyspace"), $"INFO {option} should not contain Keyspace section");
 
             // ALL excludes Modules section; DEFAULT and EVERYTHING include it
             if (option == "ALL")
@@ -263,6 +266,97 @@ namespace Garnet.test
             {
                 await setAction(db, keyToRcu, Guid.NewGuid().ToString()).ConfigureAwait(false);
             }
+        }
+
+        [TestCase(RedisProtocol.Resp2)]
+        [TestCase(RedisProtocol.Resp3)]
+        public void InfoKeyspaceEmptyDatabaseTest(RedisProtocol protocol)
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol));
+            var db = redis.GetDatabase(0);
+
+            var info = db.Execute("INFO", "KEYSPACE").ToString();
+
+            ClassicAssert.IsTrue(info.Contains("# Keyspace"), "Keyspace section header should be present");
+            // No database holds keys yet, so no dbN: lines should be emitted (matches Redis).
+            ClassicAssert.IsNull(GetKeyspaceLine(info, 0), "Empty database should not be listed in the Keyspace section");
+        }
+
+        [TestCase(RedisProtocol.Resp2)]
+        [TestCase(RedisProtocol.Resp3)]
+        public void InfoKeyspaceCountsTest(RedisProtocol protocol)
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol));
+            var db = redis.GetDatabase(0);
+
+            // 3 string keys (2 with a TTL) + 2 list (object) keys (1 with a TTL) => keys=5, expires=3
+            db.StringSet("str:1", "v1");
+            db.StringSet("str:2", "v2");
+            db.StringSet("str:3", "v3");
+            ClassicAssert.IsTrue(db.KeyExpire("str:1", TimeSpan.FromHours(1)));
+            ClassicAssert.IsTrue(db.KeyExpire("str:2", TimeSpan.FromHours(1)));
+
+            db.ListLeftPush("list:1", [new RedisValue("a"), new RedisValue("b")]);
+            db.ListLeftPush("list:2", [new RedisValue("c")]);
+            ClassicAssert.IsTrue(db.KeyExpire("list:1", TimeSpan.FromHours(1)));
+
+            var info = db.Execute("INFO", "KEYSPACE").ToString();
+            var line = GetKeyspaceLine(info, 0);
+
+            ClassicAssert.AreEqual("db0:keys=5,expires=3,avg_ttl=0", line);
+
+            // The reported key count must be consistent with DBSIZE (same non-expired predicate).
+            var dbSize = (long)db.Execute("DBSIZE");
+            ClassicAssert.AreEqual(5, dbSize);
+        }
+
+        [Test]
+        public void InfoKeyspaceExpiredKeysNotCountedTest()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            db.StringSet("live", "v");
+            db.StringSet("willexpire", "v");
+            ClassicAssert.IsTrue(db.KeyExpire("willexpire", TimeSpan.FromMilliseconds(50)));
+
+            // Let the key expire. It may not be physically reaped yet, but the scan filters expired records.
+            Thread.Sleep(250);
+
+            var info = db.Execute("INFO", "KEYSPACE").ToString();
+            var line = GetKeyspaceLine(info, 0);
+
+            ClassicAssert.AreEqual("db0:keys=1,expires=0,avg_ttl=0", line);
+        }
+
+        [Test]
+        public void InfoKeyspaceMultiDatabaseTest()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+
+            var db0 = redis.GetDatabase(0);
+            var db1 = redis.GetDatabase(1);
+
+            // db0: 2 keys, 1 with a TTL; db1: 1 key, no TTL; db2: left empty.
+            db0.StringSet("a", "1");
+            db0.StringSet("b", "2");
+            ClassicAssert.IsTrue(db0.KeyExpire("a", TimeSpan.FromHours(1)));
+
+            db1.StringSet("c", "3");
+
+            var info = db0.Execute("INFO", "KEYSPACE").ToString();
+
+            ClassicAssert.AreEqual("db0:keys=2,expires=1,avg_ttl=0", GetKeyspaceLine(info, 0));
+            ClassicAssert.AreEqual("db1:keys=1,expires=0,avg_ttl=0", GetKeyspaceLine(info, 1));
+            // An untouched database must not appear.
+            ClassicAssert.IsNull(GetKeyspaceLine(info, 2), "Empty database should not be listed in the Keyspace section");
+        }
+
+        private static string GetKeyspaceLine(string infoOutput, int dbId)
+        {
+            ClassicAssert.IsNotNull(infoOutput, "INFO output should not be null");
+            var prefix = $"db{dbId}:";
+            return infoOutput.Split("\r\n").FirstOrDefault(line => line.StartsWith(prefix));
         }
     }
 }

--- a/test/standalone/Garnet.test/RespInfoTests.cs
+++ b/test/standalone/Garnet.test/RespInfoTests.cs
@@ -320,8 +320,22 @@ namespace Garnet.test
             db.StringSet("willexpire", "v");
             ClassicAssert.IsTrue(db.KeyExpire("willexpire", TimeSpan.FromMilliseconds(50)));
 
-            // Let the key expire. It may not be physically reaped yet, but the scan filters expired records.
-            Thread.Sleep(250);
+            // Poll (bounded) until the key is observed expired, rather than a fixed sleep, to avoid
+            // flakiness on slow/loaded CI agents. The key may not be physically reaped yet, but the
+            // scan filters expired records regardless.
+            var expired = false;
+            for (var i = 0; i < 100 && !expired; i++)
+            {
+                if (!db.KeyExists("willexpire"))
+                {
+                    expired = true;
+                    break;
+                }
+
+                Thread.Sleep(20);
+            }
+
+            ClassicAssert.IsTrue(expired, "Key with a short TTL should have expired");
 
             var info = db.Execute("INFO", "KEYSPACE").ToString();
             var line = GetKeyspaceLine(info, 0);


### PR DESCRIPTION
Populate the previously-stubbed INFO KEYSPACE section with per-database key counts so tools like Navicat (which issue `INFO keyspace` and parse `dbN:keys=...`) report the correct number of keys instead of 0.

Output matches Redis format, listing only databases that hold keys:

    # Keyspace
    db0:keys=5,expires=3,avg_ttl=0

- Add UnifiedStoreGetKeyspaceStats scan + StorageSession.KeyspaceStats() counting live keys (same non-expired predicate as DBSIZE) and, among those, how many have an expiration set. avg_ttl is reported as 0.
- Plumb GetKeyspaceStats(int dbId) through IDatabaseManager / DatabaseManagerBase / Single+MultiDatabaseManager / StoreWrapper, backed by a dedicated per-DB KeyspaceScanStorageSession guarded by a lock (mirrors the existing per-DB background-session pattern).
- Exclude KEYSPACE from the default/ALL/EVERYTHING INFO sets since it requires a full store scan (Garnet has no O(1) key counter), consistent with how the scan-based HLOGSCAN section is handled. Explicit `INFO KEYSPACE` still populates the section, so the reported issue is fixed.
- Tests: empty DB, counts vs DBSIZE (string + object + TTL), expired keys not counted, and multi-database, across RESP2/RESP3.

Fixes #1668 