### PR TITLE
Stabilize disk-persisted enum values

### DIFF
--- a/.github/skills/add-garnet-command/SKILL.md
+++ b/.github/skills/add-garnet-command/SKILL.md
@@ -46,35 +46,50 @@ Adding a single new command touches **at minimum** these areas:
 
 **File:** `libs/server/Resp/Parser/RespCommand.cs`
 
-The `RespCommand` enum is divided into sections with **ordering that matters**:
+The `RespCommand` enum is **writes-first**: write (mutating) commands occupy a dense,
+explicitly-numbered block immediately after `NONE`, followed by reads, scripts, and non-data:
 
 ```
-Read commands:     BITCOUNT ... ZUNION     (before APPEND)
-Write commands:    APPEND ... BITOP_DIFF   (after APPEND)
-Script commands:   EVAL, EVALSHA
+Write commands:    APPEND = 1 ... BITOP_DIFF = 120   (EXPLICIT values; the ONLY persisted values)
+Read commands:     BITCOUNT ... RISCAN               (auto-numbered; never persisted)
+Script commands:   EVAL, EVALSHA                     (LastDataCommand = EVALSHA)
 Non-key commands:  PING, SUBSCRIBE, etc.
 Admin commands:    AUTH, CONFIG, etc.
 ```
 
-**Read/write classification uses enum ordering:**
-- `cmd < RespCommand.APPEND` → read-only
-- `cmd >= RespCommand.APPEND && cmd <= RespCommand.BITOP_DIFF` → write
+**Why writes-first:** the write command's numeric value is persisted to disk (serialized into
+`RespInputHeader.cmd` in the AOF and streamed to replicas). Keeping writes in a dense,
+explicitly-numbered leading block makes those values **stable** — adding a read/admin command
+(which is never persisted) cannot shift them.
 
-**Rules:**
-- Read-only commands go **before** `APPEND`
-- Write commands go **between** `APPEND` and `BITOP_DIFF`
-- Update the boundary comments if you add before `APPEND` or after `BITOP_DIFF`
-- Place alphabetically within the appropriate section
+**Read/write classification uses enum ranges (positional constants, not hardcoded values):**
+- `RespCommandExtensions.FirstWriteCommand (APPEND=1) .. LastWriteCommand (BITOP_DIFF=120)` → write
+- `FirstReadCommand .. LastReadCommand (= EVAL - 1)` → read-only
+
+**Rules for adding a command:**
+- **Write (mutating) command:** APPEND it at the **end** of the write block, immediately before
+  the `// Read-only commands` marker, with the **next explicit value** (e.g. `MYCMD = 121,`).
+  Then update `LastWriteCommand` if it is no longer `BITOP_DIFF`. **Never** insert into the middle
+  of the write block or change/reuse an existing value — persisted values must be append-only.
+- **Read-only / script / non-data command:** add it in the appropriate (auto-numbered) section.
+  These are never persisted, so their values may shift freely.
+- Adding a write shifts the auto-numbered reads up by one — that is harmless (reads aren't
+  persisted) and requires no other change.
+
+**Guardrails (do not bypass):**
+- `PersistedEnumStabilityTests` snapshots the write-block values and asserts the write range
+  contains exactly the write commands. If you change an existing write value it fails — that is a
+  breaking on-disk change requiring an `AofHeader.AofHeaderVersion` bump + a legacy remap in
+  `AofProcessor` / `LegacyRespCommand`, not an edited expected value.
+- If a new write command's value ever approaches the custom command range (`0xFEFF`), that is also
+  caught by a test.
 
 **Boundary markers to watch (search for these comments):**
 ```csharp
-ZUNION,  // Note: Last read command is determined by APPEND - 1
-APPEND, // Note: Update FirstWriteCommand if adding new write commands before this
-BITOP_DIFF, // Note: Update LastWriteCommand if adding new write commands after this
+APPEND = 1, // Note: FirstWriteCommand — keep as the first write command
+BITOP_DIFF = 120, // Note: LastWriteCommand — append new write commands after this with the next value
 EVALSHA, // Note: Update LastDataCommand if adding new data commands after this
 ```
-
-**⚠️ Caveat:** The boundary comments in the source may not be on the actual last/first entry (e.g., `ZSCORE` has the comment but `ZUNION` follows it). The real boundary is determined by code: `LastReadCommand = RespCommand.APPEND - 1`. Always check the actual enum ordering, not just the comments.
 
 ---
 
@@ -249,7 +264,15 @@ private unsafe bool SortedSetAdd<TGarnetApi>(ref TGarnetApi storageApi)
 - The actual data operation logic lives in `libs/server/Objects/[ObjectName]/[ObjectName]ObjectImpl.cs`, dispatched via the operation enum
 
 **For new object sub-operations:**
-Add a value to the `[ObjectName]Operation` enum in `libs/server/Objects/[ObjectName]/[ObjectName]Object.cs` and handle it in the `Operate` method's switch statement.
+Add a value to the `[ObjectName]Operation` enum in `libs/server/Objects/[ObjectName]/[ObjectName]Object.cs`
+and handle it in the `Operate` method's switch statement.
+
+> **⚠️ Persisted, append-only:** the object operation enums (`HashOperation`, `ListOperation`,
+> `SetOperation`, `SortedSetOperation`) have **explicit values** and are serialized to the AOF via
+> `RespInputHeader.SubId`. **Append** the new operation at the **end** with the next explicit value;
+> never insert into the middle, reorder, or change an existing value. `PersistedEnumStabilityTests`
+> guards these values. The id occupies a full header byte, so up to 256 sub-operations per type are
+> allowed.
 
 ### Unified command note
 

--- a/libs/cluster/Server/HashSlot.cs
+++ b/libs/cluster/Server/HashSlot.cs
@@ -6,7 +6,9 @@ using System.Runtime.InteropServices;
 namespace Garnet.cluster
 {
     /// <summary>
-    /// NodeRole identifier
+    /// Slot state.
+    /// Persisted in the cluster config (ClusterConfigSerializer) and gossiped, so values are
+    /// EXPLICIT and APPEND-ONLY: never change/reorder an existing value; add new states at the end.
     /// </summary>
     public enum SlotState : byte
     {
@@ -19,27 +21,27 @@ namespace Garnet.cluster
         /// <summary>
         /// Slot assigned and ready to be used.
         /// </summary>
-        STABLE,
+        STABLE = 0x1,
         /// <summary>
         /// Slot is being moved to another node.
         /// </summary>
-        MIGRATING,
+        MIGRATING = 0x2,
         /// <summary>
         /// Reverse of migrating, preparing node to receive commands for that slot.
         /// </summary>
-        IMPORTING,
+        IMPORTING = 0x3,
         /// <summary>
         /// Slot in FAIL state.
         /// </summary>
-        FAIL,
+        FAIL = 0x4,
         /// <summary>
         /// Not a slot state. Used with SETSLOT
         /// </summary>
-        NODE,
+        NODE = 0x5,
         /// <summary>
         /// Invalid slot state
         /// </summary>
-        INVALID,
+        INVALID = 0x6,
     }
 
     /// <summary>

--- a/libs/cluster/Server/Worker.cs
+++ b/libs/cluster/Server/Worker.cs
@@ -4,7 +4,9 @@
 namespace Garnet.cluster
 {
     /// <summary>
-    /// NodeRole identifier
+    /// NodeRole identifier.
+    /// Persisted in the cluster config (ClusterConfigSerializer) and gossiped, so values are
+    /// EXPLICIT and APPEND-ONLY: never change/reorder an existing value; add new roles at the end.
     /// </summary>
     public enum NodeRole : byte
     {
@@ -15,11 +17,11 @@ namespace Garnet.cluster
         /// <summary>
         /// REPLICA Role identifier
         /// </summary>
-        REPLICA,
+        REPLICA = 0x1,
         /// <summary>
         /// UNASSIGNED Role identifier
         /// </summary>
-        UNASSIGNED,
+        UNASSIGNED = 0x2,
     }
 
     /// <summary>

--- a/libs/server/AOF/AofHeader.cs
+++ b/libs/server/AOF/AofHeader.cs
@@ -140,13 +140,27 @@ namespace Garnet.server
 
         public const int TotalSize = 16;
 
-        // Important: Update version number whenever any of the following change:
+        // Important: Update AofHeaderVersion whenever any of the following change:
         // * Layout, size, contents of this struct
         // * Any of the AofEntryType or AofStoreType enums' existing value mappings
         // * SpanByte format or header
+        // * The persisted-value numbering of any enum serialized into an entry payload:
+        //   RespCommand (RespInputHeader.cmd), the object sub-operation enums (RespInputHeader.SubId:
+        //   HashOperation/ListOperation/SetOperation/SortedSetOperation), GarnetObjectType
+        //   (RespInputHeader.type), or RespInputFlags.
+        // * The layout of RespInputHeader itself (e.g. which byte holds cmd/type/subId/flags).
         // Version 3 repurposes the flags byte as a bitfield containing the header type
         // plus chunked-record and unsafe-truncate markers.
-        const byte AofHeaderVersion = 3;
+        // Version 4 makes the RespCommand write block dense/explicit (writes-first) and moves the
+        // object sub-operation id (SubId) from the low 5 bits of the flags byte into its own header
+        // byte; AofProcessor remaps v3 entries on replay.
+        internal const byte AofHeaderVersion = 4;
+
+        /// <summary>
+        /// Highest AOF header version this build can read/replay. Entries with a higher version were
+        /// written by a newer Garnet version and cannot be safely interpreted.
+        /// </summary>
+        internal const byte MaxSupportedAofHeaderVersion = AofHeaderVersion;
 
         /// <summary>
         /// Bits in <see cref="flags"/> that identify the <see cref="AofHeaderType"/>

--- a/libs/server/AOF/AofProcessor.cs
+++ b/libs/server/AOF/AofProcessor.cs
@@ -233,6 +233,12 @@ namespace Garnet.server
         public void ProcessAofRecordInternal(int virtualSublogIdx, byte* ptr, int length, bool asReplica, out bool isCheckpointStart, long logAddressSequenceNumber = 0)
         {
             var header = *(AofHeader*)ptr;
+
+            // Reject entries written by a newer Garnet version (higher AOF header version) rather than
+            // silently mis-interpreting them under this version's format.
+            if (header.aofHeaderVersion > AofHeader.MaxSupportedAofHeaderVersion)
+                throw new GarnetException($"Unsupported AOF header version {header.aofHeaderVersion}; this build supports up to version {AofHeader.MaxSupportedAofHeaderVersion}. The data may have been written by a newer Garnet version.");
+
             var replayContext = aofReplayCoordinator.GetReplayContext(virtualSublogIdx);
             isCheckpointStart = false;
 
@@ -451,13 +457,19 @@ namespace Garnet.server
             var bufferPtr = (byte*)Unsafe.AsPointer(ref replayContext.objectOutputBuffer[0]);
             var bufferLength = replayContext.objectOutputBuffer.Length;
             preprocessKey.PrepareKey(virtualSublogIdx, entryPtr, logAddressSequenceNumber, out var preparedParameters);
+
+            // Entries written before AOF header version 4 used the legacy RespCommand numbering
+            // (reads-first) and packed the object sub-operation id into the low 5 bits of the flags
+            // byte. Translate those on replay: remap header.cmd for string/unified entries and
+            // relocate the sub-op id for object RMW entries.
+            var legacyCmdFormat = header.aofHeaderVersion < 4;
             switch (header.opType)
             {
                 case AofEntryType.StoreUpsert:
-                    StoreUpsert(preparedParameters, stringContext, ref replayContext.parseState);
+                    StoreUpsert(preparedParameters, stringContext, ref replayContext.parseState, legacyCmdFormat);
                     break;
                 case AofEntryType.StoreRMW:
-                    StoreRMW(preparedParameters, stringContext, ref replayContext.parseState, activeVectorManager, activeRangeIndexManager, replayContext.respServerSession, obtainServerSession);
+                    StoreRMW(preparedParameters, stringContext, ref replayContext.parseState, activeVectorManager, activeRangeIndexManager, replayContext.respServerSession, obtainServerSession, legacyCmdFormat);
                     break;
                 case AofEntryType.RangeIndexStreamChunk:
                     HandleRangeIndexStreamChunk(preparedParameters, ref replayContext.parseState, activeRangeIndexManager, replayContext.respServerSession);
@@ -469,16 +481,16 @@ namespace Garnet.server
                     ObjectStoreUpsert(preparedParameters, objectContext, storeWrapper.GarnetObjectSerializer, bufferPtr, bufferLength);
                     break;
                 case AofEntryType.ObjectStoreRMW:
-                    ObjectStoreRMW(preparedParameters, objectContext, ref replayContext.parseState, bufferPtr, bufferLength);
+                    ObjectStoreRMW(preparedParameters, objectContext, ref replayContext.parseState, bufferPtr, bufferLength, legacyCmdFormat);
                     break;
                 case AofEntryType.ObjectStoreDelete:
                     ObjectStoreDelete(preparedParameters, objectContext);
                     break;
                 case AofEntryType.UnifiedStoreStringUpsert:
-                    UnifiedStoreStringUpsert(preparedParameters, unifiedContext, ref replayContext.parseState, bufferPtr, bufferLength);
+                    UnifiedStoreStringUpsert(preparedParameters, unifiedContext, ref replayContext.parseState, bufferPtr, bufferLength, legacyCmdFormat);
                     break;
                 case AofEntryType.UnifiedStoreRMW:
-                    UnifiedStoreRMW(preparedParameters, unifiedContext, ref replayContext.parseState, bufferPtr, bufferLength);
+                    UnifiedStoreRMW(preparedParameters, unifiedContext, ref replayContext.parseState, bufferPtr, bufferLength, legacyCmdFormat);
                     break;
                 case AofEntryType.UnifiedStoreObjectUpsert:
                     UnifiedStoreObjectUpsert(preparedParameters, unifiedContext, storeWrapper.GarnetObjectSerializer, bufferPtr, bufferLength);
@@ -493,7 +505,7 @@ namespace Garnet.server
             return true;
         }
 
-        static void StoreUpsert<TStringContext>(PreparedParameters preparedParameters, TStringContext stringContext, ref SessionParseState parseState)
+        static void StoreUpsert<TStringContext>(PreparedParameters preparedParameters, TStringContext stringContext, ref SessionParseState parseState, bool legacyCmdFormat)
             where TStringContext : ITsavoriteContext<FixedSpanByteKey, StringInput, StringOutput, long, MainSessionFunctions, StoreFunctions, StoreAllocator>
         {
             var curr = preparedParameters.PayloadPtr;
@@ -502,6 +514,8 @@ namespace Garnet.server
 
             var stringInput = new StringInput { parseState = parseState };
             _ = stringInput.DeserializeFrom(curr);
+            if (legacyCmdFormat)
+                stringInput.header.cmd = LegacyRespCommand.FromV3(stringInput.header.cmd);
 
             StringOutput output = default;
             var upsertOptions = new UpsertOptions() { KeyHash = preparedParameters.KeyHash };
@@ -517,12 +531,15 @@ namespace Garnet.server
             VectorManager vectorManager,
             RangeIndexManager rangeIndexManager,
             RespServerSession activeServerSession,
-            Func<RespServerSession> obtainServerSession)
+            Func<RespServerSession> obtainServerSession,
+            bool legacyCmdFormat)
             where TStringContext : ITsavoriteContext<FixedSpanByteKey, StringInput, StringOutput, long, MainSessionFunctions, StoreFunctions, StoreAllocator>
         {
             var curr = preparedParameters.PayloadPtr;
             var stringInput = new StringInput { parseState = parseState };
             _ = stringInput.DeserializeFrom(curr);
+            if (legacyCmdFormat)
+                stringInput.header.cmd = LegacyRespCommand.FromV3(stringInput.header.cmd);
 
             // VADD requires special handling, shove it over to the VectorManager
             if (stringInput.header.cmd == RespCommand.VADD)
@@ -604,13 +621,15 @@ namespace Garnet.server
                 output.SpanByteAndMemory.Dispose();
         }
 
-        static void ObjectStoreRMW<TObjectContext>(PreparedParameters preparedParameters, TObjectContext objectContext, ref SessionParseState parseState, byte* outputPtr, int outputLength)
+        static void ObjectStoreRMW<TObjectContext>(PreparedParameters preparedParameters, TObjectContext objectContext, ref SessionParseState parseState, byte* outputPtr, int outputLength, bool legacyCmdFormat)
             where TObjectContext : ITsavoriteContext<FixedSpanByteKey, ObjectInput, ObjectOutput, long, ObjectSessionFunctions, StoreFunctions, StoreAllocator>
         {
             var curr = preparedParameters.PayloadPtr;
 
             var objectInput = new ObjectInput { parseState = parseState };
             _ = objectInput.DeserializeFrom(curr);
+            if (legacyCmdFormat)
+                RelocateLegacyObjectSubId(ref objectInput.header);
 
             // Call RMW with the reconstructed key & ObjectInput
             var output = ObjectOutput.FromPinnedPointer(outputPtr, outputLength);
@@ -623,11 +642,25 @@ namespace Garnet.server
                 output.SpanByteAndMemory.Dispose();
         }
 
+        /// <summary>
+        /// Pre-v4 object entries packed the sub-operation id into the low 5 bits of the flags byte
+        /// (RespInputHeader byte 2), with byte 1 unused. v4 moves the sub-op id into its own byte
+        /// (byte 1). When replaying a legacy object header, split the flags byte: low 5 bits become
+        /// the sub-op id, high 3 bits remain RespInputFlags.
+        /// </summary>
+        static void RelocateLegacyObjectSubId(ref RespInputHeader header)
+        {
+            const byte LegacySubIdMask = 0x1F; // low 5 bits held the sub-op id
+            var legacyFlags = (byte)header.flags;
+            header.subId = (byte)(legacyFlags & LegacySubIdMask);
+            header.flags = (RespInputFlags)(legacyFlags & ~LegacySubIdMask);
+        }
+
         static void ObjectStoreDelete<TObjectContext>(PreparedParameters preparedParameters, TObjectContext objectContext)
             where TObjectContext : ITsavoriteContext<FixedSpanByteKey, ObjectInput, ObjectOutput, long, ObjectSessionFunctions, StoreFunctions, StoreAllocator>
             => objectContext.Delete((FixedSpanByteKey)preparedParameters.Key);
 
-        static void UnifiedStoreStringUpsert<TUnifiedContext>(PreparedParameters preparedParameters, TUnifiedContext unifiedContext, ref SessionParseState parseState, byte* outputPtr, int outputLength)
+        static void UnifiedStoreStringUpsert<TUnifiedContext>(PreparedParameters preparedParameters, TUnifiedContext unifiedContext, ref SessionParseState parseState, byte* outputPtr, int outputLength, bool legacyCmdFormat)
             where TUnifiedContext : ITsavoriteContext<FixedSpanByteKey, UnifiedInput, UnifiedOutput, long, UnifiedSessionFunctions, StoreFunctions, StoreAllocator>
         {
             var curr = preparedParameters.PayloadPtr;
@@ -637,6 +670,8 @@ namespace Garnet.server
 
             var unifiedInput = new UnifiedInput { parseState = parseState };
             _ = unifiedInput.DeserializeFrom(curr);
+            if (legacyCmdFormat)
+                unifiedInput.header.cmd = LegacyRespCommand.FromV3(unifiedInput.header.cmd);
 
             var output = UnifiedOutput.FromPinnedPointer(outputPtr, outputLength);
             var upsertOptions = new UpsertOptions() { KeyHash = preparedParameters.KeyHash };
@@ -660,12 +695,14 @@ namespace Garnet.server
                 output.SpanByteAndMemory.Dispose();
         }
 
-        static void UnifiedStoreRMW<TUnifiedContext>(PreparedParameters preparedParameters, TUnifiedContext unifiedContext, ref SessionParseState parseState, byte* outputPtr, int outputLength)
+        static void UnifiedStoreRMW<TUnifiedContext>(PreparedParameters preparedParameters, TUnifiedContext unifiedContext, ref SessionParseState parseState, byte* outputPtr, int outputLength, bool legacyCmdFormat)
             where TUnifiedContext : ITsavoriteContext<FixedSpanByteKey, UnifiedInput, UnifiedOutput, long, UnifiedSessionFunctions, StoreFunctions, StoreAllocator>
         {
             var curr = preparedParameters.PayloadPtr;
             var unifiedInput = new UnifiedInput { parseState = parseState };
             _ = unifiedInput.DeserializeFrom(curr);
+            if (legacyCmdFormat)
+                unifiedInput.header.cmd = LegacyRespCommand.FromV3(unifiedInput.header.cmd);
 
             // Call RMW with the reconstructed key & UnifiedInput
             var output = UnifiedOutput.FromPinnedPointer(outputPtr, outputLength);

--- a/libs/server/AOF/LegacyRespCommand.cs
+++ b/libs/server/AOF/LegacyRespCommand.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using Garnet.common;
+
+namespace Garnet.server
+{
+    /// <summary>
+    /// Backward-compatibility mapping for the pre-v4 (AOF header version 3) <see cref="RespCommand"/>
+    /// numbering. In v4 the write commands were moved to a dense, explicitly-numbered block at the
+    /// start of the enum (writes-first), which changed the numeric value of every write command that
+    /// is persisted in the AOF (RespInputHeader.cmd). When replaying a v3 AOF (local recovery or a
+    /// replica consuming an older primary's stream) the persisted v3 value must be translated to the
+    /// current value before dispatch.
+    ///
+    /// The translation is name-based and computed once at startup, so it is robust to the numeric
+    /// reshuffle. If a v3 command name no longer resolves to a current <see cref="RespCommand"/>
+    /// (e.g. a write command was renamed or removed), startup fails fast — that is a deliberate
+    /// forcing function: such a change breaks v3 AOF compatibility and must be handled explicitly.
+    /// </summary>
+    internal static class LegacyRespCommand
+    {
+        // DO NOT EDIT: frozen snapshot of the v3 RespCommand member order (excluding NONE and INVALID).
+        // Index i corresponds to the v3 numeric value (i + 1), i.e. V3Order[0] had v3 value 1.
+        // This captures the numbering that shipped with AOF header version 3 and must never change.
+        private static readonly string[] V3Order =
+        [
+            "BITCOUNT", "BITFIELD_RO", "BITPOS", "COSCAN", "DBSIZE", "DUMP", "EXISTS", "EXPIRETIME", "GEODIST", "GEOHASH",
+            "GEOPOS", "GEORADIUS_RO", "GEORADIUSBYMEMBER_RO", "GEOSEARCH", "GET", "GETBIT", "GETIFNOTMATCH", "GETRANGE", "GETWITHETAG", "HEXISTS",
+            "HGET", "HGETALL", "HKEYS", "HLEN", "HMGET", "HRANDFIELD", "HSCAN", "HSTRLEN", "HVALS", "KEYS",
+            "LCS", "HTTL", "HPTTL", "HEXPIRETIME", "HPEXPIRETIME", "LINDEX", "LLEN", "LPOS", "LRANGE", "MEMORY_USAGE",
+            "MGET", "PEXPIRETIME", "PFCOUNT", "PTTL", "SCAN", "SCARD", "SDIFF", "SINTER", "SINTERCARD", "SISMEMBER",
+            "SMEMBERS", "SMISMEMBER", "SPUBLISH", "SRANDMEMBER", "SSCAN", "SSUBSCRIBE", "STRLEN", "SUBSTR", "SUNION", "TTL",
+            "TYPE", "VCARD", "VDIM", "VEMB", "VGETATTR", "VINFO", "VISMEMBER", "VLINKS", "VRANDMEMBER", "VSIM",
+            "WATCH", "WATCHMS", "WATCHOS", "ZCARD", "ZCOUNT", "ZDIFF", "ZINTER", "ZINTERCARD", "ZLEXCOUNT", "ZMSCORE",
+            "ZRANDMEMBER", "ZRANGE", "ZRANGEBYLEX", "ZRANGEBYSCORE", "ZRANK", "ZREVRANGE", "ZREVRANGEBYLEX", "ZREVRANGEBYSCORE", "ZREVRANK", "ZTTL",
+            "ZPTTL", "ZEXPIRETIME", "ZPEXPIRETIME", "ZSCAN", "ZSCORE", "ZUNION", "RICONFIG", "RIEXISTS", "RIGET", "RIMETRICS",
+            "RIRANGE", "RISCAN", "APPEND", "BITFIELD", "BZMPOP", "BZPOPMAX", "BZPOPMIN", "DECR", "DECRBY", "DEL",
+            "DELIFEXPIM", "DELIFGREATER", "EXPIRE", "EXPIREAT", "FLUSHALL", "FLUSHDB", "GEOADD", "GEORADIUS", "GEORADIUSBYMEMBER", "GEOSEARCHSTORE",
+            "GETDEL", "GETEX", "GETSET", "HCOLLECT", "HDEL", "HEXPIRE", "HPEXPIRE", "HEXPIREAT", "HPEXPIREAT", "HPERSIST",
+            "HINCRBY", "HINCRBYFLOAT", "HMSET", "HSET", "HSETNX", "INCR", "INCRBY", "INCRBYFLOAT", "LINSERT", "LMOVE",
+            "LMPOP", "LPOP", "LPUSH", "LPUSHX", "LREM", "LSET", "LTRIM", "BLPOP", "BRPOP", "BLMOVE",
+            "BRPOPLPUSH", "BLMPOP", "MIGRATE", "MSET", "MSETNX", "PERSIST", "PEXPIRE", "PEXPIREAT", "PFADD", "PFMERGE",
+            "PSETEX", "RENAME", "RICREATE", "RIDEL", "RIPROMOTE", "RIRESTORE", "RISET", "RESTORE", "RENAMENX", "RPOP",
+            "RPOPLPUSH", "RPUSH", "RPUSHX", "SADD", "SDIFFSTORE", "SET", "SETBIT", "SETEX", "SETEXNX", "SETEXXX",
+            "SETNX", "SETIFMATCH", "SETIFGREATER", "SETWITHETAG", "SETKEEPTTL", "SETKEEPTTLXX", "SETRANGE", "SINTERSTORE", "SMOVE", "SPOP",
+            "SREM", "SUNIONSTORE", "SWAPDB", "UNLINK", "VADD", "VREM", "VSETATTR", "ZADD", "ZCOLLECT", "ZDIFFSTORE",
+            "ZEXPIRE", "ZPEXPIRE", "ZEXPIREAT", "ZPEXPIREAT", "ZPERSIST", "ZINCRBY", "ZMPOP", "ZINTERSTORE", "ZPOPMAX", "ZPOPMIN",
+            "ZRANGESTORE", "ZREM", "ZREMRANGEBYLEX", "ZREMRANGEBYRANK", "ZREMRANGEBYSCORE", "ZUNIONSTORE", "BITOP", "BITOP_AND", "BITOP_OR", "BITOP_XOR",
+            "BITOP_NOT", "BITOP_DIFF", "EVAL", "EVALSHA", "ASYNC", "PING", "PUBSUB", "PUBSUB_CHANNELS", "PUBSUB_NUMPAT", "PUBSUB_NUMSUB",
+            "PUBLISH", "SUBSCRIBE", "PSUBSCRIBE", "UNSUBSCRIBE", "PUNSUBSCRIBE", "ASKING", "SELECT", "ECHO", "CLIENT", "CLIENT_ID",
+            "CLIENT_INFO", "CLIENT_LIST", "CLIENT_KILL", "CLIENT_GETNAME", "CLIENT_SETNAME", "CLIENT_SETINFO", "CLIENT_UNBLOCK", "MONITOR", "MODULE", "MODULE_LOADCS",
+            "REGISTERCS", "MULTI", "EXEC", "DISCARD", "UNWATCH", "RUNTXP", "READONLY", "READWRITE", "REPLICAOF", "SECONDARYOF",
+            "INFO", "TIME", "ROLE", "SAVE", "EXPDELSCAN", "LASTSAVE", "BGSAVE", "COMMITAOF", "PURGEBP", "FAILOVER",
+            "SCRIPT", "SCRIPT_EXISTS", "SCRIPT_FLUSH", "SCRIPT_LOAD", "ACL", "ACL_CAT", "ACL_DELUSER", "ACL_GENPASS", "ACL_GETUSER", "ACL_LIST",
+            "ACL_LOAD", "ACL_SAVE", "ACL_SETUSER", "ACL_USERS", "ACL_WHOAMI", "COMMAND", "COMMAND_COUNT", "COMMAND_DOCS", "COMMAND_INFO", "COMMAND_GETKEYS",
+            "COMMAND_GETKEYSANDFLAGS", "MEMORY", "CONFIG", "CONFIG_GET", "CONFIG_REWRITE", "CONFIG_SET", "DEBUG", "LATENCY", "LATENCY_HELP", "LATENCY_HISTOGRAM",
+            "LATENCY_RESET", "SLOWLOG", "SLOWLOG_HELP", "SLOWLOG_LEN", "SLOWLOG_GET", "SLOWLOG_RESET", "CLUSTER", "CLUSTER_ADDSLOTS", "CLUSTER_ADDSLOTSRANGE", "CLUSTER_ADVANCE_TIME",
+            "CLUSTER_APPENDLOG", "CLUSTER_ATTACH_SYNC", "CLUSTER_BANLIST", "CLUSTER_BEGIN_REPLICA_RECOVER", "CLUSTER_BUMPEPOCH", "CLUSTER_COUNTKEYSINSLOT", "CLUSTER_DELKEYSINSLOT", "CLUSTER_DELKEYSINSLOTRANGE", "CLUSTER_DELSLOTS", "CLUSTER_DELSLOTSRANGE",
+            "CLUSTER_ENDPOINT", "CLUSTER_FAILOVER", "CLUSTER_FAILREPLICATIONOFFSET", "CLUSTER_FAILSTOPWRITES", "CLUSTER_FLUSHALL", "CLUSTER_FORGET", "CLUSTER_GETKEYSINSLOT", "CLUSTER_GOSSIP", "CLUSTER_HELP", "CLUSTER_INFO",
+            "CLUSTER_INITIATE_REPLICA_SYNC", "CLUSTER_KEYSLOT", "CLUSTER_MEET", "CLUSTER_MIGRATE", "CLUSTER_MLOG_KEY_TIME", "CLUSTER_MTASKS", "CLUSTER_MYID", "CLUSTER_MYPARENTID", "CLUSTER_NODES", "CLUSTER_PUBLISH",
+            "CLUSTER_SPUBLISH", "CLUSTER_REPLICAS", "CLUSTER_REPLICATE", "CLUSTER_RESERVE", "CLUSTER_RESET", "CLUSTER_SEND_CKPT_FILE_SEGMENT", "CLUSTER_SEND_CKPT_METADATA", "CLUSTER_SETCONFIGEPOCH", "CLUSTER_SETSLOT", "CLUSTER_SETSLOTSRANGE",
+            "CLUSTER_SHARDS", "CLUSTER_SLOTS", "CLUSTER_SLOTSTATE", "CLUSTER_SNAPSHOT_DATA", "CLUSTER_SYNC", "AUTH", "HELLO", "QUIT",
+        ];
+
+        /// <summary>
+        /// Lookup table: v3 numeric value -> current <see cref="RespCommand"/>. Index 0 (NONE) and any
+        /// value outside the built-in range map to themselves.
+        /// </summary>
+        private static readonly RespCommand[] V3ToCurrent = BuildMap();
+
+        private static RespCommand[] BuildMap()
+        {
+            // Size covers NONE (0) plus all v3 built-in members (values 1..V3Order.Length).
+            var map = new RespCommand[V3Order.Length + 1];
+            map[0] = RespCommand.NONE;
+            for (var i = 0; i < V3Order.Length; i++)
+            {
+                if (!Enum.TryParse<RespCommand>(V3Order[i], out var current))
+                {
+                    throw new GarnetException(
+                        $"v3 RespCommand '{V3Order[i]}' (legacy AOF value {i + 1}) no longer maps to a current RespCommand. " +
+                        "Renaming or removing a persisted (write) command breaks v3 AOF compatibility; add an explicit mapping.");
+                }
+
+                map[i + 1] = current;
+            }
+
+            return map;
+        }
+
+        /// <summary>
+        /// Translate a RespCommand value read from a v3 (pre-v4) AOF entry to the current numbering.
+        /// Custom raw-string command ids (anchored to <see cref="RespCommand.INVALID"/>) and any value
+        /// outside the built-in range are unchanged.
+        /// </summary>
+        internal static RespCommand FromV3(RespCommand v3Command)
+        {
+            var value = (ushort)v3Command;
+            if (value < V3ToCurrent.Length)
+                return V3ToCurrent[value];
+
+            // Custom raw-string command ids and INVALID were numbered relative to INVALID in both
+            // versions, so they are unchanged.
+            return v3Command;
+        }
+
+        /// <summary>
+        /// Force initialization of the map (so a rename regression fails fast at startup, not on first replay).
+        /// </summary>
+        internal static void EnsureInitialized() => _ = V3ToCurrent;
+    }
+}

--- a/libs/server/Custom/CustomCommandManager.cs
+++ b/libs/server/Custom/CustomCommandManager.cs
@@ -23,7 +23,10 @@ namespace Garnet.server
         // ID ranges for custom raw string commands and custom object types
         private static readonly int CustomRawStringCommandMinId = (ushort)RespCommand.INVALID - MaxCustomRawStringCommands;
         private static readonly int CustomRawStringCommandMaxId = (ushort)RespCommand.INVALID - 1;
-        private static readonly int CustomObjectTypeMinId = (byte)GarnetObjectTypeExtensions.LastObjectType + 1;
+        // Custom object type ids start at a FIXED base (not LastObjectType + 1), so that adding a new
+        // built-in GarnetObjectType (which grows within the reserved built-in band [0, 0x3F]) never
+        // shifts the persisted ids of custom objects. Range: [0x40, FirstSpecialObjectType - 1].
+        private static readonly int CustomObjectTypeMinId = (byte)GarnetObjectTypeExtensions.LastReservedBuiltinType + 1;
         private static readonly int CustomObjectTypeMaxId = (byte)GarnetObjectTypeExtensions.FirstSpecialObjectType - 1;
 
         // Maps holding different types of custom commands

--- a/libs/server/Custom/CustomObjectBase.cs
+++ b/libs/server/Custom/CustomObjectBase.cs
@@ -77,21 +77,19 @@ namespace Garnet.server
         public sealed override bool Operate(ref ObjectInput input, ref ObjectOutput output,
                                             byte respProtocolVersion)
         {
-            switch (input.header.cmd)
+            // COSCAN (custom object scan) is signalled by header.type == GarnetObjectType.All.
+            if (input.header.type == GarnetObjectType.All)
             {
-                // Scan Command
-                case RespCommand.COSCAN:
-                    Scan(ref input, ref output, respProtocolVersion);
-                    break;
-                default:
-                    if ((byte)input.header.type != this.type)
-                    {
-                        // Indicates an incorrect type of key
-                        output.OutputFlags |= ObjectOutputFlags.WrongType;
-                        output.SpanByteAndMemory.Length = 0;
-                        return true;
-                    }
-                    break;
+                Scan(ref input, ref output, respProtocolVersion);
+                return true;
+            }
+
+            if ((byte)input.header.type != this.type)
+            {
+                // Indicates an incorrect type of key
+                output.OutputFlags |= ObjectOutputFlags.WrongType;
+                output.SpanByteAndMemory.Length = 0;
+                return true;
             }
 
             return true;

--- a/libs/server/Custom/CustomObjectCommandWrapper.cs
+++ b/libs/server/Custom/CustomObjectCommandWrapper.cs
@@ -9,7 +9,7 @@ namespace Garnet.server
     class CustomObjectCommandWrapper
     {
         static readonly int MinMapSize = 8;
-        static readonly byte MaxSubId = 31; // RespInputHeader uses the 3 MSBs of SubId, so SubId must fit in the 5 LSBs
+        static readonly byte MaxSubId = 255; // SubId now occupies its own header byte (RespInputHeader.subId), so it may use the full byte range
 
         public readonly byte id;
         public readonly CustomObjectFactory factory;

--- a/libs/server/InputHeader.cs
+++ b/libs/server/InputHeader.cs
@@ -11,9 +11,10 @@ using Tsavorite.core;
 namespace Garnet.server
 {
     /// <summary>
-    /// Flags used by append-only file (AOF/WAL)
-    /// The byte representation only use the last 3 bits of the byte since the lower 5 bits of the "union" field that is used to store the flag stores other data (see RespInputHeader.FlagMask).
-    /// In the case of a Rawstring, the last 4 bits are used for flags, and the other 4 bits are unused of the byte.
+    /// Flags used by append-only file (AOF/WAL).
+    /// These occupy the top bits (32/64/128) of the header flags byte (RespInputHeader byte 2).
+    /// The object sub-operation id now lives in its own header byte (RespInputHeader.subId), so the
+    /// flags byte no longer shares space with it.
     /// </summary>
     [Flags]
     public enum RespInputFlags : byte
@@ -34,7 +35,18 @@ namespace Garnet.server
     }
 
     /// <summary>
-    /// Common input header for Garnet
+    /// Common input header for Garnet.
+    ///
+    /// Layout (3 bytes, explicit) is a discriminated union keyed by command category:
+    ///   byte 0-1 : <see cref="cmd"/> (ushort) — used by string/unified inputs.
+    ///   byte 0   : <see cref="type"/> (GarnetObjectType) — used by object inputs; overlaps cmd's low byte.
+    ///   byte 1   : <see cref="subId"/> (object sub-operation id) — used by object inputs; overlaps cmd's high byte.
+    ///   byte 2   : <see cref="flags"/> (<see cref="RespInputFlags"/>).
+    ///
+    /// Object inputs use { type, subId } and never read/write <see cref="cmd"/>; string/unified inputs use
+    /// <see cref="cmd"/> and never set <see cref="subId"/>. The two views are disjoint by command category
+    /// (store / AofEntryType), so sharing byte 1 between cmd's high byte and subId is safe. This gives the
+    /// object sub-operation a full byte (256 values/type) instead of the former 5 bits packed into flags.
     /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = Size)]
     public struct RespInputHeader
@@ -44,14 +56,14 @@ namespace Garnet.server
         /// </summary>
         public const int Size = 3;
 
-        // Flag mask separates the lower bits (used for object-associated sub-operation IDs) from the upper bits (used for RespInputFlags).
-        internal const byte FlagMask = (byte)RespInputFlags.SetGet - 1;
-
         [FieldOffset(0)]
         internal RespCommand cmd;
 
         [FieldOffset(0)]
         internal GarnetObjectType type;
+
+        [FieldOffset(1)]
+        internal byte subId;
 
         [FieldOffset(2)]
         internal RespInputFlags flags;
@@ -93,32 +105,32 @@ namespace Garnet.server
 
         internal byte SubId
         {
-            get => (byte)((byte)flags & FlagMask);
-            set => flags = (RespInputFlags)(((byte)flags & ~FlagMask) | (byte)value);
+            get => subId;
+            set => subId = value;
         }
 
         internal SortedSetOperation SortedSetOp
         {
-            get => (SortedSetOperation)((byte)flags & FlagMask);
-            set => flags = (RespInputFlags)(((byte)flags & ~FlagMask) | (byte)value);
+            get => (SortedSetOperation)subId;
+            set => subId = (byte)value;
         }
 
         internal HashOperation HashOp
         {
-            get => (HashOperation)((byte)flags & FlagMask);
-            set => flags = (RespInputFlags)(((byte)flags & ~FlagMask) | (byte)value);
+            get => (HashOperation)subId;
+            set => subId = (byte)value;
         }
 
         internal SetOperation SetOp
         {
-            get => (SetOperation)((byte)flags & FlagMask);
-            set => flags = (RespInputFlags)(((byte)flags & ~FlagMask) | (byte)value);
+            get => (SetOperation)subId;
+            set => subId = (byte)value;
         }
 
         internal ListOperation ListOp
         {
-            get => (ListOperation)((byte)flags & FlagMask);
-            set => flags = (RespInputFlags)(((byte)flags & ~FlagMask) | (byte)value);
+            get => (ListOperation)subId;
+            set => subId = (byte)value;
         }
 
         /// <summary>

--- a/libs/server/Objects/Hash/HashObject.cs
+++ b/libs/server/Objects/Hash/HashObject.cs
@@ -22,30 +22,32 @@ namespace Garnet.server
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
     /// <summary>
-    /// Operations on Hash
+    /// Operations on Hash.
+    /// Persisted in the AOF via RespInputHeader.SubId, so values are EXPLICIT and APPEND-ONLY:
+    /// never change/reorder an existing value; add new operations at the end with the next value.
     /// </summary>
     public enum HashOperation : byte
     {
-        HCOLLECT,
-        HEXPIRE,
-        HTTL,
-        HPERSIST,
-        HGET,
-        HMGET,
-        HSET,
-        HMSET,
-        HSETNX,
-        HLEN,
-        HDEL,
-        HEXISTS,
-        HGETALL,
-        HKEYS,
-        HVALS,
-        HINCRBY,
-        HINCRBYFLOAT,
-        HRANDFIELD,
-        HSCAN,
-        HSTRLEN
+        HCOLLECT = 0,
+        HEXPIRE = 1,
+        HTTL = 2,
+        HPERSIST = 3,
+        HGET = 4,
+        HMGET = 5,
+        HSET = 6,
+        HMSET = 7,
+        HSETNX = 8,
+        HLEN = 9,
+        HDEL = 10,
+        HEXISTS = 11,
+        HGETALL = 12,
+        HKEYS = 13,
+        HVALS = 14,
+        HINCRBY = 15,
+        HINCRBYFLOAT = 16,
+        HRANDFIELD = 17,
+        HSCAN = 18,
+        HSTRLEN = 19,
     }
 
 

--- a/libs/server/Objects/List/ListObject.cs
+++ b/libs/server/Objects/List/ListObject.cs
@@ -13,28 +13,30 @@ namespace Garnet.server
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
     /// <summary>
-    /// Operations on SortedSet
+    /// Operations on List.
+    /// Persisted in the AOF via RespInputHeader.SubId, so values are EXPLICIT and APPEND-ONLY:
+    /// never change/reorder an existing value; add new operations at the end with the next value.
     /// </summary>
     public enum ListOperation : byte
     {
-        LPOP,
-        LPUSH,
-        LPUSHX,
-        RPOP,
-        RPUSH,
-        RPUSHX,
-        LLEN,
-        LTRIM,
-        LRANGE,
-        LINDEX,
-        LINSERT,
-        LREM,
-        RPOPLPUSH,
-        LMOVE,
-        LSET,
-        BRPOP,
-        BLPOP,
-        LPOS,
+        LPOP = 0,
+        LPUSH = 1,
+        LPUSHX = 2,
+        RPOP = 3,
+        RPUSH = 4,
+        RPUSHX = 5,
+        LLEN = 6,
+        LTRIM = 7,
+        LRANGE = 8,
+        LINDEX = 9,
+        LINSERT = 10,
+        LREM = 11,
+        RPOPLPUSH = 12,
+        LMOVE = 13,
+        LSET = 14,
+        BRPOP = 15,
+        BLPOP = 16,
+        LPOS = 17,
     }
 
     /// <summary>

--- a/libs/server/Objects/Set/SetObject.cs
+++ b/libs/server/Objects/Set/SetObject.cs
@@ -13,26 +13,28 @@ namespace Garnet.server
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
     /// <summary>
-    /// Operations on Set
+    /// Operations on Set.
+    /// Persisted in the AOF via RespInputHeader.SubId, so values are EXPLICIT and APPEND-ONLY:
+    /// never change/reorder an existing value; add new operations at the end with the next value.
     /// </summary>
     public enum SetOperation : byte
     {
-        SADD,
-        SREM,
-        SPOP,
-        SMEMBERS,
-        SCARD,
-        SSCAN,
-        SMOVE,
-        SRANDMEMBER,
-        SISMEMBER,
-        SMISMEMBER,
-        SUNION,
-        SUNIONSTORE,
-        SDIFF,
-        SDIFFSTORE,
-        SINTER,
-        SINTERSTORE
+        SADD = 0,
+        SREM = 1,
+        SPOP = 2,
+        SMEMBERS = 3,
+        SCARD = 4,
+        SSCAN = 5,
+        SMOVE = 6,
+        SRANDMEMBER = 7,
+        SISMEMBER = 8,
+        SMISMEMBER = 9,
+        SUNION = 10,
+        SUNIONSTORE = 11,
+        SDIFF = 12,
+        SDIFFSTORE = 13,
+        SINTER = 14,
+        SINTERSTORE = 15,
     }
 
 

--- a/libs/server/Objects/SortedSet/SortedSetObject.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObject.cs
@@ -16,38 +16,40 @@ namespace Garnet.server
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
     /// <summary>
-    /// Operations on SortedSet
+    /// Operations on SortedSet.
+    /// Persisted in the AOF via RespInputHeader.SubId, so values are EXPLICIT and APPEND-ONLY:
+    /// never change/reorder an existing value; add new operations at the end with the next value.
     /// </summary>
     public enum SortedSetOperation : byte
     {
-        ZADD,
-        ZCARD,
-        ZPOPMAX,
-        ZSCORE,
-        ZREM,
-        ZCOUNT,
-        ZINCRBY,
-        ZRANK,
-        ZRANGE,
-        GEOADD,
-        GEOHASH,
-        GEODIST,
-        GEOPOS,
-        GEOSEARCH,
-        ZREVRANK,
-        ZREMRANGEBYLEX,
-        ZREMRANGEBYRANK,
-        ZREMRANGEBYSCORE,
-        ZLEXCOUNT,
-        ZPOPMIN,
-        ZRANDMEMBER,
-        ZDIFF,
-        ZSCAN,
-        ZMSCORE,
-        ZEXPIRE,
-        ZTTL,
-        ZPERSIST,
-        ZCOLLECT
+        ZADD = 0,
+        ZCARD = 1,
+        ZPOPMAX = 2,
+        ZSCORE = 3,
+        ZREM = 4,
+        ZCOUNT = 5,
+        ZINCRBY = 6,
+        ZRANK = 7,
+        ZRANGE = 8,
+        GEOADD = 9,
+        GEOHASH = 10,
+        GEODIST = 11,
+        GEOPOS = 12,
+        GEOSEARCH = 13,
+        ZREVRANK = 14,
+        ZREMRANGEBYLEX = 15,
+        ZREMRANGEBYRANK = 16,
+        ZREMRANGEBYSCORE = 17,
+        ZLEXCOUNT = 18,
+        ZPOPMIN = 19,
+        ZRANDMEMBER = 20,
+        ZDIFF = 21,
+        ZSCAN = 22,
+        ZMSCORE = 23,
+        ZEXPIRE = 24,
+        ZTTL = 25,
+        ZPERSIST = 26,
+        ZCOLLECT = 27,
     }
 
     /// <summary>

--- a/libs/server/Objects/Types/GarnetObjectSerializer.cs
+++ b/libs/server/Objects/Types/GarnetObjectSerializer.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using Garnet.common;
 using Tsavorite.core;
 
 namespace Garnet.server
@@ -50,7 +51,15 @@ namespace Garnet.server
 
         private IGarnetObject DeserializeInternal(BinaryReader binaryReader)
         {
-            var type = (GarnetObjectType)binaryReader.ReadByte();
+            var firstByte = binaryReader.ReadByte();
+
+            // 0xFC..0xFF are reserved for a future object-serialization format version/escape byte
+            // (see GarnetObjectType). No current writer emits these, so encountering one means the
+            // data was written by a newer version whose object format this build cannot read.
+            if (firstByte >= GarnetObjectTypeExtensions.ReservedObjectFormatByteStart)
+                throw new GarnetException($"Unsupported object serialization format marker 0x{firstByte:X2}; the data may have been written by a newer Garnet version.");
+
+            var type = (GarnetObjectType)firstByte;
             var obj = type switch
             {
                 GarnetObjectType.Null => null,

--- a/libs/server/Objects/Types/GarnetObjectSerializer.cs
+++ b/libs/server/Objects/Types/GarnetObjectSerializer.cs
@@ -74,8 +74,16 @@ namespace Garnet.server
 
         private IGarnetObject CustomDeserialize(byte type, BinaryReader binaryReader)
         {
-            if (type < CustomCommandManager.CustomTypeIdStartOffset ||
-                !customCommandManager.TryGetCustomObjectCommand(type, out var cmd)) return null;
+            // Built-in type ids (0..LastObjectType) are handled by the caller. A type id below the
+            // fixed custom-object base therefore lies in the reserved built-in band and is not valid
+            // for this build: it was written either by an older build whose custom objects were based
+            // at LastObjectType+1 (rather than the fixed base), or by a newer build with additional
+            // built-in types. Fail fast instead of silently returning null, which would drop the
+            // record and lose data without any indication.
+            if (type < CustomCommandManager.CustomTypeIdStartOffset)
+                throw new GarnetException($"Unsupported object type id 0x{type:X2}; the data may have been written by an incompatible Garnet version (e.g. legacy custom objects that used a different type-id range).");
+
+            if (!customCommandManager.TryGetCustomObjectCommand(type, out var cmd)) return null;
             return cmd.factory.Deserialize(type, binaryReader);
         }
 

--- a/libs/server/Objects/Types/GarnetObjectType.cs
+++ b/libs/server/Objects/Types/GarnetObjectType.cs
@@ -4,7 +4,16 @@
 namespace Garnet.server
 {
     /// <summary>
-    /// Type of Garnet object
+    /// Type of Garnet object.
+    /// This value is the first byte of every serialized object (checkpoints/object log) and is also
+    /// carried in RespInputHeader.type, so it is PERSISTED. Values are EXPLICIT and permanent:
+    ///   * Built-in type ids (0..<see cref="GarnetObjectTypeExtensions.LastReservedBuiltinType"/>)
+    ///     must never change; add a new built-in with the next unused value in that reserved band.
+    ///   * Custom object type ids are assigned dynamically from a FIXED base
+    ///     (<see cref="CustomCommandManager"/>), independent of the built-in count, so adding a
+    ///     built-in type never shifts persisted custom-object ids.
+    ///   * 0xFC..0xFF are reserved for a future object-format version/escape byte and must never be
+    ///     used as a type id.
     /// </summary>
     public enum GarnetObjectType : byte
     {
@@ -15,34 +24,54 @@ namespace Garnet.server
         /// <summary>
         /// Sorted set
         /// </summary>
-        SortedSet,
+        SortedSet = 1,
         /// <summary>
         /// List
         /// </summary>
-        List,
+        List = 2,
         /// <summary>
         /// Hash
         /// </summary>
-        Hash,
+        Hash = 3,
         /// <summary>
         /// Set
-        /// </summary>        
-        Set,
+        /// </summary>
+        Set = 4,
 
-        // Any new object type inserted here should update GarnetObjectTypeExtensions.LastObjectType
-
-        // Any new special type inserted here should update GarnetObjectTypeExtensions.FirstSpecialObjectType
+        // Built-in types occupy the reserved band [0, LastReservedBuiltinType]. Add a new built-in
+        // with the next value in that band and update GarnetObjectTypeExtensions.LastObjectType. Do
+        // NOT insert before existing built-ins (values are persisted). Custom object types live in a
+        // fixed range (CustomCommandManager) that does not move when built-ins are added.
 
         /// <summary>
         /// Indicating a Custom Object command
         /// </summary>
         All = 0xfb,
+
+        // 0xFC..0xFF are reserved for a future object-serialization format version/escape byte
+        // (see GarnetObjectSerializer); never assign them as an object type id.
     }
 
     public static class GarnetObjectTypeExtensions
     {
+        /// <summary>
+        /// Highest currently-assigned built-in object type.
+        /// </summary>
         internal const GarnetObjectType LastObjectType = GarnetObjectType.Set;
 
+        /// <summary>
+        /// Inclusive upper bound of the reserved built-in type band. Built-in types may grow up to
+        /// this value without shifting the fixed custom-object base.
+        /// </summary>
+        internal const GarnetObjectType LastReservedBuiltinType = (GarnetObjectType)0x3F;
+
         internal const GarnetObjectType FirstSpecialObjectType = GarnetObjectType.All;
+
+        /// <summary>
+        /// First reserved value for a future object-serialization format version/escape byte. Any
+        /// serialized object whose first byte is >= this value is not a legacy [type][data] record
+        /// and must be handled by a versioned reader (or rejected fail-fast).
+        /// </summary>
+        internal const byte ReservedObjectFormatByteStart = 0xFC;
     }
 }

--- a/libs/server/Resp/Objects/SharedObjectCommands.cs
+++ b/libs/server/Resp/Objects/SharedObjectCommands.cs
@@ -58,7 +58,8 @@ namespace Garnet.server
                     input.header.SortedSetOp = SortedSetOperation.ZSCAN;
                     break;
                 case GarnetObjectType.All:
-                    input.header.cmd = RespCommand.COSCAN;
+                    // COSCAN (custom object scan) is dispatched via header.type == All (already set by
+                    // the RespInputHeader(objectType) ctor). Do not overwrite cmd/type here.
                     break;
             }
 

--- a/libs/server/Resp/Parser/RespCommand.cs
+++ b/libs/server/Resp/Parser/RespCommand.cs
@@ -21,7 +21,140 @@ namespace Garnet.server
     {
         NONE = 0x00,
 
-        // Read-only commands. NOTE: Should immediately follow NONE.
+        // Write (mutating) commands. These are the ONLY RespCommand values persisted to disk
+        // (serialized into RespInputHeader.cmd in the AOF and streamed to replicas), so they are
+        // assigned EXPLICIT, STABLE numeric values and MUST be treated as append-only:
+        //   * Never change, reuse, or reorder an existing value.
+        //   * Add a new write command by appending it with the next unused value (do NOT insert
+        //     mid-block or renumber). PersistedEnumStabilityTests guards this.
+        // Placing writes first (immediately after NONE) keeps their values dense and independent
+        // of read/admin command additions, which are never persisted and may renumber freely.
+        APPEND = 1, // Note: FirstWriteCommand — keep as the first write command
+        BITFIELD = 2,
+        BZMPOP = 3,
+        BZPOPMAX = 4,
+        BZPOPMIN = 5,
+        DECR = 6,
+        DECRBY = 7,
+        DEL = 8,
+        DELIFEXPIM = 9,
+        DELIFGREATER = 10,
+        EXPIRE = 11,
+        EXPIREAT = 12,
+        FLUSHALL = 13,
+        FLUSHDB = 14,
+        GEOADD = 15,
+        GEORADIUS = 16,
+        GEORADIUSBYMEMBER = 17,
+        GEOSEARCHSTORE = 18,
+        GETDEL = 19,
+        GETEX = 20,
+        GETSET = 21,
+        HCOLLECT = 22,
+        HDEL = 23,
+        HEXPIRE = 24,
+        HPEXPIRE = 25,
+        HEXPIREAT = 26,
+        HPEXPIREAT = 27,
+        HPERSIST = 28,
+        HINCRBY = 29,
+        HINCRBYFLOAT = 30,
+        HMSET = 31,
+        HSET = 32,
+        HSETNX = 33,
+        INCR = 34,
+        INCRBY = 35,
+        INCRBYFLOAT = 36,
+        LINSERT = 37,
+        LMOVE = 38,
+        LMPOP = 39,
+        LPOP = 40,
+        LPUSH = 41,
+        LPUSHX = 42,
+        LREM = 43,
+        LSET = 44,
+        LTRIM = 45,
+        BLPOP = 46,
+        BRPOP = 47,
+        BLMOVE = 48,
+        BRPOPLPUSH = 49,
+        BLMPOP = 50,
+        MIGRATE = 51,
+        MSET = 52,
+        MSETNX = 53,
+        PERSIST = 54,
+        PEXPIRE = 55,
+        PEXPIREAT = 56,
+        PFADD = 57,
+        PFMERGE = 58,
+        PSETEX = 59,
+        RENAME = 60,
+        RICREATE = 61,
+        RIDEL = 62,
+        RIPROMOTE = 63,
+        RIRESTORE = 64,
+        RISET = 65,
+        RESTORE = 66,
+        RENAMENX = 67,
+        RPOP = 68,
+        RPOPLPUSH = 69,
+        RPUSH = 70,
+        RPUSHX = 71,
+        SADD = 72,
+        SDIFFSTORE = 73,
+        SET = 74,
+        SETBIT = 75,
+        SETEX = 76,
+        SETEXNX = 77,
+        SETEXXX = 78,
+        SETNX = 79,
+        SETIFMATCH = 80,
+        SETIFGREATER = 81,
+        SETWITHETAG = 82,
+        SETKEEPTTL = 83,
+        SETKEEPTTLXX = 84,
+        SETRANGE = 85,
+        SINTERSTORE = 86,
+        SMOVE = 87,
+        SPOP = 88,
+        SREM = 89,
+        SUNIONSTORE = 90,
+        SWAPDB = 91,
+        UNLINK = 92,
+        VADD = 93,
+        VREM = 94,
+        VSETATTR = 95,
+        ZADD = 96,
+        ZCOLLECT = 97,
+        ZDIFFSTORE = 98,
+        ZEXPIRE = 99,
+        ZPEXPIRE = 100,
+        ZEXPIREAT = 101,
+        ZPEXPIREAT = 102,
+        ZPERSIST = 103,
+        ZINCRBY = 104,
+        ZMPOP = 105,
+        ZINTERSTORE = 106,
+        ZPOPMAX = 107,
+        ZPOPMIN = 108,
+        ZRANGESTORE = 109,
+        ZREM = 110,
+        ZREMRANGEBYLEX = 111,
+        ZREMRANGEBYRANK = 112,
+        ZREMRANGEBYSCORE = 113,
+        ZUNIONSTORE = 114,
+
+        // BITOP is the true command, AND|OR|XOR|NOT are pseudo-subcommands
+        BITOP = 115,
+        BITOP_AND = 116,
+        BITOP_OR = 117,
+        BITOP_XOR = 118,
+        BITOP_NOT = 119,
+        BITOP_DIFF = 120, // Note: LastWriteCommand — append new write commands after this with the next value
+
+        // Read-only commands. NEVER persisted (reads never enter the AOF), so these are
+        // auto-numbered and may be renumbered/reordered freely across versions. They follow the
+        // write block; the read range is [FirstReadCommand, LastReadCommand].
         BITCOUNT,
         BITFIELD_RO,
         BITPOS,
@@ -116,7 +249,7 @@ namespace Garnet.server
         ZEXPIRETIME,
         ZPEXPIRETIME,
         ZSCAN,
-        ZSCORE, // Note: Last read command should immediately precede FirstWriteCommand
+        ZSCORE,
         ZUNION,
 
         // Read-only RangeIndex commands
@@ -126,130 +259,6 @@ namespace Garnet.server
         RIMETRICS,
         RIRANGE,
         RISCAN,
-
-        // Write commands
-        APPEND, // Note: Update FirstWriteCommand if adding new write commands before this
-        BITFIELD,
-        BZMPOP,
-        BZPOPMAX,
-        BZPOPMIN,
-        DECR,
-        DECRBY,
-        DEL,
-        DELIFEXPIM,
-        DELIFGREATER,
-        EXPIRE,
-        EXPIREAT,
-        FLUSHALL,
-        FLUSHDB,
-        GEOADD,
-        GEORADIUS,
-        GEORADIUSBYMEMBER,
-        GEOSEARCHSTORE,
-        GETDEL,
-        GETEX,
-        GETSET,
-        HCOLLECT,
-        HDEL,
-        HEXPIRE,
-        HPEXPIRE,
-        HEXPIREAT,
-        HPEXPIREAT,
-        HPERSIST,
-        HINCRBY,
-        HINCRBYFLOAT,
-        HMSET,
-        HSET,
-        HSETNX,
-        INCR,
-        INCRBY,
-        INCRBYFLOAT,
-        LINSERT,
-        LMOVE,
-        LMPOP,
-        LPOP,
-        LPUSH,
-        LPUSHX,
-        LREM,
-        LSET,
-        LTRIM,
-        BLPOP,
-        BRPOP,
-        BLMOVE,
-        BRPOPLPUSH,
-        BLMPOP,
-        MIGRATE,
-        MSET,
-        MSETNX,
-        PERSIST,
-        PEXPIRE,
-        PEXPIREAT,
-        PFADD,
-        PFMERGE,
-        PSETEX,
-        RENAME,
-        RICREATE,
-        RIDEL,
-        RIPROMOTE,
-        RIRESTORE,
-        RISET,
-        RESTORE,
-        RENAMENX,
-        RPOP,
-        RPOPLPUSH,
-        RPUSH,
-        RPUSHX,
-        SADD,
-        SDIFFSTORE,
-        SET,
-        SETBIT,
-        SETEX,
-        SETEXNX,
-        SETEXXX,
-        SETNX,
-        SETIFMATCH,
-        SETIFGREATER,
-        SETWITHETAG,
-        SETKEEPTTL,
-        SETKEEPTTLXX,
-        SETRANGE,
-        SINTERSTORE,
-        SMOVE,
-        SPOP,
-        SREM,
-        SUNIONSTORE,
-        SWAPDB,
-        UNLINK,
-        VADD,
-        VREM,
-        VSETATTR,
-        ZADD,
-        ZCOLLECT,
-        ZDIFFSTORE,
-        ZEXPIRE,
-        ZPEXPIRE,
-        ZEXPIREAT,
-        ZPEXPIREAT,
-        ZPERSIST,
-        ZINCRBY,
-        ZMPOP,
-        ZINTERSTORE,
-        ZPOPMAX,
-        ZPOPMIN,
-        ZRANGESTORE,
-        ZREM,
-        ZREMRANGEBYLEX,
-        ZREMRANGEBYRANK,
-        ZREMRANGEBYSCORE,
-        ZUNIONSTORE,
-
-        // BITOP is the true command, AND|OR|XOR|NOT are pseudo-subcommands
-        BITOP,
-        BITOP_AND,
-        BITOP_OR,
-        BITOP_XOR,
-        BITOP_NOT,
-        BITOP_DIFF, // Note: Update LastWriteCommand if adding new write commands after this
 
         // Script execution commands
         EVAL,
@@ -566,13 +575,22 @@ namespace Garnet.server
                 };
         }
 
-        internal const RespCommand FirstReadCommand = RespCommand.NONE + 1;
-
-        internal const RespCommand LastReadCommand = RespCommand.APPEND - 1;
-
+        // The write (mutating) command block is placed first: [FirstWriteCommand, LastWriteCommand].
+        // These are the only persisted RespCommand values (see the enum comment). The read block
+        // follows the write block, then the script commands (EVAL/EVALSHA). Reads/scripts are never
+        // persisted, so the read range is derived positionally and may shift as write commands are
+        // appended.
         internal const RespCommand FirstWriteCommand = RespCommand.APPEND;
 
         internal const RespCommand LastWriteCommand = RespCommand.BITOP_DIFF;
+
+        // Data commands span writes + reads + scripts contiguously: [FirstDataCommand, LastDataCommand].
+        internal const RespCommand FirstDataCommand = FirstWriteCommand;
+
+        // Reads immediately follow the write block and end just before the first script command (EVAL).
+        internal const RespCommand FirstReadCommand = LastWriteCommand + 1;
+
+        internal const RespCommand LastReadCommand = RespCommand.EVAL - 1;
 
         internal const RespCommand LastDataCommand = RespCommand.EVALSHA;
 
@@ -583,7 +601,12 @@ namespace Garnet.server
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsReadOnly(this RespCommand cmd)
-            => cmd <= LastReadCommand;
+        {
+            // Reads are no longer the lowest command range (writes are), so this is a two-sided
+            // range check. Kept branchless (same idiom as IsWriteOnly) as it is on the hot path.
+            var test = (uint)((int)cmd - (int)FirstReadCommand);
+            return test <= (LastReadCommand - FirstReadCommand);
+        }
 
         /// <summary>
         /// Returns true if this command can legally operate on a RangeIndex key.
@@ -628,7 +651,7 @@ namespace Garnet.server
                 RespCommand.KEYS => false,
                 RespCommand.SCAN => false,
                 RespCommand.SWAPDB => false,
-                _ => cmd >= FirstReadCommand && cmd <= LastDataCommand
+                _ => cmd >= FirstDataCommand && cmd <= LastDataCommand
             };
         }
 

--- a/libs/server/Resp/RespCommandsInfo.cs
+++ b/libs/server/Resp/RespCommandsInfo.cs
@@ -162,7 +162,7 @@ namespace Garnet.server
             }
 
             var tmpSimpleRespCommandInfo = new SimpleRespCommandInfo[(int)RespCommandExtensions.LastValidCommand + 1];
-            for (var cmdId = (int)RespCommandExtensions.FirstReadCommand; cmdId < tmpSimpleRespCommandInfo.Length; cmdId++)
+            for (var cmdId = (int)RespCommandExtensions.FirstDataCommand; cmdId < tmpSimpleRespCommandInfo.Length; cmdId++)
             {
                 if (!tmpFlattenedRespCommandsInfo.TryGetValue((RespCommand)cmdId, out var cmdInfo))
                 {
@@ -210,11 +210,11 @@ namespace Garnet.server
                         )
                 );
 
-            FastBasicRespCommandsInfo = new RespCommandsInfo[(int)RespCommandExtensions.LastDataCommand - (int)RespCommandExtensions.FirstReadCommand + 1];
-            for (var i = (int)RespCommandExtensions.FirstReadCommand; i <= (int)RespCommandExtensions.LastDataCommand; i++)
+            FastBasicRespCommandsInfo = new RespCommandsInfo[(int)RespCommandExtensions.LastDataCommand - (int)RespCommandExtensions.FirstDataCommand + 1];
+            for (var i = (int)RespCommandExtensions.FirstDataCommand; i <= (int)RespCommandExtensions.LastDataCommand; i++)
             {
                 FlattenedRespCommandsInfo.TryGetValue((RespCommand)i, out var commandInfo);
-                FastBasicRespCommandsInfo[i - (int)RespCommandExtensions.FirstReadCommand] = commandInfo;
+                FastBasicRespCommandsInfo[i - (int)RespCommandExtensions.FirstDataCommand] = commandInfo;
             }
 
             return true;
@@ -354,7 +354,7 @@ namespace Garnet.server
             respCommandsInfo = null;
             if (!IsInitialized && !TryInitialize(logger)) return false;
 
-            var offset = (int)cmd - (int)RespCommandExtensions.FirstReadCommand;
+            var offset = (int)cmd - (int)RespCommandExtensions.FirstDataCommand;
             if (offset < 0 || offset >= FastBasicRespCommandsInfo.Length)
                 return false;
 

--- a/libs/server/Storage/Functions/ObjectStore/ReadMethods.cs
+++ b/libs/server/Storage/Functions/ObjectStore/ReadMethods.cs
@@ -32,7 +32,11 @@ namespace Garnet.server
             if (input.header.type != 0)
             {
                 var garnetObject = (IGarnetObject)srcLogRecord.ValueObject;
-                if ((byte)input.header.type < CustomCommandManager.CustomTypeIdStartOffset)
+
+                // header.type == All signals a generic scan (COSCAN); dispatch it to the stored
+                // object's Operate (custom objects scan; built-in objects return WrongType).
+                if (input.header.type == GarnetObjectType.All ||
+                    (byte)input.header.type < CustomCommandManager.CustomTypeIdStartOffset)
                 {
                     var opResult = garnetObject.Operate(ref input, ref output, functionsState.respProtocolVersion);
                     if (output.HasWrongType)

--- a/test/cluster/Garnet.test.cluster.vectorsets/VectorSets/ClusterVectorSetTests.cs
+++ b/test/cluster/Garnet.test.cluster.vectorsets/VectorSets/ClusterVectorSetTests.cs
@@ -1374,7 +1374,7 @@ namespace Garnet.test.cluster
                 {
                     var migrateSimRes = (byte[][])context.clusterTestUtils.Execute(secondary1, "VSIM", [key, "XB8", data, "WITHSCORES", "WITHATTRIBS"], flags: CommandFlags.NoRedirect);
 
-                    if (migrateSimRes.Length == 1 && Encoding.UTF8.GetString(migrateSimRes[1]).StartsWith("Key has MOVED to "))
+                    if (migrateSimRes.Length == 1 && Encoding.UTF8.GetString(migrateSimRes[0]).StartsWith("Key has MOVED to "))
                     {
                         success = false;
                         break;

--- a/test/standalone/Garnet.test.scripting/RespCustomCommandTests.cs
+++ b/test/standalone/Garnet.test.scripting/RespCustomCommandTests.cs
@@ -1346,8 +1346,8 @@ namespace Garnet.test
             var factory = new MyDictFactory();
             server.Register.NewCommand("MYDICTGET", CommandType.Read, factory, new MyDictGet(), new RespCommandsInfo { Arity = 3 });
 
-            // Only able to register 31 sub-commands, try to register 32
-            var regCount = 32;
+            // Only able to register 256 sub-commands (subId occupies a full header byte); MYDICTGET above takes one slot, so try to register 256 more
+            var regCount = byte.MaxValue + 1;
             var failedTaskIdAndMessage = new ConcurrentBag<(int, string)>();
             var regCmdTasks = new Task[regCount];
             for (var i = 0; i < regCount; i++)

--- a/test/standalone/Garnet.test/PersistedEnumStabilityTests.cs
+++ b/test/standalone/Garnet.test/PersistedEnumStabilityTests.cs
@@ -1,0 +1,337 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Garnet.server;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace Garnet.test
+{
+    /// <summary>
+    /// Guards the numeric values of enums that are persisted to disk (AOF / checkpoints) or streamed to
+    /// replicas. Changing an existing member's value silently corrupts data written by an older version,
+    /// so these golden snapshots must only ever GROW (append), never change existing entries. If a test
+    /// here fails because you intentionally changed a persisted format, bump AofHeader.AofHeaderVersion
+    /// (and add the appropriate legacy remap) rather than editing the expected value.
+    /// </summary>
+    [TestFixture]
+    public class PersistedEnumStabilityTests
+    {
+        // Frozen numeric values of the RespCommand WRITE block (the only persisted RespCommand values).
+        private static readonly Dictionary<RespCommand, int> ExpectedWriteCommandValues = new()
+        {
+            [RespCommand.APPEND] = 1,
+            [RespCommand.BITFIELD] = 2,
+            [RespCommand.BZMPOP] = 3,
+            [RespCommand.BZPOPMAX] = 4,
+            [RespCommand.BZPOPMIN] = 5,
+            [RespCommand.DECR] = 6,
+            [RespCommand.DECRBY] = 7,
+            [RespCommand.DEL] = 8,
+            [RespCommand.DELIFEXPIM] = 9,
+            [RespCommand.DELIFGREATER] = 10,
+            [RespCommand.EXPIRE] = 11,
+            [RespCommand.EXPIREAT] = 12,
+            [RespCommand.FLUSHALL] = 13,
+            [RespCommand.FLUSHDB] = 14,
+            [RespCommand.GEOADD] = 15,
+            [RespCommand.GEORADIUS] = 16,
+            [RespCommand.GEORADIUSBYMEMBER] = 17,
+            [RespCommand.GEOSEARCHSTORE] = 18,
+            [RespCommand.GETDEL] = 19,
+            [RespCommand.GETEX] = 20,
+            [RespCommand.GETSET] = 21,
+            [RespCommand.HCOLLECT] = 22,
+            [RespCommand.HDEL] = 23,
+            [RespCommand.HEXPIRE] = 24,
+            [RespCommand.HPEXPIRE] = 25,
+            [RespCommand.HEXPIREAT] = 26,
+            [RespCommand.HPEXPIREAT] = 27,
+            [RespCommand.HPERSIST] = 28,
+            [RespCommand.HINCRBY] = 29,
+            [RespCommand.HINCRBYFLOAT] = 30,
+            [RespCommand.HMSET] = 31,
+            [RespCommand.HSET] = 32,
+            [RespCommand.HSETNX] = 33,
+            [RespCommand.INCR] = 34,
+            [RespCommand.INCRBY] = 35,
+            [RespCommand.INCRBYFLOAT] = 36,
+            [RespCommand.LINSERT] = 37,
+            [RespCommand.LMOVE] = 38,
+            [RespCommand.LMPOP] = 39,
+            [RespCommand.LPOP] = 40,
+            [RespCommand.LPUSH] = 41,
+            [RespCommand.LPUSHX] = 42,
+            [RespCommand.LREM] = 43,
+            [RespCommand.LSET] = 44,
+            [RespCommand.LTRIM] = 45,
+            [RespCommand.BLPOP] = 46,
+            [RespCommand.BRPOP] = 47,
+            [RespCommand.BLMOVE] = 48,
+            [RespCommand.BRPOPLPUSH] = 49,
+            [RespCommand.BLMPOP] = 50,
+            [RespCommand.MIGRATE] = 51,
+            [RespCommand.MSET] = 52,
+            [RespCommand.MSETNX] = 53,
+            [RespCommand.PERSIST] = 54,
+            [RespCommand.PEXPIRE] = 55,
+            [RespCommand.PEXPIREAT] = 56,
+            [RespCommand.PFADD] = 57,
+            [RespCommand.PFMERGE] = 58,
+            [RespCommand.PSETEX] = 59,
+            [RespCommand.RENAME] = 60,
+            [RespCommand.RICREATE] = 61,
+            [RespCommand.RIDEL] = 62,
+            [RespCommand.RIPROMOTE] = 63,
+            [RespCommand.RIRESTORE] = 64,
+            [RespCommand.RISET] = 65,
+            [RespCommand.RESTORE] = 66,
+            [RespCommand.RENAMENX] = 67,
+            [RespCommand.RPOP] = 68,
+            [RespCommand.RPOPLPUSH] = 69,
+            [RespCommand.RPUSH] = 70,
+            [RespCommand.RPUSHX] = 71,
+            [RespCommand.SADD] = 72,
+            [RespCommand.SDIFFSTORE] = 73,
+            [RespCommand.SET] = 74,
+            [RespCommand.SETBIT] = 75,
+            [RespCommand.SETEX] = 76,
+            [RespCommand.SETEXNX] = 77,
+            [RespCommand.SETEXXX] = 78,
+            [RespCommand.SETNX] = 79,
+            [RespCommand.SETIFMATCH] = 80,
+            [RespCommand.SETIFGREATER] = 81,
+            [RespCommand.SETWITHETAG] = 82,
+            [RespCommand.SETKEEPTTL] = 83,
+            [RespCommand.SETKEEPTTLXX] = 84,
+            [RespCommand.SETRANGE] = 85,
+            [RespCommand.SINTERSTORE] = 86,
+            [RespCommand.SMOVE] = 87,
+            [RespCommand.SPOP] = 88,
+            [RespCommand.SREM] = 89,
+            [RespCommand.SUNIONSTORE] = 90,
+            [RespCommand.SWAPDB] = 91,
+            [RespCommand.UNLINK] = 92,
+            [RespCommand.VADD] = 93,
+            [RespCommand.VREM] = 94,
+            [RespCommand.VSETATTR] = 95,
+            [RespCommand.ZADD] = 96,
+            [RespCommand.ZCOLLECT] = 97,
+            [RespCommand.ZDIFFSTORE] = 98,
+            [RespCommand.ZEXPIRE] = 99,
+            [RespCommand.ZPEXPIRE] = 100,
+            [RespCommand.ZEXPIREAT] = 101,
+            [RespCommand.ZPEXPIREAT] = 102,
+            [RespCommand.ZPERSIST] = 103,
+            [RespCommand.ZINCRBY] = 104,
+            [RespCommand.ZMPOP] = 105,
+            [RespCommand.ZINTERSTORE] = 106,
+            [RespCommand.ZPOPMAX] = 107,
+            [RespCommand.ZPOPMIN] = 108,
+            [RespCommand.ZRANGESTORE] = 109,
+            [RespCommand.ZREM] = 110,
+            [RespCommand.ZREMRANGEBYLEX] = 111,
+            [RespCommand.ZREMRANGEBYRANK] = 112,
+            [RespCommand.ZREMRANGEBYSCORE] = 113,
+            [RespCommand.ZUNIONSTORE] = 114,
+            [RespCommand.BITOP] = 115,
+            [RespCommand.BITOP_AND] = 116,
+            [RespCommand.BITOP_OR] = 117,
+            [RespCommand.BITOP_XOR] = 118,
+            [RespCommand.BITOP_NOT] = 119,
+            [RespCommand.BITOP_DIFF] = 120,
+        };
+
+        private static readonly Dictionary<HashOperation, int> ExpectedHashOps = new()
+        {
+            [HashOperation.HCOLLECT] = 0,
+            [HashOperation.HEXPIRE] = 1,
+            [HashOperation.HTTL] = 2,
+            [HashOperation.HPERSIST] = 3,
+            [HashOperation.HGET] = 4,
+            [HashOperation.HMGET] = 5,
+            [HashOperation.HSET] = 6,
+            [HashOperation.HMSET] = 7,
+            [HashOperation.HSETNX] = 8,
+            [HashOperation.HLEN] = 9,
+            [HashOperation.HDEL] = 10,
+            [HashOperation.HEXISTS] = 11,
+            [HashOperation.HGETALL] = 12,
+            [HashOperation.HKEYS] = 13,
+            [HashOperation.HVALS] = 14,
+            [HashOperation.HINCRBY] = 15,
+            [HashOperation.HINCRBYFLOAT] = 16,
+            [HashOperation.HRANDFIELD] = 17,
+            [HashOperation.HSCAN] = 18,
+            [HashOperation.HSTRLEN] = 19,
+        };
+
+        private static readonly Dictionary<SortedSetOperation, int> ExpectedSortedSetOps = new()
+        {
+            [SortedSetOperation.ZADD] = 0,
+            [SortedSetOperation.ZCARD] = 1,
+            [SortedSetOperation.ZPOPMAX] = 2,
+            [SortedSetOperation.ZSCORE] = 3,
+            [SortedSetOperation.ZREM] = 4,
+            [SortedSetOperation.ZCOUNT] = 5,
+            [SortedSetOperation.ZINCRBY] = 6,
+            [SortedSetOperation.ZRANK] = 7,
+            [SortedSetOperation.ZRANGE] = 8,
+            [SortedSetOperation.GEOADD] = 9,
+            [SortedSetOperation.GEOHASH] = 10,
+            [SortedSetOperation.GEODIST] = 11,
+            [SortedSetOperation.GEOPOS] = 12,
+            [SortedSetOperation.GEOSEARCH] = 13,
+            [SortedSetOperation.ZREVRANK] = 14,
+            [SortedSetOperation.ZREMRANGEBYLEX] = 15,
+            [SortedSetOperation.ZREMRANGEBYRANK] = 16,
+            [SortedSetOperation.ZREMRANGEBYSCORE] = 17,
+            [SortedSetOperation.ZLEXCOUNT] = 18,
+            [SortedSetOperation.ZPOPMIN] = 19,
+            [SortedSetOperation.ZRANDMEMBER] = 20,
+            [SortedSetOperation.ZDIFF] = 21,
+            [SortedSetOperation.ZSCAN] = 22,
+            [SortedSetOperation.ZMSCORE] = 23,
+            [SortedSetOperation.ZEXPIRE] = 24,
+            [SortedSetOperation.ZTTL] = 25,
+            [SortedSetOperation.ZPERSIST] = 26,
+            [SortedSetOperation.ZCOLLECT] = 27,
+        };
+
+        private static readonly Dictionary<ListOperation, int> ExpectedListOps = new()
+        {
+            [ListOperation.LPOP] = 0,
+            [ListOperation.LPUSH] = 1,
+            [ListOperation.LPUSHX] = 2,
+            [ListOperation.RPOP] = 3,
+            [ListOperation.RPUSH] = 4,
+            [ListOperation.RPUSHX] = 5,
+            [ListOperation.LLEN] = 6,
+            [ListOperation.LTRIM] = 7,
+            [ListOperation.LRANGE] = 8,
+            [ListOperation.LINDEX] = 9,
+            [ListOperation.LINSERT] = 10,
+            [ListOperation.LREM] = 11,
+            [ListOperation.RPOPLPUSH] = 12,
+            [ListOperation.LMOVE] = 13,
+            [ListOperation.LSET] = 14,
+            [ListOperation.BRPOP] = 15,
+            [ListOperation.BLPOP] = 16,
+            [ListOperation.LPOS] = 17,
+        };
+
+        private static readonly Dictionary<SetOperation, int> ExpectedSetOps = new()
+        {
+            [SetOperation.SADD] = 0,
+            [SetOperation.SREM] = 1,
+            [SetOperation.SPOP] = 2,
+            [SetOperation.SMEMBERS] = 3,
+            [SetOperation.SCARD] = 4,
+            [SetOperation.SSCAN] = 5,
+            [SetOperation.SMOVE] = 6,
+            [SetOperation.SRANDMEMBER] = 7,
+            [SetOperation.SISMEMBER] = 8,
+            [SetOperation.SMISMEMBER] = 9,
+            [SetOperation.SUNION] = 10,
+            [SetOperation.SUNIONSTORE] = 11,
+            [SetOperation.SDIFF] = 12,
+            [SetOperation.SDIFFSTORE] = 13,
+            [SetOperation.SINTER] = 14,
+            [SetOperation.SINTERSTORE] = 15,
+        };
+
+        [Test]
+        public void RespCommandWriteBlockValuesAreStable()
+        {
+            foreach (var (cmd, expected) in ExpectedWriteCommandValues)
+                ClassicAssert.AreEqual(expected, (int)cmd, $"RespCommand.{cmd} persisted value changed");
+
+            // FirstWriteCommand/LastWriteCommand anchor the persisted range.
+            ClassicAssert.AreEqual(1, (int)RespCommand.APPEND, "FirstWriteCommand (APPEND) must be 1");
+            ClassicAssert.AreEqual(120, (int)RespCommand.BITOP_DIFF, "LastWriteCommand (BITOP_DIFF) must be 120");
+        }
+
+        [Test]
+        public void ObjectSubOpValuesAreStable()
+        {
+            foreach (var (op, expected) in ExpectedHashOps)
+                ClassicAssert.AreEqual(expected, (int)op, $"HashOperation.{op} value changed");
+            foreach (var (op, expected) in ExpectedSortedSetOps)
+                ClassicAssert.AreEqual(expected, (int)op, $"SortedSetOperation.{op} value changed");
+            foreach (var (op, expected) in ExpectedListOps)
+                ClassicAssert.AreEqual(expected, (int)op, $"ListOperation.{op} value changed");
+            foreach (var (op, expected) in ExpectedSetOps)
+                ClassicAssert.AreEqual(expected, (int)op, $"SetOperation.{op} value changed");
+        }
+
+        [Test]
+        public void GarnetObjectTypeBuiltinValuesAreStable()
+        {
+            ClassicAssert.AreEqual(0, (int)GarnetObjectType.Null);
+            ClassicAssert.AreEqual(1, (int)GarnetObjectType.SortedSet);
+            ClassicAssert.AreEqual(2, (int)GarnetObjectType.List);
+            ClassicAssert.AreEqual(3, (int)GarnetObjectType.Hash);
+            ClassicAssert.AreEqual(4, (int)GarnetObjectType.Set);
+            ClassicAssert.AreEqual(0xFB, (int)GarnetObjectType.All);
+        }
+
+        [Test]
+        public void ObjectSubOpsFitInByte()
+        {
+            // SubId occupies a single header byte (RespInputHeader.subId); every sub-op value must fit.
+            ClassicAssert.LessOrEqual(Enum.GetValues<HashOperation>().Max(x => (int)x), 255);
+            ClassicAssert.LessOrEqual(Enum.GetValues<SortedSetOperation>().Max(x => (int)x), 255);
+            ClassicAssert.LessOrEqual(Enum.GetValues<ListOperation>().Max(x => (int)x), 255);
+            ClassicAssert.LessOrEqual(Enum.GetValues<SetOperation>().Max(x => (int)x), 255);
+        }
+
+        [Test]
+        public void WriteBlockContainsExactlyWriteCommands()
+        {
+            // Every command in [FirstWriteCommand, LastWriteCommand] must be a write/mutating command,
+            // and no mutating command may exist outside that dense block. This makes "only writes are
+            // persisted, and they are contiguous at the start" a CI-enforced invariant.
+            foreach (var cmd in Enum.GetValues<RespCommand>())
+            {
+                if (cmd == RespCommand.NONE || cmd == RespCommand.INVALID)
+                    continue;
+                if (!RespCommandsInfo.TryGetRespCommandInfo(cmd, out var info))
+                    continue;
+
+                var isInWriteBlock = (int)cmd >= 1 && (int)cmd <= 120;
+                var isWrite = info.AclCategories.HasFlag(RespAclCategories.Write);
+
+                if (isWrite)
+                    ClassicAssert.IsTrue(isInWriteBlock, $"Write command {cmd} is outside the write block [1,120]");
+                else
+                    ClassicAssert.IsFalse(isInWriteBlock, $"Non-write command {cmd} is inside the write block [1,120]");
+            }
+        }
+
+        [Test]
+        public void LegacyV3MappingIsComplete()
+        {
+            // Building the map throws if any v3 name no longer resolves (rename/removal guard).
+            Assert.DoesNotThrow(LegacyRespCommand.EnsureInitialized);
+
+            // A v3 write command translates to the current RespCommand of the same name.
+            // In v3, APPEND had value 103 (writes followed reads); it must map to the current APPEND.
+            ClassicAssert.AreEqual(RespCommand.APPEND, LegacyRespCommand.FromV3((RespCommand)103));
+            // NONE and custom-range values pass through unchanged.
+            ClassicAssert.AreEqual(RespCommand.NONE, LegacyRespCommand.FromV3(RespCommand.NONE));
+            ClassicAssert.AreEqual(RespCommand.INVALID, LegacyRespCommand.FromV3(RespCommand.INVALID));
+        }
+
+        [Test]
+        public void BuiltinRespCommandSpaceDoesNotReachCustomRange()
+        {
+            // Custom raw-string command ids are anchored just below INVALID; the built-in command space
+            // must never grow into that range.
+            ClassicAssert.Less((int)RespCommandExtensions.LastValidCommand, (ushort)RespCommand.INVALID - 256,
+                "Built-in RespCommand space has grown into the custom raw-string command range");
+        }
+    }
+}

--- a/test/standalone/Garnet.test/PersistedEnumStabilityTests.cs
+++ b/test/standalone/Garnet.test/PersistedEnumStabilityTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Garnet.common;
 using Garnet.server;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
@@ -276,6 +277,18 @@ namespace Garnet.test
             ClassicAssert.AreEqual(3, (int)GarnetObjectType.Hash);
             ClassicAssert.AreEqual(4, (int)GarnetObjectType.Set);
             ClassicAssert.AreEqual(0xFB, (int)GarnetObjectType.All);
+        }
+
+        [Test]
+        public void LegacyCustomObjectTypeIdFailsFastOnDeserialize()
+        {
+            // Older builds based custom object type ids at LastObjectType+1 (=5), which now lies in the
+            // reserved built-in band below the fixed custom base (0x40). Deserializing such a record must
+            // fail fast rather than silently return null (which would drop the object and lose data).
+            var serializer = new GarnetObjectSerializer(new CustomCommandManager());
+            var legacyCustomObjectBytes = new byte[] { 5 };
+
+            Assert.Throws<GarnetException>(() => serializer.Deserialize(legacyCustomObjectBytes));
         }
 
         [Test]

--- a/website/docs/dev/range-index-resp-api.md
+++ b/website/docs/dev/range-index-resp-api.md
@@ -766,9 +766,11 @@ public static bool IsLegalOnRangeIndex(this RespCommand cmd)
 ### Step 2: Add RESP commands to the parser
 
 > **Reference:** `libs/server/Resp/Parser/RespCommand.cs`
-> - Read commands are defined before `APPEND` (the last read command is just before `APPEND`)
-> - Write commands are defined starting at `APPEND`
-> - Read/write classification uses enum ordering: `cmd <= LastReadCommand` ⟹ read-only
+> - The enum is **writes-first**: write commands occupy a dense, explicitly-numbered block
+>   `APPEND = 1 .. BITOP_DIFF = 120` immediately after `NONE` (these are the only persisted
+>   RespCommand values); read commands follow, then scripts (EVAL/EVALSHA)
+> - Read/write classification uses enum **ranges**: `FirstReadCommand <= cmd <= LastReadCommand`
+>   ⟹ read-only; `FirstWriteCommand <= cmd <= LastWriteCommand` ⟹ write
 > - Fast parsing: `FastParseArrayCommand()` uses `ulong` pointer comparisons for short
 >   fixed-length commands
 > - Longer/unusual commands fall through to `SlowParseCommand()`


### PR DESCRIPTION
Also writes-first RespCommand + freezes for format stability

RespCommand and several other enums have their numeric values persisted to disk (AOF, checkpoints, cluster config) and streamed to replicas. Because they were auto-numbered by declaration order, adding a member (even a read-only command) shifted every subsequent value, so data written by an older Garnet version could replay/recover as the wrong member on a newer version.

Changes:
- RespCommand: move write (mutating) commands into a dense, explicitly-numbered block (APPEND=1 .. BITOP_DIFF=120) immediately after NONE. Writes are the only persisted RespCommand values; reads/scripts/admin follow and may renumber freely. Boundary checks become positional ranges (IsReadOnly is now a branchless range check); RespCommandsInfo fast arrays re-anchor to FirstDataCommand.
- Object sub-op enums (Hash/List/Set/SortedSet Operation), GarnetObjectType, NodeRole and SlotState: freeze with explicit values + append-only guidance.
- GarnetObjectType: pin the custom-object-type base to a fixed 0x40 so adding a built-in type never shifts persisted custom-object ids; reserve 0xFC..0xFF for a future object-format version byte with a fail-fast read guard.
- RespInputHeader: give the object sub-operation id its own header byte (256/type instead of 5 bits) by dispatching COSCAN via type==All instead of header.cmd, freeing byte 1. Header stays 3 bytes; string/unified layout is unchanged.
- AOF: bump header version 3->4. Replay remaps legacy (v3) RespCommand values by name (LegacyRespCommand, fail-fast on rename) and relocates the v3 object sub-op id; a max-version guard rejects unknown-higher versions loudly.
- Add PersistedEnumStabilityTests (golden values, write-block invariant, sub-op capacity, custom-range, legacy mapping). Update the add-command skill and docs.