### PR TITLE
Fix spurious NOTFOUND from ContinuePendingRead after a successful disk read

### DIFF
--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/ContinuePending.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/ContinuePending.cs
@@ -174,6 +174,13 @@ namespace Tsavorite.core
                     // See if we are copying to read cache or tail of log. If we already found the record in memory, we're done.
                     if (operationState.readCopyOptions.CopyFrom != ReadCopyFrom.None && !memoryRecord.IsSet)
                     {
+                        // The Reader() call above already succeeded, so the operation is a SUCCESS regardless of whether a copy is
+                        // actually performed below (e.g. CopyTo is None, which is a valid "track CopyFrom for stats but don't copy"
+                        // configuration, or the ReadCache copy's guard conditions are not met). Without this, 'status' retains
+                        // whatever FindTagAndTryEphemeralSLock set via its out-parameter above, which is only meaningful when that
+                        // call returns false (i.e. it is NOT a valid "found" status here) - previously causing a spurious NOTFOUND to
+                        // be returned for a completed, correctly-read pending Read() whenever neither branch below ran.
+                        status = OperationStatus.SUCCESS;
                         if (operationState.readCopyOptions.CopyTo == ReadCopyTo.MainLog)
                         {
                             // Plumb source logical address so PostCopyToTail can name per-flush snapshot files.


### PR DESCRIPTION
Addresses part of #1950 (see that issue for the full reproduction and analysis — this PR fixes one of at least two distinct causes of the flakiness described there).

## Root cause

In `ContinuePendingRead` (`libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/ContinuePending.cs`), after a pending (disk) read's `Reader()` call succeeds, `status` is only explicitly set to `SUCCESS` inside the two branches gated by `operationState.readCopyOptions.CopyTo` (`MainLog` or `ReadCache`). When `CopyFrom != ReadCopyFrom.None` but `CopyTo == ReadCopyTo.None` — a valid configuration reachable via `ReadCopyFrom.Inherit` resolution — neither branch runs, and `status` is left holding whatever `FindTagAndTryEphemeralSLock`'s out-parameter set earlier in the call, which is only meaningful on a failed lock/find and effectively behaves like `NOTFOUND` here. A fully successful disk read, with the correct value already retrieved into `output`, was therefore reported back to the caller as `NOTFOUND`, discarding the correct value.

This is reachable whenever a plain read is forced to disk (record evicted below `HeadAddress`) under that specific `CopyFrom`/`CopyTo` combination — uncommon in normal steady-state operation, but reliably triggered right after recovering into a tighter memory budget than the data was originally written under (exactly what `RespAdminCommandsTests.SeSaveRecoverMultipleKeysTest("25k","18k")` does, which is how this was found).

## Fix

One line: explicitly set `status = OperationStatus.SUCCESS;` immediately after a successful `Reader()` call, before the `CopyTo`-gated branching — matching the already-correct pattern in the synchronous read path (`InternalRead.cs`, where `status = OperationStatus.SUCCESS` is set unconditionally right after `Reader()` succeeds, before any `CopyFrom`-gated logic runs). The async/pending path was simply missing the equivalent line.

## Testing

- Reproduced the underlying symptom via `SeSaveRecoverMultipleKeysTest("25k","18k")`: on unpatched `main`, 6/20 (~30%) local runs failed. With this fix, 6/150 (~4%) failed — a ~7x reduction, confirming this addresses a real, distinct cause.
- Ran the broader relevant test surface to check for regressions: `RespAdminCommandsTests` (56 tests), `RespConfigTests` + `AofShardedTxnRecoveryTests` (18), `Tsavorite.test.recovery` (204), `CompletePendingTests`/`LowMemoryTests`/`StateMachineDriverTests` (33), `ReadAddressTests`/`ReadCacheTests` (171). All pass, no regressions observed.

## This does not fully close #1950

The residual ~4% failure rate is a second, distinct issue — in a captured failure, `ContinuePendingRead`'s `request.logicalAddress` was `0` instead of the correct address at completion time. I was not able to pin that down with confidence within a reasonable investigation budget and did not want to guess at a fix for it in this sensitive async-completion path. Full details and a working diagnostic-instrumentation approach are in the issue; happy to keep digging into the second cause separately.