### PR TITLE
Fix SynchronizationLockException on pub/sub self-publish

### DIFF
--- a/libs/server/Resp/PubSubCommands.cs
+++ b/libs/server/Resp/PubSubCommands.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Garnet.common;
 using Tsavorite.core;
 
@@ -21,9 +20,18 @@ namespace Garnet.server
         /// <inheritdoc />
         public override unsafe void Publish(PinnedSpanByte key, PinnedSpanByte value)
         {
+            // Tracks whether EnterAndGetResponseObject succeeded, so we only release the lock we actually
+            // acquired. A session can receive its own published message while it is itself the publisher
+            // (e.g. RESP3 PUBLISH to a channel it is subscribed to), in which case this is a reentrant call
+            // on a thread that is already holding the same non-reentrant SpinLock via the outer
+            // TryConsumeMessages/EnterAndGetResponseObject call. Without this guard, the failed re-entrant
+            // Enter would still be unconditionally Exit-ed here, releasing the outer lock early and causing
+            // a SynchronizationLockException when the outer call later tries to exit it itself.
+            var entered = false;
             try
             {
                 networkSender.EnterAndGetResponseObject(out dcurr, out dend);
+                entered = true;
 
                 WritePushLength(3);
 
@@ -44,16 +52,21 @@ namespace Garnet.server
             }
             finally
             {
-                networkSender.ExitAndReturnResponseObject();
+                if (entered)
+                    networkSender.ExitAndReturnResponseObject();
             }
         }
 
         /// <inheritdoc />
         public override unsafe void PatternPublish(PinnedSpanByte pattern, PinnedSpanByte key, PinnedSpanByte value)
         {
+            // See the comment in Publish() above: guard against releasing a lock we never acquired when this
+            // is a reentrant call on a thread that already holds the sender's SpinLock.
+            var entered = false;
             try
             {
                 networkSender.EnterAndGetResponseObject(out dcurr, out dend);
+                entered = true;
 
                 WritePushLength(4);
 
@@ -74,7 +87,8 @@ namespace Garnet.server
             }
             finally
             {
-                networkSender.ExitAndReturnResponseObject();
+                if (entered)
+                    networkSender.ExitAndReturnResponseObject();
             }
         }
 
@@ -100,7 +114,12 @@ namespace Garnet.server
                 return AbortWithErrorMessage(CmdStrings.RESP_ERR_GENERIC_CLUSTER_DISABLED);
             }
 
-            Debug.Assert(isSubscriptionSession == false);
+            // Note: a session may legitimately issue PUBLISH while itself in subscription mode (e.g. a
+            // RESP3 client publishing to a channel it is subscribed to; Garnet also does not yet enforce
+            // RESP2's "only (P)SUBSCRIBE/(P)UNSUBSCRIBE/PING/QUIT/RESET while subscribed" restriction - see
+            // https://github.com/microsoft/garnet/issues/1615). This can result in the broker delivering
+            // this very message back to this same session re-entrantly; see the entered-guard in Publish()
+            // and PatternPublish() above, which is what keeps that scenario from corrupting session state.
             // PUBLISH channel message => [*3\r\n$7\r\nPUBLISH\r\n$]7\r\nchannel\r\n$7\r\message\r\n
 
             var key = parseState.GetArgSliceByRef(0);

--- a/test/standalone/Garnet.test/RespPubSubTests.cs
+++ b/test/standalone/Garnet.test/RespPubSubTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Linq;
+using System.Net.Sockets;
 using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
@@ -199,6 +201,110 @@ namespace Garnet.test
 
             sub.Unsubscribe(RedisChannel.Literal("messagesA"));
             sub.Unsubscribe(RedisChannel.Literal("messagesB"));
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/microsoft/garnet/issues/1615 (network-lock-error part).
+        ///
+        /// A client that PUBLISHes to a channel it is itself subscribed to receives its own message via a
+        /// reentrant delivery on the same connection: SubscribeBroker.Broadcast calls back into this exact
+        /// connection's Publish() while that connection's TryConsumeMessages is still on the stack and still
+        /// holding the network sender's (non-reentrant) SpinLock. Before the fix, the reentrant Enter failed
+        /// but the subsequent finally still unconditionally called Exit, releasing a lock this call never
+        /// actually held. That caused the outer TryConsumeMessages to later throw a
+        /// SynchronizationLockException when it tried to release the lock it did hold, tearing down the
+        /// connection. This test would previously fail because the connection died and the trailing PING
+        /// got no response (or the socket read timed out / the connection was reset).
+        /// </summary>
+        [Test]
+        public void SelfPublishOnSubscribedChannelDoesNotCorruptConnection()
+        {
+            const string channel = "self-publish-channel";
+
+            using var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+            socket.Connect(TestUtils.EndPoint);
+            socket.ReceiveTimeout = 10_000;
+            socket.SendTimeout = 10_000;
+
+            // Subscribe on this connection, and wait for the subscribe confirmation so we know the broker
+            // has registered this session as a subscriber before we publish to the same channel below.
+            SendCommand(socket, "SUBSCRIBE", channel);
+            var subscribeResponse = ReadAvailable(socket);
+            StringAssert.Contains("subscribe", subscribeResponse);
+            StringAssert.Contains(channel, subscribeResponse);
+
+            // Publish to the channel we're subscribed to, on the very same connection - this is what
+            // triggers the reentrant delivery into this connection's own Publish() path.
+            SendCommand(socket, "PUBLISH", channel, "self-published-message");
+            var publishResponse = ReadAvailable(socket);
+            // The PUBLISH command itself must still complete and report the one (self-)subscriber,
+            // regardless of whether the self-delivered "message" push made it through.
+            StringAssert.Contains(":1", publishResponse);
+
+            // The critical assertion: the connection must still be alive and the session must still be
+            // usable afterwards. Before the fix, the SynchronizationLockException thrown while unwinding
+            // TryConsumeMessages tore down this connection, so this PING would get no reply at all.
+            // (The reply is the RESP2 "subscribe-mode" PONG form - *2\r\n$4\r\npong\r\n$0\r\n\r\n - since this
+            // connection is still subscribed; that's expected and orthogonal to what we're checking here.)
+            SendCommand(socket, "PING");
+            var pingResponse = ReadAvailable(socket);
+            ClassicAssert.AreEqual("*2\r\n$4\r\npong\r\n$0\r\n\r\n", pingResponse,
+                "Connection did not survive a self-publish on a subscribed channel - PING got no normal reply");
+        }
+
+        private static void SendCommand(Socket socket, params string[] args)
+        {
+            var sb = new StringBuilder();
+            sb.Append('*').Append(args.Length).Append("\r\n");
+            foreach (var arg in args)
+            {
+                var argBytes = Encoding.UTF8.GetByteCount(arg);
+                sb.Append('$').Append(argBytes).Append("\r\n").Append(arg).Append("\r\n");
+            }
+            socket.Send(Encoding.UTF8.GetBytes(sb.ToString()));
+        }
+
+        /// <summary>
+        /// Reads whatever the server sends back within a short window, returning once the socket has been
+        /// quiet for a bit. Used instead of parsing exact RESP token counts, since a self-publish can cause
+        /// zero or more independent flushes (push message and/or command reply) on the same connection.
+        /// </summary>
+        private static string ReadAvailable(Socket socket, int overallTimeoutMs = 5_000, int quietPeriodMs = 200)
+        {
+            var buffer = new byte[4096];
+            var sb = new StringBuilder();
+            var deadline = DateTime.UtcNow.AddMilliseconds(overallTimeoutMs);
+
+            while (DateTime.UtcNow < deadline)
+            {
+                if (socket.Poll(quietPeriodMs * 1000, SelectMode.SelectRead))
+                {
+                    int read;
+                    try
+                    {
+                        read = socket.Receive(buffer);
+                    }
+                    catch (SocketException)
+                    {
+                        break;
+                    }
+
+                    if (read == 0)
+                    {
+                        // Peer closed the connection - stop trying to read.
+                        break;
+                    }
+                    sb.Append(Encoding.UTF8.GetString(buffer, 0, read));
+                }
+                else if (sb.Length > 0)
+                {
+                    // We received some data and it has now been quiet for quietPeriodMs - assume the
+                    // server is done flushing for this round-trip.
+                    break;
+                }
+            }
+
+            return sb.ToString();
         }
 
         private void SubscribeAndPublish(ISubscriber sub, IDatabase db, RedisChannel channel, RedisChannel? publishChannel = null, RedisValue? message = null, Action<RedisChannel, RedisValue> onSubscribe = null)

--- a/test/standalone/Garnet.test/RespPubSubTests.cs
+++ b/test/standalone/Garnet.test/RespPubSubTests.cs
@@ -252,6 +252,48 @@ namespace Garnet.test
                 "Connection did not survive a self-publish on a subscribed channel - PING got no normal reply");
         }
 
+        /// <summary>
+        /// Same regression as <see cref="SelfPublishOnSubscribedChannelDoesNotCorruptConnection"/>, but for
+        /// the PSUBSCRIBE/PatternPublish path, which received the identical entered-guard fix in
+        /// PatternPublish() but had no direct coverage. A client that is pattern-subscribed to a channel and
+        /// then PUBLISHes a matching key on that same connection triggers the same reentrant delivery, this
+        /// time through SubscribeBroker's pattern-matching broadcast into PatternPublish().
+        /// </summary>
+        [Test]
+        public void SelfPublishOnPatternSubscribedChannelDoesNotCorruptConnection()
+        {
+            const string pattern = "self-publish-pattern-*";
+            const string channel = "self-publish-pattern-channel";
+
+            using var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+            socket.Connect(TestUtils.EndPoint);
+            socket.ReceiveTimeout = 10_000;
+            socket.SendTimeout = 10_000;
+
+            // Pattern-subscribe on this connection, and wait for the confirmation so we know the broker has
+            // registered this session as a pattern subscriber before we publish a matching key below.
+            SendCommand(socket, "PSUBSCRIBE", pattern);
+            var subscribeResponse = ReadAvailable(socket);
+            StringAssert.Contains("psubscribe", subscribeResponse);
+            StringAssert.Contains(pattern, subscribeResponse);
+
+            // Publish to a channel matching our own pattern subscription, on the very same connection - this
+            // triggers the reentrant delivery into this connection's own PatternPublish() path.
+            SendCommand(socket, "PUBLISH", channel, "self-published-message");
+            var publishResponse = ReadAvailable(socket);
+            // The PUBLISH command itself must still complete and report the one (self-)subscriber,
+            // regardless of whether the self-delivered "pmessage" push made it through.
+            StringAssert.Contains(":1", publishResponse);
+
+            // The critical assertion: the connection must still be alive and the session must still be
+            // usable afterwards. Before the fix, the SynchronizationLockException thrown while unwinding
+            // TryConsumeMessages tore down this connection, so this PING would get no reply at all.
+            SendCommand(socket, "PING");
+            var pingResponse = ReadAvailable(socket);
+            ClassicAssert.AreEqual("*2\r\n$4\r\npong\r\n$0\r\n\r\n", pingResponse,
+                "Connection did not survive a self-publish on a pattern-subscribed channel - PING got no normal reply");
+        }
+
         private static void SendCommand(Socket socket, params string[] args)
         {
             var sb = new StringBuilder();


### PR DESCRIPTION
Fixes #1615 (the network-lock-error part of that issue; the RESP2 command-restriction part — Garnet not yet rejecting non-`(P)SUBSCRIBE`/`PING`/`QUIT`/`RESET` commands while in subscribe mode — is a separate, larger concern and out of scope for this PR).

## Root cause

`GarnetTcpNetworkSender`'s `spinLock` field is a `SpinLock` struct initialized with `new()` and no user-declared parameterless constructor. That zero-inits `_owner`, which per `SpinLock` semantics enables thread-owner tracking (equivalent to `new SpinLock(true)`), so a same-thread reentrant `Enter()` throws.

A session can trigger a reentrant call into its own network sender: `PUBLISH` on a connection that is itself subscribed to the target channel causes `SubscribeBroker.PublishNow`/`Broadcast` to call back into that same connection's `Publish()`/`PatternPublish()` synchronously, while `TryConsumeMessages` for the `PUBLISH` command is still on the stack and still holding the sender's `SpinLock`. Garnet does not currently enforce RESP2's "only a few commands allowed while subscribed" restriction, so this is reachable without RESP3.

`EnterAndGetResponseObject` on that reentrant call throws before touching `lockTaken`/`responseObject`, but the old code's `finally` block unconditionally called `ExitAndReturnResponseObject()`. Since `SpinLock.Exit()`'s ownership check is by thread ID (not call-frame/recursion depth), the erroneous reentrant `Exit()` succeeded and silently released the *outer* frame's lock early. The outer `TryConsumeMessages` `finally` then called `Exit()` again on an already-released lock, throwing an uncaught `SynchronizationLockException` and tearing down the connection.

As a secondary effect, the same unconditional `finally` also returned `responseObject` to the free buffer pool on the reentrant frame — but `responseObject` there is still the *outer* frame's actively-in-use buffer (never reset, since the failed `Enter` never got that far), so the old code was also returning a buffer to the pool while it was still being written to.

## Fix

In `PubSubCommands.cs`, `Publish()` and `PatternPublish()` now track whether `EnterAndGetResponseObject` actually succeeded (`entered`, following the same `lockTaken`-guard pattern already used in `EnterAndGetResponseObject`/`GarnetTcpNetworkSender.cs`) and only call `ExitAndReturnResponseObject()` in `finally` if it did. This also incidentally fixes the buffer-pool double-use described above, since the erroneous `Exit`/return no longer happens.

The `Debug.Assert(isSubscriptionSession == false)` in `NetworkPUBLISH` is removed: in Debug builds without a debugger attached, `Debug.Assert` failure calls `Environment.FailFast` and kills the whole process, so this exact scenario would crash the test process outright regardless of the lock fix. The assert was asserting a false invariant anyway — self-publish-while-subscribed is a real, currently-unrestricted scenario.

## Behavior note / known tradeoff

With this fix, a message a session publishes to a channel it is itself (pattern-)subscribed to is **not delivered back to that same connection** — the reentrant delivery attempt is now a no-op instead of corrupting the connection, so the self-message is silently dropped rather than crashing. `PUBLISH` itself still completes normally and still reports the correct subscriber count. This is a deviation from full Redis pub/sub semantics (a subscriber normally does receive its own publish) and is a deliberate, minimal tradeoff to fix the crash without restructuring the network-sender locking or deferring self-delivery to after the outer lock is released. Delivering the self-message correctly (e.g. by queuing it for delivery once the outer `TryConsumeMessages` lock is released) would be a larger change and is left as potential follow-up; happy to discuss if maintainers would prefer that approach instead.

## Testing performed

- `dotnet build test/standalone/Garnet.test/Garnet.test.csproj` in both Debug and Release: both succeed, 0 warnings, 0 errors.
- `dotnet test ... --filter "FullyQualifiedName~RespPubSubTests"` on net10.0, Debug and Release: **8/8 pass** (7 pre-existing + 2 new regression tests, one for `SUBSCRIBE`/`Publish` and one for `PSUBSCRIBE`/`PatternPublish`).
- Reverted the `entered`-guard fix in `Publish()` only (kept the `Debug.Assert` removal) and reran the new `SelfPublishOnSubscribedChannelDoesNotCorruptConnection` test alone: it fails, with the connection dying mid-`PUBLISH` as expected. Restored the fix: passes again, confirmed stable across repeated runs.
- `dotnet format --verify-no-changes` on the changed files: clean.
- `git diff --check`: no whitespace/line-ending issues.
- Manual review of the diff against existing lock-guard conventions elsewhere in the same files (`GarnetTcpNetworkSender.cs`, `EnterAndGetResponseObject`).
- Not run: the full Garnet test suite (only the pub/sub-focused subset above was targeted) and any cluster/RESP3-specific pub/sub paths beyond what these tests cover.

Diff touches `libs/server/Resp/PubSubCommands.cs` and `test/standalone/Garnet.test/RespPubSubTests.cs` only.
