### PR TITLE
Fix integer underflow in BITCOUNT ... BIT byte-boundary mask

### DIFF
--- a/libs/server/Resp/Bitmap/BitmapManagerBitCount.cs
+++ b/libs/server/Resp/Bitmap/BitmapManagerBitCount.cs
@@ -43,7 +43,7 @@ namespace Garnet.server
             long endByte = (endOffset / 8);
 
             int leftBitIndex = (int)(startOffset & 7);
-            int rightBitIndex = (int)((endOffset + 1) & 7);
+            int rightBitIndex = (int)(endOffset & 7) + 1;
 
             if (startByte == endByte)
                 return BitIndexCount(value[startByte], leftBitIndex, rightBitIndex);

--- a/test/standalone/Garnet.test.complexstring/GarnetBitmapTests.cs
+++ b/test/standalone/Garnet.test.complexstring/GarnetBitmapTests.cs
@@ -2291,6 +2291,35 @@ namespace Garnet.test
 
         [Test]
         [Category("BITCOUNT")]
+        public void BitmapBitCountBitBoundaryUnderflowTest()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            var key = "BitmapBitCountBitBoundaryUnderflowTest";
+            // 0x80 = 10000000b: only the most-significant bit (bit index 0) is set.
+            _ = db.StringSet(key, new byte[] { 0x80 });
+
+            // Single-bit range ending on a byte boundary (endOffset % 8 == 7).
+            // Regression: a byte-mask integer underflow made this return 1 for an unset bit.
+            var count = db.StringBitCount(key, 7, 7, StringIndexType.Bit);
+            ClassicAssert.AreEqual(0, count);
+
+            // The set bit (index 0) must still be counted correctly.
+            count = db.StringBitCount(key, 0, 0, StringIndexType.Bit);
+            ClassicAssert.AreEqual(1, count);
+
+            // Full-byte range crossing the boundary must count exactly the one set bit.
+            count = db.StringBitCount(key, 0, 7, StringIndexType.Bit);
+            ClassicAssert.AreEqual(1, count);
+
+            // Full-key BIT range (0 -1) whose end lands on a byte boundary.
+            count = db.StringBitCount(key, 0, -1, StringIndexType.Bit);
+            ClassicAssert.AreEqual(1, count);
+        }
+
+        [Test]
+        [Category("BITCOUNT")]
         public void BitmapBitCountLongBitOffsetParsingTest()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
@@ -2302,7 +2331,11 @@ namespace Garnet.test
             var offset = (long)int.MaxValue + 1024;
             var count = (long)db.Execute("BITCOUNT", key, (-offset).ToString(), "-1", "BIT");
 
-            ClassicAssert.AreEqual(8, count);
+            // The out-of-range negative start is clamped to -MaxOffsetForBitmapLength and then
+            // wrapped modulo the bit length (Garnet's negative-offset semantics), landing on bit
+            // index 1; the end (-1) wraps to bit index 7. So bits 1..7 of 0xFF are counted => 7.
+            // (This previously asserted 8 only because of a byte-mask underflow in BitCountDriver.)
+            ClassicAssert.AreEqual(7, count);
         }
 
         [Test]


### PR DESCRIPTION
## Summary

Fixes an integer underflow in `BITCOUNT ... BIT` (`BitmapManagerBitCount.cs`) that caused non-zero counts to be returned for **unset** bits whenever a BIT-mode range ended on a byte boundary (`endOffset % 8 == 7`).

### Root cause
`BitIndexCount(byte* value, long startOffset, long endOffset)` computed the inclusive right bit index as:

```csharp
int rightBitIndex = (int)((endOffset + 1) & 7);   // endOffset=7 -> 0 (wrong)
```

When this wraps to `0`, the inner `BitIndexCount(byte, start, end)` builds `mask = (byte)((1<<0) - (1<<start))`, a wrapping byte-mask underflow (e.g. `0x81`). AND-ed with the bit-reversed payload this reports set bits that are not set. For byte `0x80`, `BITCOUNT key 7 7 BIT` returned `1` even though `GETBIT key 7 == 0`.

### Fix
Use the same formula already used (correctly) in `BitmapManagerBitPos.cs`:

```csharp
int rightBitIndex = (int)(endOffset & 7) + 1;      // endOffset=7 -> 8 (correct)
```

## Tests
- Added `BitmapBitCountBitBoundaryUnderflowTest` covering single-bit and boundary-crossing BIT ranges on byte `0x80`.
- Updated `BitmapBitCountLongBitOffsetParsingTest`: its previous expectation of `8` was an artifact of the underflow. Under Garnet''s modulo-wrapping negative-offset semantics the clamped start wraps to bit index 1, so bits 1..7 of `0xFF` = `7`.
- All BITCOUNT/BITPOS tests pass.