### PR TITLE
Deterministic repro: vectorset cleanup/recycle race on restore

### DIFF
--- a/libs/server/Resp/Vector/VectorManager.Cleanup.cs
+++ b/libs/server/Resp/Vector/VectorManager.Cleanup.cs
@@ -370,6 +370,42 @@ namespace Garnet.server
         }
 
         /// <summary>
+        /// Test-only hook that reproduces the recovery re-arm in <see cref="ResumePostRecovery"/>
+        /// (see the "mark for cleanup" loop at its end): mark an in-use context for cleanup and
+        /// pump the background cleanup task. Recovery does exactly this for any context still
+        /// marked in-use whose index record was not recovered; because context ids are recycled
+        /// and the cleanup scan matches records by context namespace only (no generation tag),
+        /// this can delete the records of a newer, live generation that recycled the same id.
+        /// </summary>
+        public void TestOnlyRequeueCleanupForContext(ulong context)
+        {
+            var (contextIndex, contextValue) = ContextMetadata.DecomposeContext(context & ~(ContextStep - 1));
+
+            lock (this)
+            {
+                contextMetadatas[contextIndex].MarkCleaningUp(contextIndex != 0, contextValue);
+                _ = dirtyContextMetadatas.Add(contextIndex);
+            }
+
+            _ = cleanupTaskChannel.Writer.TryWrite(null);
+        }
+
+        /// <summary>
+        /// Test-only accessor: is the given context still marked for cleanup? Used to await a
+        /// requeued cleanup pass deterministically (the bit is cleared by FinishedCleaningUp
+        /// once the scan completes).
+        /// </summary>
+        public bool TestOnlyIsCleaningUp(ulong context)
+        {
+            var (contextIndex, contextValue) = ContextMetadata.DecomposeContext(context & ~(ContextStep - 1));
+
+            lock (this)
+            {
+                return contextMetadatas[contextIndex].IsCleaningUp(contextIndex != 0, contextValue);
+            }
+        }
+
+        /// <summary>
         /// Block any new cleanup-task iteration from starting and wait for the current one
         /// (if any) to finish. Callers (e.g., cluster re-attach paths) MUST balance every
         /// invocation with <see cref="ResumeCleanup"/>, ideally in a finally block.

--- a/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
+++ b/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
@@ -2471,6 +2471,94 @@ namespace Garnet.test
 
         // TODO: FLUSHDB needs to cleanup too...
 
+        /// <summary>
+        /// Deterministic repro of the recreate-on-restore flake (PR #1967 / CI job 89250167325).
+        ///
+        /// The background vector-set cleanup scan (<see cref="VectorManager"/>'s cleanup task)
+        /// deletes element records matching a context id purely by its namespace, with no
+        /// generation/epoch tag, and context ids are recycled. In steady state a reuse barrier
+        /// keeps this safe: a context is not freed for reuse until its cleanup scan completes.
+        /// Recovery resets that barrier — <see cref="VectorManager.ResumePostRecovery"/> re-arms
+        /// cleanup for any context still marked in-use whose index record was not recovered, and
+        /// pumps the cleanup task. If a newer, live generation has recycled that context id, the
+        /// re-armed scan deletes the live generation's element records.
+        ///
+        /// This test drives that exact re-arm path via a test-only hook: it marks a still-live
+        /// context for cleanup and pumps the cleanup task, then saves/recovers to force a lazy
+        /// recreate that reads the now-deleted element records — so the recreated index is missing
+        /// its elements. Fails today; passes once cleanup is made generation-safe.
+        /// </summary>
+        [Test]
+        [Ignore("Reproduces the cleanup/recycle race; un-ignore once cleanup is generation-safe")]
+        public async Task RequeuedCleanupOnLiveContextLosesElementsOnRestoreAsync()
+        {
+            var addData1 = Enumerable.Range(0, 75).Select(static x => (byte)x).ToArray();
+            var addData2 = Enumerable.Range(0, 75).Select(static x => (byte)(x * 2)).ToArray();
+            var elem0 = new byte[] { 0, 0, 0, 0 };
+            var elem1 = new byte[] { 0, 0, 0, 1 };
+
+            var store = server.Provider.StoreWrapper;
+            var vectorManager = store.DefaultDatabase.VectorManager;
+
+            ulong context;
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true)))
+            {
+                var s = redis.GetServers()[0];
+                var db = redis.GetDatabase(0);
+
+                _ = db.KeyDelete("foo");
+                ClassicAssert.AreEqual(1, (int)db.Execute("VADD", ["foo", "XB8", addData1, elem0, "CAS", "NOQUANT", "EF", "16", "M", "32"]));
+                ClassicAssert.AreEqual(1, (int)db.Execute("VADD", ["foo", "XB8", addData2, elem1, "CAS", "NOQUANT", "EF", "16", "M", "32"]));
+
+                var before = (byte[][])db.Execute("VSIM", ["foo", "ELE", elem0]);
+                ClassicAssert.AreEqual(2, before.Length, "sanity: both elements present before the requeued cleanup");
+
+                // Resolve foo's currently-live context id.
+                unsafe
+                {
+                    var fooBytes = Encoding.ASCII.GetBytes("foo");
+                    fixed (byte* fooPtr = fooBytes)
+                    {
+                        var fooSpan = PinnedSpanByte.FromPinnedPointer(fooPtr, fooBytes.Length);
+                        var namespaces = vectorManager.GetNamespacesForKeys(store, [fooSpan], []);
+                        ClassicAssert.AreEqual(VectorManager.ContextStep, namespaces.Count);
+                        context = namespaces.Min();
+                    }
+                }
+
+                // Recovery re-arm on a LIVE context: mark it for cleanup and pump the cleanup task,
+                // exactly as ResumePostRecovery does for an in-use context whose index record was
+                // not recovered — which, after context-id recycling, targets a live generation.
+                vectorManager.TestOnlyRequeueCleanupForContext(context);
+
+                // Await the cleanup pass; FinishedCleaningUp clears the bit once the scan is done.
+                for (var waited = 0; vectorManager.TestOnlyIsCleaningUp(context); waited += 25)
+                {
+                    ClassicAssert.Less(waited, 30_000, "background cleanup did not complete in time");
+                    await Task.Delay(25);
+                }
+
+#pragma warning disable CS0618 // Intentionally doing bad things
+                s.Save(SaveType.ForegroundSave);
+#pragma warning restore CS0618
+
+                var commit = await server.Store.WaitForCommitAsync();
+                ClassicAssert.IsTrue(commit);
+                server.Dispose(deleteDir: false);
+
+                server = CreateGarnetServer(tryRecover: true);
+                server.Start();
+            }
+
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true)))
+            {
+                var db = redis.GetDatabase(0);
+
+                var after = (byte[][])db.Execute("VSIM", ["foo", "ELE", elem0]);
+                ClassicAssert.AreEqual(2, after.Length, "requeued cleanup on the live context deleted the vector set's elements");
+            }
+        }
+
         [Test]
         public void VINFO_NotFound()
         {


### PR DESCRIPTION
## What

Adds a **deterministic reproduction** of the flaky `RespVectorSetTests.RecreateIndexesOnRestoreAsync` failure (originally seen on PR #1967 / CI job 89250167325). No fix yet — the repro is committed `[Ignore]`d so CI stays green.

## Root cause

Garnet uses a **single unified store**; a vector set's index-config key, element records, and per-context metadata all recover from **one consistent checkpoint**. The bug is **not** a cross-store checkpoint skew.

The background cleanup scan (`PostDropCleanupFunctions.Reader`) deletes element records matched by **context-id namespace only, with no generation/epoch tag**, and context ids are **recycled**. In steady state a reuse barrier keeps this safe (a context isn't freed until its cleanup scan completes). **Recovery resets that barrier**: `ResumePostRecovery` re-arms cleanup for any in-use context whose index record was not recovered and pumps the cleanup task — which can then delete the records of a **newer, live generation** that recycled the same context id. Manifests as lost elements / `ERR asked quantization mismatch` / an `AccessViolationException` on recreate.

Empirically confirmed: a delay sweep showed delaying the cleanup scan makes the failure vanish; a TLA+ model reproduced the invariant violation.

## Changes

- `VectorManager.Cleanup.cs` — two test-only hooks: `TestOnlyRequeueCleanupForContext` (mimics the recovery re-arm) and `TestOnlyIsCleaningUp` (await the scan).
- `RespVectorSetTests.cs` — `RequeuedCleanupOnLiveContextLosesElementsOnRestoreAsync`: VADD 2 elements, requeue cleanup on the **live** context, save + recover, then assert the elements survive. Fails today with the exact CI signature (`ERR asked quantization mismatch with existing vector set`), 2/2 fixtures, deterministically.

## Fix direction (follow-up)

Make cleanup **generation-safe** by tagging element records with a per-context generation so a cleanup pass only deletes the exact generation it was armed for. Un-ignore the test once landed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 50b7a035-5389-46a7-8423-7806ef1635c3