### PR TITLE
Add quant restart support to create_index and bump diskann version to 4.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="System.Numerics.Tensors" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.5" />
-    <PackageVersion Include="diskann-garnet" Version="3.0.0" />
+    <PackageVersion Include="diskann-garnet" Version="4.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
   </ItemGroup>
 </Project>

--- a/libs/server/Resp/Vector/DiskANNService.cs
+++ b/libs/server/Resp/Vector/DiskANNService.cs
@@ -51,12 +51,9 @@ namespace Garnet.server
 #if DEBUG
             System.Threading.Interlocked.Increment(ref CreateIndexCalls);
 #endif
-            // TODO: This needs to be set appropriately - requires DiskANN changes
-            quantizationRequested = false;
-
             unsafe
             {
-                var ret = NativeDiskANNMethods.create_index(context, dimensions, reduceDims, quantType, distanceMetric, buildExplorationFactor, numLinks, (nint)readCallback, (nint)writeCallback, (nint)deleteCallback, (nint)readModifyWriteCallback, (nint)filterCallback);
+                var ret = NativeDiskANNMethods.create_index(context, dimensions, reduceDims, quantType, distanceMetric, buildExplorationFactor, numLinks, (nint)readCallback, (nint)writeCallback, (nint)deleteCallback, (nint)readModifyWriteCallback, (nint)filterCallback, out quantizationRequested);
 
                 Debug.Assert(ret != 0, "create_index failed, returning a null pointer - this shouldn't be possible");
 
@@ -347,7 +344,8 @@ namespace Garnet.server
             nint writeCallback,
             nint deleteCallback,
             nint readModifyWriteCallback,
-            nint filterCallback
+            nint filterCallback,
+            [MarshalAs(UnmanagedType.U1)] out bool quantizationNeeded
         );
 
         [LibraryImport(DISKANN_GARNET)]

--- a/test/standalone/Garnet.test.extensions/DiskANN/DiskANNServiceTests.cs
+++ b/test/standalone/Garnet.test.extensions/DiskANN/DiskANNServiceTests.cs
@@ -176,7 +176,7 @@ namespace Garnet.test
             var rmwFuncPtr = Marshal.GetFunctionPointerForDelegate(rmwDel);
             var filterFuncPtr = Marshal.GetFunctionPointerForDelegate(filterDel);
 
-            var rawIndex = NativeDiskANNMethods.create_index(Context, 75, 0, VectorQuantType.XNoQuant_U8, VectorDistanceMetricType.L2, 10, 10, readFuncPtr, writeFuncPtr, deleteFuncPtr, rmwFuncPtr, filterFuncPtr);
+            var rawIndex = NativeDiskANNMethods.create_index(Context, 75, 0, VectorQuantType.XNoQuant_U8, VectorDistanceMetricType.L2, 10, 10, readFuncPtr, writeFuncPtr, deleteFuncPtr, rmwFuncPtr, filterFuncPtr, out _);
 
             Span<byte> id = [0, 1, 2, 3];
             Span<byte> elem = Enumerable.Range(0, 75).Select(static x => (byte)x).ToArray();
@@ -379,7 +379,7 @@ namespace Garnet.test
             var rmwFuncPtr = Marshal.GetFunctionPointerForDelegate(rmwDel);
             var filterFuncPtr = Marshal.GetFunctionPointerForDelegate(filterDel);
 
-            var rawIndex = NativeDiskANNMethods.create_index(Context, 75, 0, VectorQuantType.XNoQuant_U8, VectorDistanceMetricType.L2, 10, 10, readFuncPtr, writeFuncPtr, deleteFuncPtr, rmwFuncPtr, filterFuncPtr);
+            var rawIndex = NativeDiskANNMethods.create_index(Context, 75, 0, VectorQuantType.XNoQuant_U8, VectorDistanceMetricType.L2, 10, 10, readFuncPtr, writeFuncPtr, deleteFuncPtr, rmwFuncPtr, filterFuncPtr, out _);
 
             Span<byte> id = [0, 1, 2, 3];
             Span<byte> elem = Enumerable.Range(0, 75).Select(static x => (byte)x).ToArray();
@@ -424,7 +424,7 @@ namespace Garnet.test
             {
                 NativeDiskANNMethods.drop_index(Context, rawIndex);
 
-                rawIndex = NativeDiskANNMethods.create_index(Context, 75, 0, VectorQuantType.XNoQuant_U8, VectorDistanceMetricType.L2, 10, 10, readFuncPtr, writeFuncPtr, deleteFuncPtr, rmwFuncPtr, filterFuncPtr);
+                rawIndex = NativeDiskANNMethods.create_index(Context, 75, 0, VectorQuantType.XNoQuant_U8, VectorDistanceMetricType.L2, 10, 10, readFuncPtr, writeFuncPtr, deleteFuncPtr, rmwFuncPtr, filterFuncPtr, out _);
             }
 
             // Search value

--- a/website/docs/dev/vector-sets.md
+++ b/website/docs/dev/vector-sets.md
@@ -161,17 +161,12 @@ Quantizers that start with an `X` are extensions, quantizers that are not also f
 
 Some quantizers require a sample of vectors be gathered before the actual quantization can be applied.  This gathering is opaque to Garnet, but cooperates with DiskANN to move extra calculations and backfills to background tasks.
 
-Backfills are triggered by `insert` returning `DiskANNInsertResult.QuantizationRequested`, after which:
+Backfills are triggered by `insert` returning `DiskANNInsertResult.QuantizationRequested` or `create_index` setting the out param `quantizationNeeded` to true, after which:
  - `build_quant_table` is invoked on a background task once for each `DiskANNInsertResult.QuantizationRequested` returned
  - If `build_quant_table` returns 1, some number of `backfill_quant_vectors` tasks are also executed in the background
  - `backfill_quant_vectors` tasks run in parallel, each task receiving a unique `task_index` which is &lt; `task_count`
  
  It is legal for DiskANN to request quantization multiple times - it is `diskann-garnet`'s responsibility to handle any extra, or concurrent, calls to `build_quant_table` and guarantee only one success is reported.
-
- > [!NOTE]
- > Today DiskANN does not recover quantization state.
- >
- > This will be fixed in a future `diskann-garnet` release, which will also allow us to resume quantization if it was interrupted.
 
 # Locking
 
@@ -393,7 +388,7 @@ The callback returns 1 if the key-value pair was found or created, and 0 if some
 
 Garnet calls into the following DiskANN functions:
 
- - [x] `nint create_index(ulong context, uint dimensions, uint reduceDims, VectorQuantType quantType, uint buildExplorationFactor, uint numLinks, VectorDistanceMetricType distanceMetric, nint readCallback, nint writeCallback, nint deleteCallback, nint readModifyWriteCallback)`
+ - [x] `nint create_index(ulong context, uint dimensions, uint reduceDims, VectorQuantType quantType, VectorDistanceMetricType distanceMetric, uint buildExplorationFactor, uint numLinks, nint readCallback, nint writeCallback, nint deleteCallback, nint readModifyWriteCallback, nint filterCallback, out bool quantizationNeeded)`
  - [x] `void drop_index(ulong context, nint index)`
  - [x] `DiskANNInsertResult insert(ulong context, nint index, nint id_data, nuint id_len, nint vector_data, nuint vector_len, nint attribute_data, nuint attribute_len)`
  - [x] `byte remove(ulong context, nint index, nint id_data, nuint id_len)`


### PR DESCRIPTION
diskann-garnet 4.0.0 adds support for persisting index quantization state, and this PR bumps the version and makes the Garnet side changes for this.