### PR TITLE
Exclude internal records from stats

### DIFF
--- a/libs/server/Storage/Session/Common/ArrayKeyIterationFunctions.cs
+++ b/libs/server/Storage/Session/Common/ArrayKeyIterationFunctions.cs
@@ -289,7 +289,7 @@ namespace Garnet.server
                 public virtual bool Reader<TSourceLogRecord>(in TSourceLogRecord logRecord, RecordMetadata recordMetadata, long numberOfRecords, out CursorRecordResult cursorRecordResult)
                     where TSourceLogRecord : ISourceLogRecord
                 {
-                    if (CheckExpiry(in logRecord))
+                    if (logRecord.HasNamespace || CheckExpiry(in logRecord))
                     {
                         cursorRecordResult = CursorRecordResult.Skip;
                         return true;
@@ -351,7 +351,7 @@ namespace Garnet.server
                     where TSourceLogRecord : ISourceLogRecord
                 {
                     cursorRecordResult = CursorRecordResult.Skip;
-                    if (!CheckExpiry(in logRecord))
+                    if (!logRecord.HasNamespace && !CheckExpiry(in logRecord))
                         ++info.count;
                     return true;
                 }
@@ -395,7 +395,7 @@ namespace Garnet.server
                     where TSourceLogRecord : ISourceLogRecord
                 {
                     cursorRecordResult = CursorRecordResult.Skip;
-                    if (!CheckExpiry(in logRecord))
+                    if (!logRecord.HasNamespace && !CheckExpiry(in logRecord))
                     {
                         ++info.keyCount;
                         if (logRecord.DataHeader.HasExpiration)

--- a/libs/server/Storage/Session/Common/ArrayKeyIterationFunctions.cs
+++ b/libs/server/Storage/Session/Common/ArrayKeyIterationFunctions.cs
@@ -289,7 +289,7 @@ namespace Garnet.server
                 public virtual bool Reader<TSourceLogRecord>(in TSourceLogRecord logRecord, RecordMetadata recordMetadata, long numberOfRecords, out CursorRecordResult cursorRecordResult)
                     where TSourceLogRecord : ISourceLogRecord
                 {
-                    if (logRecord.HasNamespace || CheckExpiry(in logRecord))
+                    if (IsInternalRecord(in logRecord) || CheckExpiry(in logRecord))
                     {
                         cursorRecordResult = CursorRecordResult.Skip;
                         return true;
@@ -351,7 +351,7 @@ namespace Garnet.server
                     where TSourceLogRecord : ISourceLogRecord
                 {
                     cursorRecordResult = CursorRecordResult.Skip;
-                    if (!logRecord.HasNamespace && !CheckExpiry(in logRecord))
+                    if (!IsInternalRecord(in logRecord) && !CheckExpiry(in logRecord))
                         ++info.count;
                     return true;
                 }
@@ -395,7 +395,7 @@ namespace Garnet.server
                     where TSourceLogRecord : ISourceLogRecord
                 {
                     cursorRecordResult = CursorRecordResult.Skip;
-                    if (!logRecord.HasNamespace && !CheckExpiry(in logRecord))
+                    if (!IsInternalRecord(in logRecord) && !CheckExpiry(in logRecord))
                     {
                         ++info.keyCount;
                         if (logRecord.DataHeader.HasExpiration)
@@ -477,6 +477,15 @@ namespace Garnet.server
                 public void OnStop(bool completed, long numberOfRecords) { }
                 public void OnException(Exception exception, long numberOfRecords) { }
             }
+
+            /// <summary>
+            /// Determine if a log record represents an internal record.
+            /// 
+            /// Typically these records should not be reported in statistics, or returned to users.
+            /// </summary>
+            private static bool IsInternalRecord<TSourceLogRecord>(in TSourceLogRecord logRecord)
+                where TSourceLogRecord : ISourceLogRecord
+            => logRecord.HasNamespace;
         }
     }
 }

--- a/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
+++ b/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
@@ -3580,6 +3580,63 @@ namespace Garnet.test
             }
         }
 
+        [Test]
+        public async Task HideInternalRecordsAsync()
+        {
+            // DBSIZE, INFO KEYSPACE, KEYS, SCAN shouldn't return the internal (ie. namespaced) records created for Vector Sets
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
+            var server = redis.GetServers().Single();
+            var db = redis.GetDatabase(0);
+
+            var setRes = await db.StringSetAsync("foo", "bar").ConfigureAwait(false);
+            ClassicAssert.IsTrue(setRes);
+
+            var addRes = await db.ExecuteAsync("VADD", [nameof(HideInternalRecordsAsync), "VALUES", "3", "1.0", "2.0", "3.0", "foo"]).ConfigureAwait(false);
+            ClassicAssert.AreEqual(1, (int)addRes);
+
+            // DBSIZE
+            {
+                var keyCount = await server.DatabaseSizeAsync(0).ConfigureAwait(false);
+                ClassicAssert.AreEqual(2, keyCount);
+            }
+
+            // INFO KEYSPACE
+            {
+                var info = await server.InfoAsync("keyspace").ConfigureAwait(false);
+                var keyspace = info.Single();
+                ClassicAssert.AreEqual("Keyspace", keyspace.Key);
+
+                var db0Data = keyspace.Single(static kv => kv.Key.Equals("db0", StringComparison.Ordinal)).Value;
+                var db0Values = db0Data.Split(",").ToDictionary(kv => kv.Split('=')[0], kv => kv.Split('=')[1]);
+                ClassicAssert.AreEqual("2", db0Values["keys"]);
+            }
+
+            // KEYS
+            {
+                var allKeys = (string[])await db.ExecuteAsync("KEYS", "*").ConfigureAwait(false);
+
+                ClassicAssert.AreEqual(2, allKeys.Length);
+                ClassicAssert.IsTrue(allKeys.Contains("foo"));
+                ClassicAssert.IsTrue(allKeys.Contains(nameof(HideInternalRecordsAsync)));
+            }
+
+            // SCAN
+            {
+                var allKeys = new List<string>();
+
+                var scan = server.KeysAsync(0).ConfigureAwait(false);
+                await foreach (var key in scan.ConfigureAwait(false))
+                {
+                    allKeys.Add(key);
+                }
+
+                ClassicAssert.AreEqual(2, allKeys.Count);
+                ClassicAssert.IsTrue(allKeys.Contains("foo"));
+                ClassicAssert.IsTrue(allKeys.Contains(nameof(HideInternalRecordsAsync)));
+            }
+        }
+
         /// <summary>
         /// Create a new GarnetServer instance with common parameters.
         /// </summary>


### PR DESCRIPTION
Fixes #1921.

Internal records (ie. those with namespaces) for Vector Sets are now excluded from `DBSIZE`, `INFO|KEYSPACE`, `KEYS`, and `SCAN`.