### PR TITLE
Fix one-byte out-of-bounds read in BITPOS with explicit end offset

### DIFF
--- a/libs/server/Resp/Bitmap/BitmapManagerBitPos.cs
+++ b/libs/server/Resp/Bitmap/BitmapManagerBitPos.cs
@@ -28,7 +28,7 @@ namespace Garnet.server
                 if (startOffset >= inputLen) // If startOffset greater that valLen always bitpos -1
                     return -1;
 
-                if (startOffset > endOffset) // If start offset beyond endOffset return 0
+                if (startOffset > endOffset) // If start offset beyond endOffset return -1
                     return -1;
 
                 endOffset = endOffset >= inputLen ? inputLen - 1 : endOffset;
@@ -47,7 +47,7 @@ namespace Garnet.server
                 if (startByteIndex >= inputLen) // If startOffset greater that valLen always bitpos -1
                     return -1;
 
-                if (startByteIndex > endByteIndex) // If start offset beyond endOffset return 0
+                if (startByteIndex > endByteIndex) // If start offset beyond endOffset return -1
                     return -1;
 
                 endOffset = endByteIndex >= inputLen ? bitLen - 1 : endOffset;

--- a/libs/server/Resp/Bitmap/BitmapManagerBitPos.cs
+++ b/libs/server/Resp/Bitmap/BitmapManagerBitPos.cs
@@ -31,7 +31,7 @@ namespace Garnet.server
                 if (startOffset > endOffset) // If start offset beyond endOffset return 0
                     return -1;
 
-                endOffset = endOffset >= inputLen ? inputLen : endOffset;
+                endOffset = endOffset >= inputLen ? inputLen - 1 : endOffset;
                 // BYTE search
                 return BitPosByteSearch(input, inputLen, startOffset, endOffset, searchFor);
             }
@@ -50,7 +50,7 @@ namespace Garnet.server
                 if (startByteIndex > endByteIndex) // If start offset beyond endOffset return 0
                     return -1;
 
-                endOffset = endByteIndex >= inputLen ? bitLen : endOffset;
+                endOffset = endByteIndex >= inputLen ? bitLen - 1 : endOffset;
 
                 // BIT search
                 return BitPosBitSearch(input, inputLen, startOffset, endOffset, searchFor);

--- a/test/standalone/Garnet.test.complexstring/GarnetBitmapTests.cs
+++ b/test/standalone/Garnet.test.complexstring/GarnetBitmapTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics.Tensors;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Garnet.common;
 using Garnet.server;
@@ -2406,6 +2407,76 @@ namespace Garnet.test
 
             pos = (long)db.Execute("BITPOS", key, "1", (-maxByteOffset - 1).ToString(), "-1", "BYTE");
             ClassicAssert.AreEqual(-1, pos);
+        }
+
+        /// <summary>
+        /// Regression test for an off-by-one clamp in BitPosDriver's BYTE-mode path: an explicit end
+        /// offset greater than or equal to the value's length was clamped to <c>inputLen</c> instead of
+        /// <c>inputLen - 1</c>, allowing BitPosByteSearch to read one byte past the end of the value
+        /// when no matching bit exists within the real data (mirrors the fix applied to BitCountDriver
+        /// in #1138, which was never mirrored to BITPOS).
+        ///
+        /// Calls BitmapManager.BitPosDriver directly against an unmanaged buffer with a known "canary"
+        /// byte placed immediately past the declared value length, so the out-of-bounds read is
+        /// deterministically observable: a matching bit hides in the canary byte, so the buggy driver
+        /// reports a real (non -1) position instead of -1, while the fixed driver never looks at it.
+        /// A plain end-to-end BITPOS call would rely on whatever bytes happen to follow the value on
+        /// the managed heap, which is not reliable enough to catch a one-byte overread.
+        /// </summary>
+        [Test]
+        [Category("BITPOS")]
+        public unsafe void BitmapBitPosOutOfBoundsEndOffsetByteModeTest()
+        {
+            const int valueLen = 8;
+            var buf = (byte*)NativeMemory.Alloc(valueLen + 1);
+            try
+            {
+                // Real value: no set bits anywhere within its declared bounds.
+                for (var i = 0; i < valueLen; i++)
+                    buf[i] = 0x00;
+
+                // Canary byte, one past the declared length. All bits set, so if the driver reads it
+                // while searching for a set bit, it will incorrectly report a position inside it.
+                buf[valueLen] = 0xFF;
+
+                var pos = BitmapManager.BitPosDriver(buf, valueLen, startOffset: 0, endOffset: 1_000_000, searchFor: 1, offsetType: 0x0);
+
+                ClassicAssert.AreEqual(-1, pos, "BITPOS BYTE mode must not read past the end of the value");
+            }
+            finally
+            {
+                NativeMemory.Free(buf);
+            }
+        }
+
+        /// <summary>
+        /// Same regression as <see cref="BitmapBitPosOutOfBoundsEndOffsetByteModeTest"/>, but for
+        /// BitPosDriver's BIT-mode path, whose equivalent clamp had the same off-by-one
+        /// (<c>bitLen</c> instead of <c>bitLen - 1</c>).
+        /// </summary>
+        [Test]
+        [Category("BITPOS")]
+        public unsafe void BitmapBitPosOutOfBoundsEndOffsetBitModeTest()
+        {
+            const int valueLen = 3;
+            var buf = (byte*)NativeMemory.Alloc(valueLen + 1);
+            try
+            {
+                // Real value: no set bits anywhere within its declared bounds (24 valid bit positions).
+                for (var i = 0; i < valueLen; i++)
+                    buf[i] = 0x00;
+
+                // Canary byte, one past the declared length. All bits set.
+                buf[valueLen] = 0xFF;
+
+                var pos = BitmapManager.BitPosDriver(buf, valueLen, startOffset: 0, endOffset: 1_000_000, searchFor: 1, offsetType: 0x1);
+
+                ClassicAssert.AreEqual(-1, pos, "BITPOS BIT mode must not read past the end of the value");
+            }
+            finally
+            {
+                NativeMemory.Free(buf);
+            }
         }
 
         [Test]


### PR DESCRIPTION
## Problem

`BitPosDriver` (libs/server/Resp/Bitmap/BitmapManagerBitPos.cs) clamps an explicit `end` offset to `inputLen` (BYTE mode) / `bitLen` (BIT mode) instead of `inputLen - 1` / `bitLen - 1` — one index past the last valid position:

```csharp
endOffset = endOffset >= inputLen ? inputLen : endOffset;                 // BYTE mode
...
endOffset = endByteIndex >= inputLen ? bitLen : endOffset;                // BIT mode
```

`BitPosByteSearch`/`BitPosBitSearch` iterate `while (currentOffset <= endOffset)` over an `unsafe byte*`, treating `endOffset` as an inclusive, valid last index (see e.g. `remainder = endOffset - currentStartOffset + 1` in the BYTE-mode search). When no matching bit exists within the real data and the loop actually reaches the clamped `endOffset`, it dereferences `input[inputLen]` — one byte past the value's backing buffer. Reproducible with e.g. `BITPOS key 0 0 1000000` against a short value with no `0`-bit... (i.e. any explicit end offset >= the value's real length, on a value with no match).

## Fix

Clamp to `inputLen - 1` / `bitLen - 1` in both branches, matching:
- `BitCountDriver`'s existing (correct) clamp in the same file family, itself fixed for this exact bug class in #1138 for BYTE mode but apparently never mirrored to BITPOS (or to BitCountDriver's own BIT-mode path, which was already correct).
- Real Redis's `bitposCommand` in `src/bitops.c`, which clamps `end = totlen - 1` (totlen already converted to bits in BIT mode) for both indexing modes.

`BitPosByteSearch`/`BitPosBitSearch` are private with a single caller (`BitPosDriver`), itself called from exactly one production call site, so no additional in-loop bounds check is warranted — see full investigation notes for the alternatives considered and rejected.

## Testing

Added two regression tests that call `BitmapManager.BitPosDriver` directly against an unmanaged buffer with a "canary" byte placed immediately past the declared value length (rather than relying on whatever happens to follow the value on the managed heap, which is not reliable enough to deterministically catch a one-byte overread). Confirmed both tests fail against the pre-fix clamp (reporting a position inside the canary byte instead of -1) and pass with the fix.

Full BITPOS test category (14/14) and `dotnet format --verify-no-changes` pass clean.

Note: while investigating, I found a separate, unrelated pre-existing bug — `BitCountDriver`'s `BitIndexCount` helper (BIT-mode partial-byte counting) calls the x86-only `Popcnt.X64.PopCount` intrinsic with no `IsSupported`/portable fallback, which crashes the server process on ARM64 hosts. Confirmed pre-existing on unmodified `main` and unrelated to this change; not fixed here to keep this PR scoped to the BITPOS offset-clamp bug — happy to file that separately if useful.
