### PR TITLE
Fix vectorset context reuse after checkpoint/recovery metadata skew

### DIFF
--- a/libs/common/Testing/ExceptionInjectionType.cs
+++ b/libs/common/Testing/ExceptionInjectionType.cs
@@ -125,5 +125,14 @@ namespace Garnet.common
         /// Vector Set: pause in the index-recreate window before RMW write refreshed index pointer back to the main store.
         /// </summary>
         VectorSet_Pause_Before_Recreate_Rmw,
+        /// <summary>
+        /// Vector Set: in the create-on-read path, THROW right after the index-config record (which pins
+        /// the chosen context) has been written to the store — and thus appended to the AOF — but BEFORE
+        /// <c>UpdateContextMetadata</c> flushes the matching in-use bit. This unwinds the create
+        /// immediately (releasing the vector-set lock and the store epoch), so a subsequent checkpoint +
+        /// recover reproduces the metadata-persistence-lags-index-write skew WITHOUT a live session
+        /// parked mid-operation to deadlock the checkpoint. Uses TriggerException.
+        /// </summary>
+        VectorSet_Interrupt_Before_Create_Metadata_Persist,
     }
 }

--- a/libs/server/Resp/Vector/VectorManager.Locking.cs
+++ b/libs/server/Resp/Vector/VectorManager.Locking.cs
@@ -439,6 +439,8 @@ namespace Garnet.server
 
                             if (!needsRecreate)
                             {
+                                ExceptionInjectionHelper.TriggerException(ExceptionInjectionType.VectorSet_Interrupt_Before_Create_Metadata_Persist);
+
                                 UpdateContextMetadata(ref storageSession.vectorBasicContext);
                             }
                         }

--- a/libs/server/Resp/Vector/VectorManager.cs
+++ b/libs/server/Resp/Vector/VectorManager.cs
@@ -171,7 +171,7 @@ namespace Garnet.server
 
         private readonly int dbId;
 
-        private ConcurrentDictionary<ulong, byte> recoveredIndexes;
+        private ConcurrentDictionary<ulong, ushort> recoveredIndexes;
         private ConcurrentDictionary<int, ContextMetadata> recoveredMetadata;
 
         public VectorManager(int dbId, GarnetServerOptions serverOptions, Func<IMessageConsumer> getTempSession, ILoggerFactory loggerFactory)
@@ -309,11 +309,25 @@ namespace Garnet.server
                 }
 
                 // Any non-deleted records we recovered for contexts being deleted, we need to undo that
-                foreach (var (context, _) in recoveredIndexes)
+                foreach (var (context, slot) in recoveredIndexes)
                 {
                     var (contextIndex, contextValue) = ContextMetadata.DecomposeContext(context);
 
-                    if (contextMetadatas[contextIndex].IsCleaningUp(contextIndex != 0, contextValue))
+                    // A context whose index-config record was recovered is genuinely in use. If the
+                    // persisted metadata reports it free — the index-config write became durable but
+                    // UpdateContextMetadata's in-use bit did not (a crash, or a checkpoint taken, in the
+                    // window between the two) — reconcile it here. Otherwise NextVectorSetContext would
+                    // re-hand-out this context to an unrelated vector set, whose elements would then share
+                    // the recovered index's namespace and corrupt both sets.
+                    if (!contextMetadatas[contextIndex].IsInUse(contextIndex != 0, contextValue))
+                    {
+                        contextMetadatas[contextIndex].MarkInUse(contextIndex != 0, contextValue, slot);
+
+                        _ = dirtyContextMetadatas.Add(contextIndex);
+
+                        needsUpdated = true;
+                    }
+                    else if (contextMetadatas[contextIndex].IsCleaningUp(contextIndex != 0, contextValue))
                     {
                         contextMetadatas[contextIndex].ClearIsCleaningUp(contextIndex != 0, contextValue);
 
@@ -379,7 +393,7 @@ namespace Garnet.server
             }
 
             ReadIndex(record.ValueSpan, out var context, out _, out _, out _, out _, out _, out _, out _, out _);
-            recoveredIndexes[context] = 0;
+            recoveredIndexes[context] = HashSlotUtils.HashSlot(record.KeyBytes);
         }
 
         /// <summary>

--- a/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
+++ b/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
@@ -2471,6 +2471,118 @@ namespace Garnet.test
 
         // TODO: FLUSHDB needs to cleanup too...
 
+        /// <summary>
+        /// Deterministic, REAL-operations repro of the vector-set context-reuse corruption using only
+        /// VADD / Save / recover plus a single timing gate (no synthetic state).
+        ///
+        /// Root cause: <see cref="VectorManager"/> persists the <c>ContextMetadata</c> in-use bitmap at
+        /// discrete points (<c>UpdateContextMetadata</c>), but writes the index-config record — which
+        /// pins the chosen context id — to the store immediately. In the create-on-read path the
+        /// index-config record is written (Locking.cs) BEFORE <c>UpdateContextMetadata</c> flushes the
+        /// matching in-use bit. A checkpoint taken in that window captures an index occupying context C
+        /// while the persisted metadata still reports C as free.
+        ///
+        /// After recovery the metadata hands C back out as a fresh context to the next vector set, so two
+        /// live indexes collide on the same context namespace. The cleanup scan matches records by
+        /// namespace only (no generation tag), so this is the same generation-unsafe reuse that causes
+        /// the recreate-on-restore flake.
+        ///
+        /// The gate <see cref="ExceptionInjectionType.VectorSet_Interrupt_Before_Create_Metadata_Persist"/>
+        /// makes foo's real VADD throw in exactly that window — after the index-config record is durable
+        /// but before the in-use bit is flushed; the test then checkpoints, recovers, and shows a
+        /// second vector set is issued foo's context. Fails today; passes once context reuse is made
+        /// checkpoint/generation-safe.
+        /// </summary>
+        [Test]
+        [CancelAfter(60000)]
+        public async Task CreateMetadataSkewRecyclesLiveContextOnRestoreAsync()
+        {
+            TestUtils.IgnoreIfExceptionInjectionDisabled();
+
+            // foo and bar carry IDENTICAL vector payloads (only their element ids differ). That way, if
+            // the two sets end up sharing a context namespace after restore, each set's VSIM is guaranteed
+            // to surface the other's element (distance 0) regardless of the epsilon threshold — making the
+            // namespace collision observable deterministically rather than dependent on vector distances.
+            var fooData = Enumerable.Range(0, 75).Select(static x => (byte)x).ToArray();
+            var barData = Enumerable.Range(0, 75).Select(static x => (byte)x).ToArray();
+            var fooElem = new byte[] { 0, 0, 0, 7 };
+            var barElem = new byte[] { 0, 0, 0, 9 };
+
+            const ExceptionInjectionType Gate = ExceptionInjectionType.VectorSet_Interrupt_Before_Create_Metadata_Persist;
+
+            using (var redisOp = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true)))
+            {
+                var dbOp = redisOp.GetDatabase(0);
+
+                // Arm the gate: foo's create-on-read writes its index-config record (which pins its
+                // context) and then THROWS before UpdateContextMetadata flushes the in-use bit. The throw
+                // unwinds the create, releasing the vector-set lock and the store epoch, so nothing is left
+                // parked mid-operation — which is exactly what lets us take a foreground checkpoint next
+                // without deadlocking (a checkpoint quiesces the store and would hang against a create that
+                // was merely PARKED here; a create that has already thrown holds nothing).
+                ExceptionInjectionHelper.EnableException(Gate);
+                try
+                {
+                    try
+                    {
+                        _ = dbOp.Execute("VADD", ["foo", "XB8", fooData, fooElem, "CAS", "NOQUANT", "EF", "16", "M", "32"]);
+                        Assert.Fail("foo's create was expected to be interrupted before persisting its context metadata");
+                    }
+                    catch (RedisException)
+                    {
+                        // Expected: the injected fault surfaces as a server/connection error for the VADD
+                        // and the faulted session tears its connection down.
+                    }
+
+                    // Checkpoint the skew window: foo's index-config record (which pins its context) is now
+                    // durable, but the persisted metadata still marks that context free. Recovery from a
+                    // checkpoint marks recovered vector indexes for lazy recreate-on-access, which is the
+                    // path the bug corrupts. A fresh connection is used because the injected fault dropped
+                    // foo's original connection.
+                    using (var redisSave = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true)))
+                    {
+                        var saveServer = redisSave.GetServers()[0];
+#pragma warning disable CS0618 // ForegroundSave is intentional here
+                        saveServer.Save(SaveType.ForegroundSave);
+#pragma warning restore CS0618
+                    }
+
+                    var commit = await server.Store.WaitForCommitAsync();
+                    ClassicAssert.IsTrue(commit);
+                }
+                finally
+                {
+                    ExceptionInjectionHelper.DisableException(Gate);
+                }
+
+                // Simulate a crash after the skewed checkpoint: recovery restores foo's index-config (and
+                // marks it for lazy recreate) but the persisted metadata reports foo's context free.
+                server.Dispose(deleteDir: false);
+                server = CreateGarnetServer(tryRecover: true);
+                server.Start();
+            }
+
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true)))
+            {
+                var db = redis.GetDatabase(0);
+
+                // A brand-new vector set bar must NOT be issued foo's recovered context. Under the bug the
+                // recovered metadata reports foo's context free, so bar is handed the very same context and
+                // its element lands in foo's recovered namespace.
+                ClassicAssert.AreEqual(1, (int)db.Execute("VADD", ["bar", "XB8", barData, barElem, "CAS", "NOQUANT", "EF", "16", "M", "32"]));
+
+                // bar must contain only its own element.
+                var barMembers = (byte[][])db.Execute("VSIM", ["bar", "XB8", barData, "COUNT", "100", "EPSILON", "1.0", "EF", "40"]);
+                ClassicAssert.AreEqual(1, barMembers.Length, "bar does not contain exactly its own element");
+
+                // foo's create was interrupted before it ever added an element, so foo MUST be empty after
+                // restore. Under the bug foo's recovered index shares bar's context namespace, so a
+                // similarity query on foo surfaces bar's element (Expected 0 But was 1).
+                var fooMembers = (byte[][])db.Execute("VSIM", ["foo", "XB8", barData, "COUNT", "100", "EPSILON", "1.0", "EF", "40"]);
+                ClassicAssert.AreEqual(0, fooMembers.Length, "foo surfaced bar's element — bar was issued foo's recovered context (namespace collision after restore)");
+            }
+        }
+
         [Test]
         public void VINFO_NotFound()
         {


### PR DESCRIPTION
## Problem

Element records in a vector set are keyed by **context namespace only** (no generation/epoch tag), and context ids are recycled. In the create-on-read path the index-config record — which pins the chosen context id — is written to the store **before** `UpdateContextMetadata` flushes that context's in-use bit.

If a checkpoint is taken (or a crash occurs) in that window, the index-config becomes durable while the persisted `ContextMetadata` still reports the context **free**. On recovery, `NextVectorSetContext` re-hands-out that context to an unrelated vector set, and the two sets collide on the same namespace. This is the root cause of the flaky `RecreateIndexesOnRestoreAsync` failure (`Expected: 2 But was: 4`).

## Fix

In `ResumePostRecovery`, for every recovered index-config whose context metadata reports it free, reconcile it back to in-use — using the hash slot recovered from the index record's key. A recovered context can never be re-handed-out, closing the skew window.

## Test

Adds `CreateMetadataSkewRecyclesLiveContextOnRestoreAsync` — a **deterministic** repro driven purely by real ops (VADD / VSIM / Save / recover) plus a single timing gate (`VectorSet_Interrupt_Before_Create_Metadata_Persist`) that throws in the skew window. No synthetic state mutation. The gate throws (rather than parks) so the create unwinds and releases its lock/epoch, allowing a foreground checkpoint without deadlock.

- **Without the fix:** fails deterministically (`Expected 0 But was 1` — a second vector set surfaces through the recovered context's namespace).
- **With the fix:** passes.

## Validation

- Repro fails without the fix, passes with it (both `TestFixture` variants).
- Full `Garnet.test.vectorset` suite: **167 passed, 2 skipped, 0 failed**.