### PR TITLE
Add `ICompactionFunctions.OnImplicitlyDeleted`

### DIFF
--- a/libs/server/Databases/DatabaseManagerBase.cs
+++ b/libs/server/Databases/DatabaseManagerBase.cs
@@ -445,7 +445,7 @@ namespace Garnet.server
                         break;
 
                     case LogCompactionType.Scan:
-                        storeLog.Compact<PinnedSpanByte, Empty, Empty>(untilAddress, CompactionType.Scan);
+                        storeLog.Compact<PinnedSpanByte, Empty, Empty, StoreFunctions<GarnetKeyComparer, GarnetRecordTriggers>>(db.Store.StoreFunctions, untilAddress, CompactionType.Scan);
                         if (compactionForceDelete)
                         {
                             await CompactionCommitAofAsync(db).ConfigureAwait(false);
@@ -454,7 +454,7 @@ namespace Garnet.server
                         break;
 
                     case LogCompactionType.Lookup:
-                        storeLog.Compact<PinnedSpanByte, Empty, Empty>(untilAddress, CompactionType.Lookup);
+                        storeLog.Compact<PinnedSpanByte, Empty, Empty, StoreFunctions<GarnetKeyComparer, GarnetRecordTriggers>>(db.Store.StoreFunctions, untilAddress, CompactionType.Lookup);
                         if (compactionForceDelete)
                         {
                             await CompactionCommitAofAsync(db).ConfigureAwait(false);

--- a/libs/server/Storage/Functions/GarnetRecordTriggers.cs
+++ b/libs/server/Storage/Functions/GarnetRecordTriggers.cs
@@ -11,7 +11,7 @@ namespace Garnet.server
     /// to handle per-record cleanup on delete, eviction, flush, copy-to-tail, log truncation,
     /// and disk read for BfTree stubs (RangeIndex).
     /// </summary>
-    public readonly struct GarnetRecordTriggers : IRecordTriggers
+    public readonly struct GarnetRecordTriggers : IRecordTriggers, ICompactionFunctions
     {
         /// <summary>
         /// Cache size tracker for heap size accounting.
@@ -260,6 +260,14 @@ namespace Garnet.server
         public readonly void OnTruncate(long newBeginAddress)
         {
             rangeIndexManager?.OnTruncateImpl(newBeginAddress);
+        }
+
+        /// <inheritdoc/>
+        public bool IsDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) where TSourceLogRecord : ISourceLogRecord => false;
+
+        /// <inheritdoc/>
+        public void OnImplicitlyDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) where TSourceLogRecord : ISourceLogRecord
+        {
         }
     }
 }

--- a/libs/storage/Tsavorite/cs/src/core/Compaction/ICompactionFunctions.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Compaction/ICompactionFunctions.cs
@@ -18,12 +18,28 @@ namespace Tsavorite.core
         /// </remarks>
         bool IsDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord)
             where TSourceLogRecord : ISourceLogRecord;
+
+        /// <summary>
+        /// Called when a record is determined to be unreachable during a compaction.
+        /// 
+        /// If a record was deleted the usual Delete() way (i.e. its tombstone is set), then this function is not called for it.
+        /// If <see cref="IsDeleted{TSourceLogRecord}(in TSourceLogRecord)"/> returns true, then this function is not called for it.
+        /// </summary>
+        void OnImplicitlyDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord)
+            where TSourceLogRecord : ISourceLogRecord;
     }
 
     internal struct DefaultCompactionFunctions : ICompactionFunctions
     {
+        /// <inheritdoc/>
         public bool IsDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord)
             where TSourceLogRecord : ISourceLogRecord
             => false;
+
+        /// <inheritdoc/>
+        public void OnImplicitlyDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord)
+            where TSourceLogRecord : ISourceLogRecord
+        {
+        }
     }
 }

--- a/libs/storage/Tsavorite/cs/src/core/Compaction/TsavoriteCompaction.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Compaction/TsavoriteCompaction.cs
@@ -40,7 +40,6 @@ namespace Tsavorite.core
 
             using (var iter1 = Log.Scan(Log.BeginAddress, untilAddress))
             {
-                long numPending = 0;
                 while (iter1.GetNext())
                 {
                     var key = iter1.Key;
@@ -49,18 +48,30 @@ namespace Tsavorite.core
                     {
                         var iter1AsLogSource = iter1 as ISourceLogRecord;   // Can't use 'ref' on a 'using' variable
                         var status = storebContext.CompactionCopyToTail(in iter1AsLogSource, iter1.CurrentAddress, iter1.NextAddress);
-                        if (status.IsPending && ++numPending > 256)
+
+                        // TODO: Figure out a way to restore a pending buffer, like with Scan
+                        //
+                        //       Maybe remember the address?  Pass an input that saves the key if we go async?
+                        if (status.IsPending)
                         {
-                            _ = storebContext.CompletePending(wait: true);
-                            numPending = 0;
+                            _ = storebContext.CompletePendingWithOutputs(out var outputs, wait: true);
+
+                            if (outputs.Next())
+                            {
+                                status = outputs.Current.Status;
+                            }
+                        }
+
+                        if (status.Found)
+                        {
+                            // Inform CF that we found a record that was implicitly deleted
+                            cf.OnImplicitlyDeleted(in iter1AsLogSource);
                         }
                     }
 
                     // Ensure address is at record boundary
                     untilAddress = iter1.NextAddress;
                 }
-                if (numPending > 0)
-                    _ = storebContext.CompletePending(wait: true);
             }
             Log.ShiftBeginAddress(untilAddress, false);
             return untilAddress;
@@ -109,7 +120,6 @@ namespace Tsavorite.core
                 if (untilAddress < scanUntil)
                     ScanImmutableTailToRemoveFromTempKv(ref untilAddress, scanUntil, tempbContext);
 
-                var numPending = 0;
                 using var iter3 = tempKv.Log.Scan(tempKv.Log.BeginAddress, tempKv.Log.TailAddress);
                 while (iter3.GetNext())
                 {
@@ -123,20 +133,38 @@ namespace Tsavorite.core
 
                     // If record is not the latest in tempKv's memory for this key, ignore it (will not be returned if deleted)
                     if (!tempbContext.ContainsKeyInMemory(iter3, out var tempKeyAddress).Found || iter3.CurrentAddress != tempKeyAddress)
+                    {
+                        // Inform CF that we found a record that was implicitly deleted
+                        cf.OnImplicitlyDeleted(in iter3);
+
                         continue;
+                    }
 
                     // As long as there's no record of the same key whose address is >= untilAddress (scan boundary), we are safe to copy the old record
                     // to the tail. We don't know the actualAddress of the key in the main kv, but we it will not be below untilAddress.
                     var iter3AsLogSource = iter3 as ISourceLogRecord;   // Can't use 'ref' on a 'using' variable
                     var status = storebContext.CompactionCopyToTail(in iter3AsLogSource, iter3.CurrentAddress, untilAddress - 1);
-                    if (status.IsPending && ++numPending > 256)
+
+                    // TODO: Figure out a way to restore a pending buffer, like with Scan
+                    //
+                    //       Maybe remember the address?  Pass an input that saves the key if we go async?
+                    if (status.IsPending)
                     {
-                        _ = storebContext.CompletePending(wait: true);
-                        numPending = 0;
+                        _ = storebContext.CompletePendingWithOutputs(out var outputs, wait: true);
+
+                        if (outputs.Next())
+                        {
+                            status = outputs.Current.Status;
+                        }
                     }
+
+                    if (status.Found)
+                    {
+                        // Inform CF that we found a record that was implicitly deleted
+                        cf.OnImplicitlyDeleted(in iter3);
+                    }
+
                 }
-                if (numPending > 0)
-                    _ = storebContext.CompletePending(wait: true);
             }
             Log.ShiftBeginAddress(originalUntilAddress, false);
             return originalUntilAddress;

--- a/libs/storage/Tsavorite/cs/src/core/Index/StoreFunctions/IRecordTriggers.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/StoreFunctions/IRecordTriggers.cs
@@ -175,10 +175,10 @@ namespace Tsavorite.core
     }
 
     /// <summary>
-    /// Default no-op implementation of <see cref="IRecordTriggers"/>.
+    /// Default no-op implementation of <see cref="IRecordTriggers"/> and <see cref="ICompactionFunctions"/>.
     /// </summary>
     /// <remarks>It is appropriate to call methods on this instance as a no-op.</remarks>
-    public readonly struct DefaultRecordTriggers : IRecordTriggers
+    public readonly struct DefaultRecordTriggers : IRecordTriggers, ICompactionFunctions
     {
         /// <summary>Default instance.</summary>
         public static readonly DefaultRecordTriggers Instance = new();
@@ -201,6 +201,15 @@ namespace Tsavorite.core
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void OnDisposeDiskRecord(ref DiskLogRecord logRecord, DisposeReason reason) { }
+
+        public bool IsDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord)
+            where TSourceLogRecord : ISourceLogRecord
+        => false;
+
+        public void OnImplicitlyDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) 
+            where TSourceLogRecord : ISourceLogRecord
+        {
+        }
     }
 
     /// <summary>

--- a/libs/storage/Tsavorite/cs/src/core/Index/StoreFunctions/IRecordTriggers.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/StoreFunctions/IRecordTriggers.cs
@@ -206,7 +206,7 @@ namespace Tsavorite.core
             where TSourceLogRecord : ISourceLogRecord
         => false;
 
-        public void OnImplicitlyDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) 
+        public void OnImplicitlyDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord)
             where TSourceLogRecord : ISourceLogRecord
         {
         }
@@ -215,7 +215,7 @@ namespace Tsavorite.core
     /// <summary>
     /// No-op implementation of <see cref="IRecordTriggers"/> for SpanByte.
     /// </summary>
-    public readonly struct SpanByteRecordTriggers : IRecordTriggers    // TODO remove for dual
+    public readonly struct SpanByteRecordTriggers : IRecordTriggers, ICompactionFunctions    // TODO remove for dual
     {
         /// <summary>Default instance.</summary>
         public static readonly SpanByteRecordTriggers Instance = new();
@@ -235,8 +235,12 @@ namespace Tsavorite.core
         /// <inheritdoc/>
         public bool CallOnTruncate => false;
 
+        public bool IsDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) where TSourceLogRecord : ISourceLogRecord => false;
+
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void OnDisposeDiskRecord(ref DiskLogRecord logRecord, DisposeReason reason) { }
+
+        public void OnImplicitlyDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) where TSourceLogRecord : ISourceLogRecord { }
     }
 }

--- a/libs/storage/Tsavorite/cs/src/core/Index/StoreFunctions/StoreFunctions.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/StoreFunctions/StoreFunctions.cs
@@ -16,9 +16,9 @@ namespace Tsavorite.core
     /// because there is no need to wrap calls to them with additional functionality. This can be changed to redirect if such wrapper
     /// functionality is needed.
     /// </remarks>
-    public struct StoreFunctions<TKeyComparer, TRecordTriggers>(TKeyComparer keyComparer, Func<IObjectSerializer<IHeapObject>> valueSerializerCreator, TRecordTriggers recordTriggers) : IStoreFunctions
+    public struct StoreFunctions<TKeyComparer, TRecordTriggers>(TKeyComparer keyComparer, Func<IObjectSerializer<IHeapObject>> valueSerializerCreator, TRecordTriggers recordTriggers) : IStoreFunctions, ICompactionFunctions
         where TKeyComparer : IKeyComparer
-        where TRecordTriggers : IRecordTriggers
+        where TRecordTriggers : IRecordTriggers, ICompactionFunctions
     {
         #region Fields
         /// <summary>Compare two keys for equality, and get a key's hash code.</summary>
@@ -144,6 +144,20 @@ namespace Tsavorite.core
         public readonly void OnTruncate(long newBeginAddress) => recordTriggers.OnTruncate(newBeginAddress);
         #endregion Record Triggers
 
+        #region Compacton Functions
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly bool IsDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord)
+            where TSourceLogRecord : ISourceLogRecord
+            => recordTriggers.IsDeleted(in logRecord);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly void OnImplicitlyDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord)
+            where TSourceLogRecord : ISourceLogRecord
+            => recordTriggers.OnImplicitlyDeleted(in logRecord);
+        #endregion Compaction Functions
+
         #region Checkpoint Completion
         /// <inheritdoc/>
         public void SetCheckpointCompletedCallback(Action callback) => checkpointCompletionCallback = callback;
@@ -164,7 +178,7 @@ namespace Tsavorite.core
         public static StoreFunctions<TKeyComparer, TRecordTriggers> Create<TKeyComparer, TRecordTriggers>
                 (TKeyComparer keyComparer, Func<IObjectSerializer<IHeapObject>> valueSerializerCreator, TRecordTriggers recordTriggers)
             where TKeyComparer : IKeyComparer
-            where TRecordTriggers : IRecordTriggers
+            where TRecordTriggers : IRecordTriggers, ICompactionFunctions
             => new(keyComparer, valueSerializerCreator, recordTriggers);
 
         /// <summary>
@@ -179,7 +193,7 @@ namespace Tsavorite.core
         /// </summary>
         public static StoreFunctions<TKeyComparer, TRecordTriggers> Create<TKeyComparer, TRecordTriggers>(TKeyComparer keyComparer, TRecordTriggers recordTriggers)
             where TKeyComparer : IKeyComparer
-            where TRecordTriggers : IRecordTriggers
+            where TRecordTriggers : IRecordTriggers, ICompactionFunctions
             => new(keyComparer, valueSerializerCreator: null, recordTriggers);
 
         /// <summary>

--- a/libs/storage/Tsavorite/cs/test/RecordTriggersExtTests.cs
+++ b/libs/storage/Tsavorite/cs/test/RecordTriggersExtTests.cs
@@ -49,7 +49,7 @@ namespace Tsavorite.test
             public int PostCopyCount => PostCopyToTailEvents.Count;
         }
 
-        internal struct ExtRecordTriggers : IRecordTriggers
+        internal struct ExtRecordTriggers : IRecordTriggers, ICompactionFunctions
         {
             internal readonly TriggerEvents events;
             public ExtRecordTriggers(TriggerEvents events) { this.events = events; }
@@ -60,9 +60,15 @@ namespace Tsavorite.test
             public readonly bool CallPostCopyToTail => events?.CallPostCopyToTailFlag ?? false;
             public readonly bool CallOnTruncate => events?.CallOnTruncateFlag ?? false;
 
+            public bool IsDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) where TSourceLogRecord : ISourceLogRecord => false;
+
             public readonly void OnFlush(ref LogRecord logRecord, long logicalAddress)
             {
                 events?.FlushAddresses.Add(logicalAddress);
+            }
+
+            public void OnImplicitlyDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) where TSourceLogRecord : ISourceLogRecord
+            {
             }
 
             public readonly void OnTruncate(long newBeginAddress)

--- a/libs/storage/Tsavorite/cs/test/test.hlog/SpanByteLogCompactionTests.cs
+++ b/libs/storage/Tsavorite/cs/test/test.hlog/SpanByteLogCompactionTests.cs
@@ -385,6 +385,7 @@ namespace Tsavorite.test
             public bool IsDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord)
                 where TSourceLogRecord : ISourceLogRecord
                 => logRecord.ValueSpan.AsRef<ValueStruct>().vfield1 % 2 != 0;
+            public void OnImplicitlyDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) where TSourceLogRecord : ISourceLogRecord { }
         }
     }
 }

--- a/libs/storage/Tsavorite/cs/test/test.recordops/DeleteDisposeTests.cs
+++ b/libs/storage/Tsavorite/cs/test/test.recordops/DeleteDisposeTests.cs
@@ -19,15 +19,19 @@ namespace Tsavorite.test
     [TestFixture]
     internal class DeleteDisposeTests : TestBase
     {
-        internal struct TrackingRecordTriggers : IRecordTriggers
+        internal struct TrackingRecordTriggers : IRecordTriggers, ICompactionFunctions
         {
             internal readonly DisposeTracker tracker;
             public TrackingRecordTriggers(DisposeTracker tracker) => this.tracker = tracker;
             public readonly bool CallOnEvict => false;
             public readonly bool CallOnFlush => false;
             public readonly bool CallOnDiskRead => false;
+
+            public bool IsDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) where TSourceLogRecord : ISourceLogRecord => false;
             public readonly void OnDispose(ref LogRecord logRecord, DisposeReason reason) => tracker?.RecordDispose(reason);
             public readonly void OnDisposeDiskRecord(ref DiskLogRecord logRecord, DisposeReason reason) { }
+
+            public void OnImplicitlyDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) where TSourceLogRecord : ISourceLogRecord { }
         }
 
         internal class DisposeTracker
@@ -242,7 +246,7 @@ namespace Tsavorite.test
     [TestFixture]
     internal class ObjectDeleteDisposeTests : TestBase
     {
-        internal struct ObjTrackingRecordTriggers : IRecordTriggers
+        internal struct ObjTrackingRecordTriggers : IRecordTriggers, ICompactionFunctions
         {
             internal readonly ObjDisposeTracker tracker;
             public ObjTrackingRecordTriggers(ObjDisposeTracker tracker) => this.tracker = tracker;
@@ -250,10 +254,14 @@ namespace Tsavorite.test
             public readonly bool CallOnFlush => false;
             public readonly bool CallOnDiskRead => false;
 
+            public bool IsDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) where TSourceLogRecord : ISourceLogRecord => false;
+
             public readonly void OnDispose(ref LogRecord logRecord, DisposeReason reason)
                 => tracker?.RecordDispose(reason);
 
             public readonly void OnDisposeDiskRecord(ref DiskLogRecord logRecord, DisposeReason reason) { }
+
+            public void OnImplicitlyDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) where TSourceLogRecord : ISourceLogRecord { }
         }
 
         internal class ObjDisposeTracker

--- a/libs/storage/Tsavorite/cs/test/test.recordops/RecordLifecycleTests.cs
+++ b/libs/storage/Tsavorite/cs/test/test.recordops/RecordLifecycleTests.cs
@@ -132,7 +132,7 @@ namespace Tsavorite.test
             }
         }
 
-        internal struct LifecycleRecordTriggers : IRecordTriggers
+        internal struct LifecycleRecordTriggers : IRecordTriggers, ICompactionFunctions
         {
             internal readonly LifecycleTracker tracker;
             public LifecycleRecordTriggers(LifecycleTracker tracker) => this.tracker = tracker;
@@ -183,6 +183,9 @@ namespace Tsavorite.test
                 if (tracker is null) return;
                 _ = Interlocked.Increment(ref tracker.EvictCounts[(int)source]);
             }
+
+            public bool IsDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) where TSourceLogRecord : ISourceLogRecord => false;
+            public void OnImplicitlyDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) where TSourceLogRecord : ISourceLogRecord { }
         }
 
         private TsavoriteKV<LifecycleStoreFunctions, LifecycleAllocator> store;

--- a/libs/storage/Tsavorite/cs/test/test.recovery/ObjectLogCompactionTests.cs
+++ b/libs/storage/Tsavorite/cs/test/test.recovery/ObjectLogCompactionTests.cs
@@ -327,6 +327,8 @@ namespace Tsavorite.test
             public bool IsDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord)
                 where TSourceLogRecord : ISourceLogRecord
                 => false;
+
+            public void OnImplicitlyDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) where TSourceLogRecord : ISourceLogRecord { }
         }
 
         private struct EvenCompactionFunctions : ICompactionFunctions
@@ -334,6 +336,8 @@ namespace Tsavorite.test
             public readonly bool IsDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord)
                 where TSourceLogRecord : ISourceLogRecord
                 => ((TestObjectValue)logRecord.ValueObject).value % 2 != 0;
+
+            public void OnImplicitlyDeleted<TSourceLogRecord>(in TSourceLogRecord logRecord) where TSourceLogRecord : ISourceLogRecord { }
         }
     }
 }


### PR DESCRIPTION
This also threads `ICompactionFunctions` through Garnet (as `GarnetRecordTriggers`).

Changes `TsavoriteCompaction.cs` to make the callbacks where I _think_ we'd want them.

This removes pending operations from compaction to keep this easier to reason about, that will have to be restored before merging.

This is subtle enough that, while it compiles, I'm far from certain it's logically correct.

Pushing up for consultation, do not merge.