### PR TITLE
test: repro AOF data loss on graceful shutdown

### DIFF
--- a/libs/common/Testing/ExceptionInjectionType.cs
+++ b/libs/common/Testing/ExceptionInjectionType.cs
@@ -117,5 +117,11 @@ namespace Garnet.common
         /// reassembles, to exercise the publish-failure throw path in ProcessStreamChunk.
         /// </summary>
         RangeIndex_Replay_Force_Publish_Failure,
+        /// <summary>
+        /// Drop the AOF auto-commit page flush before it reaches the device, so an acked write never becomes
+        /// durable (CommittedUntilAddress lags TailAddress). Used to exercise the graceful-shutdown durability
+        /// race where the async flush has not completed before the log is disposed.
+        /// </summary>
+        Aof_AutoCommit_Drop_Page_Flush,
     }
 }

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/TsavoriteLogAllocatorImpl.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/TsavoriteLogAllocatorImpl.cs
@@ -15,13 +15,15 @@ namespace Tsavorite.core
     {
         private readonly OverflowPool<PageUnit<Empty>> freePagePool;
 
+#if DEBUG
         /// <summary>
         /// Test-only hook: when set and it returns true, <see cref="WriteAsync"/> drops the page flush instead of
         /// issuing the device write, so the bytes never become durable. This reproduces the graceful-shutdown
         /// durability race where an acked write's async flush has not completed before the log is disposed
-        /// (CommittedUntilAddress lags TailAddress). Null (and free) in production.
+        /// (CommittedUntilAddress lags TailAddress). Compiled out in Release.
         /// </summary>
         public static Func<bool> DropPageFlushTestHook;
+#endif
 
         /// <summary>Constructor</summary>
 #pragma warning disable IDE0290 // Use primary constructor
@@ -102,8 +104,10 @@ namespace Tsavorite.core
         /// <inheritdoc/>
         protected override void WriteAsync<TContext>(long flushPage, DeviceIOCompletionCallback callback, PageAsyncFlushResult<TContext> asyncResult)
         {
+#if DEBUG
             if (DropPageFlushTestHook != null && DropPageFlushTestHook())
                 return;
+#endif
 
             WriteInlinePageAsync((IntPtr)pagePointers[flushPage % BufferSize],
                     (ulong)(AlignedPageSizeBytes * flushPage),

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/TsavoriteLogAllocatorImpl.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/TsavoriteLogAllocatorImpl.cs
@@ -15,6 +15,14 @@ namespace Tsavorite.core
     {
         private readonly OverflowPool<PageUnit<Empty>> freePagePool;
 
+        /// <summary>
+        /// Test-only hook: when set and it returns true, <see cref="WriteAsync"/> drops the page flush instead of
+        /// issuing the device write, so the bytes never become durable. This reproduces the graceful-shutdown
+        /// durability race where an acked write's async flush has not completed before the log is disposed
+        /// (CommittedUntilAddress lags TailAddress). Null (and free) in production.
+        /// </summary>
+        public static Func<bool> DropPageFlushTestHook;
+
         /// <summary>Constructor</summary>
 #pragma warning disable IDE0290 // Use primary constructor
         public TsavoriteLogAllocatorImpl(AllocatorSettings settings)
@@ -94,6 +102,9 @@ namespace Tsavorite.core
         /// <inheritdoc/>
         protected override void WriteAsync<TContext>(long flushPage, DeviceIOCompletionCallback callback, PageAsyncFlushResult<TContext> asyncResult)
         {
+            if (DropPageFlushTestHook != null && DropPageFlushTestHook())
+                return;
+
             WriteInlinePageAsync((IntPtr)pagePointers[flushPage % BufferSize],
                     (ulong)(AlignedPageSizeBytes * flushPage),
                     (uint)AlignedPageSizeBytes,

--- a/test/standalone/Garnet.test/RespAofGracefulShutdownDurabilityInjectedTests.cs
+++ b/test/standalone/Garnet.test/RespAofGracefulShutdownDurabilityInjectedTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#if DEBUG
+using System;
+using System.Threading;
+using Garnet.common;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using StackExchange.Redis;
+using Tsavorite.core;
+
+namespace Garnet.test
+{
+    /// <summary>
+    /// Forces the auto-commit (<c>CommitFrequencyMs = 0</c>) durability race deterministically: a SET is acked
+    /// without waiting for its commit, its device page flush is dropped, and a graceful shutdown then loses it.
+    /// DEBUG-only: relies on <see cref="ExceptionInjectionHelper"/> and the injected page-flush hook.
+    /// </summary>
+    [TestFixture]
+    public class RespAofGracefulShutdownDurabilityInjectedTests : TestBase
+    {
+        GarnetServer server;
+
+        [SetUp]
+        public void Setup()
+        {
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            server?.Dispose();
+            TestUtils.OnTearDown();
+        }
+
+        /// <summary>
+        /// With auto-commit on, the SET's page flush is dropped so the bytes never reach the device and
+        /// <c>CommittedUntilAddress</c> lags <c>TailAddress</c> - exactly the observed failure signature. A graceful
+        /// shutdown in that window loses the acked write, proving auto-commit is not durable on graceful shutdown when
+        /// the flush has not completed.
+        /// </summary>
+        [Test]
+        public void AutoCommitUnflushedWriteLostOnGracefulShutdown()
+        {
+            const ExceptionInjectionType dropFlush = ExceptionInjectionType.Aof_AutoCommit_Drop_Page_Flush;
+            using var flushDropped = new ManualResetEventSlim(false);
+
+            TsavoriteLogAllocatorImpl.DropPageFlushTestHook = () =>
+            {
+                if (!ExceptionInjectionHelper.IsEnabled(dropFlush))
+                    return false;
+
+                flushDropped.Set();
+                return true;
+            };
+
+            try
+            {
+                server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableAOF: true, commitFrequencyMs: 0);
+                server.Start();
+
+                ExceptionInjectionHelper.EnableException(dropFlush);
+
+                using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
+                {
+                    var db = redis.GetDatabase(0);
+                    ClassicAssert.IsTrue(db.StringSet("k", "v"), "SET should be acknowledged to the client");
+                }
+
+                ClassicAssert.IsTrue(flushDropped.Wait(TimeSpan.FromSeconds(10)),
+                    "the auto-commit page flush should have been attempted (and dropped) before shutdown");
+
+                server.Dispose(false);
+                server = null;
+            }
+            finally
+            {
+                ExceptionInjectionHelper.DisableException(dropFlush);
+                TsavoriteLogAllocatorImpl.DropPageFlushTestHook = null;
+            }
+
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, tryRecover: true, enableAOF: true, commitFrequencyMs: 0);
+            server.Start();
+
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
+            {
+                var db = redis.GetDatabase(0);
+                ClassicAssert.IsFalse(db.KeyExists("k"),
+                    "acked write must be LOST: its auto-commit flush had not reached the device when graceful shutdown occurred");
+            }
+        }
+    }
+}
+#endif

--- a/test/standalone/Garnet.test/RespAofGracefulShutdownDurabilityInjectedTests.cs
+++ b/test/standalone/Garnet.test/RespAofGracefulShutdownDurabilityInjectedTests.cs
@@ -18,6 +18,7 @@ namespace Garnet.test
     /// DEBUG-only: relies on <see cref="ExceptionInjectionHelper"/> and the injected page-flush hook.
     /// </summary>
     [TestFixture]
+    [NonParallelizable]
     public class RespAofGracefulShutdownDurabilityInjectedTests : TestBase
     {
         GarnetServer server;
@@ -61,12 +62,19 @@ namespace Garnet.test
                 server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableAOF: true, commitFrequencyMs: 0);
                 server.Start();
 
+                using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
+                {
+                    var db = redis.GetDatabase(0);
+                    ClassicAssert.IsTrue(db.StringSet("control", "cv"), "control SET should be acknowledged");
+                    db.Execute("COMMITAOF");
+                }
+
                 ExceptionInjectionHelper.EnableException(dropFlush);
 
                 using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
                 {
                     var db = redis.GetDatabase(0);
-                    ClassicAssert.IsTrue(db.StringSet("k", "v"), "SET should be acknowledged to the client");
+                    ClassicAssert.IsTrue(db.StringSet("k", "v"), "target SET should be acknowledged to the client");
                 }
 
                 ClassicAssert.IsTrue(flushDropped.Wait(TimeSpan.FromSeconds(10)),
@@ -87,8 +95,10 @@ namespace Garnet.test
             using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
             {
                 var db = redis.GetDatabase(0);
+                ClassicAssert.AreEqual("cv", db.StringGet("control").ToString(),
+                    "explicitly committed control write must survive recovery (proves the AOF/recovery pipeline works)");
                 ClassicAssert.IsFalse(db.KeyExists("k"),
-                    "acked write must be LOST: its auto-commit flush had not reached the device when graceful shutdown occurred");
+                    "target write must be LOST: its auto-commit flush had not reached the device when graceful shutdown occurred");
             }
         }
     }

--- a/test/standalone/Garnet.test/RespAofGracefulShutdownDurabilityTests.cs
+++ b/test/standalone/Garnet.test/RespAofGracefulShutdownDurabilityTests.cs
@@ -31,11 +31,13 @@ namespace Garnet.test
         }
 
         /// <summary>
-        /// With a high commit frequency (auto-commit disabled and the periodic commit far from firing),
-        /// a SET is acked but never committed. A graceful shutdown before the periodic commit loses it.
+        /// With a high commit frequency (auto-commit disabled and the periodic commit far from firing), a write
+        /// that is not explicitly committed is acked but never made durable, so a graceful shutdown loses it while
+        /// an explicitly committed control write survives. This characterizes the shutdown contract: graceful
+        /// <c>Dispose</c> does not flush the AOF, so durability requires an explicit commit (COMMITAOF/WaitForCommit).
         /// </summary>
         [Test]
-        public void HighCommitFrequencyLosesAckedWriteOnGracefulShutdown()
+        public void UncommittedWriteLostButCommittedWriteSurvivesOnGracefulShutdown()
         {
             const int farOffCommitMs = 60 * 60 * 1000;
 
@@ -45,7 +47,9 @@ namespace Garnet.test
             using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
             {
                 var db = redis.GetDatabase(0);
-                ClassicAssert.IsTrue(db.StringSet("k", "v"), "SET should be acknowledged to the client");
+                ClassicAssert.IsTrue(db.StringSet("control", "cv"), "control SET should be acknowledged");
+                db.Execute("COMMITAOF");
+                ClassicAssert.IsTrue(db.StringSet("k", "v"), "target SET should be acknowledged to the client");
             }
 
             server.Dispose(false);
@@ -57,8 +61,10 @@ namespace Garnet.test
             using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
             {
                 var db = redis.GetDatabase(0);
+                ClassicAssert.AreEqual("cv", db.StringGet("control").ToString(),
+                    "explicitly committed control write must survive recovery (proves the AOF/recovery pipeline works)");
                 ClassicAssert.IsFalse(db.KeyExists("k"),
-                    "acked write must be LOST: it was never committed and graceful shutdown does not flush the AOF");
+                    "target write must be LOST: it was never committed and graceful shutdown does not flush the AOF");
             }
         }
     }

--- a/test/standalone/Garnet.test/RespAofGracefulShutdownDurabilityTests.cs
+++ b/test/standalone/Garnet.test/RespAofGracefulShutdownDurabilityTests.cs
@@ -1,13 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System;
-using System.Threading;
-using Garnet.common;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using StackExchange.Redis;
-using Tsavorite.core;
 
 namespace Garnet.test
 {
@@ -65,66 +61,5 @@ namespace Garnet.test
                     "acked write must be LOST: it was never committed and graceful shutdown does not flush the AOF");
             }
         }
-
-#if DEBUG
-        /// <summary>
-        /// With auto-commit on (<c>CommitFrequencyMs = 0</c>), a SET is acked without waiting for its commit. The
-        /// page flush that would make it durable is dropped (via <see cref="TsavoriteLogAllocatorImpl.DropPageFlushTestHook"/>
-        /// gated by an <see cref="ExceptionInjectionHelper"/> flag), so the bytes never reach the device and
-        /// <c>CommittedUntilAddress</c> lags <c>TailAddress</c> - exactly the observed failure signature. A graceful
-        /// shutdown in that window loses the acked write, proving auto-commit is not durable on graceful shutdown when
-        /// the flush has not completed. DEBUG-only: the injection flag is a no-op in Release.
-        /// </summary>
-        [Test]
-        public void AutoCommitUnflushedWriteLostOnGracefulShutdown()
-        {
-            const ExceptionInjectionType dropFlush = ExceptionInjectionType.Aof_AutoCommit_Drop_Page_Flush;
-            using var flushDropped = new ManualResetEventSlim(false);
-
-            TsavoriteLogAllocatorImpl.DropPageFlushTestHook = () =>
-            {
-                if (!ExceptionInjectionHelper.IsEnabled(dropFlush))
-                    return false;
-
-                flushDropped.Set();
-                return true;
-            };
-
-            try
-            {
-                server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableAOF: true, commitFrequencyMs: 0);
-                server.Start();
-
-                ExceptionInjectionHelper.EnableException(dropFlush);
-
-                using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
-                {
-                    var db = redis.GetDatabase(0);
-                    ClassicAssert.IsTrue(db.StringSet("k", "v"), "SET should be acknowledged to the client");
-                }
-
-                ClassicAssert.IsTrue(flushDropped.Wait(TimeSpan.FromSeconds(10)),
-                    "the auto-commit page flush should have been attempted (and dropped) before shutdown");
-
-                server.Dispose(false);
-                server = null;
-            }
-            finally
-            {
-                ExceptionInjectionHelper.DisableException(dropFlush);
-                TsavoriteLogAllocatorImpl.DropPageFlushTestHook = null;
-            }
-
-            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, tryRecover: true, enableAOF: true, commitFrequencyMs: 0);
-            server.Start();
-
-            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
-            {
-                var db = redis.GetDatabase(0);
-                ClassicAssert.IsFalse(db.KeyExists("k"),
-                    "acked write must be LOST: its auto-commit flush had not reached the device when graceful shutdown occurred");
-            }
-        }
-#endif
     }
 }

--- a/test/standalone/Garnet.test/RespAofGracefulShutdownDurabilityTests.cs
+++ b/test/standalone/Garnet.test/RespAofGracefulShutdownDurabilityTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Threading;
+using Garnet.common;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using StackExchange.Redis;
+using Tsavorite.core;
+
+namespace Garnet.test
+{
+    /// <summary>
+    /// Proves that a write which was acknowledged to the client but whose AOF commit has not become
+    /// durable is LOST on a graceful shutdown. Graceful <c>Dispose</c> cancels the commit task and tears
+    /// the log down without flushing, so recovery only sees data up to <c>CommittedUntilAddress</c>.
+    /// </summary>
+    [TestFixture]
+    public class RespAofGracefulShutdownDurabilityTests : TestBase
+    {
+        GarnetServer server;
+
+        [SetUp]
+        public void Setup()
+        {
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            server?.Dispose();
+            TestUtils.OnTearDown();
+        }
+
+        /// <summary>
+        /// With a high commit frequency (auto-commit disabled and the periodic commit far from firing),
+        /// a SET is acked but never committed. A graceful shutdown before the periodic commit loses it.
+        /// </summary>
+        [Test]
+        public void HighCommitFrequencyLosesAckedWriteOnGracefulShutdown()
+        {
+            const int farOffCommitMs = 60 * 60 * 1000;
+
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableAOF: true, commitFrequencyMs: farOffCommitMs);
+            server.Start();
+
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
+            {
+                var db = redis.GetDatabase(0);
+                ClassicAssert.IsTrue(db.StringSet("k", "v"), "SET should be acknowledged to the client");
+            }
+
+            server.Dispose(false);
+            server = null;
+
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, tryRecover: true, enableAOF: true, commitFrequencyMs: farOffCommitMs);
+            server.Start();
+
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
+            {
+                var db = redis.GetDatabase(0);
+                ClassicAssert.IsFalse(db.KeyExists("k"),
+                    "acked write must be LOST: it was never committed and graceful shutdown does not flush the AOF");
+            }
+        }
+
+#if DEBUG
+        /// <summary>
+        /// With auto-commit on (<c>CommitFrequencyMs = 0</c>), a SET is acked without waiting for its commit. The
+        /// page flush that would make it durable is dropped (via <see cref="TsavoriteLogAllocatorImpl.DropPageFlushTestHook"/>
+        /// gated by an <see cref="ExceptionInjectionHelper"/> flag), so the bytes never reach the device and
+        /// <c>CommittedUntilAddress</c> lags <c>TailAddress</c> - exactly the observed failure signature. A graceful
+        /// shutdown in that window loses the acked write, proving auto-commit is not durable on graceful shutdown when
+        /// the flush has not completed. DEBUG-only: the injection flag is a no-op in Release.
+        /// </summary>
+        [Test]
+        public void AutoCommitUnflushedWriteLostOnGracefulShutdown()
+        {
+            const ExceptionInjectionType dropFlush = ExceptionInjectionType.Aof_AutoCommit_Drop_Page_Flush;
+            using var flushDropped = new ManualResetEventSlim(false);
+
+            TsavoriteLogAllocatorImpl.DropPageFlushTestHook = () =>
+            {
+                if (!ExceptionInjectionHelper.IsEnabled(dropFlush))
+                    return false;
+
+                flushDropped.Set();
+                return true;
+            };
+
+            try
+            {
+                server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableAOF: true, commitFrequencyMs: 0);
+                server.Start();
+
+                ExceptionInjectionHelper.EnableException(dropFlush);
+
+                using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
+                {
+                    var db = redis.GetDatabase(0);
+                    ClassicAssert.IsTrue(db.StringSet("k", "v"), "SET should be acknowledged to the client");
+                }
+
+                ClassicAssert.IsTrue(flushDropped.Wait(TimeSpan.FromSeconds(10)),
+                    "the auto-commit page flush should have been attempted (and dropped) before shutdown");
+
+                server.Dispose(false);
+                server = null;
+            }
+            finally
+            {
+                ExceptionInjectionHelper.DisableException(dropFlush);
+                TsavoriteLogAllocatorImpl.DropPageFlushTestHook = null;
+            }
+
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, tryRecover: true, enableAOF: true, commitFrequencyMs: 0);
+            server.Start();
+
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
+            {
+                var db = redis.GetDatabase(0);
+                ClassicAssert.IsFalse(db.KeyExists("k"),
+                    "acked write must be LOST: its auto-commit flush had not reached the device when graceful shutdown occurred");
+            }
+        }
+#endif
+    }
+}


### PR DESCRIPTION
## Summary

Adds two standalone (String-`SET`) tests that prove a write **acknowledged to the client is lost after a graceful shutdown** when its AOF commit has not yet become durable. These document the root cause behind the intermittent CI failure in `ClusterMigrateRangeIndexCheckpointThenRecover` ("post-checkpoint RI.SET should survive recovery").

> Draft / repro-only: these tests intentionally assert the **current (buggy) behavior** (data loss). They document the bug and should be flipped to assert survival once the fix lands.

## Root cause

With auto-commit (`CommitFrequencyMs = 0`), `Enqueue` calls `Commit()`, which only *proposes* a commit — the actual durability (device page flush -> `CommitCallback` -> `SerialCommitCallbackWorker` advancing `CommittedUntilAddress`) happens **asynchronously**. The client `SET` returns before that completes.

`StoreWrapper.Dispose()` does **not** flush/commit the AOF: it cancels the commit task and tears the log down (`TrueDispose` -> `commitQueue.Dispose()` does not join the worker; `allocator.Dispose()` does not flush; `CompleteLog()`/`WaitForCommit()` are never called). So if the async flush has not completed when `Dispose` runs, the tail pages (with the last write) are dropped and recovery never replays them.

Under CPU/GC contention (e.g. a preceding test in the same process) the async flush loses the race against `Dispose` — which is why the failure is intermittent and only reproduces after a prior test.

Observed signature at dispose in the failing runs: `tail=13344`, `committedUntil=13176` (the range holding the post-checkpoint write was never flushed).

## Tests

- **`HighCommitFrequencyLosesAckedWriteOnGracefulShutdown`** — far-off `CommitFrequencyMs` (auto-commit off, periodic commit never fires): the `SET` is never committed, so graceful shutdown loses it. Config-agnostic, deterministic.
- **`AutoCommitUnflushedWriteLostOnGracefulShutdown`** (DEBUG-only) — `CommitFrequencyMs=0` (auto-commit) with the page flush dropped via a new `ExceptionInjectionType.Aof_AutoCommit_Drop_Page_Flush` gating `TsavoriteLogAllocatorImpl.DropPageFlushTestHook`, reproducing the exact `committedUntil < tail` signature.

## Changes

- `libs/common/Testing/ExceptionInjectionType.cs` — new injection type.
- `libs/storage/Tsavorite/cs/src/core/Allocator/TsavoriteLogAllocatorImpl.cs` — `DropPageFlushTestHook` (null/free in production).
- `test/standalone/Garnet.test/RespAofGracefulShutdownDurabilityTests.cs` — the two tests.

Both pass deterministically (3/3 locally, Debug/net8.0).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>