### PR TITLE
Handle overflows in `RespMemoryWriter`

### DIFF
--- a/libs/common/RespMemoryWriter.cs
+++ b/libs/common/RespMemoryWriter.cs
@@ -507,7 +507,7 @@ namespace Garnet.common
             }
 
             if (length <= 0)
-                throw new OverflowException("length");
+                throw new GarnetException($"Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", disposeSession: false);
 
             var newMem = MemoryPool<byte>.Shared.Rent(length);
             var newPtrHandle = newMem.Memory.Pin();

--- a/test/standalone/Garnet.test/RespMemoryWriterOverflowTests.cs
+++ b/test/standalone/Garnet.test/RespMemoryWriterOverflowTests.cs
@@ -52,8 +52,6 @@ namespace Garnet.test
             var writeReses = await Task.WhenAll(writeTasks).ConfigureAwait(false);
             ClassicAssert.IsTrue(writeReses.All(static x => x));
 
-            var x = await db.HashGetAllAsync(Key).ConfigureAwait(false);
-
             var exc = ClassicAssert.ThrowsAsync<RedisServerException>(() => db.HashGetAllAsync(Key));
             ClassicAssert.AreEqual($"ERR Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
         }
@@ -79,9 +77,7 @@ namespace Garnet.test
 
             _ = await Task.WhenAll(writeTasks).ConfigureAwait(false);
 
-            var x = await db.ListRangeAsync(Key).ConfigureAwait(false);
-
-            var exc = ClassicAssert.ThrowsAsync<RedisServerException>(() => db.HashGetAllAsync(Key));
+            var exc = ClassicAssert.ThrowsAsync<RedisServerException>(() => db.ListRangeAsync(Key));
             ClassicAssert.AreEqual($"ERR Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
         }
 
@@ -106,9 +102,7 @@ namespace Garnet.test
             var writeReses = await Task.WhenAll(writeTasks).ConfigureAwait(false);
             ClassicAssert.IsTrue(writeReses.All(static x => x));
 
-            var x = await db.SetMembersAsync(Key).ConfigureAwait(false);
-
-            var exc = ClassicAssert.ThrowsAsync<RedisServerException>(() => db.HashGetAllAsync(Key));
+            var exc = ClassicAssert.ThrowsAsync<RedisServerException>(() => db.SetMembersAsync(Key));
             ClassicAssert.AreEqual($"ERR Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
         }
 
@@ -133,9 +127,7 @@ namespace Garnet.test
             var writeReses = await Task.WhenAll(writeTasks).ConfigureAwait(false);
             ClassicAssert.IsTrue(writeReses.All(static x => x));
 
-            var x = await db.SortedSetRangeByScoreWithScoresAsync(Key).ConfigureAwait(false);
-
-            var exc = ClassicAssert.ThrowsAsync<RedisServerException>(() => db.HashGetAllAsync(Key));
+            var exc = ClassicAssert.ThrowsAsync<RedisServerException>(() => db.SortedSetRangeByScoreWithScoresAsync(Key));
             ClassicAssert.AreEqual($"ERR Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
         }
     }

--- a/test/standalone/Garnet.test/RespMemoryWriterOverflowTests.cs
+++ b/test/standalone/Garnet.test/RespMemoryWriterOverflowTests.cs
@@ -13,7 +13,9 @@ namespace Garnet.test
     [TestFixture]
     public class RespMemoryWriterOverflowTests : TestBase
     {
-        GarnetServer server;
+        private const int BatchSize = 1_000;
+
+        private GarnetServer server;
 
         [SetUp]
         public void Setup()
@@ -27,7 +29,7 @@ namespace Garnet.test
         public void TearDown()
         {
             server.Dispose();
-            TestUtils.OnTearDown();
+            TestUtils.OnTearDown(waitForDelete: true);
         }
 
         [Test]
@@ -42,18 +44,22 @@ namespace Garnet.test
 
             var fieldValue = new string('h', FieldLength);
 
-            var writeTasks = new Task<bool>[NumFields];
-
-            for (var i = 0; i < NumFields; i++)
+            for (var i = 0; i < NumFields; i += BatchSize)
             {
-                writeTasks[i] = db.HashSetAsync(Key, $"field:{i}", fieldValue);
+                var writeTasks = new Task<bool>[BatchSize];
+                writeTasks.AsSpan().Fill(Task.FromResult(true));
+
+                for (var j = 0; j < writeTasks.Length; j++)
+                {
+                    writeTasks[j] = db.HashSetAsync(Key, $"field:{(i + j)}", fieldValue);
+                }
+
+                var writeReses = await Task.WhenAll(writeTasks).ConfigureAwait(false);
+                ClassicAssert.IsTrue(writeReses.All(static x => x));
             }
 
-            var writeReses = await Task.WhenAll(writeTasks).ConfigureAwait(false);
-            ClassicAssert.IsTrue(writeReses.All(static x => x));
-
             var exc = ClassicAssert.ThrowsAsync<RedisServerException>(() => db.HashGetAllAsync(Key));
-            ClassicAssert.AreEqual($"ERR Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
+            ClassicAssert.AreEqual($"ERR Garnet Exception: Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
         }
 
         [Test]
@@ -68,17 +74,21 @@ namespace Garnet.test
 
             var elementValue = new string('l', ElementLength);
 
-            var writeTasks = new Task<long>[NumElements];
-
-            for (var i = 0; i < NumElements; i++)
+            for (var i = 0; i < NumElements; i += BatchSize)
             {
-                writeTasks[i] = db.ListLeftPushAsync(Key, elementValue);
+                var writeTasks = new Task[BatchSize];
+                writeTasks.AsSpan().Fill(Task.CompletedTask);
+
+                for (var j = 0; j < writeTasks.Length; j++)
+                {
+                    writeTasks[j] = db.ListRightPushAsync(Key, elementValue);
+                }
+
+                await Task.WhenAll(writeTasks).ConfigureAwait(false);
             }
 
-            _ = await Task.WhenAll(writeTasks).ConfigureAwait(false);
-
             var exc = ClassicAssert.ThrowsAsync<RedisServerException>(() => db.ListRangeAsync(Key));
-            ClassicAssert.AreEqual($"ERR Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
+            ClassicAssert.AreEqual($"ERR Garnet Exception: Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
         }
 
         [Test]
@@ -91,19 +101,25 @@ namespace Garnet.test
             using var redis = await ConnectionMultiplexer.ConnectAsync(TestUtils.GetConfig()).ConfigureAwait(false);
             var db = redis.GetDatabase();
 
-            var writeTasks = new Task<bool>[NumMembers];
+            var longValue = new string('s', MemberLength);
 
-            for (var i = 0; i < NumMembers; i++)
+            for (var i = 0; i < NumMembers; i += BatchSize)
             {
-                var memberName = $"{i}_{new string('s', MemberLength)}";
-                writeTasks[i] = db.SetAddAsync(Key, memberName);
+                var writeTasks = new Task<bool>[BatchSize];
+                writeTasks.AsSpan().Fill(Task.FromResult(true));
+
+                for (var j = 0; j < writeTasks.Length; j++)
+                {
+                    var memberName = $"{(i + j)}_{longValue}";
+                    writeTasks[j] = db.SetAddAsync(Key, memberName);
+                }
+
+                var writeReses = await Task.WhenAll(writeTasks).ConfigureAwait(false);
+                ClassicAssert.IsTrue(writeReses.All(static x => x));
             }
 
-            var writeReses = await Task.WhenAll(writeTasks).ConfigureAwait(false);
-            ClassicAssert.IsTrue(writeReses.All(static x => x));
-
             var exc = ClassicAssert.ThrowsAsync<RedisServerException>(() => db.SetMembersAsync(Key));
-            ClassicAssert.AreEqual($"ERR Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
+            ClassicAssert.AreEqual($"ERR Garnet Exception: Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
         }
 
         [Test]
@@ -116,19 +132,25 @@ namespace Garnet.test
             using var redis = await ConnectionMultiplexer.ConnectAsync(TestUtils.GetConfig()).ConfigureAwait(false);
             var db = redis.GetDatabase();
 
-            var writeTasks = new Task<bool>[NumMembers];
+            var longValue = new string('z', MemberLength);
 
-            for (var i = 0; i < NumMembers; i++)
+            for (var i = 0; i < NumMembers; i += BatchSize)
             {
-                var memberName = $"{i}_{new string('z', MemberLength)}";
-                writeTasks[i] = db.SortedSetAddAsync(Key, memberName, i);
+                var writeTasks = new Task<bool>[BatchSize];
+                writeTasks.AsSpan().Fill(Task.FromResult(true));
+
+                for (var j = 0; j < writeTasks.Length; j++)
+                {
+                    var memberName = $"{(i + j)}_{longValue}";
+                    writeTasks[j] = db.SortedSetAddAsync(Key, memberName, (i + j));
+                }
+
+                var writeReses = await Task.WhenAll(writeTasks).ConfigureAwait(false);
+                ClassicAssert.IsTrue(writeReses.All(static x => x));
             }
 
-            var writeReses = await Task.WhenAll(writeTasks).ConfigureAwait(false);
-            ClassicAssert.IsTrue(writeReses.All(static x => x));
-
             var exc = ClassicAssert.ThrowsAsync<RedisServerException>(() => db.SortedSetRangeByScoreWithScoresAsync(Key));
-            ClassicAssert.AreEqual($"ERR Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
+            ClassicAssert.AreEqual($"ERR Garnet Exception: Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
         }
     }
 }

--- a/test/standalone/Garnet.test/RespMemoryWriterOverflowTests.cs
+++ b/test/standalone/Garnet.test/RespMemoryWriterOverflowTests.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using StackExchange.Redis;
+
+namespace Garnet.test
+{
+    [TestFixture]
+    public class RespMemoryWriterOverflowTests : TestBase
+    {
+        GarnetServer server;
+
+        [SetUp]
+        public void Setup()
+        {
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
+            server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableReadCache: false, enableAOF: false, lowMemory: false);
+            server.Start();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            server.Dispose();
+            TestUtils.OnTearDown();
+        }
+
+        [Test]
+        public async Task HashAsync()
+        {
+            const string Key = nameof(HashAsync);
+            const int NumFields = 250_000;
+            const int FieldLength = 20_000;
+
+            using var redis = await ConnectionMultiplexer.ConnectAsync(TestUtils.GetConfig()).ConfigureAwait(false);
+            var db = redis.GetDatabase();
+
+            var fieldValue = new string('h', FieldLength);
+
+            var writeTasks = new Task<bool>[NumFields];
+
+            for (var i = 0; i < NumFields; i++)
+            {
+                writeTasks[i] = db.HashSetAsync(Key, $"field:{i}", fieldValue);
+            }
+
+            var writeReses = await Task.WhenAll(writeTasks).ConfigureAwait(false);
+            ClassicAssert.IsTrue(writeReses.All(static x => x));
+
+            var x = await db.HashGetAllAsync(Key).ConfigureAwait(false);
+
+            var exc = ClassicAssert.ThrowsAsync<RedisServerException>(() => db.HashGetAllAsync(Key));
+            ClassicAssert.AreEqual($"ERR Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
+        }
+
+        [Test]
+        public async Task ListAsync()
+        {
+            const string Key = nameof(ListAsync);
+            const int NumElements = 250_000;
+            const int ElementLength = 40_000;
+
+            using var redis = await ConnectionMultiplexer.ConnectAsync(TestUtils.GetConfig()).ConfigureAwait(false);
+            var db = redis.GetDatabase();
+
+            var elementValue = new string('l', ElementLength);
+
+            var writeTasks = new Task<long>[NumElements];
+
+            for (var i = 0; i < NumElements; i++)
+            {
+                writeTasks[i] = db.ListLeftPushAsync(Key, elementValue);
+            }
+
+            _ = await Task.WhenAll(writeTasks).ConfigureAwait(false);
+
+            var x = await db.ListRangeAsync(Key).ConfigureAwait(false);
+
+            var exc = ClassicAssert.ThrowsAsync<RedisServerException>(() => db.HashGetAllAsync(Key));
+            ClassicAssert.AreEqual($"ERR Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
+        }
+
+        [Test]
+        public async Task SetAsync()
+        {
+            const string Key = nameof(SetAsync);
+            const int NumMembers = 250_000;
+            const int MemberLength = 40_000;
+
+            using var redis = await ConnectionMultiplexer.ConnectAsync(TestUtils.GetConfig()).ConfigureAwait(false);
+            var db = redis.GetDatabase();
+
+            var writeTasks = new Task<bool>[NumMembers];
+
+            for (var i = 0; i < NumMembers; i++)
+            {
+                var memberName = $"{i}_{new string('s', MemberLength)}";
+                writeTasks[i] = db.SetAddAsync(Key, memberName);
+            }
+
+            var writeReses = await Task.WhenAll(writeTasks).ConfigureAwait(false);
+            ClassicAssert.IsTrue(writeReses.All(static x => x));
+
+            var x = await db.SetMembersAsync(Key).ConfigureAwait(false);
+
+            var exc = ClassicAssert.ThrowsAsync<RedisServerException>(() => db.HashGetAllAsync(Key));
+            ClassicAssert.AreEqual($"ERR Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
+        }
+
+        [Test]
+        public async Task SortedSetAsync()
+        {
+            const string Key = nameof(SortedSetAsync);
+            const int NumMembers = 250_000;
+            const int MemberLength = 40_000;
+
+            using var redis = await ConnectionMultiplexer.ConnectAsync(TestUtils.GetConfig()).ConfigureAwait(false);
+            var db = redis.GetDatabase();
+
+            var writeTasks = new Task<bool>[NumMembers];
+
+            for (var i = 0; i < NumMembers; i++)
+            {
+                var memberName = $"{i}_{new string('z', MemberLength)}";
+                writeTasks[i] = db.SortedSetAddAsync(Key, memberName, i);
+            }
+
+            var writeReses = await Task.WhenAll(writeTasks).ConfigureAwait(false);
+            ClassicAssert.IsTrue(writeReses.All(static x => x));
+
+            var x = await db.SortedSetRangeByScoreWithScoresAsync(Key).ConfigureAwait(false);
+
+            var exc = ClassicAssert.ThrowsAsync<RedisServerException>(() => db.HashGetAllAsync(Key));
+            ClassicAssert.AreEqual($"ERR Exceeded maximum response size of ({Array.MaxLength:N0}) bytes", exc.Message);
+        }
+    }
+}

--- a/test/standalone/Garnet.test/RespMemoryWriterOverflowTests.cs
+++ b/test/standalone/Garnet.test/RespMemoryWriterOverflowTests.cs
@@ -36,8 +36,8 @@ namespace Garnet.test
         public async Task HashAsync()
         {
             const string Key = nameof(HashAsync);
-            const int NumFields = 250_000;
-            const int FieldLength = 20_000;
+            const int NumFields = 60_000;
+            const int FieldLength = 40_000;
 
             using var redis = await ConnectionMultiplexer.ConnectAsync(TestUtils.GetConfig()).ConfigureAwait(false);
             var db = redis.GetDatabase();
@@ -66,7 +66,7 @@ namespace Garnet.test
         public async Task ListAsync()
         {
             const string Key = nameof(ListAsync);
-            const int NumElements = 250_000;
+            const int NumElements = 60_000;
             const int ElementLength = 40_000;
 
             using var redis = await ConnectionMultiplexer.ConnectAsync(TestUtils.GetConfig()).ConfigureAwait(false);
@@ -95,7 +95,7 @@ namespace Garnet.test
         public async Task SetAsync()
         {
             const string Key = nameof(SetAsync);
-            const int NumMembers = 250_000;
+            const int NumMembers = 60_000;
             const int MemberLength = 40_000;
 
             using var redis = await ConnectionMultiplexer.ConnectAsync(TestUtils.GetConfig()).ConfigureAwait(false);
@@ -126,7 +126,7 @@ namespace Garnet.test
         public async Task SortedSetAsync()
         {
             const string Key = nameof(SortedSetAsync);
-            const int NumMembers = 250_000;
+            const int NumMembers = 60_000;
             const int MemberLength = 40_000;
 
             using var redis = await ConnectionMultiplexer.ConnectAsync(TestUtils.GetConfig()).ConfigureAwait(false);


### PR DESCRIPTION
Fixes #1616
Supercedes #1945 

Simplest possible fix (just changes the exception type and adds a message).
Includes tests for the `RespMemoryWriter`-using types (Hash, List, Set, and SortedSet) to prevent regressions.