### PR TITLE
Fix Lua allocator corruption from disposing a session mid-script

### DIFF
--- a/libs/server/Lua/LuaCommands.cs
+++ b/libs/server/Lua/LuaCommands.cs
@@ -335,9 +335,10 @@ namespace Garnet.server
         /// <summary>
         /// Run a resolved script for the current session.
         /// 
-        /// Gated so it cannot execute while the session's Lua state is being disposed; if the session
-        /// is disposing this is a no-op. On failure the runner is removed from the session cache from
-        /// inside the guarded window, so it can't race disposal on the runner dictionary.
+        /// Gated so it can't execute while the session's Lua state is being disposed. If disposing,
+        /// <see cref="SessionScriptCache.StartRunningScript"/> returns false and this is a no-op: no reply
+        /// is written since the connection is already closing. On failure the runner is removed inside the
+        /// guarded window so it can't race disposal.
         /// </summary>
         private void RunScriptForSession(int count, LuaRunner runner, ScriptHashKey scriptKey)
         {

--- a/libs/server/Lua/LuaCommands.cs
+++ b/libs/server/Lua/LuaCommands.cs
@@ -78,16 +78,7 @@ namespace Garnet.server
             }
             else
             {
-                // We assume here that ExecuteScript does not raise exceptions
-                sessionScriptCache.StartRunningScript(runner);
-                var res = TryExecuteScript(count - 1, runner);
-                sessionScriptCache.StopRunningScript();
-
-                if (!res)
-                {
-                    // Note we DON'T dispose the script handle because this is just the session cache
-                    sessionScriptCache.Remove(scriptKey);
-                }
+                RunScriptForSession(count, runner, scriptKey);
             }
 
             return true;
@@ -168,15 +159,7 @@ namespace Garnet.server
             }
             else
             {
-                // We assume here that ExecuteScript does not raise exceptions
-                sessionScriptCache.StartRunningScript(runner);
-                var res = TryExecuteScript(count - 1, runner);
-                sessionScriptCache.StopRunningScript();
-
-                if (!res)
-                {
-                    sessionScriptCache.Remove(onStackScriptKey);
-                }
+                RunScriptForSession(count, runner, onStackScriptKey);
             }
 
             return true;
@@ -347,6 +330,33 @@ namespace Garnet.server
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Run a resolved script for the current session.
+        /// 
+        /// Gated so it cannot execute while the session's Lua state is being disposed; if the session
+        /// is disposing this is a no-op. On failure the runner is removed from the session cache from
+        /// inside the guarded window, so it can't race disposal on the runner dictionary.
+        /// </summary>
+        private void RunScriptForSession(int count, LuaRunner runner, ScriptHashKey scriptKey)
+        {
+            // We assume here that ExecuteScript does not raise exceptions
+            if (!sessionScriptCache.StartRunningScript(runner))
+                return;
+
+            try
+            {
+                if (!TryExecuteScript(count - 1, runner))
+                {
+                    // Note we DON'T dispose the script handle because this is just the session cache
+                    sessionScriptCache.Remove(scriptKey);
+                }
+            }
+            finally
+            {
+                sessionScriptCache.StopRunningScript();
+            }
         }
 
         /// <summary>

--- a/libs/server/Lua/SessionScriptCache.cs
+++ b/libs/server/Lua/SessionScriptCache.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Security.Cryptography;
+using Garnet.common;
 using Garnet.server.ACL;
 using Garnet.server.Auth;
 using Garnet.server.Lua;
@@ -35,6 +36,11 @@ namespace Garnet.server
 
         LuaRunner timeoutRunningScript;
         LuaTimeoutManager.Registration timeoutRegistration;
+
+        // Tracks in-flight script executions so disposal can wait for a running script to
+        // finish before freeing the Lua state. The Lua allocators are single-thread-by-design,
+        // so closing the state (lua_close) concurrently with an executing script corrupts the heap.
+        readonly ActiveWorkerMonitor scriptRunMonitor = new();
 
         // Provides a unique value for script invocations
         //
@@ -81,21 +87,29 @@ namespace Garnet.server
         /// 
         /// Enables timeouts, if they are configured.
         /// 
-        /// Should always be paired with a call to <see cref="StopRunningScript"/>.
+        /// Returns <c>false</c> if the session is being disposed, in which case the caller
+        /// must NOT execute the script (the Lua state may be freed concurrently).
+        /// 
+        /// Should always be paired with a call to <see cref="StopRunningScript"/> when it returns <c>true</c>.
         /// </summary>
-        public void StartRunningScript(LuaRunner script)
+        public bool StartRunningScript(LuaRunner script)
         {
+            if (!scriptRunMonitor.TryEnter())
+                return false;
+
             if (timeoutRegistration != null)
             {
                 timeoutRegistration.SetCookie(++timeoutRunningCookie);
                 timeoutRunningScript = script;
             }
+
+            return true;
         }
 
         /// <summary>
         /// Indicate that a script has stopped running.
         /// 
-        /// Should always be paired with a call to <see cref="StartRunningScript"/>.
+        /// Should always be paired with a preceding call to <see cref="StartRunningScript"/> that returned <c>true</c>.
         /// </summary>
         public void StopRunningScript()
         {
@@ -104,6 +118,8 @@ namespace Garnet.server
                 timeoutRegistration.SetCookie(0);
                 timeoutRunningScript = null;
             }
+
+            _ = scriptRunMonitor.Exit();
         }
 
         /// <summary>
@@ -237,6 +253,11 @@ namespace Garnet.server
         /// </summary>
         public void Clear()
         {
+            // Prevent new script executions and block until any in-flight script has exited before
+            // disposing runners (which frees the Lua state via lua_close). This avoids corrupting the
+            // single-threaded Lua allocator by freeing it while a script is still executing.
+            scriptRunMonitor.Dispose();
+
             timeoutRegistration?.Dispose();
             timeoutRegistration = null;
 

--- a/test/standalone/Garnet.test.scripting/LuaScriptTests.cs
+++ b/test/standalone/Garnet.test.scripting/LuaScriptTests.cs
@@ -3542,41 +3542,41 @@ return count";
         }
 
         /// <summary>
-        /// Reproduces the Lua allocator corruption that occurs when a session (and its Lua state)
-        /// is disposed while a script is still executing on another thread.
-        ///
-        /// The Lua allocators are single-thread-by-design: one script runs on one thread at a time.
-        /// Disposing the session calls <c>SessionScriptCache.Clear</c> -> <c>LuaRunner.Dispose</c> ->
-        /// <c>lua_close</c>, which frees the entire Lua heap. If a worker thread is concurrently inside
-        /// <c>LuaRunner.RunForSession</c> allocating on that same allocator, the free-list is corrupted.
-        ///
-        /// To make the otherwise-tiny race window reliable, the script does nothing but allocate in a
-        /// tight loop, so a dispose landing at any moment overlaps an in-flight allocation.
+        /// Disposing a session while a script runs on another thread frees the Lua heap
+        /// (<c>lua_close</c>) underneath the single-threaded allocator, corrupting it. The script here
+        /// only allocates in a tight loop, so a concurrent dispose reliably lands mid-allocation.
         /// </summary>
         [Test]
         public void DisposeDuringScriptExecutionAllocatorRace()
         {
-            // Allocates continuously on the Lua heap, keeping a worker thread inside the allocator.
-            // The iteration count is sized so the script runs for a few seconds: long enough to still
-            // be executing when the dispose lands, but bounded so the (fixed) dispose wait stays short.
+            // Signals (via a store write another connection can observe) that execution has begun, then
+            // allocates in a tight loop. Kept short so the concurrent dispose's drain wait stays small.
             const string BusyAllocScript = @"
+                redis.call('SET', KEYS[1], '1')
                 local x
-                for i = 1, 5000000 do
+                for i = 1, 1000000 do
                     x = { i, i, i, i, i, i, i, i }
                 end
                 return 1";
 
-            var scriptConn = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            const string StartedKey = "alloc-race-started";
+
+            using var scriptConn = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var probeConn = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = scriptConn.GetDatabase(0);
+            var probeDb = probeConn.GetDatabase(0);
 
-            // Fire the long-running script without awaiting; it keeps allocating on the Lua heap.
-            var scriptTask = db.ScriptEvaluateAsync(BusyAllocScript);
+            // Fire the script without awaiting; it keeps allocating on the Lua heap.
+            var scriptTask = db.ScriptEvaluateAsync(BusyAllocScript, [(RedisKey)StartedKey]);
 
-            // Give the script time to enter the allocation loop.
-            Thread.Sleep(250);
+            // Wait until the script has actually entered execution (bounded), so the dispose lands
+            // mid-run regardless of how quickly the host starts the script.
+            var sw = Stopwatch.StartNew();
+            while (!probeDb.KeyExists(StartedKey) && sw.ElapsedMilliseconds < 5000)
+                Thread.Sleep(5);
 
-            // Dispose the server while the script is mid-allocation. Without the fix this frees the
-            // Lua heap (lua_close) concurrently with allocation -> allocator corruption / crash.
+            // Dispose the server while the script is mid-allocation. In a previous regression, this
+            // would free the Lua heap (lua_close) concurrently with allocation -> corruption / crash.
             var toDispose = server;
             server = null;
             toDispose.Dispose();
@@ -3589,8 +3589,6 @@ return count";
             {
                 // Expected: the connection is dropped when the server is disposed mid-script.
             }
-
-            scriptConn.Dispose();
         }
 
     }

--- a/test/standalone/Garnet.test.scripting/LuaScriptTests.cs
+++ b/test/standalone/Garnet.test.scripting/LuaScriptTests.cs
@@ -147,7 +147,7 @@ namespace Garnet.test
         [TearDown]
         public void TearDown()
         {
-            server.Dispose();
+            server?.Dispose();
             try
             {
                 if (aclFile != null)
@@ -3539,6 +3539,58 @@ return count";
 
             ClassicAssert.IsTrue(exc.Message.Contains("not allowed from script"),
                 $"SUBSCRIBE should remain blocked in scripts, got: {exc.Message}");
+        }
+
+        /// <summary>
+        /// Reproduces the Lua allocator corruption that occurs when a session (and its Lua state)
+        /// is disposed while a script is still executing on another thread.
+        ///
+        /// The Lua allocators are single-thread-by-design: one script runs on one thread at a time.
+        /// Disposing the session calls <c>SessionScriptCache.Clear</c> -> <c>LuaRunner.Dispose</c> ->
+        /// <c>lua_close</c>, which frees the entire Lua heap. If a worker thread is concurrently inside
+        /// <c>LuaRunner.RunForSession</c> allocating on that same allocator, the free-list is corrupted.
+        ///
+        /// To make the otherwise-tiny race window reliable, the script does nothing but allocate in a
+        /// tight loop, so a dispose landing at any moment overlaps an in-flight allocation.
+        /// </summary>
+        [Test]
+        public void DisposeDuringScriptExecutionAllocatorRace()
+        {
+            // Allocates continuously on the Lua heap, keeping a worker thread inside the allocator.
+            // The iteration count is sized so the script runs for a few seconds: long enough to still
+            // be executing when the dispose lands, but bounded so the (fixed) dispose wait stays short.
+            const string BusyAllocScript = @"
+                local x
+                for i = 1, 5000000 do
+                    x = { i, i, i, i, i, i, i, i }
+                end
+                return 1";
+
+            var scriptConn = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = scriptConn.GetDatabase(0);
+
+            // Fire the long-running script without awaiting; it keeps allocating on the Lua heap.
+            var scriptTask = db.ScriptEvaluateAsync(BusyAllocScript);
+
+            // Give the script time to enter the allocation loop.
+            Thread.Sleep(250);
+
+            // Dispose the server while the script is mid-allocation. Without the fix this frees the
+            // Lua heap (lua_close) concurrently with allocation -> allocator corruption / crash.
+            var toDispose = server;
+            server = null;
+            toDispose.Dispose();
+
+            try
+            {
+                _ = scriptTask.GetAwaiter().GetResult();
+            }
+            catch
+            {
+                // Expected: the connection is dropped when the server is disposed mid-script.
+            }
+
+            scriptConn.Dispose();
         }
 
     }


### PR DESCRIPTION
## Problem

A session's Lua state is closed (lua_close, which frees the entire Lua heap) from SessionScriptCache.Clear() during RespServerSession / GarnetServer disposal. This can execute on a **different thread** than the one running a script for that session.

The clearest trigger is server shutdown: GarnetServer.Dispose() -> GarnetServerBase.DisposeActiveHandlers() -> RespServerSession.Dispose() -> SessionScriptCache.Clear() -> LuaRunner.Dispose() -> lua_close() runs on the disposing thread, while a **.NET ThreadPool network worker** may still be inside RunForSession for an in-flight `EVAL`/`EVALSHA`.

The Lua allocators (LuaManagedAllocator / LuaLimitedManagedAllocator) are single-threaded by design. Freeing the heap (`lua_close`) while a script is still allocating on the same allocator corrupts its free list. The corruption then surfaces as unrelated, hard-to-diagnose failures (scrambled interned strings, bad ACL/RESP argument parsing, `Bit`/`Struct` errors, etc.).

## Root cause evidence

Reproduced deterministically under CPU-throttled containers with allocator-integrity instrumentation. Every capture showed the **same two threads on the same allocator**:
- `NUnit` / disposer thread in `lua_close` (`SessionScriptCache.Clear`), and
- a `.NET TP Worker` in `LuaRunner.RunForSession` (`TryEVAL`),

racing on the free list. `LuaStateWrapper.Dispose` already serializes `lua_close` with hook-setting via `stateUpdateLock` and is idempotent, so the timeout thread and double-dispose are **not** the culprit - the only unguarded conflict is *script execution vs. state close*.

This is the source of the flaky `LuaScriptTests` failures, and is also a genuine (if lower-severity) production shutdown-time race.

## Fix

Add a small **interlocked gate in `SessionScriptCache`, scoped to script execution only** (zero cost for non-Lua commands; one interlocked increment/decrement per script eval):

- `StartRunningScript` increments an in-flight counter and returns `false` (refusing to start) once disposal has begun.
- `StopRunningScript` decrements it.
- `Clear` sets a `disposing` flag and **drains** in-flight executions (waits for the counter to reach 0) before disposing any runner.
- The `Remove`-on-failure path is kept **inside** the guarded window (via `try/finally`), so it also cannot race `Clear` on the runner dictionary.

Full store-load fencing via `Interlocked` on both sides guarantees a started execution and an in-progress disposal can never both proceed.

## Testing
- `dotnet build libs/server/Garnet.server.csproj -c Release` — clean (0 warnings).
- Draft: still validating against the full scripting suite / repro fleet.
