### PR TITLE
Fix GETRANGE DivideByZeroException on empty-string value with negative start

### DIFF
--- a/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
@@ -362,6 +362,11 @@ namespace Garnet.server
 
         static (int, int) NormalizeRange(int start, int end, int len)
         {
+            // len == 0 has no valid range regardless of start/end; returning early also avoids
+            // a division/modulo by zero below when start < 0.
+            if (len == 0)
+                return (0, 0);
+
             if (start >= 0 && start <= len)//start in [0,len]
             {
                 if (end < 0 && (len + end) > 0)

--- a/test/standalone/Garnet.test/RespTests.cs
+++ b/test/standalone/Garnet.test/RespTests.cs
@@ -3575,6 +3575,33 @@ namespace Garnet.test
             ClassicAssert.AreEqual(value.Substring(5, 3), resp);
         }
 
+        /// <summary>
+        /// Regression test for GETRANGE on a key holding an empty string throwing
+        /// DivideByZeroException when start is negative (NormalizeRange's start %= len hits
+        /// len == 0). Real Redis returns an empty string for any range on an empty value.
+        /// </summary>
+        [Test]
+        public void GetRangeEmptyValueTest()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            string key = "emptyRangeKey";
+            ClassicAssert.IsTrue(db.StringSet(key, ""));
+
+            var resp = (string)db.StringGetRange(key, -1, -1);
+            ClassicAssert.AreEqual(string.Empty, resp);
+
+            resp = (string)db.StringGetRange(key, -1, 0);
+            ClassicAssert.AreEqual(string.Empty, resp);
+
+            resp = (string)db.StringGetRange(key, 0, 0);
+            ClassicAssert.AreEqual(string.Empty, resp);
+
+            resp = (string)db.StringGetRange(key, 0, -1);
+            ClassicAssert.AreEqual(string.Empty, resp);
+        }
+
         [Test]
         public void SetRangeTest()
         {


### PR DESCRIPTION
## Summary

`GETRANGE` on a key holding an empty string, with a negative `start` such that `start <= end` (e.g. `GETRANGE key -1 -1`), crashes the connection with a `DivideByZeroException` instead of returning an empty string.

## Root cause

`NormalizeRange(int start, int end, int len)` in `libs/server/Storage/Functions/MainStore/PrivateMethods.cs` does `start %= len` unconditionally inside its `start < 0` branch. When `len == 0` (empty string value), this is a modulo by zero.

## Fix

Add an early guard returning `(0, 0)` when `len == 0` — the same sentinel `NormalizeRange` already returns from its other "no valid range" branches (e.g. `if (start > end) return (0, 0);`), so it's consistent with the function's existing convention rather than a new special case. `NormalizeRange` has exactly one caller (`GETRANGE`'s handling in `CopyRespToWithInput`), and `(0, 0)` correctly resolves to an empty RESP reply there.

## Tests

Added `GetRangeEmptyValueTest` to `test/standalone/Garnet.test/RespTests.cs`, covering the crashing case (`GETRANGE key -1 -1`, `GETRANGE key -1 0`) alongside non-crashing empty-value cases (`GETRANGE key 0 0`, `GETRANGE key 0 -1`) to confirm all correctly return empty string. Confirmed the test reproduces a connection-level failure against the pre-fix code and passes with the fix.

```release-notes
* Fix `GETRANGE` on an empty-string value throwing `DivideByZeroException` (and dropping the connection) for a negative start offset.
```
