### PR TITLE
Vector Set recall smoke tests + diskann-garnet 4.0.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="System.Numerics.Tensors" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.5" />
-    <PackageVersion Include="diskann-garnet" Version="4.0.0" />
+    <PackageVersion Include="diskann-garnet" Version="4.0.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
   </ItemGroup>
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- VersionPrefix property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>2.1.0</VersionPrefix>
+		<VersionPrefix>2.1.1</VersionPrefix>
 	</PropertyGroup>
 </Project>

--- a/libs/server/Storage/Functions/VectorStore/VectorSessionFunctions.cs
+++ b/libs/server/Storage/Functions/VectorStore/VectorSessionFunctions.cs
@@ -185,14 +185,7 @@ namespace Garnet.server
             // Constant size indicated
             if (needsAlignmentPadding)
             {
-                // CopyUpdater copies the full existing value into the new record before invoking the
-                // DiskANN callback (which reads it back as part of its read-modify-write). The
-                // destination must therefore be large enough to hold whichever is larger: the requested
-                // write size (padded for alignment), or the existing value being copied in. Sizing it to
-                // only WriteDesiredSize truncates a shrinking update and overflows the CopyTo in
-                // CopyUpdater ("Destination is too short").
-                var valueSize = Math.Max(input.WriteDesiredSize + ValueAlignmentBytes, value.Length);
-                return new() { KeySize = srcLogRecord.Key.Length, ValueSize = valueSize, ExtendedNamespaceSize = GetExtendedNamespaceSize(in srcLogRecord) };
+                return new() { KeySize = srcLogRecord.Key.Length, ValueSize = input.WriteDesiredSize + ValueAlignmentBytes, ExtendedNamespaceSize = GetExtendedNamespaceSize(in srcLogRecord) };
             }
             else
             {

--- a/libs/server/Storage/Functions/VectorStore/VectorSessionFunctions.cs
+++ b/libs/server/Storage/Functions/VectorStore/VectorSessionFunctions.cs
@@ -185,7 +185,14 @@ namespace Garnet.server
             // Constant size indicated
             if (needsAlignmentPadding)
             {
-                return new() { KeySize = srcLogRecord.Key.Length, ValueSize = input.WriteDesiredSize + ValueAlignmentBytes, ExtendedNamespaceSize = GetExtendedNamespaceSize(in srcLogRecord) };
+                // CopyUpdater copies the full existing value into the new record before invoking the
+                // DiskANN callback (which reads it back as part of its read-modify-write). The
+                // destination must therefore be large enough to hold whichever is larger: the requested
+                // write size (padded for alignment), or the existing value being copied in. Sizing it to
+                // only WriteDesiredSize truncates a shrinking update and overflows the CopyTo in
+                // CopyUpdater ("Destination is too short").
+                var valueSize = Math.Max(input.WriteDesiredSize + ValueAlignmentBytes, value.Length);
+                return new() { KeySize = srcLogRecord.Key.Length, ValueSize = valueSize, ExtendedNamespaceSize = GetExtendedNamespaceSize(in srcLogRecord) };
             }
             else
             {

--- a/test/standalone/Garnet.test.vectorset/VectorSetRecallSmokeTests.cs
+++ b/test/standalone/Garnet.test.vectorset/VectorSetRecallSmokeTests.cs
@@ -30,11 +30,11 @@ namespace Garnet.test
     /// fixed graph parameters) so the tests are stable and fast.
     ///
     /// NOTE: the Q8 (8-bit scalar) cases that read from disk (FlushAndEvict, larger-than-memory load,
-    /// and recover) are EXPECTED TO FAIL against diskann-garnet 4.0.0: the per-dimension Q8
-    /// quantization table is native in-memory-only state that is lost when the index is recreated after
-    /// eviction/recovery and cannot be rebuilt, so codes are decoded with a missing table and recall
-    /// collapses (~1.0 -> ~0.02-0.11). NOQUANT and BIN (table-free) are robust. This is a deliberate
-    /// regression guard, not a flaky test. See gist 52a9739f8963462d695576b5c1fe9deb.
+    /// and recover) used to fail against diskann-garnet 4.0.0/4.0.1 because the per-dimension Q8
+    /// quantization table was native in-memory-only state that was lost when the index is recreated
+    /// after eviction/recovery, so codes were decoded with a missing table and recall collapsed
+    /// (~1.0 -> ~0.02-0.11). This was fixed in diskann-garnet 4.0.2; the Q8 disk cases now pass and
+    /// stand as regression guards. NOQUANT and BIN (table-free) were always robust.
     /// </summary>
     [TestFixture]
     public class VectorSetRecallSmokeTests : TestBase
@@ -55,7 +55,8 @@ namespace Garnet.test
         private const double MinInMemoryRecall = 0.80;
 
         // Robustness budget: a physical-config change (evict-to-disk / recover) may only cost this much
-        // recall. NOQUANT/BIN cost ~0.0; the Q8 disk bug costs ~0.9 and blows through this budget.
+        // recall. NOQUANT/BIN/Q8 all cost ~0.0 on 4.0.2; the pre-4.0.2 Q8 disk bug cost ~0.9 and blew
+        // through this budget.
         private const double MaxRecallDrop = 0.20;
 
         private global::Garnet.GarnetServer server;
@@ -114,8 +115,8 @@ namespace Garnet.test
             var onDisk = MeasureRecall(db, key, data);
             ClassicAssert.GreaterOrEqual(onDisk, inMemory - MaxRecallDrop,
                 $"{quant} [{readMode}]: recall collapsed after eviction to disk " +
-                $"(in-memory {inMemory:F3} -> on-disk {onDisk:F3}). For Q8 this is the known " +
-                "quantization-table-lost-on-recreate bug (diskann-garnet 4.0.0).");
+                $"(in-memory {inMemory:F3} -> on-disk {onDisk:F3}). For Q8, a regression here is the " +
+                "quantization-table-lost-on-recreate bug fixed in diskann-garnet 4.0.2.");
         }
 
         /// <summary>
@@ -149,7 +150,7 @@ namespace Garnet.test
             var onDisk = MeasureRecall(db, key, data);
             ClassicAssert.GreaterOrEqual(onDisk, MinInMemoryRecall,
                 $"{quant}: recall {onDisk:F3} is broken for a graph built and served larger-than-memory. " +
-                "For Q8 this is the known quantization-table-lost-on-recreate bug (diskann-garnet 4.0.0).");
+                "For Q8, a regression here is the quantization-table-lost-on-recreate bug fixed in diskann-garnet 4.0.2.");
         }
 
         /// <summary>
@@ -218,8 +219,8 @@ namespace Garnet.test
                 var after = MeasureRecall(db, key, data);
                 ClassicAssert.GreaterOrEqual(after, before - MaxRecallDrop,
                     $"{quant} [recoverIntoSmallerLog={recoverIntoSmallerLog}]: recall collapsed after save+restart+recover " +
-                    $"(before {before:F3} -> after {after:F3}). For Q8 this is the known " +
-                    "quantization-table-lost-on-recreate bug (diskann-garnet 4.0.0).");
+                    $"(before {before:F3} -> after {after:F3}). For Q8, a regression here is the " +
+                    "quantization-table-lost-on-recreate bug fixed in diskann-garnet 4.0.2.");
             }
         }
 

--- a/test/standalone/Garnet.test.vectorset/VectorSetRecallSmokeTests.cs
+++ b/test/standalone/Garnet.test.vectorset/VectorSetRecallSmokeTests.cs
@@ -19,7 +19,7 @@ namespace Garnet.test
     ///   * quantization mode (NOQUANT / Q8 / BIN),
     ///   * larger-than-memory (records spill to the storage tier during load, or are evicted to disk),
     ///   * read-cache vs copy-reads-to-tail vs neither,
-    ///   * save -> restart -> recover (optionally evicting the recovered graph back to disk).
+    ///   * save -> restart -> recover (optionally recovering into a much smaller log).
     ///
     /// The invariant under test is <b>physical robustness</b>: a graph that answers queries well while
     /// resident in memory must keep answering them well once the same records are served from disk, or
@@ -154,23 +154,28 @@ namespace Garnet.test
 
         /// <summary>
         /// Build a graph, checkpoint it, restart the server and recover. Recall must survive the round
-        /// trip. When <paramref name="evictAfterRecover"/> is set, the recovered graph is flushed to disk
-        /// before querying — exercising recover + served-from-disk (larger-than-memory) together.
+        /// trip. When <paramref name="recoverIntoSmallerLog"/> is set, the graph is recovered into a much
+        /// smaller log (same, valid page geometry) so its records no longer fit in memory and are served
+        /// from disk — recovering onto a "smaller box" must still work correctly.
         /// </summary>
         [Test]
         public async Task RecallSurvivesSaveAndRecover(
             [Values("NOQUANT", "Q8", "BIN")] string quant,
-            [Values(false, true)] bool evictAfterRecover)
+            [Values(false, true)] bool recoverIntoSmallerLog)
         {
+            // Vector sets require PageSize >= 16K; keep it fixed across build + recover (checkpoints are
+            // page-size sensitive), and only shrink the log *memory* on recover.
             server = TestUtils.CreateGarnetServer(
                 TestUtils.MethodTestDir,
+                memorySize: "8m",
+                pageSize: "16k",
                 enableAOF: true,
                 aofMemorySize: "2g",
                 enableVectorSetPreview: true);
             server.Start();
 
             var data = GenerateData(500);
-            var key = $"recover_{quant}_{evictAfterRecover}";
+            var key = $"recover_{quant}_{recoverIntoSmallerLog}";
 
             double before;
             using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true)))
@@ -190,10 +195,13 @@ namespace Garnet.test
                 ClassicAssert.IsTrue(committed, "checkpoint commit did not complete");
             }
 
-            // Restart and recover from the checkpoint (same log/page geometry — checkpoints are size-sensitive).
+            // Restart and recover. Optionally recover into a much smaller log (same 16K pages) so the
+            // recovered graph spills to disk — "recover onto a smaller box".
             server.Dispose(deleteDir: false);
             server = TestUtils.CreateGarnetServer(
                 TestUtils.MethodTestDir,
+                memorySize: recoverIntoSmallerLog ? "64k" : "8m",
+                pageSize: "16k",
                 enableAOF: true,
                 aofMemorySize: "2g",
                 tryRecover: true,
@@ -204,15 +212,12 @@ namespace Garnet.test
             {
                 var db = redis.GetDatabase(0);
 
-                if (evictAfterRecover)
-                {
-                    _ = db.Execute("DEBUG", "FLUSHANDEVICT");
-                    AssertEvictedToDisk(redis, "recovered records should have been evicted to disk");
-                }
+                if (recoverIntoSmallerLog)
+                    AssertEvictedToDisk(redis, "recovering into a smaller log should leave records on disk");
 
                 var after = MeasureRecall(db, key, data);
                 ClassicAssert.GreaterOrEqual(after, before - MaxRecallDrop,
-                    $"{quant} [evictAfterRecover={evictAfterRecover}]: recall collapsed after save+restart+recover " +
+                    $"{quant} [recoverIntoSmallerLog={recoverIntoSmallerLog}]: recall collapsed after save+restart+recover " +
                     $"(before {before:F3} -> after {after:F3}). For Q8 this is the known " +
                     "quantization-table-lost-on-recreate bug (diskann-garnet 4.0.0).");
             }

--- a/test/standalone/Garnet.test.vectorset/VectorSetRecallSmokeTests.cs
+++ b/test/standalone/Garnet.test.vectorset/VectorSetRecallSmokeTests.cs
@@ -29,12 +29,9 @@ namespace Garnet.test
     /// Everything is single-threaded (one connection, sequential VADD) and deterministic (fixed seed,
     /// fixed graph parameters) so the tests are stable and fast.
     ///
-    /// NOTE: the Q8 (8-bit scalar) cases that read from disk (FlushAndEvict, larger-than-memory load,
-    /// and recover) used to fail against diskann-garnet 4.0.0/4.0.1 because the per-dimension Q8
-    /// quantization table was native in-memory-only state that was lost when the index is recreated
-    /// after eviction/recovery, so codes were decoded with a missing table and recall collapsed
-    /// (~1.0 -> ~0.02-0.11). This was fixed in diskann-garnet 4.0.2; the Q8 disk cases now pass and
-    /// stand as regression guards. NOQUANT and BIN (table-free) were always robust.
+    /// All three quantization modes must stay robust across the disk paths. For Q8 (8-bit scalar) this
+    /// guards the per-dimension quantization table surviving index recreation after eviction or
+    /// recovery; NOQUANT and BIN are table-free.
     /// </summary>
     [TestFixture]
     public class VectorSetRecallSmokeTests : TestBase
@@ -55,8 +52,7 @@ namespace Garnet.test
         private const double MinInMemoryRecall = 0.80;
 
         // Robustness budget: a physical-config change (evict-to-disk / recover) may only cost this much
-        // recall. NOQUANT/BIN/Q8 all cost ~0.0 on 4.0.2; the pre-4.0.2 Q8 disk bug cost ~0.9 and blew
-        // through this budget.
+        // recall. A healthy graph costs ~0.0; a broken one collapses well past this budget.
         private const double MaxRecallDrop = 0.20;
 
         private global::Garnet.GarnetServer server;
@@ -115,8 +111,8 @@ namespace Garnet.test
             var onDisk = MeasureRecall(db, key, data);
             ClassicAssert.GreaterOrEqual(onDisk, inMemory - MaxRecallDrop,
                 $"{quant} [{readMode}]: recall collapsed after eviction to disk " +
-                $"(in-memory {inMemory:F3} -> on-disk {onDisk:F3}). For Q8, a regression here is the " +
-                "quantization-table-lost-on-recreate bug fixed in diskann-garnet 4.0.2.");
+                $"(in-memory {inMemory:F3} -> on-disk {onDisk:F3}). For Q8, this indicates the " +
+                "quantization table did not survive index recreation.");
         }
 
         /// <summary>
@@ -129,8 +125,7 @@ namespace Garnet.test
             [Values("NOQUANT", "Q8", "BIN")] string quant)
         {
             // A 256 KB log with 32 KB pages is much smaller than the ~800-node graph, so inserts spill
-            // and construction pages earlier records back from disk. (The 4 KB-page lowMemory helper also
-            // forces spill but is an order of magnitude slower here.)
+            // and construction pages earlier records back from disk.
             server = TestUtils.CreateGarnetServer(
                 TestUtils.MethodTestDir,
                 memorySize: "256k",
@@ -150,7 +145,7 @@ namespace Garnet.test
             var onDisk = MeasureRecall(db, key, data);
             ClassicAssert.GreaterOrEqual(onDisk, MinInMemoryRecall,
                 $"{quant}: recall {onDisk:F3} is broken for a graph built and served larger-than-memory. " +
-                "For Q8, a regression here is the quantization-table-lost-on-recreate bug fixed in diskann-garnet 4.0.2.");
+                "For Q8, this indicates the quantization table did not survive index recreation.");
         }
 
         /// <summary>
@@ -219,8 +214,8 @@ namespace Garnet.test
                 var after = MeasureRecall(db, key, data);
                 ClassicAssert.GreaterOrEqual(after, before - MaxRecallDrop,
                     $"{quant} [recoverIntoSmallerLog={recoverIntoSmallerLog}]: recall collapsed after save+restart+recover " +
-                    $"(before {before:F3} -> after {after:F3}). For Q8, a regression here is the " +
-                    "quantization-table-lost-on-recreate bug fixed in diskann-garnet 4.0.2.");
+                    $"(before {before:F3} -> after {after:F3}). For Q8, this indicates the " +
+                    "quantization table did not survive index recreation.");
             }
         }
 

--- a/test/standalone/Garnet.test.vectorset/VectorSetRecallSmokeTests.cs
+++ b/test/standalone/Garnet.test.vectorset/VectorSetRecallSmokeTests.cs
@@ -1,0 +1,355 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using StackExchange.Redis;
+
+namespace Garnet.test
+{
+    /// <summary>
+    /// Recall-oriented smoke tests that stress a DiskANN Vector Set graph across the physical
+    /// storage configurations we care about:
+    ///   * quantization mode (NOQUANT / Q8 / BIN),
+    ///   * larger-than-memory (records spill to the storage tier during load, or are evicted to disk),
+    ///   * read-cache vs copy-reads-to-tail vs neither,
+    ///   * save -> restart -> recover (optionally evicting the recovered graph back to disk).
+    ///
+    /// The invariant under test is <b>physical robustness</b>: a graph that answers queries well while
+    /// resident in memory must keep answering them well once the same records are served from disk, or
+    /// recovered from a checkpoint. We build a small, well-clustered graph, measure recall against a
+    /// brute-force ground truth, apply a physical stressor, and assert recall does not collapse.
+    ///
+    /// Everything is single-threaded (one connection, sequential VADD) and deterministic (fixed seed,
+    /// fixed graph parameters) so the tests are stable and fast.
+    ///
+    /// NOTE: the Q8 (8-bit scalar) cases that read from disk (FlushAndEvict, larger-than-memory load,
+    /// and recover) are EXPECTED TO FAIL against diskann-garnet 4.0.0: the per-dimension Q8
+    /// quantization table is native in-memory-only state that is lost when the index is recreated after
+    /// eviction/recovery and cannot be rebuilt, so codes are decoded with a missing table and recall
+    /// collapses (~1.0 -> ~0.02-0.11). NOQUANT and BIN (table-free) are robust. This is a deliberate
+    /// regression guard, not a flaky test. See gist 52a9739f8963462d695576b5c1fe9deb.
+    /// </summary>
+    [TestFixture]
+    public class VectorSetRecallSmokeTests : TestBase
+    {
+        // Small graph so the tests finish quickly while still exercising the disk paths.
+        private const int Dim = 32;
+        private const int Clusters = 16;
+        private const int EfBuild = 64;
+        private const int EfSearch = 64;
+        private const int M = 16;
+        private const int K = 10;
+        private const int NumQueries = 40;
+        private const int Seed = 2026_07_28;
+        private const string Metric = "COSINE";
+
+        // Sanity floor: an in-memory graph with these parameters recalls ~1.0 on this clustered data,
+        // so 0.80 is a comfortable margin that still fails hard if the graph is broken.
+        private const double MinInMemoryRecall = 0.80;
+
+        // Robustness budget: a physical-config change (evict-to-disk / recover) may only cost this much
+        // recall. NOQUANT/BIN cost ~0.0; the Q8 disk bug costs ~0.9 and blows through this budget.
+        private const double MaxRecallDrop = 0.20;
+
+        private global::Garnet.GarnetServer server;
+
+        [SetUp]
+        public void Setup()
+        {
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            try { server?.Dispose(); } catch { /* best effort */ }
+            server = null;
+            TestUtils.OnTearDown();
+        }
+
+        /// <summary>
+        /// Build a graph fully in memory, then flush+evict the main store to disk and re-query.
+        /// Recall must survive being served from disk, under each read-back mode (none / read cache /
+        /// copy-reads-to-tail). This is the core "larger than memory" served-from-disk guard.
+        /// </summary>
+        [Test]
+        public void RecallSurvivesFlushAndEvict(
+            [Values("NOQUANT", "Q8", "BIN")] string quant,
+            [Values("none", "readcache", "copytotail")] string readMode)
+        {
+            var enableReadCache = readMode == "readcache";
+            var copyReadsToTail = readMode == "copytotail";
+
+            server = TestUtils.CreateGarnetServer(
+                TestUtils.MethodTestDir,
+                memorySize: "16m",
+                pageSize: "1m",
+                enableVectorSetPreview: true,
+                enableReadCache: enableReadCache,
+                copyReadsToTail: copyReadsToTail);
+            server.Start();
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
+            var db = redis.GetDatabase(0);
+
+            var data = GenerateData(600);
+            var key = $"evict_{quant}_{readMode}";
+            LoadVectorSet(db, key, data, quant);
+
+            var inMemory = MeasureRecall(db, key, data);
+            ClassicAssert.GreaterOrEqual(inMemory, MinInMemoryRecall,
+                $"{quant}: in-memory recall {inMemory:F3} is below the sanity floor — the graph is not usable even in memory");
+
+            // Force the main store's hybrid log to disk; subsequent reads are served from the storage tier.
+            _ = db.Execute("DEBUG", "FLUSHANDEVICT");
+            AssertEvictedToDisk(redis, "records should have been evicted to disk by FLUSHANDEVICT");
+
+            var onDisk = MeasureRecall(db, key, data);
+            ClassicAssert.GreaterOrEqual(onDisk, inMemory - MaxRecallDrop,
+                $"{quant} [{readMode}]: recall collapsed after eviction to disk " +
+                $"(in-memory {inMemory:F3} -> on-disk {onDisk:F3}). For Q8 this is the known " +
+                "quantization-table-lost-on-recreate bug (diskann-garnet 4.0.0).");
+        }
+
+        /// <summary>
+        /// Build a graph in a log far smaller than the data so records spill to the storage tier
+        /// <b>during</b> construction — the graph is both built and served larger-than-memory, and graph
+        /// construction reads earlier records back via pending disk IO. Recall must still be usable.
+        /// </summary>
+        [Test]
+        public void RecallSurvivesLargerThanMemoryLoad(
+            [Values("NOQUANT", "Q8", "BIN")] string quant)
+        {
+            // A 256 KB log with 32 KB pages is much smaller than the ~800-node graph, so inserts spill
+            // and construction pages earlier records back from disk. (The 4 KB-page lowMemory helper also
+            // forces spill but is an order of magnitude slower here.)
+            server = TestUtils.CreateGarnetServer(
+                TestUtils.MethodTestDir,
+                memorySize: "256k",
+                pageSize: "32k",
+                enableVectorSetPreview: true);
+            server.Start();
+
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
+            var db = redis.GetDatabase(0);
+
+            var data = GenerateData(800);
+            var key = $"largerthanmem_{quant}";
+            LoadVectorSet(db, key, data, quant);
+
+            AssertEvictedToDisk(redis, "the graph should exceed the log and spill to disk during load");
+
+            var onDisk = MeasureRecall(db, key, data);
+            ClassicAssert.GreaterOrEqual(onDisk, MinInMemoryRecall,
+                $"{quant}: recall {onDisk:F3} is broken for a graph built and served larger-than-memory. " +
+                "For Q8 this is the known quantization-table-lost-on-recreate bug (diskann-garnet 4.0.0).");
+        }
+
+        /// <summary>
+        /// Build a graph, checkpoint it, restart the server and recover. Recall must survive the round
+        /// trip. When <paramref name="evictAfterRecover"/> is set, the recovered graph is flushed to disk
+        /// before querying — exercising recover + served-from-disk (larger-than-memory) together.
+        /// </summary>
+        [Test]
+        public async Task RecallSurvivesSaveAndRecover(
+            [Values("NOQUANT", "Q8", "BIN")] string quant,
+            [Values(false, true)] bool evictAfterRecover)
+        {
+            server = TestUtils.CreateGarnetServer(
+                TestUtils.MethodTestDir,
+                enableAOF: true,
+                aofMemorySize: "2g",
+                enableVectorSetPreview: true);
+            server.Start();
+
+            var data = GenerateData(500);
+            var key = $"recover_{quant}_{evictAfterRecover}";
+
+            double before;
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true)))
+            {
+                var db = redis.GetDatabase(0);
+                LoadVectorSet(db, key, data, quant);
+
+                before = MeasureRecall(db, key, data);
+                ClassicAssert.GreaterOrEqual(before, MinInMemoryRecall,
+                    $"{quant}: in-memory recall {before:F3} is below the sanity floor before checkpoint");
+
+                // Take a foreground checkpoint and wait for it to be durable.
+#pragma warning disable CS0618 // ForegroundSave is obsolete but is what the recovery tests use
+                redis.GetServers()[0].Save(SaveType.ForegroundSave);
+#pragma warning restore CS0618
+                var committed = await server.Store.WaitForCommitAsync();
+                ClassicAssert.IsTrue(committed, "checkpoint commit did not complete");
+            }
+
+            // Restart and recover from the checkpoint (same log/page geometry — checkpoints are size-sensitive).
+            server.Dispose(deleteDir: false);
+            server = TestUtils.CreateGarnetServer(
+                TestUtils.MethodTestDir,
+                enableAOF: true,
+                aofMemorySize: "2g",
+                tryRecover: true,
+                enableVectorSetPreview: true);
+            server.Start();
+
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true)))
+            {
+                var db = redis.GetDatabase(0);
+
+                if (evictAfterRecover)
+                {
+                    _ = db.Execute("DEBUG", "FLUSHANDEVICT");
+                    AssertEvictedToDisk(redis, "recovered records should have been evicted to disk");
+                }
+
+                var after = MeasureRecall(db, key, data);
+                ClassicAssert.GreaterOrEqual(after, before - MaxRecallDrop,
+                    $"{quant} [evictAfterRecover={evictAfterRecover}]: recall collapsed after save+restart+recover " +
+                    $"(before {before:F3} -> after {after:F3}). For Q8 this is the known " +
+                    "quantization-table-lost-on-recreate bug (diskann-garnet 4.0.0).");
+            }
+        }
+
+        // ---- helpers ------------------------------------------------------------------------------
+
+        /// <summary>Deterministic, well-separated clustered data so nearest neighbours are stable.</summary>
+        private sealed class Dataset
+        {
+            public float[][] Vectors;   // inserted vectors
+            public byte[][] Ids;        // 4-byte little-endian element ids (== index)
+            public float[][] Queries;   // held-out query vectors from the same clusters
+        }
+
+        private static Dataset GenerateData(int count)
+        {
+            var rng = new Random(Seed);
+
+            var centers = new float[Clusters][];
+            for (var c = 0; c < Clusters; c++)
+                centers[c] = Normalized(RandomGaussianVector(rng));
+
+            var vectors = new float[count][];
+            var ids = new byte[count][];
+            for (var i = 0; i < count; i++)
+            {
+                vectors[i] = Normalized(Jitter(centers[rng.Next(Clusters)], rng));
+                var id = new byte[4];
+                BinaryPrimitives.WriteInt32LittleEndian(id, i);
+                ids[i] = id;
+            }
+
+            var queries = new float[NumQueries][];
+            for (var q = 0; q < NumQueries; q++)
+                queries[q] = Normalized(Jitter(centers[rng.Next(Clusters)], rng));
+
+            return new Dataset { Vectors = vectors, Ids = ids, Queries = queries };
+        }
+
+        private static float[] RandomGaussianVector(Random rng)
+        {
+            var v = new float[Dim];
+            for (var d = 0; d < Dim; d++)
+                v[d] = NextGaussian(rng);
+            return v;
+        }
+
+        private static float[] Jitter(float[] center, Random rng)
+        {
+            var v = new float[Dim];
+            for (var d = 0; d < Dim; d++)
+                v[d] = center[d] + (0.1f * NextGaussian(rng));
+            return v;
+        }
+
+        private static float NextGaussian(Random rng)
+        {
+            // Box-Muller transform.
+            var u1 = 1.0 - rng.NextDouble();
+            var u2 = 1.0 - rng.NextDouble();
+            return (float)(Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2));
+        }
+
+        private static float[] Normalized(float[] v)
+        {
+            double norm = 0;
+            for (var d = 0; d < v.Length; d++)
+                norm += (double)v[d] * v[d];
+            norm = Math.Sqrt(norm);
+            if (norm == 0)
+                return v;
+            for (var d = 0; d < v.Length; d++)
+                v[d] = (float)(v[d] / norm);
+            return v;
+        }
+
+        private static void LoadVectorSet(IDatabase db, string key, Dataset data, string quant)
+        {
+            for (var i = 0; i < data.Vectors.Length; i++)
+            {
+                var vecBytes = MemoryMarshal.Cast<float, byte>(data.Vectors[i].AsSpan()).ToArray();
+                var res = db.Execute("VADD",
+                    [key, "FP32", vecBytes, data.Ids[i], quant, "EF", EfBuild.ToString(), "M", M.ToString(), "XDISTANCE_METRIC", Metric]);
+                ClassicAssert.AreEqual(1, (int)res, $"VADD #{i} should succeed");
+            }
+        }
+
+        /// <summary>Mean recall@K of VSIM against a brute-force cosine ground truth.</summary>
+        private static double MeasureRecall(IDatabase db, string key, Dataset data)
+        {
+            double total = 0;
+            for (var q = 0; q < data.Queries.Length; q++)
+            {
+                var groundTruth = BruteForceTopK(data.Vectors, data.Queries[q]);
+
+                var queryBytes = MemoryMarshal.Cast<float, byte>(data.Queries[q].AsSpan()).ToArray();
+                var res = (byte[][])db.Execute("VSIM",
+                    [key, "FP32", queryBytes, "COUNT", K.ToString(), "EF", EfSearch.ToString()]);
+
+                var returned = new HashSet<int>();
+                foreach (var idBytes in res)
+                    returned.Add(BinaryPrimitives.ReadInt32LittleEndian(idBytes));
+
+                var hits = groundTruth.Count(returned.Contains);
+                total += (double)hits / K;
+            }
+            return total / data.Queries.Length;
+        }
+
+        private static int[] BruteForceTopK(float[][] vectors, float[] query)
+        {
+            var scored = new (float sim, int idx)[vectors.Length];
+            for (var i = 0; i < vectors.Length; i++)
+                scored[i] = (Dot(vectors[i], query), i);
+
+            // Descending cosine similarity (vectors are normalized, so dot == cosine); nearest first.
+            Array.Sort(scored, static (a, b) => b.sim.CompareTo(a.sim));
+
+            var top = new int[K];
+            for (var i = 0; i < K; i++)
+                top[i] = scored[i].idx;
+            return top;
+        }
+
+        private static float Dot(float[] a, float[] b)
+        {
+            float sum = 0;
+            for (var d = 0; d < a.Length; d++)
+                sum += a[d] * b[d];
+            return sum;
+        }
+
+        private static void AssertEvictedToDisk(ConnectionMultiplexer redis, string message)
+        {
+            var info = TestUtils.GetStoreAddressInfo(redis.GetServers()[0]);
+            ClassicAssert.Greater(info.HeadAddress, info.BeginAddress, message);
+        }
+    }
+}

--- a/test/standalone/Garnet.test.vectorset/VectorSetRecallSmokeTests.cs
+++ b/test/standalone/Garnet.test.vectorset/VectorSetRecallSmokeTests.cs
@@ -66,7 +66,7 @@ namespace Garnet.test
         [TearDown]
         public void TearDown()
         {
-            try { server?.Dispose(); } catch { /* best effort */ }
+            server?.Dispose();
             server = null;
             TestUtils.OnTearDown();
         }
@@ -105,7 +105,9 @@ namespace Garnet.test
                 $"{quant}: in-memory recall {inMemory:F3} is below the sanity floor — the graph is not usable even in memory");
 
             // Force the main store's hybrid log to disk; subsequent reads are served from the storage tier.
-            _ = db.Execute("DEBUG", "FLUSHANDEVICT");
+            var flushResult = (string)db.Execute("DEBUG", "FLUSHANDEVICT");
+            ClassicAssert.IsTrue(flushResult is not null && flushResult.StartsWith("OK"),
+                $"DEBUG FLUSHANDEVICT should succeed; got '{flushResult}'");
             AssertEvictedToDisk(redis, "records should have been evicted to disk by FLUSHANDEVICT");
 
             var onDisk = MeasureRecall(db, key, data);
@@ -185,7 +187,7 @@ namespace Garnet.test
 
                 // Take a foreground checkpoint and wait for it to be durable.
 #pragma warning disable CS0618 // ForegroundSave is obsolete but is what the recovery tests use
-                redis.GetServers()[0].Save(SaveType.ForegroundSave);
+                redis.GetServers().Single().Save(SaveType.ForegroundSave);
 #pragma warning restore CS0618
                 var committed = await server.Store.WaitForCommitAsync();
                 ClassicAssert.IsTrue(committed, "checkpoint commit did not complete");
@@ -349,7 +351,7 @@ namespace Garnet.test
 
         private static void AssertEvictedToDisk(ConnectionMultiplexer redis, string message)
         {
-            var info = TestUtils.GetStoreAddressInfo(redis.GetServers()[0]);
+            var info = TestUtils.GetStoreAddressInfo(redis.GetServers().Single());
             ClassicAssert.Greater(info.HeadAddress, info.BeginAddress, message);
         }
     }


### PR DESCRIPTION
## What

Recall-oriented smoke tests for Garnet Vector Sets that stress a DiskANN graph across the physical storage configurations that matter for disk-tiered operation.

### Smoke test coverage

- **quantization mode** — NOQUANT / Q8 / BIN
- **larger-than-memory** — records spill to the storage tier during load, or are evicted to disk after an in-memory build
- **read-cache** vs **copy-reads-to-tail** vs neither
- **save → restart → recover**, optionally recovering into a much smaller log

## Invariant

**Physical robustness:** a graph that answers queries well while resident in memory must keep answering them well once the same records are served from disk or recovered from a checkpoint.

Each test builds a small, well-clustered, **deterministic** graph (Dim=32, 16 clusters, M=16, EF=64, fixed seed, single connection, sequential `VADD`), measures recall@10 against a brute-force ground truth, applies a physical stressor, and asserts recall does not collapse (`MaxRecallDrop = 0.20`). Spill is forced and verified with `DEBUG FLUSHANDEVICT` + the store head/tail addresses. Everything is single-threaded and the graphs are intentionally tiny, so the whole suite runs in ~30s.

### Tests (18 cases)

| Test | Coverage |
|---|---|
| `RecallSurvivesFlushAndEvict(quant, {none/readcache/copytotail})` | larger-than-memory served from disk × read-cache combinations |
| `RecallSurvivesLargerThanMemoryLoad(quant)` | graph **built** while spilling to disk (256k log / 32k pages) |
| `RecallSurvivesSaveAndRecover(quant, recoverIntoSmallerLog)` | save → restart → recover, optionally into a much smaller (disk-tiered) log |

## Status: all green on diskann-garnet 4.0.2

Requires **diskann-garnet 4.0.2** (bumped in this PR from 4.0.0). **All 18 cases pass on net8.0 and net10.0.**

The **Q8** cases that read from disk (FlushAndEvict, larger-than-memory load, and recover) previously **failed** against diskann-garnet 4.0.0/4.0.1: the per-dimension Q8 quantization table was native in-memory-only state that was lost when the index was recreated after eviction/recovery, so stored codes were decoded with a missing table and recall collapsed (~1.0 → ~0.02–0.11). **4.0.2 fixes this** (the table is preserved/rebuilt on index recreate), so the Q8 disk cases now pass and stand as regression guards. NOQUANT and BIN (table-free) were always robust.

Result on `main` + diskann 4.0.2: **18 pass / 0 fail** (was 12 / 6 on 4.0.0).

## Notes

- Follows the existing `Garnet.test.vectorset` conventions (`TestBase`, `TestUtils.CreateGarnetServer`, `VADD`/`VSIM` via StackExchange.Redis, binary int element ids).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
