### PR TITLE
[RESP] Fix InlinePing SIMD-scan regression and MGET per-key boxing allocation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -194,6 +194,7 @@ To add a new Garnet server setting:
 - Central package version management via `Directory.Packages.props`
 - XML doc comments (`/// <summary>`) are strongly recommended on public methods, with `<param>` tags for each parameter; analyzer rules for missing docs are currently configured as suggestions (see `.editorconfig`)
 - Comment format: `// Comment starting with a capital letter` (one space after `//`)
+- Keep comments tight, factual, and to the point: describe what the code does and why, in the present tense. Don't narrate history, reference issues/PRs, or describe problems, bugs, or prior approaches.
 
 ### Performance Conventions
 

--- a/libs/server/Resp/MGetReadArgBatch.cs
+++ b/libs/server/Resp/MGetReadArgBatch.cs
@@ -31,6 +31,20 @@ namespace Garnet.server
         public readonly ReadOnlySpan<PinnedSpanByte> Parameters
             => session.parseState.Parameters;
 
+        // Explicitly implement these two IReadArgBatch members (rather than inheriting the interface
+        // defaults) so calls through the generic TBatch constraint bind to these struct methods directly
+        // instead of boxing this struct on every invocation. InitialIORecordSize is read once per key in
+        // the ContextReadWithPrefetch loop, so relying on the default would box once per key (e.g. 100
+        // boxes / ~4.8 KB for a 100-key MGET). Both return the same values as the interface defaults.
+
+        /// <inheritdoc/>
+        public readonly int InitialIORecordSize
+        => KVSettings.UseDefaultInitialIORecordSize;
+
+        /// <inheritdoc/>
+        public readonly ReadCopyOptions ReadCopyOptions
+        => default;
+
         private readonly bool HasGoneAsync
         => !runningStatus.IsEmpty;
 

--- a/libs/server/Resp/MGetReadArgBatch.cs
+++ b/libs/server/Resp/MGetReadArgBatch.cs
@@ -31,11 +31,8 @@ namespace Garnet.server
         public readonly ReadOnlySpan<PinnedSpanByte> Parameters
             => session.parseState.Parameters;
 
-        // Explicitly implement these two IReadArgBatch members (rather than inheriting the interface
-        // defaults) so calls through the generic TBatch constraint bind to these struct methods directly
-        // instead of boxing this struct on every invocation. InitialIORecordSize is read once per key in
-        // the ContextReadWithPrefetch loop, so relying on the default would box once per key (e.g. 100
-        // boxes / ~4.8 KB for a 100-key MGET). Both return the same values as the interface defaults.
+        // Implemented explicitly (not via the IReadArgBatch defaults) so calls through the generic
+        // TBatch constraint bind directly instead of boxing this struct.
 
         /// <inheritdoc/>
         public readonly int InitialIORecordSize

--- a/libs/server/Resp/Parser/RespCommand.cs
+++ b/libs/server/Resp/Parser/RespCommand.cs
@@ -823,7 +823,9 @@ namespace Garnet.server
             var remainingBytes = bytesRead - readHead;
 
             // SIMD fast path delegated to non-inlined helper to keep this method small enough to inline.
-            if (Vector128.IsHardwareAccelerated && remainingBytes >= 16)
+            // Gate on the leading '*': SIMD patterns are array-framed, so inline commands (e.g. PING\r\n)
+            // skip the scan and fall through to FastParseInlineCommand.
+            if (Vector128.IsHardwareAccelerated && remainingBytes >= 16 && *ptr == (byte)'*')
             {
                 var simdResult = SimdFastParse(ptr, out count);
                 if (simdResult != RespCommand.NONE)


### PR DESCRIPTION
## Summary

Two independent performance fixes for regressions surfaced by the BDN CI benchmarks, both in `libs/server/Resp/`. Split into two commits (one per fix).

---

### 1. InlinePing SIMD-scan regression — `RespCommand.cs`

**Root cause:** #1658 added an unconditional SIMD `Vector128` scan at the top of `FastParseCommand`, gated only on `remainingBytes >= 16`. Every SIMD pattern is RESP array-framed (`*N\r\n$L\r\nCMD\r\n`), so an inline command such as `PING\r\n` (starts with a command letter, not `*`) can never match. In a batched inline workload the buffer is always ≥ 16 bytes, so each inline command paid a `NoInlining` call plus ~18 vector comparisons before falling through to `FastParseInlineCommand`.

**Fix:** Gate the SIMD scan on a leading `*`. Inline commands skip it and go straight to `FastParseInlineCommand` (pre-#1658 behavior). This loses no SIMD matches (all patterns require `*`) and adds only a single byte compare to the array-framed hot path.

**Measured** — `Operations.BasicOperations.InlinePing (None)`, net10.0:

| Version | Mean |
|---|---|
| pre-#1658 | 1.64 µs |
| #1658 (regressed) | 2.22 µs (+35%) |
| **fixed** | **1.73 µs** |

Array-framed commands (`GetNotFound`/`GetFound`) verified unaffected.

---

### 2. MGET per-key struct boxing allocation — `MGetReadArgBatch.cs`

**Root cause:** `MGetReadArgBatch_SG` is a `struct` implementing `IReadArgBatch`, whose `InitialIORecordSize` and `ReadCopyOptions` are **default interface methods**. The struct did not implement them, so calling them through the generic `TBatch` constraint in `ContextReadWithPrefetch` **boxed the struct** on every call. `InitialIORecordSize` is read once per key in the read loop, so a 100-key MGET boxed 100× (plus one box for `ReadCopyOptions`) → **4848 B allocated per MGET**, tripping the BDN allocation gate (expected 0) for `Cluster.ClusterOperations.MGet` and `Cluster.ClusterMigrate.MGet`.

**Fix:** Explicitly implement both members on the struct (returning the same values as the interface defaults) so the calls bind directly and no longer box. This matches the existing `VectorReadBatch` implementation.

**Measured:** MGet allocation **4848 B → 0 B**; mean also improves ~13.3 → 11.95 µs.

---

### Key technical details

**Affected types:**
- `RespServerSession.FastParseCommand` (`libs/server/Resp/Parser/RespCommand.cs`)
- `MGetReadArgBatch_SG` : `IReadArgBatch` (`libs/server/Resp/MGetReadArgBatch.cs`)

Both fixes are behavior-preserving: identical parse results, and the MGET members return the same values as the interface defaults.

### What NOT to do (for future agents)
- ❌ **Don't run the SIMD command scan for buffers that aren't `*`-framed** — inline commands can never match array-framed patterns, so the scan is pure overhead.
- ❌ **Don't rely on `IReadArgBatch` default interface members from a struct batch** — calling a default interface method on a value type through a generic constraint boxes it (once per call). Implement the members explicitly.

### Testing
- `RespTests` (347), `RespParseFuzzRegressionTests` (4), and `RespGetLowMemoryTests.ScatterGatherMGet` (disk/async completion, 30/300/3000 keys) all pass.
- BDN: `InlinePing` recovered to ~pre-#1658; `ClusterOperations.MGet` / `ClusterMigrate.MGet` allocation now `0`.
- `dotnet format --verify-no-changes` clean; Release build has no new warnings.

### Issues Fixed

_These regressions were surfaced by the BDN charts / CI perf gate rather than tracked issues. Link an issue here if one exists._
