### PR TITLE
Fix LoadModuleCS parsing for module paths containing spaces (#1951)

### DIFF
--- a/libs/common/FileUtils.cs
+++ b/libs/common/FileUtils.cs
@@ -68,7 +68,7 @@ namespace Garnet.common
             {
                 if (File.Exists(path))
                 {
-                    if ((anyExtension || Regex.IsMatch(path, extensionPattern, RegexOptions.IgnoreCase)) &&
+                    if ((anyExtension || Regex.IsMatch(path, extensionPattern)) &&
                         !ignoreFiles.Contains(Path.GetFileName(path)))
                     {
                         tmpFiles.Add(path);
@@ -98,7 +98,7 @@ namespace Garnet.common
 
                 foreach (var filePath in filePaths)
                 {
-                    if ((anyExtension || Regex.IsMatch(filePath, extensionPattern, RegexOptions.IgnoreCase)) &&
+                    if ((anyExtension || Regex.IsMatch(filePath, extensionPattern)) &&
                         !ignoreFiles.Contains(Path.GetFileName(path)))
                     {
                         tmpFiles.Add(filePath);

--- a/libs/common/FileUtils.cs
+++ b/libs/common/FileUtils.cs
@@ -68,7 +68,7 @@ namespace Garnet.common
             {
                 if (File.Exists(path))
                 {
-                    if ((anyExtension || Regex.IsMatch(path, extensionPattern)) &&
+                    if ((anyExtension || Regex.IsMatch(path, extensionPattern, RegexOptions.IgnoreCase)) &&
                         !ignoreFiles.Contains(Path.GetFileName(path)))
                     {
                         tmpFiles.Add(path);
@@ -98,7 +98,7 @@ namespace Garnet.common
 
                 foreach (var filePath in filePaths)
                 {
-                    if ((anyExtension || Regex.IsMatch(filePath, extensionPattern)) &&
+                    if ((anyExtension || Regex.IsMatch(filePath, extensionPattern, RegexOptions.IgnoreCase)) &&
                         !ignoreFiles.Contains(Path.GetFileName(path)))
                     {
                         tmpFiles.Add(filePath);

--- a/libs/host/Configuration/OptionsValidators.cs
+++ b/libs/host/Configuration/OptionsValidators.cs
@@ -320,7 +320,11 @@ namespace Garnet
             foreach (var filePathArg in filePaths)
             {
                 if (!ModuleUtils.TryParseModuleSpec(filePathArg, out var filePath, out _))
+                {
+                    isValid = false;
+                    errorSb.AppendLine($"Invalid module specification: '{filePathArg}'.");
                     continue;
+                }
                 var result = base.IsValid(filePath, validationContext);
                 if (result != null && result != ValidationResult.Success)
                 {

--- a/libs/host/Configuration/OptionsValidators.cs
+++ b/libs/host/Configuration/OptionsValidators.cs
@@ -319,7 +319,8 @@ namespace Garnet
             var isValid = true;
             foreach (var filePathArg in filePaths)
             {
-                var filePath = filePathArg.Split(' ')[0];
+                if (!ModuleUtils.TryParseModuleSpec(filePathArg, out var filePath, out _))
+                    continue;
                 var result = base.IsValid(filePath, validationContext);
                 if (result != null && result != ValidationResult.Success)
                 {

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -407,12 +407,8 @@ namespace Garnet
 
             foreach (var moduleCS in opts.LoadModuleCS)
             {
-                var moduleCSData = moduleCS.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                if (moduleCSData.Length < 1)
+                if (!ModuleUtils.TryParseModuleSpec(moduleCS, out var modulePath, out var moduleArgs))
                     continue;
-
-                var modulePath = moduleCSData[0];
-                var moduleArgs = moduleCSData.Length > 1 ? moduleCSData.Skip(1).ToArray() : [];
 
                 if (!ModuleUtils.LoadAssemblies([modulePath], null, opts.ExtensionAllowUnsignedAssemblies,
                         out var loadedAssemblies, out var errorMsg, ignorePathCheckWhenUndefined: true)

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -415,8 +415,20 @@ namespace Garnet
                 }
 
                 if (!ModuleUtils.LoadAssemblies([modulePath], null, opts.ExtensionAllowUnsignedAssemblies,
-                        out var loadedAssemblies, out var errorMsg, ignorePathCheckWhenUndefined: true)
-                    || !ModuleRegistrar.Instance.LoadModule(customCommandManager, loadedAssemblies.ToList()[0], moduleArgs, logger, out errorMsg))
+                        out var loadedAssemblies, out var errorMsg, ignorePathCheckWhenUndefined: true))
+                {
+                    logger?.LogError("Module {0} failed to load with error {1}", modulePath, Encoding.UTF8.GetString(errorMsg));
+                    continue;
+                }
+
+                var assembliesList = loadedAssemblies.ToList();
+                if (assembliesList.Count == 0)
+                {
+                    logger?.LogError("Module {0} failed to load: no assembly was found at the specified path.", modulePath);
+                    continue;
+                }
+
+                if (!ModuleRegistrar.Instance.LoadModule(customCommandManager, assembliesList[0], moduleArgs, logger, out errorMsg))
                 {
                     logger?.LogError("Module {0} failed to load with error {1}", modulePath, Encoding.UTF8.GetString(errorMsg));
                 }

--- a/libs/host/GarnetServer.cs
+++ b/libs/host/GarnetServer.cs
@@ -408,7 +408,11 @@ namespace Garnet
             foreach (var moduleCS in opts.LoadModuleCS)
             {
                 if (!ModuleUtils.TryParseModuleSpec(moduleCS, out var modulePath, out var moduleArgs))
+                {
+                    if (!string.IsNullOrWhiteSpace(moduleCS))
+                        logger?.LogError("Invalid module specification: {0}", moduleCS);
                     continue;
+                }
 
                 if (!ModuleUtils.LoadAssemblies([modulePath], null, opts.ExtensionAllowUnsignedAssemblies,
                         out var loadedAssemblies, out var errorMsg, ignorePathCheckWhenUndefined: true)

--- a/libs/server/Module/ModuleUtils.cs
+++ b/libs/server/Module/ModuleUtils.cs
@@ -94,7 +94,7 @@ namespace Garnet.server
 
                 foreach (var ext in ModuleAssemblyExtensions)
                 {
-                    if (candidatePath.EndsWith(ext, StringComparison.OrdinalIgnoreCase))
+                    if (candidatePath.EndsWith(ext, StringComparison.Ordinal))
                     {
                         modulePath = candidatePath;
                         moduleArgs = spaceIdx < 0 ? [] : SplitModuleArgs(spec[(spaceIdx + 1)..]);

--- a/libs/server/Module/ModuleUtils.cs
+++ b/libs/server/Module/ModuleUtils.cs
@@ -16,33 +16,22 @@ namespace Garnet.server
     public class ModuleUtils
     {
         /// <summary>
-        /// Recognized file extensions for a C# module assembly.
-        /// </summary>
-        private static readonly string[] ModuleAssemblyExtensions = [".dll", ".exe"];
-
-        /// <summary>
         /// Parses a single module specification (as provided to the <c>--loadmodulecs</c> option) into its
         /// module path and optional arguments. The specification has the form
         /// <c>&lt;module-path&gt; [arg0 arg1 ...]</c>, where the path and each argument are separated by spaces.
         ///
-        /// Because a module path may itself contain spaces, the path is delimited from its arguments as follows:
+        /// The path is delimited from its arguments deterministically:
         /// <list type="number">
         /// <item>If the specification begins with a double quote, the path is the text between that quote and the
-        /// next double quote, and any remaining (space-separated) text is treated as the module arguments. Such a
-        /// specification is invalid (returns false) if the quote is not terminated or the quoted path is empty or
-        /// whitespace-only.</item>
-        /// <item>Otherwise, the filesystem is probed: starting from the whole specification, trailing space-separated
-        /// tokens are progressively treated as arguments until the remaining prefix exists as a file or directory
-        /// (the longest matching prefix is used as the path). This reliably handles paths containing spaces.</item>
-        /// <item>If no prefix exists on disk, the path is the text up to and including the first space-separated
-        /// token that ends with a recognized module assembly extension (.dll or .exe) - preserving any spaces
-        /// within the path - and the remaining tokens are treated as the module arguments.</item>
-        /// <item>If no such token is found either, the entire specification is treated as the module path with no
-        /// arguments.</item>
+        /// next double quote (so it may contain spaces), and any remaining space-separated text is treated as the
+        /// module arguments. Such a specification is invalid (returns false) if the quote is not terminated or the
+        /// quoted path is empty or whitespace-only.</item>
+        /// <item>Otherwise, the first space-separated token is the module path and the remaining tokens are its
+        /// arguments. A path that contains spaces must therefore be wrapped in double quotes.</item>
         /// </list>
         /// </summary>
         /// <param name="moduleSpec">The raw module specification string.</param>
-        /// <param name="modulePath">The parsed module path (may contain spaces).</param>
+        /// <param name="modulePath">The parsed module path.</param>
         /// <param name="moduleArgs">The parsed module arguments (empty if none).</param>
         /// <returns>True if a non-empty module path was parsed; otherwise false (e.g. empty, whitespace-only or
         /// malformed quoted specification).</returns>
@@ -56,9 +45,8 @@ namespace Garnet.server
 
             var spec = moduleSpec.Trim();
 
-            // 1) Explicitly double-quoted path: "<path>" [args...]
-            //    A leading double quote signals an explicitly quoted path; it must be terminated and
-            //    contain a non-empty, non-whitespace path, otherwise the specification is invalid.
+            // A double-quoted path may contain spaces: "<path>" [args...]. The quote must be terminated and the
+            // quoted path must be non-empty and non-whitespace, otherwise the specification is invalid.
             if (spec[0] == '"')
             {
                 var closingQuoteIdx = spec.IndexOf('"', 1);
@@ -74,75 +62,16 @@ namespace Garnet.server
                 return true;
             }
 
-            // 2) Unquoted path: prefer a path that actually exists on disk. Try the longest candidate
-            //    (the whole specification) first, then progressively strip trailing space-separated tokens
-            //    and treat them as arguments, until the remaining prefix exists as a file or directory. The
-            //    module and any arguments are resolved locally (during config validation and server startup),
-            //    so this reliably delimits a path containing spaces from its arguments, regardless of extension
-            //    casing or '.dll'/'.exe' fragments appearing in directory names.
-            if (TrySplitAtExistingPath(spec, out modulePath, out moduleArgs))
-                return true;
-
-            // 3) The path does not exist yet: fall back to the module assembly extension (.dll/.exe) to delimit
-            //    the path from its arguments, still preserving spaces within the path.
-            var tokenStart = 0;
-            while (tokenStart < spec.Length)
-            {
-                var spaceIdx = spec.IndexOf(' ', tokenStart);
-                var pathEnd = spaceIdx < 0 ? spec.Length : spaceIdx;
-                var candidatePath = spec[..pathEnd];
-
-                foreach (var ext in ModuleAssemblyExtensions)
-                {
-                    if (candidatePath.EndsWith(ext, StringComparison.Ordinal))
-                    {
-                        modulePath = candidatePath;
-                        moduleArgs = spaceIdx < 0 ? [] : SplitModuleArgs(spec[(spaceIdx + 1)..]);
-                        return true;
-                    }
-                }
-
-                if (spaceIdx < 0)
-                    break;
-                tokenStart = spaceIdx + 1;
-            }
-
-            // 4) Fallback: no recognized module extension token; treat the entire specification as the path.
-            modulePath = spec;
+            // Otherwise the path must not contain spaces: the first space-separated token is the path and the
+            // remaining tokens are its arguments. To use a path containing spaces, wrap it in double quotes.
+            var tokens = spec.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            modulePath = tokens[0];
+            moduleArgs = tokens.Length > 1 ? tokens[1..] : [];
             return true;
         }
 
         private static string[] SplitModuleArgs(string args)
             => args.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-
-        /// <summary>
-        /// Attempts to delimit the module path from its arguments by probing the filesystem. Starting from the
-        /// whole specification, trailing space-separated tokens are progressively treated as arguments until the
-        /// remaining prefix exists on disk as a file or directory (the longest matching prefix wins). This handles
-        /// paths that contain spaces without relying on the module assembly extension.
-        /// </summary>
-        private static bool TrySplitAtExistingPath(string spec, out string modulePath, out string[] moduleArgs)
-        {
-            modulePath = null;
-            moduleArgs = [];
-
-            var pathEnd = spec.Length;
-            while (true)
-            {
-                var candidatePath = spec[..pathEnd];
-                if (File.Exists(candidatePath) || Directory.Exists(candidatePath))
-                {
-                    modulePath = candidatePath;
-                    moduleArgs = pathEnd == spec.Length ? [] : SplitModuleArgs(spec[(pathEnd + 1)..]);
-                    return true;
-                }
-
-                var lastSpace = spec.LastIndexOf(' ', pathEnd - 1);
-                if (lastSpace < 0)
-                    return false;
-                pathEnd = lastSpace;
-            }
-        }
 
         /// <summary>
         /// Loads only the assemblies that the module at <paramref name="modulePath"/> references (transitively)

--- a/libs/server/Module/ModuleUtils.cs
+++ b/libs/server/Module/ModuleUtils.cs
@@ -31,11 +31,14 @@ namespace Garnet.server
         /// next double quote, and any remaining (space-separated) text is treated as the module arguments. Such a
         /// specification is invalid (returns false) if the quote is not terminated or the quoted path is empty or
         /// whitespace-only.</item>
-        /// <item>Otherwise, the path is the text up to and including the first space-separated token that ends with
-        /// a recognized module assembly extension (.dll or .exe) - preserving any spaces within the path - and the
-        /// remaining tokens are treated as the module arguments.</item>
-        /// <item>If no such token is found (e.g. the path points to a directory), the entire specification is
-        /// treated as the module path with no arguments.</item>
+        /// <item>Otherwise, the filesystem is probed: starting from the whole specification, trailing space-separated
+        /// tokens are progressively treated as arguments until the remaining prefix exists as a file or directory
+        /// (the longest matching prefix is used as the path). This reliably handles paths containing spaces.</item>
+        /// <item>If no prefix exists on disk, the path is the text up to and including the first space-separated
+        /// token that ends with a recognized module assembly extension (.dll or .exe) - preserving any spaces
+        /// within the path - and the remaining tokens are treated as the module arguments.</item>
+        /// <item>If no such token is found either, the entire specification is treated as the module path with no
+        /// arguments.</item>
         /// </list>
         /// </summary>
         /// <param name="moduleSpec">The raw module specification string.</param>
@@ -71,8 +74,17 @@ namespace Garnet.server
                 return true;
             }
 
-            // 2) Unquoted path: delimit the path from its arguments using the module assembly extension,
-            //    so that spaces within the path are preserved (e.g. "C:\Program Files\My Module.dll arg0").
+            // 2) Unquoted path: prefer a path that actually exists on disk. Try the longest candidate
+            //    (the whole specification) first, then progressively strip trailing space-separated tokens
+            //    and treat them as arguments, until the remaining prefix exists as a file or directory. The
+            //    module and any arguments are resolved locally (during config validation and server startup),
+            //    so this reliably delimits a path containing spaces from its arguments, regardless of extension
+            //    casing or '.dll'/'.exe' fragments appearing in directory names.
+            if (TrySplitAtExistingPath(spec, out modulePath, out moduleArgs))
+                return true;
+
+            // 3) The path does not exist yet: fall back to the module assembly extension (.dll/.exe) to delimit
+            //    the path from its arguments, still preserving spaces within the path.
             var tokenStart = 0;
             while (tokenStart < spec.Length)
             {
@@ -95,13 +107,42 @@ namespace Garnet.server
                 tokenStart = spaceIdx + 1;
             }
 
-            // 3) Fallback: no recognized module extension token; treat the entire specification as the path.
+            // 4) Fallback: no recognized module extension token; treat the entire specification as the path.
             modulePath = spec;
             return true;
         }
 
         private static string[] SplitModuleArgs(string args)
             => args.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        /// <summary>
+        /// Attempts to delimit the module path from its arguments by probing the filesystem. Starting from the
+        /// whole specification, trailing space-separated tokens are progressively treated as arguments until the
+        /// remaining prefix exists on disk as a file or directory (the longest matching prefix wins). This handles
+        /// paths that contain spaces without relying on the module assembly extension.
+        /// </summary>
+        private static bool TrySplitAtExistingPath(string spec, out string modulePath, out string[] moduleArgs)
+        {
+            modulePath = null;
+            moduleArgs = [];
+
+            var pathEnd = spec.Length;
+            while (true)
+            {
+                var candidatePath = spec[..pathEnd];
+                if (File.Exists(candidatePath) || Directory.Exists(candidatePath))
+                {
+                    modulePath = candidatePath;
+                    moduleArgs = pathEnd == spec.Length ? [] : SplitModuleArgs(spec[(pathEnd + 1)..]);
+                    return true;
+                }
+
+                var lastSpace = spec.LastIndexOf(' ', pathEnd - 1);
+                if (lastSpace < 0)
+                    return false;
+                pathEnd = lastSpace;
+            }
+        }
 
         /// <summary>
         /// Loads only the assemblies that the module at <paramref name="modulePath"/> references (transitively)

--- a/libs/server/Module/ModuleUtils.cs
+++ b/libs/server/Module/ModuleUtils.cs
@@ -28,7 +28,9 @@ namespace Garnet.server
         /// Because a module path may itself contain spaces, the path is delimited from its arguments as follows:
         /// <list type="number">
         /// <item>If the specification begins with a double quote, the path is the text between that quote and the
-        /// next double quote, and any remaining (space-separated) text is treated as the module arguments.</item>
+        /// next double quote, and any remaining (space-separated) text is treated as the module arguments. Such a
+        /// specification is invalid (returns false) if the quote is not terminated or the quoted path is empty or
+        /// whitespace-only.</item>
         /// <item>Otherwise, the path is the text up to and including the first space-separated token that ends with
         /// a recognized module assembly extension (.dll or .exe) - preserving any spaces within the path - and the
         /// remaining tokens are treated as the module arguments.</item>
@@ -39,7 +41,8 @@ namespace Garnet.server
         /// <param name="moduleSpec">The raw module specification string.</param>
         /// <param name="modulePath">The parsed module path (may contain spaces).</param>
         /// <param name="moduleArgs">The parsed module arguments (empty if none).</param>
-        /// <returns>True if a non-empty module path was parsed; otherwise false.</returns>
+        /// <returns>True if a non-empty module path was parsed; otherwise false (e.g. empty, whitespace-only or
+        /// malformed quoted specification).</returns>
         public static bool TryParseModuleSpec(string moduleSpec, out string modulePath, out string[] moduleArgs)
         {
             modulePath = null;
@@ -51,15 +54,21 @@ namespace Garnet.server
             var spec = moduleSpec.Trim();
 
             // 1) Explicitly double-quoted path: "<path>" [args...]
+            //    A leading double quote signals an explicitly quoted path; it must be terminated and
+            //    contain a non-empty, non-whitespace path, otherwise the specification is invalid.
             if (spec[0] == '"')
             {
                 var closingQuoteIdx = spec.IndexOf('"', 1);
-                if (closingQuoteIdx > 1)
-                {
-                    modulePath = spec[1..closingQuoteIdx];
-                    moduleArgs = SplitModuleArgs(spec[(closingQuoteIdx + 1)..]);
-                    return modulePath.Length > 0;
-                }
+                if (closingQuoteIdx < 0)
+                    return false;
+
+                var quotedPath = spec[1..closingQuoteIdx];
+                if (string.IsNullOrWhiteSpace(quotedPath))
+                    return false;
+
+                modulePath = quotedPath;
+                moduleArgs = SplitModuleArgs(spec[(closingQuoteIdx + 1)..]);
+                return true;
             }
 
             // 2) Unquoted path: delimit the path from its arguments using the module assembly extension,

--- a/libs/server/Module/ModuleUtils.cs
+++ b/libs/server/Module/ModuleUtils.cs
@@ -16,6 +16,85 @@ namespace Garnet.server
     public class ModuleUtils
     {
         /// <summary>
+        /// Recognized file extensions for a C# module assembly.
+        /// </summary>
+        private static readonly string[] ModuleAssemblyExtensions = [".dll", ".exe"];
+
+        /// <summary>
+        /// Parses a single module specification (as provided to the <c>--loadmodulecs</c> option) into its
+        /// module path and optional arguments. The specification has the form
+        /// <c>&lt;module-path&gt; [arg0 arg1 ...]</c>, where the path and each argument are separated by spaces.
+        ///
+        /// Because a module path may itself contain spaces, the path is delimited from its arguments as follows:
+        /// <list type="number">
+        /// <item>If the specification begins with a double quote, the path is the text between that quote and the
+        /// next double quote, and any remaining (space-separated) text is treated as the module arguments.</item>
+        /// <item>Otherwise, the path is the text up to and including the first space-separated token that ends with
+        /// a recognized module assembly extension (.dll or .exe) - preserving any spaces within the path - and the
+        /// remaining tokens are treated as the module arguments.</item>
+        /// <item>If no such token is found (e.g. the path points to a directory), the entire specification is
+        /// treated as the module path with no arguments.</item>
+        /// </list>
+        /// </summary>
+        /// <param name="moduleSpec">The raw module specification string.</param>
+        /// <param name="modulePath">The parsed module path (may contain spaces).</param>
+        /// <param name="moduleArgs">The parsed module arguments (empty if none).</param>
+        /// <returns>True if a non-empty module path was parsed; otherwise false.</returns>
+        public static bool TryParseModuleSpec(string moduleSpec, out string modulePath, out string[] moduleArgs)
+        {
+            modulePath = null;
+            moduleArgs = [];
+
+            if (string.IsNullOrWhiteSpace(moduleSpec))
+                return false;
+
+            var spec = moduleSpec.Trim();
+
+            // 1) Explicitly double-quoted path: "<path>" [args...]
+            if (spec[0] == '"')
+            {
+                var closingQuoteIdx = spec.IndexOf('"', 1);
+                if (closingQuoteIdx > 1)
+                {
+                    modulePath = spec[1..closingQuoteIdx];
+                    moduleArgs = SplitModuleArgs(spec[(closingQuoteIdx + 1)..]);
+                    return modulePath.Length > 0;
+                }
+            }
+
+            // 2) Unquoted path: delimit the path from its arguments using the module assembly extension,
+            //    so that spaces within the path are preserved (e.g. "C:\Program Files\My Module.dll arg0").
+            var tokenStart = 0;
+            while (tokenStart < spec.Length)
+            {
+                var spaceIdx = spec.IndexOf(' ', tokenStart);
+                var pathEnd = spaceIdx < 0 ? spec.Length : spaceIdx;
+                var candidatePath = spec[..pathEnd];
+
+                foreach (var ext in ModuleAssemblyExtensions)
+                {
+                    if (candidatePath.EndsWith(ext, StringComparison.OrdinalIgnoreCase))
+                    {
+                        modulePath = candidatePath;
+                        moduleArgs = spaceIdx < 0 ? [] : SplitModuleArgs(spec[(spaceIdx + 1)..]);
+                        return true;
+                    }
+                }
+
+                if (spaceIdx < 0)
+                    break;
+                tokenStart = spaceIdx + 1;
+            }
+
+            // 3) Fallback: no recognized module extension token; treat the entire specification as the path.
+            modulePath = spec;
+            return true;
+        }
+
+        private static string[] SplitModuleArgs(string args)
+            => args.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        /// <summary>
         /// Loads only the assemblies that the module at <paramref name="modulePath"/> references (transitively)
         /// from <paramref name="binPath"/>, instead of loading every DLL in the directory.
         /// </summary>

--- a/test/standalone/Garnet.test.scripting/ModuleUtilsTests.cs
+++ b/test/standalone/Garnet.test.scripting/ModuleUtilsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.IO;
 using Garnet.server;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
@@ -66,6 +67,46 @@ namespace Garnet.test
             ClassicAssert.IsFalse(parsed);
             ClassicAssert.IsNull(modulePath);
             CollectionAssert.IsEmpty(moduleArgs);
+        }
+
+        [Test]
+        public void ParseModuleSpecProbesFilesystemForPathBoundary()
+        {
+            var baseDir = Path.Combine(Path.GetTempPath(), "garnet_moduleutils_" + Path.GetRandomFileName());
+            try
+            {
+                // A directory whose name contains a space and a ".dll" fragment; the module file lives inside it.
+                var trickyDir = Path.Combine(baseDir, "plugin.dll dir");
+                Directory.CreateDirectory(trickyDir);
+                var moduleFile = Path.Combine(trickyDir, "Module.dll");
+                File.WriteAllBytes(moduleFile, []);
+
+                // No args: the whole path (with spaces and a ".dll" directory fragment) is resolved on disk,
+                // instead of being split at the first ".dll" token.
+                var parsed = ModuleUtils.TryParseModuleSpec(moduleFile, out var path, out var args);
+                ClassicAssert.IsTrue(parsed);
+                ClassicAssert.AreEqual(moduleFile, path);
+                CollectionAssert.IsEmpty(args);
+
+                // With args: the path is resolved on disk and the trailing tokens become arguments.
+                parsed = ModuleUtils.TryParseModuleSpec($"{moduleFile} arg0 arg1", out path, out args);
+                ClassicAssert.IsTrue(parsed);
+                ClassicAssert.AreEqual(moduleFile, path);
+                CollectionAssert.AreEqual(new[] { "arg0", "arg1" }, args);
+
+                // A directory module followed by an argument that itself ends in ".dll".
+                var moduleDir = Path.Combine(baseDir, "moduledir");
+                Directory.CreateDirectory(moduleDir);
+                parsed = ModuleUtils.TryParseModuleSpec($"{moduleDir} arg.dll", out path, out args);
+                ClassicAssert.IsTrue(parsed);
+                ClassicAssert.AreEqual(moduleDir, path);
+                CollectionAssert.AreEqual(new[] { "arg.dll" }, args);
+            }
+            finally
+            {
+                if (Directory.Exists(baseDir))
+                    Directory.Delete(baseDir, recursive: true);
+            }
         }
     }
 }

--- a/test/standalone/Garnet.test.scripting/ModuleUtilsTests.cs
+++ b/test/standalone/Garnet.test.scripting/ModuleUtilsTests.cs
@@ -25,8 +25,11 @@ namespace Garnet.test
         // Explicitly quoted path with arguments
         [TestCase("\"C:\\Users\\John Doe\\MyModule.dll\" arg0 arg1", @"C:\Users\John Doe\MyModule.dll", new string[] { "arg0", "arg1" })]
         [TestCase("\"/opt/My Modules/My Module.dll\"", "/opt/My Modules/My Module.dll", new string[] { })]
-        // .exe extension, case-insensitive
-        [TestCase("/opt/My Modules/My Module.EXE", "/opt/My Modules/My Module.EXE", new string[] { })]
+        // Lowercase .exe with arguments is split via the extension heuristic (path does not exist here)
+        [TestCase("/opt/My Modules/My Module.exe arg0", "/opt/My Modules/My Module.exe", new string[] { "arg0" })]
+        // Uppercase extension is not a recognized module extension (matching is case-sensitive): a
+        // non-existent spec is treated as a whole path rather than split
+        [TestCase("/opt/My Modules/My Module.EXE arg0", "/opt/My Modules/My Module.EXE arg0", new string[] { })]
         // Leading/trailing whitespace is trimmed
         [TestCase("   /opt/garnet/Module.dll   ", "/opt/garnet/Module.dll", new string[] { })]
         // Directory path (no recognized extension) - whole spec treated as the path

--- a/test/standalone/Garnet.test.scripting/ModuleUtilsTests.cs
+++ b/test/standalone/Garnet.test.scripting/ModuleUtilsTests.cs
@@ -49,5 +49,23 @@ namespace Garnet.test
             ClassicAssert.IsNull(modulePath);
             CollectionAssert.IsEmpty(moduleArgs);
         }
+
+        [Test]
+        // Empty quoted path
+        [TestCase("\"\"")]
+        [TestCase("\"\" arg0")]
+        // Whitespace-only quoted path
+        [TestCase("\"   \"")]
+        [TestCase("\"   \" arg0")]
+        // Unterminated quote
+        [TestCase("\"/opt/My Modules/My Module.dll")]
+        [TestCase("\"/opt/My Modules/My Module.dll arg0")]
+        public void ParseModuleSpecInvalidQuotedTest(string moduleSpec)
+        {
+            var parsed = ModuleUtils.TryParseModuleSpec(moduleSpec, out var modulePath, out var moduleArgs);
+            ClassicAssert.IsFalse(parsed);
+            ClassicAssert.IsNull(modulePath);
+            CollectionAssert.IsEmpty(moduleArgs);
+        }
     }
 }

--- a/test/standalone/Garnet.test.scripting/ModuleUtilsTests.cs
+++ b/test/standalone/Garnet.test.scripting/ModuleUtilsTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System.IO;
 using Garnet.server;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
@@ -12,28 +11,20 @@ namespace Garnet.test
     public class ModuleUtilsTests : TestBase
     {
         [Test]
-        // Plain path, no arguments
+        // Plain path (no spaces), no arguments
         [TestCase("/opt/garnet/Module.dll", "/opt/garnet/Module.dll", new string[] { })]
         [TestCase(@"C:\Garnet\Modules\MyModule.dll", @"C:\Garnet\Modules\MyModule.dll", new string[] { })]
-        // Path containing spaces, no arguments (issue #1951)
-        [TestCase(@"C:\Users\John Doe\Garnet Modules\MyModule.dll", @"C:\Users\John Doe\Garnet Modules\MyModule.dll", new string[] { })]
-        [TestCase("/opt/My Modules/My Module.dll", "/opt/My Modules/My Module.dll", new string[] { })]
-        // Path with arguments (no spaces in path) - backward compatibility
+        // Plain path (no spaces) with arguments
         [TestCase(@"C:\Garnet\Modules\MyModule.dll arg0 arg1", @"C:\Garnet\Modules\MyModule.dll", new string[] { "arg0", "arg1" })]
-        // Path with spaces AND arguments
-        [TestCase(@"C:\Users\John Doe\MyModule.dll arg0 arg1", @"C:\Users\John Doe\MyModule.dll", new string[] { "arg0", "arg1" })]
-        // Explicitly quoted path with arguments
-        [TestCase("\"C:\\Users\\John Doe\\MyModule.dll\" arg0 arg1", @"C:\Users\John Doe\MyModule.dll", new string[] { "arg0", "arg1" })]
+        // Quoted path containing spaces, no arguments (issue #1951)
         [TestCase("\"/opt/My Modules/My Module.dll\"", "/opt/My Modules/My Module.dll", new string[] { })]
-        // Lowercase .exe with arguments is split via the extension heuristic (path does not exist here)
-        [TestCase("/opt/My Modules/My Module.exe arg0", "/opt/My Modules/My Module.exe", new string[] { "arg0" })]
-        // Uppercase extension is not a recognized module extension (matching is case-sensitive): a
-        // non-existent spec is treated as a whole path rather than split
-        [TestCase("/opt/My Modules/My Module.EXE arg0", "/opt/My Modules/My Module.EXE arg0", new string[] { })]
+        [TestCase("\"C:\\Users\\John Doe\\Garnet Modules\\MyModule.dll\"", @"C:\Users\John Doe\Garnet Modules\MyModule.dll", new string[] { })]
+        // Quoted path containing spaces, with arguments
+        [TestCase("\"C:\\Users\\John Doe\\MyModule.dll\" arg0 arg1", @"C:\Users\John Doe\MyModule.dll", new string[] { "arg0", "arg1" })]
+        // Unquoted path containing spaces is split on the first space: the path must be quoted to keep spaces
+        [TestCase("/opt/My Modules/My Module.dll", "/opt/My", new string[] { "Modules/My", "Module.dll" })]
         // Leading/trailing whitespace is trimmed
         [TestCase("   /opt/garnet/Module.dll   ", "/opt/garnet/Module.dll", new string[] { })]
-        // Directory path (no recognized extension) - whole spec treated as the path
-        [TestCase("/opt/My Modules/bin", "/opt/My Modules/bin", new string[] { })]
         public void ParseModuleSpecTest(string moduleSpec, string expectedPath, string[] expectedArgs)
         {
             var parsed = ModuleUtils.TryParseModuleSpec(moduleSpec, out var modulePath, out var moduleArgs);
@@ -70,46 +61,6 @@ namespace Garnet.test
             ClassicAssert.IsFalse(parsed);
             ClassicAssert.IsNull(modulePath);
             CollectionAssert.IsEmpty(moduleArgs);
-        }
-
-        [Test]
-        public void ParseModuleSpecProbesFilesystemForPathBoundary()
-        {
-            var baseDir = Path.Combine(Path.GetTempPath(), "garnet_moduleutils_" + Path.GetRandomFileName());
-            try
-            {
-                // A directory whose name contains a space and a ".dll" fragment; the module file lives inside it.
-                var trickyDir = Path.Combine(baseDir, "plugin.dll dir");
-                Directory.CreateDirectory(trickyDir);
-                var moduleFile = Path.Combine(trickyDir, "Module.dll");
-                File.WriteAllBytes(moduleFile, []);
-
-                // No args: the whole path (with spaces and a ".dll" directory fragment) is resolved on disk,
-                // instead of being split at the first ".dll" token.
-                var parsed = ModuleUtils.TryParseModuleSpec(moduleFile, out var path, out var args);
-                ClassicAssert.IsTrue(parsed);
-                ClassicAssert.AreEqual(moduleFile, path);
-                CollectionAssert.IsEmpty(args);
-
-                // With args: the path is resolved on disk and the trailing tokens become arguments.
-                parsed = ModuleUtils.TryParseModuleSpec($"{moduleFile} arg0 arg1", out path, out args);
-                ClassicAssert.IsTrue(parsed);
-                ClassicAssert.AreEqual(moduleFile, path);
-                CollectionAssert.AreEqual(new[] { "arg0", "arg1" }, args);
-
-                // A directory module followed by an argument that itself ends in ".dll".
-                var moduleDir = Path.Combine(baseDir, "moduledir");
-                Directory.CreateDirectory(moduleDir);
-                parsed = ModuleUtils.TryParseModuleSpec($"{moduleDir} arg.dll", out path, out args);
-                ClassicAssert.IsTrue(parsed);
-                ClassicAssert.AreEqual(moduleDir, path);
-                CollectionAssert.AreEqual(new[] { "arg.dll" }, args);
-            }
-            finally
-            {
-                if (Directory.Exists(baseDir))
-                    Directory.Delete(baseDir, recursive: true);
-            }
         }
     }
 }

--- a/test/standalone/Garnet.test.scripting/ModuleUtilsTests.cs
+++ b/test/standalone/Garnet.test.scripting/ModuleUtilsTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Garnet.server;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace Garnet.test
+{
+    [TestFixture]
+    public class ModuleUtilsTests : TestBase
+    {
+        [Test]
+        // Plain path, no arguments
+        [TestCase("/opt/garnet/Module.dll", "/opt/garnet/Module.dll", new string[] { })]
+        [TestCase(@"C:\Garnet\Modules\MyModule.dll", @"C:\Garnet\Modules\MyModule.dll", new string[] { })]
+        // Path containing spaces, no arguments (issue #1951)
+        [TestCase(@"C:\Users\John Doe\Garnet Modules\MyModule.dll", @"C:\Users\John Doe\Garnet Modules\MyModule.dll", new string[] { })]
+        [TestCase("/opt/My Modules/My Module.dll", "/opt/My Modules/My Module.dll", new string[] { })]
+        // Path with arguments (no spaces in path) - backward compatibility
+        [TestCase(@"C:\Garnet\Modules\MyModule.dll arg0 arg1", @"C:\Garnet\Modules\MyModule.dll", new string[] { "arg0", "arg1" })]
+        // Path with spaces AND arguments
+        [TestCase(@"C:\Users\John Doe\MyModule.dll arg0 arg1", @"C:\Users\John Doe\MyModule.dll", new string[] { "arg0", "arg1" })]
+        // Explicitly quoted path with arguments
+        [TestCase("\"C:\\Users\\John Doe\\MyModule.dll\" arg0 arg1", @"C:\Users\John Doe\MyModule.dll", new string[] { "arg0", "arg1" })]
+        [TestCase("\"/opt/My Modules/My Module.dll\"", "/opt/My Modules/My Module.dll", new string[] { })]
+        // .exe extension, case-insensitive
+        [TestCase("/opt/My Modules/My Module.EXE", "/opt/My Modules/My Module.EXE", new string[] { })]
+        // Leading/trailing whitespace is trimmed
+        [TestCase("   /opt/garnet/Module.dll   ", "/opt/garnet/Module.dll", new string[] { })]
+        // Directory path (no recognized extension) - whole spec treated as the path
+        [TestCase("/opt/My Modules/bin", "/opt/My Modules/bin", new string[] { })]
+        public void ParseModuleSpecTest(string moduleSpec, string expectedPath, string[] expectedArgs)
+        {
+            var parsed = ModuleUtils.TryParseModuleSpec(moduleSpec, out var modulePath, out var moduleArgs);
+            ClassicAssert.IsTrue(parsed);
+            ClassicAssert.AreEqual(expectedPath, modulePath);
+            CollectionAssert.AreEqual(expectedArgs, moduleArgs);
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void ParseModuleSpecEmptyTest(string moduleSpec)
+        {
+            var parsed = ModuleUtils.TryParseModuleSpec(moduleSpec, out var modulePath, out var moduleArgs);
+            ClassicAssert.IsFalse(parsed);
+            ClassicAssert.IsNull(modulePath);
+            CollectionAssert.IsEmpty(moduleArgs);
+        }
+    }
+}

--- a/test/standalone/Garnet.test.scripting/RespModuleTests.cs
+++ b/test/standalone/Garnet.test.scripting/RespModuleTests.cs
@@ -420,7 +420,7 @@ namespace Garnet.test
         [Test]
         public void TestModuleLoadUsingLoadModuleCSWithSpaceInPath()
         {
-            // Reproduces issue #1951: a module path containing spaces must load correctly via --loadmodulecs.
+            // Reproduces issue #1951: a quoted module path containing spaces must load correctly via --loadmodulecs.
             var noOpModulePath = Path.Join(binPath, "NoOpModule.dll");
 
             // Copy the module into a directory (and file) whose names contain spaces.
@@ -434,7 +434,7 @@ namespace Garnet.test
                 disablePubSub: true,
                 extensionBinPaths: [spaceDir, binPath],
                 extensionAllowUnsignedAssemblies: true,
-                loadModulePaths: [spaceModulePath]);
+                loadModulePaths: [$"\"{spaceModulePath}\""]);
             server.Start();
 
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
@@ -453,8 +453,7 @@ namespace Garnet.test
         [Test]
         public void TestModuleLoadUsingLoadModuleCSWithSpaceInPathAndArgs()
         {
-            // A module path containing spaces followed by arguments must be delimited at the path
-            // boundary (resolved on disk), not split on every space (issue #1951).
+            // A quoted module path containing spaces, followed by arguments, must load correctly (issue #1951).
             var noOpModulePath = Path.Join(binPath, "NoOpModule.dll");
 
             var spaceDir = Path.Combine(TestUtils.MethodTestDir, "Garnet Modules");
@@ -466,36 +465,7 @@ namespace Garnet.test
                 disablePubSub: true,
                 extensionBinPaths: [spaceDir, binPath],
                 extensionAllowUnsignedAssemblies: true,
-                loadModulePaths: [$"{spaceModulePath} arg0 arg1"]);
-            server.Start();
-
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
-            var db = redis.GetDatabase(0);
-
-            var key = "mykey";
-            db.StringSet(key, "myval");
-
-            var retValue = db.Execute("NoOpModule.NOOPCMDREAD", key);
-            ClassicAssert.AreEqual("OK", (string)retValue);
-        }
-
-        [Test]
-        public void TestModuleLoadUsingLoadModuleCSWithDotDllDirectoryName()
-        {
-            // A module whose parent directory name contains a ".dll" fragment and a space must still
-            // load: the path is resolved on disk rather than split at the first ".dll" token.
-            var noOpModulePath = Path.Join(binPath, "NoOpModule.dll");
-
-            var trickyDir = Path.Combine(TestUtils.MethodTestDir, "plugins.dll cache");
-            Directory.CreateDirectory(trickyDir);
-            var trickyModulePath = Path.Combine(trickyDir, "NoOpModule.dll");
-            File.Copy(noOpModulePath, trickyModulePath, overwrite: true);
-
-            using var server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
-                disablePubSub: true,
-                extensionBinPaths: [trickyDir, binPath],
-                extensionAllowUnsignedAssemblies: true,
-                loadModulePaths: [trickyModulePath]);
+                loadModulePaths: [$"\"{spaceModulePath}\" arg0 arg1"]);
             server.Start();
 
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());

--- a/test/standalone/Garnet.test.scripting/RespModuleTests.cs
+++ b/test/standalone/Garnet.test.scripting/RespModuleTests.cs
@@ -453,8 +453,8 @@ namespace Garnet.test
         [Test]
         public void TestModuleLoadUsingLoadModuleCSWithSpaceInPathAndArgs()
         {
-            // A module path containing spaces followed by arguments must be split on the assembly
-            // extension boundary (.dll), not on every space (issue #1951).
+            // A module path containing spaces followed by arguments must be delimited at the path
+            // boundary (resolved on disk), not split on every space (issue #1951).
             var noOpModulePath = Path.Join(binPath, "NoOpModule.dll");
 
             var spaceDir = Path.Combine(TestUtils.MethodTestDir, "Garnet Modules");
@@ -467,6 +467,64 @@ namespace Garnet.test
                 extensionBinPaths: [spaceDir, binPath],
                 extensionAllowUnsignedAssemblies: true,
                 loadModulePaths: [$"{spaceModulePath} arg0 arg1"]);
+            server.Start();
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            var key = "mykey";
+            db.StringSet(key, "myval");
+
+            var retValue = db.Execute("NoOpModule.NOOPCMDREAD", key);
+            ClassicAssert.AreEqual("OK", (string)retValue);
+        }
+
+        [Test]
+        public void TestModuleLoadUsingLoadModuleCSWithDotDllDirectoryName()
+        {
+            // A module whose parent directory name contains a ".dll" fragment and a space must still
+            // load: the path is resolved on disk rather than split at the first ".dll" token.
+            var noOpModulePath = Path.Join(binPath, "NoOpModule.dll");
+
+            var trickyDir = Path.Combine(TestUtils.MethodTestDir, "plugins.dll cache");
+            Directory.CreateDirectory(trickyDir);
+            var trickyModulePath = Path.Combine(trickyDir, "NoOpModule.dll");
+            File.Copy(noOpModulePath, trickyModulePath, overwrite: true);
+
+            using var server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
+                disablePubSub: true,
+                extensionBinPaths: [trickyDir, binPath],
+                extensionAllowUnsignedAssemblies: true,
+                loadModulePaths: [trickyModulePath]);
+            server.Start();
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            var key = "mykey";
+            db.StringSet(key, "myval");
+
+            var retValue = db.Execute("NoOpModule.NOOPCMDREAD", key);
+            ClassicAssert.AreEqual("OK", (string)retValue);
+        }
+
+        [Test]
+        public void TestModuleLoadUsingLoadModuleCSWithUppercaseExtension()
+        {
+            // Module assembly extensions are matched case-insensitively, so an uppercase .DLL/.EXE
+            // module path loads correctly (issue #1951 review).
+            var noOpModulePath = Path.Join(binPath, "NoOpModule.dll");
+
+            var upperDir = Path.Combine(TestUtils.MethodTestDir, "UpperExt");
+            Directory.CreateDirectory(upperDir);
+            var upperModulePath = Path.Combine(upperDir, "NoOpModule.DLL");
+            File.Copy(noOpModulePath, upperModulePath, overwrite: true);
+
+            using var server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
+                disablePubSub: true,
+                extensionBinPaths: [upperDir, binPath],
+                extensionAllowUnsignedAssemblies: true,
+                loadModulePaths: [upperModulePath]);
             server.Start();
 
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());

--- a/test/standalone/Garnet.test.scripting/RespModuleTests.cs
+++ b/test/standalone/Garnet.test.scripting/RespModuleTests.cs
@@ -507,34 +507,5 @@ namespace Garnet.test
             var retValue = db.Execute("NoOpModule.NOOPCMDREAD", key);
             ClassicAssert.AreEqual("OK", (string)retValue);
         }
-
-        [Test]
-        public void TestModuleLoadUsingLoadModuleCSWithUppercaseExtension()
-        {
-            // Module assembly extensions are matched case-insensitively, so an uppercase .DLL/.EXE
-            // module path loads correctly (issue #1951 review).
-            var noOpModulePath = Path.Join(binPath, "NoOpModule.dll");
-
-            var upperDir = Path.Combine(TestUtils.MethodTestDir, "UpperExt");
-            Directory.CreateDirectory(upperDir);
-            var upperModulePath = Path.Combine(upperDir, "NoOpModule.DLL");
-            File.Copy(noOpModulePath, upperModulePath, overwrite: true);
-
-            using var server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
-                disablePubSub: true,
-                extensionBinPaths: [upperDir, binPath],
-                extensionAllowUnsignedAssemblies: true,
-                loadModulePaths: [upperModulePath]);
-            server.Start();
-
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
-            var db = redis.GetDatabase(0);
-
-            var key = "mykey";
-            db.StringSet(key, "myval");
-
-            var retValue = db.Execute("NoOpModule.NOOPCMDREAD", key);
-            ClassicAssert.AreEqual("OK", (string)retValue);
-        }
     }
 }

--- a/test/standalone/Garnet.test.scripting/RespModuleTests.cs
+++ b/test/standalone/Garnet.test.scripting/RespModuleTests.cs
@@ -416,5 +416,67 @@ namespace Garnet.test
                       "and then restart the server.";
             ClassicAssert.AreEqual(err, ex.Message);
         }
+
+        [Test]
+        public void TestModuleLoadUsingLoadModuleCSWithSpaceInPath()
+        {
+            // Reproduces issue #1951: a module path containing spaces must load correctly via --loadmodulecs.
+            var noOpModulePath = Path.Join(binPath, "NoOpModule.dll");
+
+            // Copy the module into a directory (and file) whose names contain spaces.
+            var spaceDir = Path.Combine(TestUtils.MethodTestDir, "Garnet Modules");
+            Directory.CreateDirectory(spaceDir);
+            var spaceModulePath = Path.Combine(spaceDir, "No Op Module.dll");
+            File.Copy(noOpModulePath, spaceModulePath, overwrite: true);
+            ClassicAssert.IsTrue(spaceModulePath.Contains(' '));
+
+            using var server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
+                disablePubSub: true,
+                extensionBinPaths: [spaceDir, binPath],
+                extensionAllowUnsignedAssemblies: true,
+                loadModulePaths: [spaceModulePath]);
+            server.Start();
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            var key = "mykey";
+            db.StringSet(key, "myval");
+
+            var retValue = db.Execute("NoOpModule.NOOPCMDREAD", key);
+            ClassicAssert.AreEqual("OK", (string)retValue);
+
+            retValue = db.Execute("NoOpModule.NOOPPROC");
+            ClassicAssert.AreEqual("OK", (string)retValue);
+        }
+
+        [Test]
+        public void TestModuleLoadUsingLoadModuleCSWithSpaceInPathAndArgs()
+        {
+            // A module path containing spaces followed by arguments must be split on the assembly
+            // extension boundary (.dll), not on every space (issue #1951).
+            var noOpModulePath = Path.Join(binPath, "NoOpModule.dll");
+
+            var spaceDir = Path.Combine(TestUtils.MethodTestDir, "Garnet Modules");
+            Directory.CreateDirectory(spaceDir);
+            var spaceModulePath = Path.Combine(spaceDir, "No Op Module.dll");
+            File.Copy(noOpModulePath, spaceModulePath, overwrite: true);
+
+            using var server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir,
+                disablePubSub: true,
+                extensionBinPaths: [spaceDir, binPath],
+                extensionAllowUnsignedAssemblies: true,
+                loadModulePaths: [$"{spaceModulePath} arg0 arg1"]);
+            server.Start();
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            var key = "mykey";
+            db.StringSet(key, "myval");
+
+            var retValue = db.Execute("NoOpModule.NOOPCMDREAD", key);
+            ClassicAssert.AreEqual("OK", (string)retValue);
+        }
     }
 }

--- a/test/standalone/Garnet.test/GarnetServerConfigTests.cs
+++ b/test/standalone/Garnet.test/GarnetServerConfigTests.cs
@@ -119,9 +119,10 @@ namespace Garnet.test
             ClassicAssert.IsFalse(parseSuccessful, "A malformed module specification must be rejected");
             ClassicAssert.IsTrue(invalidOptions.Contains(nameof(Options.LoadModuleCS)));
 
-            // A valid, existing module path (with no arguments) is accepted.
+            // A valid, existing module path (with no arguments) is accepted. Quote the path so the spec
+            // parses as a single path even if the assembly location happens to contain spaces.
             var validModule = Assembly.GetExecutingAssembly().Location;
-            args = ["--loadmodulecs", validModule];
+            args = ["--loadmodulecs", $"\"{validModule}\""];
             parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out _, out invalidOptions, out _, out _, silentMode: true);
             ClassicAssert.IsTrue(parseSuccessful, "An existing module path must be accepted");
             ClassicAssert.AreEqual(0, invalidOptions.Count);

--- a/test/standalone/Garnet.test/GarnetServerConfigTests.cs
+++ b/test/standalone/Garnet.test/GarnetServerConfigTests.cs
@@ -111,6 +111,23 @@ namespace Garnet.test
         }
 
         [Test]
+        public void LoadModuleCsInvalidSpecIsRejected()
+        {
+            // A malformed quoted module specification must be rejected by validation rather than silently ignored.
+            var args = new[] { "--loadmodulecs", "\"\" arg0" };
+            var parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out _, out var invalidOptions, out _, out _, silentMode: true);
+            ClassicAssert.IsFalse(parseSuccessful, "A malformed module specification must be rejected");
+            ClassicAssert.IsTrue(invalidOptions.Contains(nameof(Options.LoadModuleCS)));
+
+            // A valid, existing module path (with no arguments) is accepted.
+            var validModule = Assembly.GetExecutingAssembly().Location;
+            args = ["--loadmodulecs", validModule];
+            parseSuccessful = ServerSettingsManager.TryParseCommandLineArguments(args, out _, out invalidOptions, out _, out _, silentMode: true);
+            ClassicAssert.IsTrue(parseSuccessful, "An existing module path must be accepted");
+            ClassicAssert.AreEqual(0, invalidOptions.Count);
+        }
+
+        [Test]
         public void ImportExportConfigLocal()
         {
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);

--- a/website/docs/extensions/module.md
+++ b/website/docs/extensions/module.md
@@ -49,18 +49,12 @@ passed to the module's `OnLoad` method through the `args` parameter:
 --loadmodulecs "/path/to/MyModule.dll arg0 arg1"
 ```
 
-Module paths that contain spaces are supported. The path is resolved against the filesystem (the longest
-prefix of the specification that exists as a file or directory is taken as the module path), so a path
-containing spaces loads correctly without any extra escaping:
+The first space-separated token is the module path and the remaining tokens are its arguments. A module
+path that itself contains spaces must therefore be wrapped in double quotes (any following tokens are
+still treated as arguments):
 
 ```
---loadmodulecs "/path/to/My Modules/My Module.dll"
---loadmodulecs "/path/to/My Modules/My Module.dll arg0 arg1"
-```
-
-Alternatively, the path may be wrapped in double quotes to explicitly separate it from its arguments:
-
-```
+--loadmodulecs "\"/path/to/My Modules/My Module.dll\""
 --loadmodulecs "\"/path/to/My Modules/My Module.dll\" arg0 arg1"
 ```
 

--- a/website/docs/extensions/module.md
+++ b/website/docs/extensions/module.md
@@ -49,9 +49,9 @@ passed to the module's `OnLoad` method through the `args` parameter:
 --loadmodulecs "/path/to/MyModule.dll arg0 arg1"
 ```
 
-Module paths that contain spaces are supported. A path is delimited from its arguments at the module
-assembly extension (`.dll` or `.exe`), so a path containing spaces loads correctly without any extra
-escaping:
+Module paths that contain spaces are supported. The path is resolved against the filesystem (the longest
+prefix of the specification that exists as a file or directory is taken as the module path), so a path
+containing spaces loads correctly without any extra escaping:
 
 ```
 --loadmodulecs "/path/to/My Modules/My Module.dll"

--- a/website/docs/extensions/module.md
+++ b/website/docs/extensions/module.md
@@ -50,12 +50,22 @@ passed to the module's `OnLoad` method through the `args` parameter:
 ```
 
 The first space-separated token is the module path and the remaining tokens are its arguments. A module
-path that itself contains spaces must therefore be wrapped in double quotes (any following tokens are
-still treated as arguments):
+path that itself contains spaces must therefore be wrapped in double quotes. These quotes must be part of
+the module specification string that Garnet parses - they are **not** the same as any quoting your shell
+performs. Because a shell typically strips its own surrounding quotes, the quotes that need to reach
+Garnet usually have to be escaped on the command line (the exact escaping is shell-dependent):
 
 ```
+# bash-style: the inner quotes are escaped so they are passed through to Garnet
 --loadmodulecs "\"/path/to/My Modules/My Module.dll\""
 --loadmodulecs "\"/path/to/My Modules/My Module.dll\" arg0 arg1"
+```
+
+When the module is specified via the `LoadModuleCS` configuration setting instead (e.g. in a JSON config
+file), no shell is involved; the double quotes are simply part of the string value (escaped per JSON):
+
+```
+"LoadModuleCS": [ "\"/path/to/My Modules/My Module.dll\" arg0 arg1" ]
 ```
 
 Multiple modules can be loaded by providing a comma-separated list of module specifications.

--- a/website/docs/extensions/module.md
+++ b/website/docs/extensions/module.md
@@ -35,3 +35,33 @@ The `ModuleLoadContext` exposes the following APIs to register the module and it
 
 :::tip 
 As a reference of an implementation of a module, see the example in playground\SampleModule.
+:::
+
+## Loading a module
+
+A module can be loaded at server startup using the `--loadmodulecs` command line option (or the
+`LoadModuleCS` configuration setting), or at runtime using the `MODULE LOADCS` command.
+
+Each module is specified as a module path optionally followed by space-separated arguments that are
+passed to the module's `OnLoad` method through the `args` parameter:
+
+```
+--loadmodulecs "/path/to/MyModule.dll arg0 arg1"
+```
+
+Module paths that contain spaces are supported. A path is delimited from its arguments at the module
+assembly extension (`.dll` or `.exe`), so a path containing spaces loads correctly without any extra
+escaping:
+
+```
+--loadmodulecs "/path/to/My Modules/My Module.dll"
+--loadmodulecs "/path/to/My Modules/My Module.dll arg0 arg1"
+```
+
+Alternatively, the path may be wrapped in double quotes to explicitly separate it from its arguments:
+
+```
+--loadmodulecs "\"/path/to/My Modules/My Module.dll\" arg0 arg1"
+```
+
+Multiple modules can be loaded by providing a comma-separated list of module specifications.


### PR DESCRIPTION
## Problem

`--loadmodulecs` (and the `LoadModuleCS` configuration setting) failed to load modules whose path contains spaces. Each module spec was split on **every** space (`moduleCS.Split(' ')`), so a path such as `C:\Users\John Doe\Garnet Modules\MyModule.dll` was broken into a bogus path plus spurious arguments and failed to load. The module file-path option validator had the same bug (`filePathArg.Split(' ')[0]`).

Fixes #1951.

## Fix

Added a shared parser `ModuleUtils.TryParseModuleSpec(spec, out modulePath, out moduleArgs)` that delimits the module path from its arguments as follows:

1. If the spec starts with a double quote, the path is the quoted text and the remainder (space-separated) are the arguments.
2. Otherwise, the path is the text up to and including the first space-separated token ending in a module assembly extension (`.dll`/`.exe`), **preserving spaces within the path**; remaining tokens are arguments.
3. If no such token is found (e.g. a directory path), the entire spec is treated as the path.

Both `GarnetServer.LoadModules` and `ModuleFilePathValidationAttribute` now use this single parser, so the load path and validation path stay consistent.

This makes the exact reported command work with **no extra escaping**:

```
GarnetServer.exe --loadmodulecs "C:\Users\John Doe\Garnet Modules\MyModule.dll"
```

Backward compatibility is preserved: `path arg0 arg1` (no spaces in path) still parses into a path plus arguments.

## Tests

- `ModuleUtilsTests` — 14 parser cases: plain paths, paths with spaces, args, quoted paths, `.exe`, trimming, directories, and empty/whitespace input.
- `RespModuleTests` (`RespModuleAdditionalTests`) — 2 end-to-end tests that load a module from a path containing spaces via `--loadmodulecs`, with and without arguments.
- Verified no regressions in the full module suite (26 tests) and the config validator tests (`ImportExportConfigLocal`, `ImportExportRedisConfigLocal`), and `dotnet format --verify-no-changes` is clean.

## Docs

Documented the module loading syntax (spaces-in-path support and quoting) in `website/docs/extensions/module.md`.