### PR TITLE
Fix object-log position over-read in DeserializeObjectsOnPage on partial page reads

### DIFF
--- a/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
@@ -2106,7 +2106,10 @@ namespace Tsavorite.core
                 context = context,
                 handle = completed,
                 cts = cts,
-                readBuffers = readBuffers
+                readBuffers = readBuffers,
+                // Default to a full page; overridden below for a partial last page. This bounds the object-record walk in
+                // ObjectAllocatorImpl.DeserializeObjectsOnPage to the valid data extent, not the sector-aligned device read length.
+                maxAddressOffsetOnPage = PageSize
             };
 
             ulong offsetInFile = (ulong)(AlignedPageSizeBytes * readPage);
@@ -2116,6 +2119,12 @@ namespace Tsavorite.core
             if (adjustedUntilAddress > 0 && ((adjustedUntilAddress - (long)offsetInFile) < PageSize))
             {
                 readLength = (uint)(adjustedUntilAddress - (long)offsetInFile);
+                // Record the scan's true end (untilAddress) before rounding up to a sector boundary: the object-record walk must
+                // stop here. untilAddress can be mid-page, so the sector-aligned read pulls in records that lie ABOVE the requested
+                // range and can straddle the read end -- their ObjectLogPosition word and R11 value-length high bits then fall past
+                // the bytes actually transferred and are read from the un-read (only incidentally zeroed) buffer tail, yielding a
+                // bogus position/length. Such records must not be parsed as in-range records.
+                asyncResult.maxAddressOffsetOnPage = readLength;
                 readLength = (uint)((readLength + (sectorSize - 1)) & ~(sectorSize - 1));
             }
 

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/ObjectAllocatorImpl.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/ObjectAllocatorImpl.cs
@@ -1180,7 +1180,18 @@ namespace Tsavorite.core
 
             asyncResult.callback = callback;
             asyncResult.destinationPtr = destinationPtr;
-            asyncResult.maxAddressOffsetOnPage = aligned_read_length;
+
+            // Bound the object-record walk (in DeserializeObjectsOnPage) to the caller's valid-data extent when one was provided.
+            // For a partial page read the caller sets maxAddressOffsetOnPage to the scan/recovery end (untilAddress), which can be
+            // mid-page and is smaller than the sector-aligned device read length. Walking to the aligned length would process records
+            // that lie ABOVE untilAddress (the page physically continues past the requested range). Such a record can straddle the
+            // read end, so the fields GetObjectLogRecordStartPositionAndLengths reads near its tail -- the ObjectLogPosition word and
+            // the R11 value-length high bits -- fall past the bytes actually transferred and are read from the un-read buffer tail.
+            // That tail is only incidentally zero (the read buffer is cleared before the read); a different boundary alignment could
+            // bisect a field and yield arbitrary bytes. Either way the resulting position/length is bogus and corrupts the computed
+            // object-log range. Only fall back to the read length when the caller left the extent unset.
+            if (asyncResult.maxAddressOffsetOnPage == 0)
+                asyncResult.maxAddressOffsetOnPage = aligned_read_length;
 
             device.ReadAsync(alignedSourceAddress, destinationPtr, aligned_read_length, AsyncReadPageWithObjectsCallback<TContext>, asyncResult);
         }


### PR DESCRIPTION
Scan/compaction/recovery frame reads round the requested end (untilAddress) up to a sector boundary, so ObjectAllocatorImpl.DeserializeObjectsOnPage was walking records past untilAddress. untilAddress can be mid-page, so the walk stepped into records that physically continue above the requested range; such a record can straddle the device-read end, making GetObjectLogRecordStartPositionAndLengths read the ObjectLogPosition word and R11 value-length high bits from the un-read (only incidentally zeroed) buffer tail. That yields a bogus position that is smaller than the in-range records' positions, tripping the "comparison position must be greater" assert in ObjectLogFilePositionInfo.operator- (and a NullReferenceException in compaction's TryCopyToTail).

AsyncReadPagesForRecovery already sets maxAddressOffsetOnPage to the true data length before sector-aligning the device read; AsyncReadPagesFromDeviceToFrame (scan/compaction) did not, and the ObjectAllocator ReadAsync override then set it to the aligned read length. Set maxAddressOffsetOnPage to the true length in the frame-read path and make the override only fall back to the aligned length when a caller left it unset, so the object-record walk stops at untilAddress.


Copilot-Session: 7debceeb-339a-4785-8271-557bc759c26e