### PR TITLE
Clear the Vector Set index pointer on the diskless replication stream-in path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
         os: [ ubuntu-latest, windows-latest ]
         framework: [ 'net8.0' , 'net10.0']
         configuration: [ 'Debug', 'Release' ]
-        test: [ 'Garnet.test.cluster', 'Garnet.test.cluster.migrate', 'Garnet.test.cluster.migrate.rangeindex', 'Garnet.test.cluster.replication', 'Garnet.test.cluster.replication.tls', 'Garnet.test.cluster.replication.disklesssync', 'Garnet.test.cluster.replication.rangeindex', 'Garnet.test.cluster.vectorsets', 'Garnet.test.cluster.multilog' ]
+        test: [ 'Garnet.test.cluster', 'Garnet.test.cluster.migrate', 'Garnet.test.cluster.migrate.rangeindex', 'Garnet.test.cluster.replication', 'Garnet.test.cluster.replication.tls', 'Garnet.test.cluster.replication.disklesssync', 'Garnet.test.cluster.replication.rangeindex', 'Garnet.test.cluster.replication.vectorsets', 'Garnet.test.cluster.vectorsets', 'Garnet.test.cluster.multilog' ]
     if: needs.changes.outputs.garnet == 'true'
     steps:
       - name: Check out code

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [ 'Garnet.test.cluster', 'Garnet.test.cluster.migrate', 'Garnet.test.cluster.replication', 'Garnet.test.cluster.replication.tls', 'Garnet.test.cluster.replication.asyncreplay', 'Garnet.test.cluster.replication.disklesssync', 'Garnet.test.cluster.vectorsets', 'Garnet.test.cluster.multilog' ]
+        test: [ 'Garnet.test.cluster', 'Garnet.test.cluster.migrate', 'Garnet.test.cluster.replication', 'Garnet.test.cluster.replication.tls', 'Garnet.test.cluster.replication.asyncreplay', 'Garnet.test.cluster.replication.disklesssync', 'Garnet.test.cluster.replication.vectorsets', 'Garnet.test.cluster.vectorsets', 'Garnet.test.cluster.multilog' ]
         os: [ ubuntu-latest, windows-latest ]
         framework: [ 'net8.0', 'net10.0' ]
         configuration: [ 'Debug', 'Release' ]

--- a/Garnet.slnx
+++ b/Garnet.slnx
@@ -97,5 +97,6 @@
     <Project Path="test/cluster/Garnet.test.cluster.replication.tls/Garnet.test.cluster.replication.tls.csproj" />
     <Project Path="test/cluster/Garnet.test.cluster.vectorsets/Garnet.test.cluster.vectorsets.csproj" />
     <Project Path="test/cluster/Garnet.test.cluster.replication.rangeindex/Garnet.test.cluster.replication.rangeindex.csproj" />
+    <Project Path="test/cluster/Garnet.test.cluster.replication.vectorsets/Garnet.test.cluster.replication.vectorsets.csproj" />
   </Folder>
 </Solution>

--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaDisklessSync.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaDisklessSync.cs
@@ -238,6 +238,21 @@ namespace Garnet.cluster
                 // Before advertising updated replication offset, wait for Vector Set ops to finish
                 storeWrapper.DefaultDatabase.VectorManager?.WaitForVectorOperationsToComplete();
 
+                // A diskless full sync streams the Vector Set index and ContextMetadata records straight
+                // into the store, bypassing the metadata RMW path that maintains the in-memory context
+                // reservation. Rebuild it from the streamed records (fed via RecoverStreamedRecord during
+                // CLUSTER SYNC) so a fresh set created after promotion can't be handed a context a
+                // streamed set already owns.
+                if (primarySyncMetadata.fullSync)
+                {
+                    var vectorManager = storeWrapper.DefaultDatabase.VectorManager;
+                    if (vectorManager != null)
+                    {
+                        vectorManager.Initialize();
+                        vectorManager.ResumePostRecovery();
+                    }
+                }
+
                 this.replicationOffset = _replicationOffset;
 
                 // Mark this txn run as a read-write session if we are replaying as a replica

--- a/libs/cluster/Session/RespClusterReplicationCommands.cs
+++ b/libs/cluster/Session/RespClusterReplicationCommands.cs
@@ -565,6 +565,13 @@ namespace Garnet.cluster
                             return false;
 
                         diskLogRecord = DiskLogRecord.Deserialize(recordSpan, storeWrapper.GarnetObjectSerializer, transientObjectIdMap, storeWrapper.storeFunctions);
+
+                        // Diskless sync streams records verbatim, so the index record still carries the
+                        // primary's native DiskANN handle. OnDiskRead only fires for records faulted in
+                        // from disk, so nothing else clears it on this path.
+                        if (diskLogRecord.RecordType == VectorManager.RecordType)
+                            VectorManager.ClearIndexPointer(diskLogRecord.ValueSpan);
+
                         _ = basicGarnetApi.SET(in diskLogRecord);
                         storeWrapper.storeFunctions.OnDisposeDiskRecord(ref diskLogRecord, DisposeReason.DeserializedFromDisk);
                         diskLogRecord.Dispose();

--- a/libs/cluster/Session/RespClusterReplicationCommands.cs
+++ b/libs/cluster/Session/RespClusterReplicationCommands.cs
@@ -548,6 +548,7 @@ namespace Garnet.cluster
 
             TrackImportProgress(recordCount, recordCount == 0);
             var storeWrapper = clusterProvider.storeWrapper;
+            var vectorManager = storeWrapper.DefaultDatabase.VectorManager;
             var transientObjectIdMap = storeWrapper.store.Log.TransientObjectIdMap;
 
             DiskLogRecord diskLogRecord = default;
@@ -571,6 +572,12 @@ namespace Garnet.cluster
                         // from disk, so nothing else clears it on this path.
                         if (diskLogRecord.RecordType == VectorManager.RecordType)
                             VectorManager.ClearIndexPointer(diskLogRecord.ValueSpan);
+
+                        // Diskless sync SETs records verbatim, bypassing the metadata RMW path that
+                        // maintains the in-memory context reservation. Feed the streamed index and
+                        // ContextMetadata records into recovery bookkeeping so the reservation is
+                        // rebuilt once the stream completes (see TryReplicaDisklessRecovery).
+                        vectorManager?.RecoverStreamedRecord(ref diskLogRecord);
 
                         _ = basicGarnetApi.SET(in diskLogRecord);
                         storeWrapper.storeFunctions.OnDisposeDiskRecord(ref diskLogRecord, DisposeReason.DeserializedFromDisk);

--- a/libs/server/Properties/AssemblyInfo.cs
+++ b/libs/server/Properties/AssemblyInfo.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Garnet.test" + AssemblyRef.GarnetPublicKey)]
 [assembly: InternalsVisibleTo("Garnet.test.cluster" + AssemblyRef.GarnetPublicKey)]
+[assembly: InternalsVisibleTo("Garnet.test.cluster.replication.vectorsets" + AssemblyRef.GarnetPublicKey)]
 [assembly: InternalsVisibleTo("Garnet.test.collections" + AssemblyRef.GarnetPublicKey)]
 [assembly: InternalsVisibleTo("Garnet.test.acl" + AssemblyRef.GarnetPublicKey)]
 [assembly: InternalsVisibleTo("Garnet.test.scripting" + AssemblyRef.GarnetPublicKey)]

--- a/libs/server/Resp/Vector/VectorManager.cs
+++ b/libs/server/Resp/Vector/VectorManager.cs
@@ -706,7 +706,7 @@ namespace Garnet.server
         /// 
         /// Next time the record is touched, we'll recreate the index.
         /// </summary>
-        internal static void ClearIndexPointer(Span<byte> value)
+        public static void ClearIndexPointer(Span<byte> value)
         {
             if (value.Length != IndexSize)
             {

--- a/libs/server/Resp/Vector/VectorManager.cs
+++ b/libs/server/Resp/Vector/VectorManager.cs
@@ -273,6 +273,11 @@ namespace Garnet.server
 
             lock (this)
             {
+                // A runtime full sync (diskless) may reach here without the recovery hooks ever
+                // allocating these — treat a missing set as empty rather than faulting.
+                recoveredMetadata ??= new();
+                recoveredIndexes ??= new();
+
                 // Any ContextMetadatas we found need to be restored
                 if (!recoveredMetadata.IsEmpty)
                 {
@@ -373,7 +378,8 @@ namespace Garnet.server
         /// <summary>
         /// Called during recovery for each Vector Set index key.
         /// </summary>
-        public void RecoveredVectorSetIndexKey(ref LogRecord record)
+        public void RecoveredVectorSetIndexKey<TSourceLogRecord>(ref TSourceLogRecord record)
+            where TSourceLogRecord : ISourceLogRecord
         {
             if (record.ValueSpan.Length != IndexSize)
             {
@@ -381,20 +387,26 @@ namespace Garnet.server
             }
 
             ReadIndex(record.ValueSpan, out var context, out _, out _, out _, out _, out _, out _, out _, out _);
-            recoveredIndexes[context] = 0;
+
+            lock (this)
+            {
+                recoveredIndexes ??= new();
+                recoveredIndexes[context] = 0;
+            }
         }
 
         /// <summary>
         /// Called during recovery for each ContextMetadata record.
         /// </summary>
-        public void RecoveredContextMetadata(ref LogRecord record)
+        public void RecoveredContextMetadata<TSourceLogRecord>(ref TSourceLogRecord record)
+            where TSourceLogRecord : ISourceLogRecord
         {
-            if (record.ValueSpan.Length != ContextMetadata.Size || record.KeyBytes.Length != sizeof(int))
+            if (record.ValueSpan.Length != ContextMetadata.Size || record.Key.Length != sizeof(int))
             {
                 return;
             }
 
-            var index = BinaryPrimitives.ReadInt32LittleEndian(record.KeyBytes);
+            var index = BinaryPrimitives.ReadInt32LittleEndian(record.Key);
             var metadata = MemoryMarshal.Cast<byte, ContextMetadata>(record.ValueSpan)[0];
 
             // During recovery, we can trim off empty ContextMetadata
@@ -405,9 +417,39 @@ namespace Garnet.server
                 return;
             }
 
-            if (!recoveredMetadata.TryAdd(index, metadata))
+            lock (this)
             {
-                throw new GarnetException($"Recovered multiple instances of the same ContextMetadata: {index}");
+                recoveredMetadata ??= new();
+                if (!recoveredMetadata.TryAdd(index, metadata))
+                {
+                    throw new GarnetException($"Recovered multiple instances of the same ContextMetadata: {index}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Route a record streamed in during a diskless full sync into the recovery bookkeeping so that
+        /// <see cref="ResumePostRecovery"/> can rebuild the in-memory context reservation. Diskless sync
+        /// SETs records straight into the store, bypassing the metadata RMW path that maintains the
+        /// reservation bitmap, so without this a fresh Vector Set created after the sync can be handed a
+        /// context that a streamed set already owns.
+        /// </summary>
+        public void RecoverStreamedRecord<TSourceLogRecord>(ref TSourceLogRecord record)
+            where TSourceLogRecord : ISourceLogRecord
+        {
+            if (!IsEnabled || record.Info.Tombstone)
+            {
+                return;
+            }
+
+            var ns = record.Namespace;
+            if (ns.Length == 1 && ns[0] == MetadataNamespace)
+            {
+                RecoveredContextMetadata(ref record);
+            }
+            else if (record.RecordType == RecordType)
+            {
+                RecoveredVectorSetIndexKey(ref record);
             }
         }
 

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/Garnet.test.cluster.replication.vectorsets.csproj
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/Garnet.test.cluster.replication.vectorsets.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../../../Garnet.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <NoWarn>1701;1702;1591</NoWarn>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\testcerts\testcert.pfx" Link="testcert.pfx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="Microsoft.CodeAnalysis" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StackExchange.Redis" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\libs\client\Garnet.client.csproj" />
+    <ProjectReference Include="..\..\..\libs\cluster\Garnet.cluster.csproj" />
+    <ProjectReference Include="..\..\..\libs\common\Garnet.common.csproj" />
+    <ProjectReference Include="..\..\..\libs\host\Garnet.host.csproj" />
+    <ProjectReference Include="..\..\..\libs\server\Garnet.server.csproj" />
+    <ProjectReference Include="..\..\..\libs\storage\Tsavorite\cs\src\devices\AzureStorageDevice\Tsavorite.devices.AzureStorageDevice.csproj" />
+    <ProjectReference Include="..\Garnet.test.cluster\Garnet.test.cluster.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <AspectInjector_Enabled>false</AspectInjector_Enabled>
+  </PropertyGroup>
+</Project>

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetAsyncReplayTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetAsyncReplayTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System.Linq;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 
@@ -30,9 +29,8 @@ namespace Garnet.test.cluster
                 replayTaskCount: replayTaskCount,
                 vectorSetReplayTaskCount: vectorSetReplayTaskCount,
                 timeout: timeout);
-            context.CreateConnection();
 
-            context.clusterTestUtils.FormCluster(PrimaryIndex, [.. Enumerable.Range(1, nodeCount - 1)], context.logger);
+            FormClusterAllNodes(nodeCount);
         }
 
         /// <summary>Baseline: asynchronously replayed VADDs must land with identical embeddings.</summary>

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetAsyncReplayTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetAsyncReplayTests.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 
@@ -19,13 +17,6 @@ namespace Garnet.test.cluster
     {
         private const int PrimaryIndex = 0;
         private const int ReplicaIndex = 1;
-
-        protected override Dictionary<string, LogLevel> MonitorTests => new()
-        {
-            [nameof(VectorSetReplicatedUnderAsyncReplay)] = LogLevel.Trace,
-            [nameof(VectorSetReplicatedUnderAsyncReplayAfterFullSync)] = LogLevel.Trace,
-            [nameof(VectorSetReplicatedUnderParallelAsyncReplay)] = LogLevel.Trace,
-        };
 
         private void SetupAsyncReplayCluster(int nodeCount, bool disklessSync, int replayTaskCount = 1, int vectorSetReplayTaskCount = 0)
         {
@@ -47,7 +38,6 @@ namespace Garnet.test.cluster
         /// <summary>Baseline: asynchronously replayed VADDs must land with identical embeddings.</summary>
         [Test]
         [Category("REPLICATION")]
-        [CancelAfter(180_000)]
         public void VectorSetReplicatedUnderAsyncReplay()
         {
             const string Key = "{vsdisk}async";
@@ -69,7 +59,6 @@ namespace Garnet.test.cluster
         /// </summary>
         [Test]
         [Category("REPLICATION")]
-        [CancelAfter(180_000)]
         public void VectorSetReplicatedUnderAsyncReplayAfterFullSync()
         {
             const string Key = "{vsdisk}asyncfullsync";
@@ -101,7 +90,6 @@ namespace Garnet.test.cluster
         /// </summary>
         [Test]
         [Category("REPLICATION")]
-        [CancelAfter(180_000)]
         public void VectorSetReplicatedUnderParallelAsyncReplay()
         {
             const string FirstKey = "{vsdisk}asyncpar1";

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetAsyncReplayTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetAsyncReplayTests.cs
@@ -70,9 +70,8 @@ namespace Garnet.test.cluster
             // Populated before the replica exists, so attach carries the index record.
             PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_27);
 
-            var before = FullSyncCount();
+            // The replica has its own replication id, so the attach takes a full sync.
             Attach(ReplicaIndex, PrimaryIndex);
-            AssertTookFullSync(before);
 
             MakeReadable(ReplicaIndex);
             AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetAsyncReplayTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetAsyncReplayTests.cs
@@ -32,7 +32,7 @@ namespace Garnet.test.cluster
                 timeout: timeout);
             context.CreateConnection();
 
-            FormCluster(PrimaryIndex, [.. Enumerable.Range(1, nodeCount - 1)]);
+            context.clusterTestUtils.FormCluster(PrimaryIndex, [.. Enumerable.Range(1, nodeCount - 1)], context.logger);
         }
 
         /// <summary>Baseline: asynchronously replayed VADDs must land with identical embeddings.</summary>
@@ -44,7 +44,7 @@ namespace Garnet.test.cluster
             const int Elements = 300;
 
             SetupAsyncReplayCluster(2, disklessSync: false);
-            Attach(ReplicaIndex, PrimaryIndex);
+            context.clusterTestUtils.Attach(ReplicaIndex, PrimaryIndex, logger: context.logger);
 
             PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_26);
             context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
@@ -71,7 +71,7 @@ namespace Garnet.test.cluster
             PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_27);
 
             // The replica has its own replication id, so the attach takes a full sync.
-            Attach(ReplicaIndex, PrimaryIndex);
+            context.clusterTestUtils.Attach(ReplicaIndex, PrimaryIndex, logger: context.logger);
 
             MakeReadable(ReplicaIndex);
             AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
@@ -100,7 +100,7 @@ namespace Garnet.test.cluster
             const int ThirdPerRound = 20;
 
             SetupAsyncReplayCluster(2, disklessSync: false, replayTaskCount: 4, vectorSetReplayTaskCount: 4);
-            Attach(ReplicaIndex, PrimaryIndex);
+            context.clusterTestUtils.Attach(ReplicaIndex, PrimaryIndex, logger: context.logger);
 
             // Interleaved so replay tasks see records for all three keys mixed together.
             for (var round = 0; round < Rounds; round++)

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetAsyncReplayTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetAsyncReplayTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace Garnet.test.cluster
+{
+    /// <summary>
+    /// Vector Set coverage for asynchronous AOF replay. VADDs mutate native indexes on
+    /// VectorManager replay tasks, so async replay is a distinct execution path.
+    /// </summary>
+    [TestFixture]
+    [NonParallelizable]
+    public class ClusterVectorSetAsyncReplayTests : VectorSetReplicationTestBase
+    {
+        private const int PrimaryIndex = 0;
+        private const int ReplicaIndex = 1;
+
+        protected override Dictionary<string, LogLevel> MonitorTests => new()
+        {
+            [nameof(VectorSetReplicatedUnderAsyncReplay)] = LogLevel.Trace,
+            [nameof(VectorSetReplicatedUnderAsyncReplayAfterFullSync)] = LogLevel.Trace,
+            [nameof(VectorSetReplicatedUnderParallelAsyncReplay)] = LogLevel.Trace,
+        };
+
+        private void SetupAsyncReplayCluster(int nodeCount, bool disklessSync, int replayTaskCount = 1, int vectorSetReplayTaskCount = 0)
+        {
+            context.CreateInstances(
+                nodeCount,
+                enableAOF: true,
+                asyncReplay: true,
+                enableDisklessSync: disklessSync,
+                replicaDisklessSyncFullSyncAofThreshold: disklessSync ? "1k" : null,
+                OnDemandCheckpoint: !disklessSync,
+                replayTaskCount: replayTaskCount,
+                vectorSetReplayTaskCount: vectorSetReplayTaskCount,
+                timeout: timeout);
+            context.CreateConnection();
+
+            FormCluster(PrimaryIndex, [.. Enumerable.Range(1, nodeCount - 1)]);
+        }
+
+        /// <summary>Baseline: asynchronously replayed VADDs must land with identical embeddings.</summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetReplicatedUnderAsyncReplay()
+        {
+            const string Key = "{vsdisk}async";
+            const int Elements = 300;
+
+            SetupAsyncReplayCluster(2, disklessSync: false);
+            Attach(ReplicaIndex, PrimaryIndex);
+
+            PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_26);
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
+        }
+
+        /// <summary>
+        /// Combines async replay with diskless full sync of the index record; the replica rebuilds
+        /// the streamed index and applies later VADDs.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetReplicatedUnderAsyncReplayAfterFullSync()
+        {
+            const string Key = "{vsdisk}asyncfullsync";
+            const int Elements = 250;
+            const int AfterSyncElements = 100;
+
+            SetupAsyncReplayCluster(2, disklessSync: true);
+
+            // Populated before the replica exists, so attach carries the index record.
+            PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_27);
+
+            var before = FullSyncCount();
+            Attach(ReplicaIndex, PrimaryIndex);
+            AssertTookFullSync(before);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
+
+            // Writes after sync exercise async replay against the rebuilt index.
+            PopulateVectorSet(PrimaryIndex, Key, AfterSyncElements, seed: 2026_07_29_28);
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
+        }
+
+        /// <summary>
+        /// Multiple replay tasks apply VADDs for different keys concurrently; each key must keep exactly its own elements.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetReplicatedUnderParallelAsyncReplay()
+        {
+            const string FirstKey = "{vsdisk}asyncpar1";
+            const string SecondKey = "{vsdisk}asyncpar2";
+            const string ThirdKey = "{vsdisk}asyncpar3";
+            const int Rounds = 4;
+            const int FirstPerRound = 50;
+            const int SecondPerRound = 37;
+            const int ThirdPerRound = 20;
+
+            SetupAsyncReplayCluster(2, disklessSync: false, replayTaskCount: 4, vectorSetReplayTaskCount: 4);
+            Attach(ReplicaIndex, PrimaryIndex);
+
+            // Interleaved so replay tasks see records for all three keys mixed together.
+            for (var round = 0; round < Rounds; round++)
+            {
+                PopulateVectorSet(PrimaryIndex, FirstKey, FirstPerRound, seed: 2026_07_29_29 + round);
+                PopulateVectorSet(PrimaryIndex, SecondKey, SecondPerRound, seed: 2026_07_29_33 + round);
+                PopulateVectorSet(PrimaryIndex, ThirdKey, ThirdPerRound, seed: 2026_07_29_37 + round);
+            }
+
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, FirstKey);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, SecondKey);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, ThirdKey);
+
+            ClassicAssert.AreEqual(Rounds * FirstPerRound, VectorSetSize(ReplicaIndex, FirstKey));
+            ClassicAssert.AreEqual(Rounds * SecondPerRound, VectorSetSize(ReplicaIndex, SecondKey));
+            ClassicAssert.AreEqual(Rounds * ThirdPerRound, VectorSetSize(ReplicaIndex, ThirdKey));
+        }
+    }
+}

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDisklessSyncTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDisklessSyncTests.cs
@@ -35,16 +35,15 @@ namespace Garnet.test.cluster
 
         /// <summary>
         /// Forces the model's reset/snapshot path: detach, move past incremental replay, then re-attach.
+        /// Full sync is guaranteed by two independent triggers in ReplicaSyncSession.NeedToFullSync:
+        /// the soft reset gives the node a fresh replication id, and the padding writes push the AOF
+        /// gap past the 1k threshold configured in SetupDisklessCluster.
         /// </summary>
         private void ForceDisklessFullSync(int replicaIndex = ReplicaIndex)
         {
-            var before = FullSyncCount();
-
             ResetReplica(replicaIndex, PrimaryIndex);
             PushPrimaryAhead(PrimaryIndex);
             Attach(replicaIndex, PrimaryIndex);
-
-            AssertTookFullSync(before);
         }
 
         /// <summary>
@@ -149,14 +148,11 @@ namespace Garnet.test.cluster
             // Populated before any replica exists, so each attach carries the index record.
             PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_06);
 
-            var before = FullSyncCount();
-
+            // Each replica starts with its own replication id, so every attach takes a full sync.
             for (var replica = 1; replica <= ReplicaCount; replica++)
             {
                 Attach(replica, PrimaryIndex);
             }
-
-            AssertTookFullSync(before);
 
             for (var replica = 1; replica <= ReplicaCount; replica++)
             {
@@ -189,9 +185,8 @@ namespace Garnet.test.cluster
 
             PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_07);
 
-            var before = FullSyncCount();
+            // The replica has its own replication id, so the attach takes a full sync.
             Attach(ReplicaIndex, PrimaryIndex);
-            AssertTookFullSync(before);
 
             MakeReadable(ReplicaIndex);
             AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDisklessSyncTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDisklessSyncTests.cs
@@ -204,6 +204,46 @@ namespace Garnet.test.cluster
         }
 
         /// <summary>
+        /// A brand-new Vector Set created on a node that received a set by diskless full sync must
+        /// not be handed the streamed set's context. The stream-in path installs the index record
+        /// but never reserves its context in the receiver's allocator, so the next allocation can
+        /// collide with it. Promoting the receiver makes it writable so the fresh create runs there.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        public void FreshVectorSetDoesNotReuseStreamedContextAfterDisklessFullSync()
+        {
+            const string StreamedKey = "{vsctx}streamed";
+            const string FreshKey = "{vsctx}fresh";
+            const int Elements = 200;
+
+            SetupDisklessCluster(2);
+
+            PopulateVectorSet(PrimaryIndex, StreamedKey, Elements, seed: 2026_07_29_10);
+
+            // The replica has its own replication id, so the attach takes a full sync that carries
+            // the streamed set's index record (and its context) verbatim.
+            context.clusterTestUtils.Attach(ReplicaIndex, PrimaryIndex, logger: context.logger);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, StreamedKey);
+
+            // Promote the receiver so the fresh create allocates a context on the very node that
+            // took the diskless full sync.
+            FailoverTo(ReplicaIndex, PrimaryIndex);
+
+            var streamedContext = ReadPersistedContext(ReplicaIndex, StreamedKey);
+
+            PopulateVectorSet(ReplicaIndex, FreshKey, count: 50, seed: 2026_07_29_11);
+            var freshContext = ReadPersistedContext(ReplicaIndex, FreshKey);
+
+            ClassicAssert.AreNotEqual(
+                streamedContext,
+                freshContext,
+                $"a fresh Vector Set '{FreshKey}' was handed the streamed set '{StreamedKey}' context ({streamedContext}); the diskless full-sync receiver never reserved the streamed context, so the allocator reissued it");
+        }
+
+        /// <summary>
         /// Migrates a populated Vector Set between primaries while diskless sync is enabled.
         /// All four nodes must agree and no two may share a handle.
         /// </summary>

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDisklessSyncTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDisklessSyncTests.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 
@@ -20,16 +18,6 @@ namespace Garnet.test.cluster
     {
         private const int PrimaryIndex = 0;
         private const int ReplicaIndex = 1;
-
-        protected override Dictionary<string, LogLevel> MonitorTests => new()
-        {
-            [nameof(VectorSetReadableOnReplicaAfterDisklessFullSync)] = LogLevel.Trace,
-            [nameof(VectorSetsStayPartitionedAcrossDisklessFullSync)] = LogLevel.Trace,
-            [nameof(VectorSetReadableOnReplicaWithoutFullSync)] = LogLevel.Trace,
-            [nameof(VectorSetReplicatedToEveryReplicaByDisklessFullSync)] = LogLevel.Trace,
-            [nameof(VectorSetSurvivesFailoverAfterDisklessFullSync)] = LogLevel.Trace,
-            [nameof(VectorSetMigratedBetweenPrimariesWithDisklessSync)] = LogLevel.Trace,
-        };
 
         /// <summary>Creates a diskless-sync cluster with a low threshold so re-attach takes full sync.</summary>
         private void SetupDisklessCluster(int nodeCount)
@@ -65,7 +53,6 @@ namespace Garnet.test.cluster
         /// </summary>
         [Test]
         [Category("REPLICATION")]
-        [CancelAfter(180_000)]
         public void VectorSetReadableOnReplicaAfterDisklessFullSync()
         {
             const string Key = "{vsdisk}solo";
@@ -93,7 +80,6 @@ namespace Garnet.test.cluster
         /// </summary>
         [Test]
         [Category("REPLICATION")]
-        [CancelAfter(180_000)]
         public void VectorSetsStayPartitionedAcrossDisklessFullSync()
         {
             // Same hash slot, so both keys live on the single primary in this topology.
@@ -129,7 +115,6 @@ namespace Garnet.test.cluster
         /// </summary>
         [Test]
         [Category("REPLICATION")]
-        [CancelAfter(180_000)]
         public void VectorSetReadableOnReplicaWithoutFullSync()
         {
             const string Key = "{vsdisk}control";
@@ -153,7 +138,6 @@ namespace Garnet.test.cluster
         /// </summary>
         [Test]
         [Category("REPLICATION")]
-        [CancelAfter(180_000)]
         public void VectorSetReplicatedToEveryReplicaByDisklessFullSync()
         {
             const string Key = "{vsdisk}fanout";
@@ -196,7 +180,6 @@ namespace Garnet.test.cluster
         /// </summary>
         [Test]
         [Category("REPLICATION")]
-        [CancelAfter(180_000)]
         public void VectorSetSurvivesFailoverAfterDisklessFullSync()
         {
             const string Key = "{vsdisk}failover";
@@ -236,7 +219,6 @@ namespace Garnet.test.cluster
         /// </summary>
         [Test]
         [Category("REPLICATION")]
-        [CancelAfter(180_000)]
         public void VectorSetMigratedBetweenPrimariesWithDisklessSync()
         {
             const int Primary0 = 0;

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDisklessSyncTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDisklessSyncTests.cs
@@ -30,7 +30,7 @@ namespace Garnet.test.cluster
                 timeout: timeout);
             context.CreateConnection();
 
-            FormCluster(PrimaryIndex, [.. Enumerable.Range(1, nodeCount - 1)]);
+            context.clusterTestUtils.FormCluster(PrimaryIndex, [.. Enumerable.Range(1, nodeCount - 1)], context.logger);
         }
 
         /// <summary>
@@ -41,9 +41,9 @@ namespace Garnet.test.cluster
         /// </summary>
         private void ForceDisklessFullSync(int replicaIndex = ReplicaIndex)
         {
-            ResetReplica(replicaIndex, PrimaryIndex);
+            context.clusterTestUtils.ResetReplica(replicaIndex, PrimaryIndex, context.logger);
             PushPrimaryAhead(PrimaryIndex);
-            Attach(replicaIndex, PrimaryIndex);
+            context.clusterTestUtils.Attach(replicaIndex, PrimaryIndex, logger: context.logger);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Garnet.test.cluster
             const int Elements = 500;
 
             SetupDisklessCluster(2);
-            Attach(ReplicaIndex, PrimaryIndex);
+            context.clusterTestUtils.Attach(ReplicaIndex, PrimaryIndex, logger: context.logger);
 
             // Attached writes arrive as VADD replay, so the replica builds its own index.
             PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_00);
@@ -88,7 +88,7 @@ namespace Garnet.test.cluster
             const int LargeElements = 400;
 
             SetupDisklessCluster(2);
-            Attach(ReplicaIndex, PrimaryIndex);
+            context.clusterTestUtils.Attach(ReplicaIndex, PrimaryIndex, logger: context.logger);
 
             PopulateVectorSet(PrimaryIndex, LargeKey, LargeElements, seed: 2026_07_29_02);
             PopulateVectorSet(PrimaryIndex, SmallKey, SmallElements, seed: 2026_07_29_03);
@@ -120,7 +120,7 @@ namespace Garnet.test.cluster
             const int Elements = 500;
 
             SetupDisklessCluster(2);
-            Attach(ReplicaIndex, PrimaryIndex);
+            context.clusterTestUtils.Attach(ReplicaIndex, PrimaryIndex, logger: context.logger);
 
             PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_04);
             context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
@@ -151,7 +151,7 @@ namespace Garnet.test.cluster
             // Each replica starts with its own replication id, so every attach takes a full sync.
             for (var replica = 1; replica <= ReplicaCount; replica++)
             {
-                Attach(replica, PrimaryIndex);
+                context.clusterTestUtils.Attach(replica, PrimaryIndex, logger: context.logger);
             }
 
             for (var replica = 1; replica <= ReplicaCount; replica++)
@@ -186,7 +186,7 @@ namespace Garnet.test.cluster
             PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_07);
 
             // The replica has its own replication id, so the attach takes a full sync.
-            Attach(ReplicaIndex, PrimaryIndex);
+            context.clusterTestUtils.Attach(ReplicaIndex, PrimaryIndex, logger: context.logger);
 
             MakeReadable(ReplicaIndex);
             AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDisklessSyncTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDisklessSyncTests.cs
@@ -1,0 +1,306 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace Garnet.test.cluster
+{
+    /// <summary>
+    /// Diskless full-sync coverage for populated Vector Sets. The iterator streams IndexPtr,
+    /// so the receiver must sanitize and rebuild before the TLA+ quiet-read counterexample.
+    /// Executable form of the model in tla/VectorIndexLifetime.tla.
+    /// </summary>
+    [TestFixture]
+    [NonParallelizable]
+    public class ClusterVectorSetDisklessSyncTests : VectorSetReplicationTestBase
+    {
+        private const int PrimaryIndex = 0;
+        private const int ReplicaIndex = 1;
+
+        protected override Dictionary<string, LogLevel> MonitorTests => new()
+        {
+            [nameof(VectorSetReadableOnReplicaAfterDisklessFullSync)] = LogLevel.Trace,
+            [nameof(VectorSetsStayPartitionedAcrossDisklessFullSync)] = LogLevel.Trace,
+            [nameof(VectorSetReadableOnReplicaWithoutFullSync)] = LogLevel.Trace,
+            [nameof(VectorSetReplicatedToEveryReplicaByDisklessFullSync)] = LogLevel.Trace,
+            [nameof(VectorSetSurvivesFailoverAfterDisklessFullSync)] = LogLevel.Trace,
+            [nameof(VectorSetMigratedBetweenPrimariesWithDisklessSync)] = LogLevel.Trace,
+        };
+
+        /// <summary>Creates a diskless-sync cluster with a low threshold so re-attach takes full sync.</summary>
+        private void SetupDisklessCluster(int nodeCount)
+        {
+            context.CreateInstances(
+                nodeCount,
+                enableAOF: true,
+                enableDisklessSync: true,
+                replicaDisklessSyncFullSyncAofThreshold: "1k",
+                timeout: timeout);
+            context.CreateConnection();
+
+            FormCluster(PrimaryIndex, [.. Enumerable.Range(1, nodeCount - 1)]);
+        }
+
+        /// <summary>
+        /// Forces the model's reset/snapshot path: detach, move past incremental replay, then re-attach.
+        /// </summary>
+        private void ForceDisklessFullSync(int replicaIndex = ReplicaIndex)
+        {
+            var before = FullSyncCount();
+
+            ResetReplica(replicaIndex, PrimaryIndex);
+            PushPrimaryAhead(PrimaryIndex);
+            Attach(replicaIndex, PrimaryIndex);
+
+            AssertTookFullSync(before);
+        }
+
+        /// <summary>
+        /// A populated set travels by diskless full sync, then the replica reads it. This catches
+        /// foreign IndexPtr dereferences that used to surface at NativeDiskANNMethods.card.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetReadableOnReplicaAfterDisklessFullSync()
+        {
+            const string Key = "{vsdisk}solo";
+            const int Elements = 500;
+
+            SetupDisklessCluster(2);
+            Attach(ReplicaIndex, PrimaryIndex);
+
+            // Attached writes arrive as VADD replay, so the replica builds its own index.
+            PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_00);
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
+
+            ForceDisklessFullSync();
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
+        }
+
+        /// <summary>
+        /// Multiple sets can make a foreign handle point at the wrong live index instead of faulting.
+        /// Different sizes plus element checks expose cross-set substitution.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetsStayPartitionedAcrossDisklessFullSync()
+        {
+            // Same hash slot, so both keys live on the single primary in this topology.
+            const string SmallKey = "{vsdisk}small";
+            const string LargeKey = "{vsdisk}large";
+            const int SmallElements = 10;
+            const int LargeElements = 400;
+
+            SetupDisklessCluster(2);
+            Attach(ReplicaIndex, PrimaryIndex);
+
+            PopulateVectorSet(PrimaryIndex, LargeKey, LargeElements, seed: 2026_07_29_02);
+            PopulateVectorSet(PrimaryIndex, SmallKey, SmallElements, seed: 2026_07_29_03);
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
+
+            ClassicAssert.AreEqual(LargeElements, VectorSetSize(PrimaryIndex, LargeKey));
+            ClassicAssert.AreEqual(SmallElements, VectorSetSize(PrimaryIndex, SmallKey));
+
+            ForceDisklessFullSync();
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, SmallKey);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, LargeKey);
+
+            // Neither key may report the other's cardinality.
+            ClassicAssert.AreEqual(SmallElements, VectorSetSize(ReplicaIndex, SmallKey), "small set must not report elements belonging to another Vector Set");
+            ClassicAssert.AreEqual(LargeElements, VectorSetSize(ReplicaIndex, LargeKey), "large set must report exactly its own elements");
+        }
+
+        /// <summary>
+        /// Control: without full sync, replicated VADD payloads build the replica's local index,
+        /// so this should pass even if full-sync cases fail.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetReadableOnReplicaWithoutFullSync()
+        {
+            const string Key = "{vsdisk}control";
+            const int Elements = 500;
+
+            SetupDisklessCluster(2);
+            Attach(ReplicaIndex, PrimaryIndex);
+
+            PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_04);
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
+
+            MakeReadable(ReplicaIndex);
+
+            // Without full sync, VADD replay builds a local index and isolates full sync as the cause.
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
+        }
+
+        /// <summary>
+        /// Every replica takes its own diskless full sync from the same populated primary.
+        /// Each must rebuild its own index, not share per-primary state.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetReplicatedToEveryReplicaByDisklessFullSync()
+        {
+            const string Key = "{vsdisk}fanout";
+            const int Elements = 200;
+            const int ReplicaCount = 3;
+
+            SetupDisklessCluster(1 + ReplicaCount);
+
+            // Populated before any replica exists, so each attach carries the index record.
+            PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_06);
+
+            var before = FullSyncCount();
+
+            for (var replica = 1; replica <= ReplicaCount; replica++)
+            {
+                Attach(replica, PrimaryIndex);
+            }
+
+            AssertTookFullSync(before);
+
+            for (var replica = 1; replica <= ReplicaCount; replica++)
+            {
+                MakeReadable(replica);
+                AssertFullyReplicated(PrimaryIndex, replica, Key);
+            }
+
+            // No two nodes may share a handle.
+            for (var a = 0; a <= ReplicaCount; a++)
+            {
+                for (var b = a + 1; b <= ReplicaCount; b++)
+                {
+                    AssertOwnsItsIndex(b, a, Key);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Promotes a replica after diskless full sync, then syncs back to the old primary.
+        /// The record crosses both directions and both nodes must own their indexes.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetSurvivesFailoverAfterDisklessFullSync()
+        {
+            const string Key = "{vsdisk}failover";
+            const int Elements = 200;
+
+            SetupDisklessCluster(2);
+
+            PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_07);
+
+            var before = FullSyncCount();
+            Attach(ReplicaIndex, PrimaryIndex);
+            AssertTookFullSync(before);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
+
+            context.ClusterFailoverSpinWait(ReplicaIndex, context.logger);
+            context.clusterTestUtils.WaitForReplicaAofSync(ReplicaIndex, PrimaryIndex, logger: context.logger);
+
+            ClassicAssert.AreEqual("master", context.clusterTestUtils.RoleCommand(Node(ReplicaIndex), logger: context.logger).Value);
+            ClassicAssert.AreEqual("slave", context.clusterTestUtils.RoleCommand(Node(PrimaryIndex), logger: context.logger).Value);
+
+            MakeReadable(PrimaryIndex);
+            AssertFullyReplicated(ReplicaIndex, PrimaryIndex, Key);
+
+            // Inherited sets must still accept writes and replicate them back.
+            PopulateVectorSet(ReplicaIndex, Key, count: 50, seed: 2026_07_29_08);
+            context.clusterTestUtils.WaitForReplicaAofSync(ReplicaIndex, PrimaryIndex, logger: context.logger);
+
+            MakeReadable(PrimaryIndex);
+            AssertFullyReplicated(ReplicaIndex, PrimaryIndex, Key);
+        }
+
+        /// <summary>
+        /// Migrates a populated Vector Set between primaries while diskless sync is enabled.
+        /// All four nodes must agree and no two may share a handle.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetMigratedBetweenPrimariesWithDisklessSync()
+        {
+            const int Primary0 = 0;
+            const int Primary1 = 1;
+            const int Replica0 = 2;
+            const int Replica1 = 3;
+            const int Elements = 150;
+
+            context.CreateInstances(
+                4,
+                enableAOF: true,
+                enableDisklessSync: true,
+                timeout: timeout);
+            context.CreateConnection();
+
+            _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: 2, replica_count: 1, logger: context.logger);
+
+            var primary0 = Node(Primary0);
+            var primary1 = Node(Primary1);
+            var primary0Id = context.clusterTestUtils.ClusterMyId(primary0, logger: context.logger);
+            var slots = context.clusterTestUtils.ClusterSlots(primary0, logger: context.logger);
+
+            // Find a key that hashes into a slot Primary0 owns.
+            string key;
+            int hashSlot;
+            var ix = 0;
+            while (true)
+            {
+                key = $"{nameof(VectorSetMigratedBetweenPrimariesWithDisklessSync)}_{ix}";
+                hashSlot = context.clusterTestUtils.HashSlot(key);
+
+                if (slots.Any(x => x.nnInfo.Any(y => y.nodeid == primary0Id) && hashSlot >= x.startSlot && hashSlot <= x.endSlot))
+                    break;
+
+                ix++;
+            }
+
+            PopulateVectorSet(Primary0, key, Elements, seed: 2026_07_29_09);
+            context.clusterTestUtils.WaitForReplicaAofSync(Primary0, Replica0, logger: context.logger);
+
+            WaitUntilServes(Replica0, key);
+            AssertFullyReplicated(Primary0, Replica0, key);
+
+            // Read before migration because Primary0 drops the record once the slot moves.
+            var handleBeforeMigration = ReadPersistedIndexPtr(Primary0, key);
+            ClassicAssert.AreNotEqual(nint.Zero, handleBeforeMigration);
+
+            context.clusterTestUtils.MigrateSlots(primary0, primary1, [hashSlot], logger: context.logger);
+            context.clusterTestUtils.WaitForMigrationCleanup(Primary0, context.cts.Token, context.logger);
+            context.clusterTestUtils.WaitForMigrationCleanup(Primary1, context.cts.Token, context.logger);
+
+            context.clusterTestUtils.WaitForReplicaAofSync(Primary0, Replica0, logger: context.logger);
+            context.clusterTestUtils.WaitForReplicaAofSync(Primary1, Replica1, logger: context.logger);
+
+            ClassicAssert.IsFalse(context.clusterTestUtils.GetOwnedSlotsFromNode(primary0, context.logger).Contains(hashSlot));
+            ClassicAssert.IsTrue(context.clusterTestUtils.GetOwnedSlotsFromNode(primary1, context.logger).Contains(hashSlot));
+
+            WaitUntilServes(Replica1, key);
+            AssertFullyReplicated(Primary1, Replica1, key);
+
+            // The migrated-to primary must build its own index, not reuse Primary0's handle.
+            var handleAfterMigration = ReadPersistedIndexPtr(Primary1, key);
+            ClassicAssert.AreNotEqual(nint.Zero, handleAfterMigration, $"node {Primary1} should have built its own index for '{key}'");
+            ClassicAssert.AreNotEqual(handleBeforeMigration, handleAfterMigration, $"node {Primary1} adopted node {Primary0}'s DiskANN handle for '{key}' across the migration");
+        }
+    }
+}

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDisklessSyncTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDisklessSyncTests.cs
@@ -194,8 +194,8 @@ namespace Garnet.test.cluster
             context.ClusterFailoverSpinWait(ReplicaIndex, context.logger);
             context.clusterTestUtils.WaitForReplicaAofSync(ReplicaIndex, PrimaryIndex, logger: context.logger);
 
-            ClassicAssert.AreEqual("master", context.clusterTestUtils.RoleCommand(Node(ReplicaIndex), logger: context.logger).Value);
-            ClassicAssert.AreEqual("slave", context.clusterTestUtils.RoleCommand(Node(PrimaryIndex), logger: context.logger).Value);
+            ClassicAssert.AreEqual("master", context.clusterTestUtils.RoleCommand(context.clusterTestUtils.GetEndPoint(ReplicaIndex), logger: context.logger).Value);
+            ClassicAssert.AreEqual("slave", context.clusterTestUtils.RoleCommand(context.clusterTestUtils.GetEndPoint(PrimaryIndex), logger: context.logger).Value);
 
             MakeReadable(PrimaryIndex);
             AssertFullyReplicated(ReplicaIndex, PrimaryIndex, Key);
@@ -231,8 +231,8 @@ namespace Garnet.test.cluster
 
             _ = context.clusterTestUtils.SimpleSetupCluster(primary_count: 2, replica_count: 1, logger: context.logger);
 
-            var primary0 = Node(Primary0);
-            var primary1 = Node(Primary1);
+            var primary0 = context.clusterTestUtils.GetEndPoint(Primary0);
+            var primary1 = context.clusterTestUtils.GetEndPoint(Primary1);
             var primary0Id = context.clusterTestUtils.ClusterMyId(primary0, logger: context.logger);
             var slots = context.clusterTestUtils.ClusterSlots(primary0, logger: context.logger);
 

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDisklessSyncTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDisklessSyncTests.cs
@@ -28,9 +28,8 @@ namespace Garnet.test.cluster
                 enableDisklessSync: true,
                 replicaDisklessSyncFullSyncAofThreshold: "1k",
                 timeout: timeout);
-            context.CreateConnection();
 
-            context.clusterTestUtils.FormCluster(PrimaryIndex, [.. Enumerable.Range(1, nodeCount - 1)], context.logger);
+            FormClusterAllNodes(nodeCount);
         }
 
         /// <summary>
@@ -191,11 +190,7 @@ namespace Garnet.test.cluster
             MakeReadable(ReplicaIndex);
             AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
 
-            context.ClusterFailoverSpinWait(ReplicaIndex, context.logger);
-            context.clusterTestUtils.WaitForReplicaAofSync(ReplicaIndex, PrimaryIndex, logger: context.logger);
-
-            ClassicAssert.AreEqual("master", context.clusterTestUtils.RoleCommand(context.clusterTestUtils.GetEndPoint(ReplicaIndex), logger: context.logger).Value);
-            ClassicAssert.AreEqual("slave", context.clusterTestUtils.RoleCommand(context.clusterTestUtils.GetEndPoint(PrimaryIndex), logger: context.logger).Value);
+            FailoverTo(ReplicaIndex, PrimaryIndex);
 
             MakeReadable(PrimaryIndex);
             AssertFullyReplicated(ReplicaIndex, PrimaryIndex, Key);

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetFailoverTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetFailoverTests.cs
@@ -28,7 +28,7 @@ namespace Garnet.test.cluster
                 timeout: timeout);
             context.CreateConnection();
 
-            FormCluster(PrimaryIndex, [.. Enumerable.Range(1, nodeCount - 1)]);
+            context.clusterTestUtils.FormCluster(PrimaryIndex, [.. Enumerable.Range(1, nodeCount - 1)], context.logger);
         }
 
         private void FailoverTo(int replicaIndex, int oldPrimaryIndex)
@@ -49,7 +49,7 @@ namespace Garnet.test.cluster
             const int Elements = 250;
 
             SetupCluster(2);
-            Attach(ReplicaIndex, PrimaryIndex);
+            context.clusterTestUtils.Attach(ReplicaIndex, PrimaryIndex, logger: context.logger);
 
             PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_21);
             context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
@@ -78,7 +78,7 @@ namespace Garnet.test.cluster
             const int AddedElements = 150;
 
             SetupCluster(2);
-            Attach(ReplicaIndex, PrimaryIndex);
+            context.clusterTestUtils.Attach(ReplicaIndex, PrimaryIndex, logger: context.logger);
 
             PopulateVectorSet(PrimaryIndex, Key, InitialElements, seed: 2026_07_29_22);
             context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
@@ -111,7 +111,7 @@ namespace Garnet.test.cluster
             const int Rounds = 3;
 
             SetupCluster(2);
-            Attach(ReplicaIndex, PrimaryIndex);
+            context.clusterTestUtils.Attach(ReplicaIndex, PrimaryIndex, logger: context.logger);
 
             PopulateVectorSet(PrimaryIndex, Key, InitialElements, seed: 2026_07_29_24);
             context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetFailoverTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetFailoverTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System.Linq;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 
@@ -26,18 +25,8 @@ namespace Garnet.test.cluster
                 enableDisklessSync: false,
                 OnDemandCheckpoint: true,
                 timeout: timeout);
-            context.CreateConnection();
 
-            context.clusterTestUtils.FormCluster(PrimaryIndex, [.. Enumerable.Range(1, nodeCount - 1)], context.logger);
-        }
-
-        private void FailoverTo(int replicaIndex, int oldPrimaryIndex)
-        {
-            context.ClusterFailoverSpinWait(replicaIndex, context.logger);
-            context.clusterTestUtils.WaitForReplicaAofSync(replicaIndex, oldPrimaryIndex, logger: context.logger);
-
-            ClassicAssert.AreEqual("master", context.clusterTestUtils.RoleCommand(context.clusterTestUtils.GetEndPoint(replicaIndex), logger: context.logger).Value);
-            ClassicAssert.AreEqual("slave", context.clusterTestUtils.RoleCommand(context.clusterTestUtils.GetEndPoint(oldPrimaryIndex), logger: context.logger).Value);
+            FormClusterAllNodes(nodeCount);
         }
 
         /// <summary>After promotion, the new primary must keep every element and the demoted node must agree.</summary>

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetFailoverTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetFailoverTests.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 
@@ -19,13 +17,6 @@ namespace Garnet.test.cluster
     {
         private const int PrimaryIndex = 0;
         private const int ReplicaIndex = 1;
-
-        protected override Dictionary<string, LogLevel> MonitorTests => new()
-        {
-            [nameof(VectorSetSurvivesFailover)] = LogLevel.Trace,
-            [nameof(PromotedReplicaServesVectorSetToDemotedPrimary)] = LogLevel.Trace,
-            [nameof(VectorSetSurvivesRepeatedFailovers)] = LogLevel.Trace,
-        };
 
         private void SetupCluster(int nodeCount)
         {
@@ -52,7 +43,6 @@ namespace Garnet.test.cluster
         /// <summary>After promotion, the new primary must keep every element and the demoted node must agree.</summary>
         [Test]
         [Category("REPLICATION")]
-        [CancelAfter(180_000)]
         public void VectorSetSurvivesFailover()
         {
             const string Key = "{vsdisk}failoverbasic";
@@ -81,7 +71,6 @@ namespace Garnet.test.cluster
         /// </summary>
         [Test]
         [Category("REPLICATION")]
-        [CancelAfter(180_000)]
         public void PromotedReplicaServesVectorSetToDemotedPrimary()
         {
             const string Key = "{vsdisk}failoverwrite";
@@ -114,7 +103,6 @@ namespace Garnet.test.cluster
         /// </summary>
         [Test]
         [Category("REPLICATION")]
-        [CancelAfter(180_000)]
         public void VectorSetSurvivesRepeatedFailovers()
         {
             const string Key = "{vsdisk}failoverloop";

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetFailoverTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetFailoverTests.cs
@@ -36,8 +36,8 @@ namespace Garnet.test.cluster
             context.ClusterFailoverSpinWait(replicaIndex, context.logger);
             context.clusterTestUtils.WaitForReplicaAofSync(replicaIndex, oldPrimaryIndex, logger: context.logger);
 
-            ClassicAssert.AreEqual("master", context.clusterTestUtils.RoleCommand(Node(replicaIndex), logger: context.logger).Value);
-            ClassicAssert.AreEqual("slave", context.clusterTestUtils.RoleCommand(Node(oldPrimaryIndex), logger: context.logger).Value);
+            ClassicAssert.AreEqual("master", context.clusterTestUtils.RoleCommand(context.clusterTestUtils.GetEndPoint(replicaIndex), logger: context.logger).Value);
+            ClassicAssert.AreEqual("slave", context.clusterTestUtils.RoleCommand(context.clusterTestUtils.GetEndPoint(oldPrimaryIndex), logger: context.logger).Value);
         }
 
         /// <summary>After promotion, the new primary must keep every element and the demoted node must agree.</summary>

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetFailoverTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetFailoverTests.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace Garnet.test.cluster
+{
+    /// <summary>
+    /// Failover coverage for populated Vector Sets. Promotion reverses replication direction,
+    /// so aliased handles get observed from the other side.
+    /// </summary>
+    [TestFixture]
+    [NonParallelizable]
+    public class ClusterVectorSetFailoverTests : VectorSetReplicationTestBase
+    {
+        private const int PrimaryIndex = 0;
+        private const int ReplicaIndex = 1;
+
+        protected override Dictionary<string, LogLevel> MonitorTests => new()
+        {
+            [nameof(VectorSetSurvivesFailover)] = LogLevel.Trace,
+            [nameof(PromotedReplicaServesVectorSetToDemotedPrimary)] = LogLevel.Trace,
+            [nameof(VectorSetSurvivesRepeatedFailovers)] = LogLevel.Trace,
+        };
+
+        private void SetupCluster(int nodeCount)
+        {
+            context.CreateInstances(
+                nodeCount,
+                enableAOF: true,
+                enableDisklessSync: false,
+                OnDemandCheckpoint: true,
+                timeout: timeout);
+            context.CreateConnection();
+
+            FormCluster(PrimaryIndex, [.. Enumerable.Range(1, nodeCount - 1)]);
+        }
+
+        private void FailoverTo(int replicaIndex, int oldPrimaryIndex)
+        {
+            context.ClusterFailoverSpinWait(replicaIndex, context.logger);
+            context.clusterTestUtils.WaitForReplicaAofSync(replicaIndex, oldPrimaryIndex, logger: context.logger);
+
+            ClassicAssert.AreEqual("master", context.clusterTestUtils.RoleCommand(Node(replicaIndex), logger: context.logger).Value);
+            ClassicAssert.AreEqual("slave", context.clusterTestUtils.RoleCommand(Node(oldPrimaryIndex), logger: context.logger).Value);
+        }
+
+        /// <summary>After promotion, the new primary must keep every element and the demoted node must agree.</summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetSurvivesFailover()
+        {
+            const string Key = "{vsdisk}failoverbasic";
+            const int Elements = 250;
+
+            SetupCluster(2);
+            Attach(ReplicaIndex, PrimaryIndex);
+
+            PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_21);
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
+
+            FailoverTo(ReplicaIndex, PrimaryIndex);
+
+            ClassicAssert.AreEqual(Elements, VectorSetSize(ReplicaIndex, Key), "the promoted node lost elements across the failover");
+
+            MakeReadable(PrimaryIndex);
+            AssertFullyReplicated(ReplicaIndex, PrimaryIndex, Key);
+        }
+
+        /// <summary>
+        /// After promotion, the new primary extends the inherited set and replicates those writes
+        /// back to the demoted original writer.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void PromotedReplicaServesVectorSetToDemotedPrimary()
+        {
+            const string Key = "{vsdisk}failoverwrite";
+            const int InitialElements = 200;
+            const int AddedElements = 150;
+
+            SetupCluster(2);
+            Attach(ReplicaIndex, PrimaryIndex);
+
+            PopulateVectorSet(PrimaryIndex, Key, InitialElements, seed: 2026_07_29_22);
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
+
+            FailoverTo(ReplicaIndex, PrimaryIndex);
+
+            // ReplicaIndex is now primary; write through it.
+            PopulateVectorSet(ReplicaIndex, Key, AddedElements, seed: 2026_07_29_23);
+            context.clusterTestUtils.WaitForReplicaAofSync(ReplicaIndex, PrimaryIndex, logger: context.logger);
+
+            ClassicAssert.AreEqual(InitialElements + AddedElements, VectorSetSize(ReplicaIndex, Key));
+
+            MakeReadable(PrimaryIndex);
+            AssertFullyReplicated(ReplicaIndex, PrimaryIndex, Key);
+        }
+
+        /// <summary>
+        /// Repeated failovers re-point the replication stream several times, surfacing state that only resets in one direction.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetSurvivesRepeatedFailovers()
+        {
+            const string Key = "{vsdisk}failoverloop";
+            const int InitialElements = 100;
+            const int PerRoundElements = 40;
+            const int Rounds = 3;
+
+            SetupCluster(2);
+            Attach(ReplicaIndex, PrimaryIndex);
+
+            PopulateVectorSet(PrimaryIndex, Key, InitialElements, seed: 2026_07_29_24);
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
+
+            var primary = PrimaryIndex;
+            var replica = ReplicaIndex;
+
+            for (var round = 0; round < Rounds; round++)
+            {
+                FailoverTo(replica, primary);
+                (primary, replica) = (replica, primary);
+
+                PopulateVectorSet(primary, Key, PerRoundElements, seed: 2026_07_29_25 + round);
+                context.clusterTestUtils.WaitForReplicaAofSync(primary, replica, logger: context.logger);
+
+                MakeReadable(replica);
+                AssertFullyReplicated(primary, replica, Key);
+            }
+
+            ClassicAssert.AreEqual(
+                InitialElements + (PerRoundElements * Rounds),
+                VectorSetSize(primary, Key),
+                "elements were lost across repeated failovers");
+        }
+    }
+}

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
@@ -1,0 +1,506 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Garnet.server;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using StackExchange.Redis;
+using Tsavorite.core;
+
+namespace Garnet.test.cluster
+{
+    /// <summary>
+    /// Shared harness for Vector Set replication tests. Asserts both index ownership
+    /// and element-level equality, since either can hold while the other is broken.
+    /// </summary>
+    public abstract class VectorSetReplicationTestBase : TestBase
+    {
+        /// <summary>Length in bytes of an XB8 vector.</summary>
+        protected const int VectorDimensions = 64;
+
+        /// <summary>
+        /// Enough padding keys to force a re-attach down the full-sync path instead of incremental replay.
+        /// </summary>
+        protected const int FullSyncForcingKeys = 256;
+
+        /// <summary>Diskless full-sync marker emitted by SyncMetadata.</summary>
+        private const string DisklessFullSyncMarker = "recoverFullSync:True";
+
+        /// <summary>Disk-based full-sync marker emitted when the primary ships a checkpoint.</summary>
+        private const string DiskBasedFullSyncMarker = "Sending main store checkpoint";
+
+        /// <summary>Captures node logs while still forwarding them to the test output.</summary>
+        protected sealed class CaptureLogWriter(TextWriter passThrough) : TextWriter
+        {
+            private readonly StringBuilder buffer = new();
+
+            public override Encoding Encoding => passThrough.Encoding;
+
+            public override void Write(string value)
+            {
+                passThrough.Write(value);
+                lock (buffer)
+                {
+                    _ = buffer.Append(value);
+                }
+            }
+
+            public string Snapshot()
+            {
+                lock (buffer)
+                {
+                    return buffer.ToString();
+                }
+            }
+        }
+
+        protected ClusterTestContext context;
+        protected CaptureLogWriter captureLogWriter;
+
+        protected readonly int timeout = (int)TimeSpan.FromSeconds(15).TotalSeconds;
+        protected readonly int testTimeout = (int)TimeSpan.FromSeconds(180).TotalSeconds;
+
+        /// <summary>Elements written through PopulateVectorSet, used for source-vs-target checks.</summary>
+        private readonly Dictionary<string, List<byte[]>> writtenElements = [];
+
+        /// <summary>Trace logging is required to distinguish full sync from incremental replay.</summary>
+        protected abstract Dictionary<string, LogLevel> MonitorTests { get; }
+
+        [SetUp]
+        public virtual void Setup()
+        {
+            writtenElements.Clear();
+            captureLogWriter = new(TestContext.Progress);
+
+            context = new ClusterTestContext();
+            context.logTextWriter = captureLogWriter;
+            context.Setup(MonitorTests, testTimeoutSeconds: testTimeout);
+        }
+
+        [TearDown]
+        public virtual void TearDown()
+        {
+            context?.TearDown();
+        }
+
+        protected IPEndPoint Node(int index) => (IPEndPoint)context.endpoints[index];
+
+        #region cluster formation
+
+        /// <summary>
+        /// Assigns all slots to primaryIndex and introduces the other nodes without attaching replicas.
+        /// </summary>
+        protected void FormCluster(int primaryIndex, params int[] otherIndexes)
+        {
+            _ = context.clusterTestUtils.AddDelSlotsRange(primaryIndex, [(0, 16383)], addslot: true, logger: context.logger);
+            context.clusterTestUtils.SetConfigEpoch(primaryIndex, primaryIndex + 1, logger: context.logger);
+
+            foreach (var other in otherIndexes)
+            {
+                context.clusterTestUtils.SetConfigEpoch(other, other + 1, logger: context.logger);
+                context.clusterTestUtils.Meet(primaryIndex, other, logger: context.logger);
+                context.clusterTestUtils.WaitUntilNodeIsKnown(primaryIndex, other, logger: context.logger);
+            }
+        }
+
+        protected void Attach(int replicaIndex, int primaryIndex, bool waitForRecovery = false)
+        {
+            _ = context.clusterTestUtils.ClusterReplicate(replicaNodeIndex: replicaIndex, primaryNodeIndex: primaryIndex, logger: context.logger);
+
+            if (waitForRecovery)
+                context.clusterTestUtils.WaitForReplicaRecovery(replicaIndex, context.logger);
+
+            context.clusterTestUtils.WaitForReplicaAofSync(primaryIndex, replicaIndex, logger: context.logger);
+        }
+
+        /// <summary>Detaches and re-introduces a replica so the next attach starts from scratch.</summary>
+        protected void ResetReplica(int replicaIndex, int primaryIndex)
+        {
+            _ = context.clusterTestUtils.ClusterReset(replicaIndex, soft: true, expiry: 1, logger: context.logger);
+            context.clusterTestUtils.BumpEpoch(replicaIndex, logger: context.logger);
+
+            while (!context.clusterTestUtils.IsKnown(replicaIndex, primaryIndex, logger: context.logger))
+            {
+                ClusterTestUtils.BackOff(cancellationToken: context.cts.Token);
+                context.clusterTestUtils.Meet(replicaIndex, primaryIndex, logger: context.logger);
+            }
+        }
+
+        /// <summary>Moves the primary far enough ahead that a re-attach cannot be incremental.</summary>
+        protected void PushPrimaryAhead(int primaryIndex)
+        {
+            var primary = Node(primaryIndex);
+            for (var i = 0; i < FullSyncForcingKeys; i++)
+            {
+                _ = context.clusterTestUtils.Execute(primary, "SET", [$"{{padding}}key{i}", new string('x', 64)], skipLogging: true);
+            }
+        }
+
+        private int CountLogOccurrences(string marker)
+        {
+            var log = captureLogWriter.Snapshot();
+            var count = 0;
+            var at = 0;
+
+            while ((at = log.IndexOf(marker, at, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                at += marker.Length;
+            }
+
+            return count;
+        }
+
+        protected int FullSyncCount() => CountLogOccurrences(DisklessFullSyncMarker);
+
+        protected int DiskBasedFullSyncCount() => CountLogOccurrences(DiskBasedFullSyncMarker);
+
+        /// <summary>Asserts the attach took diskless full sync, not incremental replay.</summary>
+        protected void AssertTookFullSync(int since = 0)
+        {
+            ClassicAssert.Greater(
+                FullSyncCount(),
+                since,
+                "no new diskless streaming full sync was observed, so this test is not exercising the scenario it claims to");
+        }
+
+        /// <summary>Disk-based counterpart of AssertTookFullSync.</summary>
+        protected void AssertTookDiskBasedFullSync(int since = 0)
+        {
+            ClassicAssert.Greater(
+                DiskBasedFullSyncCount(),
+                since,
+                "the primary never shipped a main store checkpoint, so no disk-based full sync took place and this test is not exercising the scenario it claims to");
+        }
+
+        /// <summary>
+        /// Takes a checkpoint after waiting past LASTSAVE's one-second resolution, so
+        /// WaitCheckpoint observes the new save.
+        /// </summary>
+        protected void TakeCheckpoint(int nodeIndex)
+        {
+            var lastSave = context.clusterTestUtils.LastSave(nodeIndex, logger: context.logger);
+            context.clusterTestUtils.WaitUntilNextSecond(nodeIndex, lastSave, logger: context.logger);
+            context.clusterTestUtils.Checkpoint(nodeIndex, logger: context.logger);
+            context.clusterTestUtils.WaitCheckpoint(nodeIndex, lastSave, logger: context.logger);
+        }
+
+        protected void MakeReadable(int nodeIndex)
+        {
+            var ok = (string)context.clusterTestUtils.Execute(Node(nodeIndex), "READONLY", [], logger: context.logger);
+            ClassicAssert.AreEqual("OK", ok);
+        }
+
+        /// <summary>
+        /// Waits until nodeIndex serves key instead of returning MOVED after a slot migration.
+        /// </summary>
+        protected void WaitUntilServes(int nodeIndex, string key)
+        {
+            var endpoint = Node(nodeIndex);
+
+            for (var attempt = 0; attempt < 200; attempt++)
+            {
+                MakeReadable(nodeIndex);
+                WaitForVectorReplay(nodeIndex);
+
+                var reply = context.clusterTestUtils.Execute(endpoint, "VINFO", [key], skipLogging: true);
+                if (reply.Resp2Type == ResultType.Array)
+                    return;
+
+                ClusterTestUtils.BackOff(cancellationToken: context.cts.Token);
+            }
+
+            Assert.Fail($"node {nodeIndex} never began serving '{key}'");
+        }
+
+        #endregion
+
+        #region vector set operations
+
+        /// <summary>
+        /// Adds deterministic XB8 elements and records them so targets can be compared with the
+        /// actual writes. XPREQ8 round-trips exactly through VEMB.
+        /// </summary>
+        protected void PopulateVectorSet(int nodeIndex, string key, int count, int seed)
+        {
+            var endpoint = Node(nodeIndex);
+            var r = new Random(seed);
+
+            if (!writtenElements.TryGetValue(key, out var elements))
+            {
+                writtenElements[key] = elements = [];
+            }
+
+            for (var i = 0; i < count; i++)
+            {
+                var vector = new byte[VectorDimensions];
+                r.NextBytes(vector);
+
+                var element = new byte[4];
+                BinaryPrimitives.WriteInt32LittleEndian(element, elements.Count);
+
+                var added = (int)context.clusterTestUtils.Execute(endpoint, "VADD", [key, "XB8", vector, element, "XPREQ8"], skipLogging: true);
+                ClassicAssert.AreEqual(1, added, $"VADD of element {i} into '{key}' should have inserted a new element");
+
+                elements.Add(element);
+            }
+        }
+
+        protected IReadOnlyList<byte[]> ElementsWrittenTo(string key) => writtenElements.TryGetValue(key, out var e) ? e : [];
+
+        /// <summary>Reads VINFO size, the path that reaches NativeDiskANNMethods.card.</summary>
+        protected long VectorSetSize(int nodeIndex, string key)
+        {
+            var reply = context.clusterTestUtils.Execute(Node(nodeIndex), "VINFO", [key], logger: context.logger);
+
+            // Execute returns failures as bulk strings, so non-array replies mean the read failed.
+            if (reply.Resp2Type != ResultType.Array)
+                Assert.Fail($"VINFO on '{key}' at node {nodeIndex} did not return an array, got {reply.Resp2Type}: {reply}");
+
+            var fields = (RedisValue[])reply;
+            if (fields is null)
+                Assert.Fail($"VINFO on '{key}' at node {nodeIndex} returned a nil array, so that node does not hold the Vector Set at all");
+
+            for (var i = 0; i + 1 < fields.Length; i += 2)
+            {
+                if (((string)fields[i]).Equals("size", StringComparison.OrdinalIgnoreCase))
+                    return (long)fields[i + 1];
+            }
+
+            Assert.Fail($"VINFO reply for '{key}' had no 'size' field: [{string.Join(", ", fields.Select(static f => (string)f))}]");
+            return -1;
+        }
+
+        protected long VectorSetDimensions(int nodeIndex, string key)
+        {
+            var reply = context.clusterTestUtils.Execute(Node(nodeIndex), "VDIM", [key], logger: context.logger);
+            if (reply.Resp2Type != ResultType.Integer)
+                Assert.Fail($"VDIM on '{key}' at node {nodeIndex} did not return an integer, got {reply.Resp2Type}: {reply}");
+
+            return (long)reply;
+        }
+
+        /// <summary>Returns the stored embedding for an element, or an empty array when absent.</summary>
+        protected string[] ElementEmbedding(int nodeIndex, string key, byte[] element)
+        {
+            var reply = context.clusterTestUtils.Execute(Node(nodeIndex), "VEMB", [key, element], skipLogging: true);
+            if (reply.Resp2Type != ResultType.Array)
+                Assert.Fail($"VEMB on '{key}' at node {nodeIndex} did not return an array, got {reply.Resp2Type}: {reply}");
+
+            return (string[])reply;
+        }
+
+        protected byte[][] Search(int nodeIndex, string key, byte[] query, int count)
+        {
+            var reply = context.clusterTestUtils.Execute(Node(nodeIndex), "VSIM", [key, "XB8", query, "COUNT", count.ToString()], skipLogging: true);
+            if (reply.Resp2Type != ResultType.Array)
+                Assert.Fail($"VSIM on '{key}' at node {nodeIndex} did not return an array, got {reply.Resp2Type}: {reply}");
+
+            return (byte[][])reply;
+        }
+
+        #endregion
+
+        #region assertions
+
+        /// <summary>
+        /// Compares cardinality, dimensions, embeddings, and VSIM behavior against the elements
+        /// actually written; the embedding sweep catches correct counts with wrong vectors.
+        /// </summary>
+        protected void AssertVectorSetsMatch(int sourceIndex, int targetIndex, string key)
+        {
+            var expected = ElementsWrittenTo(key);
+            ClassicAssert.Greater(expected.Count, 0, $"no elements were recorded for '{key}'; the test is asserting nothing");
+
+            WaitForVectorReplay(sourceIndex);
+            WaitForVectorReplay(targetIndex);
+
+            var sourceSize = VectorSetSize(sourceIndex, key);
+            var targetSize = VectorSetSize(targetIndex, key);
+
+            ClassicAssert.AreEqual(expected.Count, sourceSize, $"node {sourceIndex} lost elements of '{key}'");
+            ClassicAssert.AreEqual(sourceSize, targetSize, $"node {targetIndex} disagrees with node {sourceIndex} on the cardinality of '{key}'");
+
+            ClassicAssert.AreEqual(
+                VectorSetDimensions(sourceIndex, key),
+                VectorSetDimensions(targetIndex, key),
+                $"node {targetIndex} disagrees with node {sourceIndex} on the dimensionality of '{key}'");
+
+            var missing = new List<int>();
+            var mismatched = new List<int>();
+
+            for (var i = 0; i < expected.Count; i++)
+            {
+                var element = expected[i];
+                var targetEmbedding = ElementEmbedding(targetIndex, key, element);
+
+                if (targetEmbedding.Length == 0)
+                {
+                    missing.Add(i);
+                    continue;
+                }
+
+                var sourceEmbedding = ElementEmbedding(sourceIndex, key, element);
+                if (!sourceEmbedding.SequenceEqual(targetEmbedding))
+                    mismatched.Add(i);
+            }
+
+            ClassicAssert.IsEmpty(
+                missing,
+                $"{missing.Count} of {expected.Count} elements VADDed into '{key}' on node {sourceIndex} are missing on node {targetIndex} (first few: {string.Join(", ", missing.Take(10))})");
+
+            ClassicAssert.IsEmpty(
+                mismatched,
+                $"{mismatched.Count} of {expected.Count} elements of '{key}' have a different embedding on node {targetIndex} than on node {sourceIndex} (first few: {string.Join(", ", mismatched.Take(10))})");
+
+            AssertSearchesAgree(sourceIndex, targetIndex, key);
+        }
+
+        /// <summary>
+        /// Verifies VSIM on the target without requiring identical tails: rebuilt approximate-NN
+        /// graphs can legitimately return different tail orderings.
+        /// </summary>
+        protected void AssertSearchesAgree(int sourceIndex, int targetIndex, string key, int queries = 8, int count = 10)
+        {
+            var members = ElementsWrittenTo(key);
+            var membership = new HashSet<string>(members.Select(Convert.ToHexString));
+
+            // Exact queries must find the element itself regardless of graph construction.
+            var r = new Random(20260729);
+            for (var q = 0; q < queries; q++)
+            {
+                var element = members[r.Next(members.Count)];
+                var embedding = ElementEmbedding(targetIndex, key, element);
+                ClassicAssert.Greater(embedding.Length, 0, $"element {q} of '{key}' is missing on node {targetIndex}");
+
+                var query = embedding.Select(static component => (byte)Math.Clamp((int)float.Parse(component, CultureInfo.InvariantCulture), byte.MinValue, byte.MaxValue)).ToArray();
+                var hits = Search(targetIndex, key, query, count);
+
+                ClassicAssert.Greater(hits.Length, 0, $"VSIM on node {targetIndex} returned nothing for an element of '{key}' that it holds");
+                ClassicAssert.IsTrue(
+                    hits[0].AsSpan().SequenceEqual(element),
+                    $"VSIM on node {targetIndex} for the exact embedding of element [{string.Join(",", element)}] of '{key}' returned [{string.Join(",", hits[0])}] as its nearest neighbour, so the index is not navigable to its own elements");
+            }
+
+            // Random-query tails may differ, but hits must be real members and broadly agree.
+            for (var q = 0; q < queries; q++)
+            {
+                var query = new byte[VectorDimensions];
+                r.NextBytes(query);
+
+                var sourceHits = Search(sourceIndex, key, query, count);
+                var targetHits = Search(targetIndex, key, query, count);
+
+                ClassicAssert.Greater(sourceHits.Length, 0, $"VSIM on node {sourceIndex} returned nothing for '{key}'");
+                ClassicAssert.AreEqual(
+                    sourceHits.Length,
+                    targetHits.Length,
+                    $"VSIM for query {q} on '{key}' returned {sourceHits.Length} hits on node {sourceIndex} but {targetHits.Length} on node {targetIndex}");
+
+                var foreign = targetHits.Where(hit => !membership.Contains(Convert.ToHexString(hit))).ToList();
+                ClassicAssert.IsEmpty(
+                    foreign,
+                    $"VSIM for query {q} on '{key}' returned {foreign.Count} neighbours on node {targetIndex} that were never VADDed into that set (first: [{string.Join(",", foreign.FirstOrDefault() ?? [])}])");
+
+                var sourceSet = new HashSet<string>(sourceHits.Select(Convert.ToHexString));
+                var overlap = targetHits.Count(hit => sourceSet.Contains(Convert.ToHexString(hit)));
+
+                ClassicAssert.GreaterOrEqual(
+                    overlap * 2,
+                    sourceHits.Length,
+                    $"VSIM for query {q} on '{key}' agreed on only {overlap} of {sourceHits.Length} neighbours between node {sourceIndex} and node {targetIndex}; the two indexes are not searching the same vectors");
+            }
+        }
+
+        /// <summary>
+        /// AOF offsets are insufficient: replicas queue VADDs onto VectorManager's replay
+        /// channel, so offset sync can run ahead of index state.
+        /// </summary>
+        protected void WaitForVectorReplay(int nodeIndex)
+            => GetStoreWrapper(context.nodes[nodeIndex]).DefaultDatabase.VectorManager.WaitForVectorOperationsToComplete();
+
+        /// <summary>
+        /// Reads the persisted DiskANN handle via Read_MainStore so ReadVectorIndex cannot
+        /// lazily rebuild and rewrite it.
+        /// </summary>
+        protected nint ReadPersistedIndexPtr(int nodeIndex, string key)
+        {
+            var storeWrapper = GetStoreWrapper(context.nodes[nodeIndex]);
+            var db = storeWrapper.DefaultDatabase;
+
+            using var storageSession = new StorageSession(storeWrapper, new ScratchBufferBuilder(), new ScratchBufferAllocator(), null, null, db.Id, readSessionState: null, db.VectorManager, null);
+
+            var keyBytes = GC.AllocateArray<byte>(Encoding.ASCII.GetByteCount(key), pinned: true);
+            _ = Encoding.ASCII.GetBytes(key, keyBytes);
+
+            StringInput input = new(RespCommand.VINFO);
+            input.parseState.Initialize(1);
+            input.parseState.SetArgument(0, PinnedSpanByte.FromPinnedSpan(keyBytes));
+
+            Span<byte> indexSpan = stackalloc byte[VectorManager.IndexSize];
+            StringOutput output = new(SpanByteAndMemory.FromPinnedSpan(indexSpan));
+
+            var status = storageSession.Read_MainStore(keyBytes, ref input, ref output, ref storageSession.stringBasicContext);
+            ClassicAssert.AreEqual(GarnetStatus.OK, status, $"could not read the index record for '{key}' on node {nodeIndex}");
+            ClassicAssert.IsTrue(output.SpanByteAndMemory.IsSpanByte, $"index record for '{key}' did not come back inline");
+            ClassicAssert.AreEqual(VectorManager.IndexSize, output.SpanByteAndMemory.Length, $"value under '{key}' is not a Vector Set index record");
+
+            VectorManager.ReadIndex(output.SpanByteAndMemory.Span, out _, out _, out _, out _, out _, out _, out _, out _, out var indexPtr);
+
+            return indexPtr;
+        }
+
+        /// <summary>
+        /// Asserts a node does not hold another node's DiskANN handle. A zero handle is valid
+        /// after sanitization until lazy rebuild; only foreign non-zero pointers fail.
+        /// </summary>
+        protected void AssertOwnsItsIndex(int nodeIndex, int otherNodeIndex, string key)
+        {
+            var otherPtr = ReadPersistedIndexPtr(otherNodeIndex, key);
+            var nodePtr = ReadPersistedIndexPtr(nodeIndex, key);
+
+            if (nodePtr == nint.Zero || otherPtr == nint.Zero)
+                return;
+
+            ClassicAssert.AreNotEqual(
+                otherPtr,
+                nodePtr,
+                $"node {nodeIndex} holds node {otherNodeIndex}'s DiskANN handle for '{key}' (0x{otherPtr:x}); it is pointing into another node's heap and will fault once the two are separate processes");
+        }
+
+        /// <summary>
+        /// Asserts data equality before ownership because reads trigger lazy rebuild; checking
+        /// ownership first can see the expected zero sanitized pointer.
+        /// </summary>
+        protected void AssertFullyReplicated(int sourceIndex, int targetIndex, string key)
+        {
+            AssertVectorSetsMatch(sourceIndex, targetIndex, key);
+
+            var sourcePtr = ReadPersistedIndexPtr(sourceIndex, key);
+            var targetPtr = ReadPersistedIndexPtr(targetIndex, key);
+
+            ClassicAssert.AreNotEqual(nint.Zero, sourcePtr, $"node {sourceIndex} should have a live index for '{key}' after being read");
+            ClassicAssert.AreNotEqual(nint.Zero, targetPtr, $"node {targetIndex} should have built its own index for '{key}' after being read");
+
+            ClassicAssert.AreNotEqual(
+                sourcePtr,
+                targetPtr,
+                $"node {targetIndex} holds node {sourceIndex}'s DiskANN handle for '{key}' (0x{sourcePtr:x}); it is pointing into another node's heap and will fault once the two are separate processes");
+        }
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "storeWrapper")]
+        private static extern ref StoreWrapper GetStoreWrapper(GarnetServer server);
+
+        #endregion
+    }
+}

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
@@ -6,7 +6,6 @@ using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Garnet.server;
@@ -58,8 +57,6 @@ namespace Garnet.test.cluster
             context?.TearDown();
         }
 
-        protected IPEndPoint Node(int index) => (IPEndPoint)context.endpoints[index];
-
         #region cluster formation
 
         /// <summary>
@@ -104,7 +101,7 @@ namespace Garnet.test.cluster
         /// <summary>Moves the primary far enough ahead that a re-attach cannot be incremental.</summary>
         protected void PushPrimaryAhead(int primaryIndex)
         {
-            var primary = Node(primaryIndex);
+            var primary = context.clusterTestUtils.GetEndPoint(primaryIndex);
             for (var i = 0; i < FullSyncForcingKeys; i++)
             {
                 _ = context.clusterTestUtils.Execute(primary, "SET", [$"{{padding}}key{i}", new string('x', 64)], skipLogging: true);
@@ -125,7 +122,7 @@ namespace Garnet.test.cluster
 
         protected void MakeReadable(int nodeIndex)
         {
-            var ok = (string)context.clusterTestUtils.Execute(Node(nodeIndex), "READONLY", [], logger: context.logger);
+            var ok = (string)context.clusterTestUtils.Execute(context.clusterTestUtils.GetEndPoint(nodeIndex), "READONLY", [], logger: context.logger);
             ClassicAssert.AreEqual("OK", ok);
         }
 
@@ -134,7 +131,7 @@ namespace Garnet.test.cluster
         /// </summary>
         protected void WaitUntilServes(int nodeIndex, string key)
         {
-            var endpoint = Node(nodeIndex);
+            var endpoint = context.clusterTestUtils.GetEndPoint(nodeIndex);
 
             for (var attempt = 0; attempt < 200; attempt++)
             {
@@ -161,7 +158,7 @@ namespace Garnet.test.cluster
         /// </summary>
         protected void PopulateVectorSet(int nodeIndex, string key, int count, int seed)
         {
-            var endpoint = Node(nodeIndex);
+            var endpoint = context.clusterTestUtils.GetEndPoint(nodeIndex);
             var r = new Random(seed);
 
             if (!writtenElements.TryGetValue(key, out var elements))
@@ -189,7 +186,7 @@ namespace Garnet.test.cluster
         /// <summary>Reads VINFO size, the path that reaches NativeDiskANNMethods.card.</summary>
         protected long VectorSetSize(int nodeIndex, string key)
         {
-            var reply = context.clusterTestUtils.Execute(Node(nodeIndex), "VINFO", [key], logger: context.logger);
+            var reply = context.clusterTestUtils.Execute(context.clusterTestUtils.GetEndPoint(nodeIndex), "VINFO", [key], logger: context.logger);
 
             // Execute returns failures as bulk strings, so non-array replies mean the read failed.
             if (reply.Resp2Type != ResultType.Array)
@@ -211,7 +208,7 @@ namespace Garnet.test.cluster
 
         protected long VectorSetDimensions(int nodeIndex, string key)
         {
-            var reply = context.clusterTestUtils.Execute(Node(nodeIndex), "VDIM", [key], logger: context.logger);
+            var reply = context.clusterTestUtils.Execute(context.clusterTestUtils.GetEndPoint(nodeIndex), "VDIM", [key], logger: context.logger);
             if (reply.Resp2Type != ResultType.Integer)
                 Assert.Fail($"VDIM on '{key}' at node {nodeIndex} did not return an integer, got {reply.Resp2Type}: {reply}");
 
@@ -221,7 +218,7 @@ namespace Garnet.test.cluster
         /// <summary>Returns the stored embedding for an element, or an empty array when absent.</summary>
         protected string[] ElementEmbedding(int nodeIndex, string key, byte[] element)
         {
-            var reply = context.clusterTestUtils.Execute(Node(nodeIndex), "VEMB", [key, element], skipLogging: true);
+            var reply = context.clusterTestUtils.Execute(context.clusterTestUtils.GetEndPoint(nodeIndex), "VEMB", [key, element], skipLogging: true);
             if (reply.Resp2Type != ResultType.Array)
                 Assert.Fail($"VEMB on '{key}' at node {nodeIndex} did not return an array, got {reply.Resp2Type}: {reply}");
 
@@ -230,7 +227,7 @@ namespace Garnet.test.cluster
 
         protected byte[][] Search(int nodeIndex, string key, byte[] query, int count)
         {
-            var reply = context.clusterTestUtils.Execute(Node(nodeIndex), "VSIM", [key, "XB8", query, "COUNT", count.ToString()], skipLogging: true);
+            var reply = context.clusterTestUtils.Execute(context.clusterTestUtils.GetEndPoint(nodeIndex), "VSIM", [key, "XB8", query, "COUNT", count.ToString()], skipLogging: true);
             if (reply.Resp2Type != ResultType.Array)
                 Assert.Fail($"VSIM on '{key}' at node {nodeIndex} did not return an array, got {reply.Resp2Type}: {reply}");
 

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
@@ -68,13 +68,13 @@ namespace Garnet.test.cluster
         protected CaptureLogWriter captureLogWriter;
 
         protected readonly int timeout = (int)TimeSpan.FromSeconds(15).TotalSeconds;
-        protected readonly int testTimeout = (int)TimeSpan.FromSeconds(180).TotalSeconds;
+        protected readonly int testTimeout = (int)TimeSpan.FromSeconds(60).TotalSeconds;
 
         /// <summary>Elements written through PopulateVectorSet, used for source-vs-target checks.</summary>
         private readonly Dictionary<string, List<byte[]>> writtenElements = [];
 
         /// <summary>Trace logging is required to distinguish full sync from incremental replay.</summary>
-        protected abstract Dictionary<string, LogLevel> MonitorTests { get; }
+        protected virtual LogLevel MonitorLogLevel => LogLevel.Trace;
 
         [SetUp]
         public virtual void Setup()
@@ -84,7 +84,7 @@ namespace Garnet.test.cluster
 
             context = new ClusterTestContext();
             context.logTextWriter = captureLogWriter;
-            context.Setup(MonitorTests, testTimeoutSeconds: testTimeout);
+            context.Setup(new Dictionary<string, LogLevel> { [TestContext.CurrentContext.Test.MethodName] = MonitorLogLevel }, testTimeoutSeconds: testTimeout);
         }
 
         [TearDown]

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
@@ -82,8 +82,8 @@ namespace Garnet.test.cluster
             context.ClusterFailoverSpinWait(replicaIndex, context.logger);
             context.clusterTestUtils.WaitForReplicaAofSync(replicaIndex, oldPrimaryIndex, logger: context.logger);
 
-            ClassicAssert.AreEqual("master", context.clusterTestUtils.RoleCommand(context.clusterTestUtils.GetEndPoint(replicaIndex), logger: context.logger).Value);
-            ClassicAssert.AreEqual("slave", context.clusterTestUtils.RoleCommand(context.clusterTestUtils.GetEndPoint(oldPrimaryIndex), logger: context.logger).Value);
+            context.clusterTestUtils.AssertRole(replicaIndex, "master", context.logger);
+            context.clusterTestUtils.AssertRole(oldPrimaryIndex, "slave", context.logger);
         }
 
         protected void MakeReadable(int nodeIndex)

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
@@ -5,7 +5,6 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Runtime.CompilerServices;
@@ -33,39 +32,7 @@ namespace Garnet.test.cluster
         /// </summary>
         protected const int FullSyncForcingKeys = 256;
 
-        /// <summary>Diskless full-sync marker emitted by SyncMetadata.</summary>
-        private const string DisklessFullSyncMarker = "recoverFullSync:True";
-
-        /// <summary>Disk-based full-sync marker emitted when the primary ships a checkpoint.</summary>
-        private const string DiskBasedFullSyncMarker = "Sending main store checkpoint";
-
-        /// <summary>Captures node logs while still forwarding them to the test output.</summary>
-        protected sealed class CaptureLogWriter(TextWriter passThrough) : TextWriter
-        {
-            private readonly StringBuilder buffer = new();
-
-            public override Encoding Encoding => passThrough.Encoding;
-
-            public override void Write(string value)
-            {
-                passThrough.Write(value);
-                lock (buffer)
-                {
-                    _ = buffer.Append(value);
-                }
-            }
-
-            public string Snapshot()
-            {
-                lock (buffer)
-                {
-                    return buffer.ToString();
-                }
-            }
-        }
-
         protected ClusterTestContext context;
-        protected CaptureLogWriter captureLogWriter;
 
         protected readonly int timeout = (int)TimeSpan.FromSeconds(15).TotalSeconds;
         protected readonly int testTimeout = (int)TimeSpan.FromSeconds(60).TotalSeconds;
@@ -73,17 +40,15 @@ namespace Garnet.test.cluster
         /// <summary>Elements written through PopulateVectorSet, used for source-vs-target checks.</summary>
         private readonly Dictionary<string, List<byte[]>> writtenElements = [];
 
-        /// <summary>Trace logging is required to distinguish full sync from incremental replay.</summary>
-        protected virtual LogLevel MonitorLogLevel => LogLevel.Trace;
+        /// <summary>Raise this in a fixture to get more detail while debugging a replication failure.</summary>
+        protected virtual LogLevel MonitorLogLevel => LogLevel.Error;
 
         [SetUp]
         public virtual void Setup()
         {
             writtenElements.Clear();
-            captureLogWriter = new(TestContext.Progress);
 
             context = new ClusterTestContext();
-            context.logTextWriter = captureLogWriter;
             context.Setup(new Dictionary<string, LogLevel> { [TestContext.CurrentContext.Test.MethodName] = MonitorLogLevel }, testTimeoutSeconds: testTimeout);
         }
 
@@ -144,43 +109,6 @@ namespace Garnet.test.cluster
             {
                 _ = context.clusterTestUtils.Execute(primary, "SET", [$"{{padding}}key{i}", new string('x', 64)], skipLogging: true);
             }
-        }
-
-        private int CountLogOccurrences(string marker)
-        {
-            var log = captureLogWriter.Snapshot();
-            var count = 0;
-            var at = 0;
-
-            while ((at = log.IndexOf(marker, at, StringComparison.Ordinal)) >= 0)
-            {
-                count++;
-                at += marker.Length;
-            }
-
-            return count;
-        }
-
-        protected int FullSyncCount() => CountLogOccurrences(DisklessFullSyncMarker);
-
-        protected int DiskBasedFullSyncCount() => CountLogOccurrences(DiskBasedFullSyncMarker);
-
-        /// <summary>Asserts the attach took diskless full sync, not incremental replay.</summary>
-        protected void AssertTookFullSync(int since = 0)
-        {
-            ClassicAssert.Greater(
-                FullSyncCount(),
-                since,
-                "no new diskless streaming full sync was observed, so this test is not exercising the scenario it claims to");
-        }
-
-        /// <summary>Disk-based counterpart of AssertTookFullSync.</summary>
-        protected void AssertTookDiskBasedFullSync(int since = 0)
-        {
-            ClassicAssert.Greater(
-                DiskBasedFullSyncCount(),
-                since,
-                "the primary never shipped a main store checkpoint, so no disk-based full sync took place and this test is not exercising the scenario it claims to");
         }
 
         /// <summary>

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
@@ -326,6 +326,22 @@ namespace Garnet.test.cluster
         /// </summary>
         protected nint ReadPersistedIndexPtr(int nodeIndex, string key)
         {
+            ReadPersistedIndexFields(nodeIndex, key, out _, out var indexPtr);
+            return indexPtr;
+        }
+
+        /// <summary>
+        /// Reads the persisted context id for a Vector Set. Two distinct sets must never share a
+        /// context; a collision means the allocator handed out a context that another set owns.
+        /// </summary>
+        protected ulong ReadPersistedContext(int nodeIndex, string key)
+        {
+            ReadPersistedIndexFields(nodeIndex, key, out var ctx, out _);
+            return ctx;
+        }
+
+        private void ReadPersistedIndexFields(int nodeIndex, string key, out ulong ctx, out nint indexPtr)
+        {
             var storeWrapper = GetStoreWrapper(context.nodes[nodeIndex]);
             var db = storeWrapper.DefaultDatabase;
 
@@ -346,9 +362,7 @@ namespace Garnet.test.cluster
             ClassicAssert.IsTrue(output.SpanByteAndMemory.IsSpanByte, $"index record for '{key}' did not come back inline");
             ClassicAssert.AreEqual(VectorManager.IndexSize, output.SpanByteAndMemory.Length, $"value under '{key}' is not a Vector Set index record");
 
-            VectorManager.ReadIndex(output.SpanByteAndMemory.Span, out _, out _, out _, out _, out _, out _, out _, out _, out var indexPtr);
-
-            return indexPtr;
+            VectorManager.ReadIndex(output.SpanByteAndMemory.Span, out ctx, out _, out _, out _, out _, out _, out _, out _, out indexPtr);
         }
 
         /// <summary>

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
@@ -59,45 +59,6 @@ namespace Garnet.test.cluster
 
         #region cluster formation
 
-        /// <summary>
-        /// Assigns all slots to primaryIndex and introduces the other nodes without attaching replicas.
-        /// </summary>
-        protected void FormCluster(int primaryIndex, params int[] otherIndexes)
-        {
-            _ = context.clusterTestUtils.AddDelSlotsRange(primaryIndex, [(0, 16383)], addslot: true, logger: context.logger);
-            context.clusterTestUtils.SetConfigEpoch(primaryIndex, primaryIndex + 1, logger: context.logger);
-
-            foreach (var other in otherIndexes)
-            {
-                context.clusterTestUtils.SetConfigEpoch(other, other + 1, logger: context.logger);
-                context.clusterTestUtils.Meet(primaryIndex, other, logger: context.logger);
-                context.clusterTestUtils.WaitUntilNodeIsKnown(primaryIndex, other, logger: context.logger);
-            }
-        }
-
-        protected void Attach(int replicaIndex, int primaryIndex, bool waitForRecovery = false)
-        {
-            _ = context.clusterTestUtils.ClusterReplicate(replicaNodeIndex: replicaIndex, primaryNodeIndex: primaryIndex, logger: context.logger);
-
-            if (waitForRecovery)
-                context.clusterTestUtils.WaitForReplicaRecovery(replicaIndex, context.logger);
-
-            context.clusterTestUtils.WaitForReplicaAofSync(primaryIndex, replicaIndex, logger: context.logger);
-        }
-
-        /// <summary>Detaches and re-introduces a replica so the next attach starts from scratch.</summary>
-        protected void ResetReplica(int replicaIndex, int primaryIndex)
-        {
-            _ = context.clusterTestUtils.ClusterReset(replicaIndex, soft: true, expiry: 1, logger: context.logger);
-            context.clusterTestUtils.BumpEpoch(replicaIndex, logger: context.logger);
-
-            while (!context.clusterTestUtils.IsKnown(replicaIndex, primaryIndex, logger: context.logger))
-            {
-                ClusterTestUtils.BackOff(cancellationToken: context.cts.Token);
-                context.clusterTestUtils.Meet(replicaIndex, primaryIndex, logger: context.logger);
-            }
-        }
-
         /// <summary>Moves the primary far enough ahead that a re-attach cannot be incremental.</summary>
         protected void PushPrimaryAhead(int primaryIndex)
         {

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/VectorSetReplicationTestBase.cs
@@ -69,16 +69,21 @@ namespace Garnet.test.cluster
             }
         }
 
-        /// <summary>
-        /// Takes a checkpoint after waiting past LASTSAVE's one-second resolution, so
-        /// WaitCheckpoint observes the new save.
-        /// </summary>
-        protected void TakeCheckpoint(int nodeIndex)
+        /// <summary>Opens a connection and forms a single-primary cluster over every created node.</summary>
+        protected void FormClusterAllNodes(int nodeCount, int primaryIndex = 0)
         {
-            var lastSave = context.clusterTestUtils.LastSave(nodeIndex, logger: context.logger);
-            context.clusterTestUtils.WaitUntilNextSecond(nodeIndex, lastSave, logger: context.logger);
-            context.clusterTestUtils.Checkpoint(nodeIndex, logger: context.logger);
-            context.clusterTestUtils.WaitCheckpoint(nodeIndex, lastSave, logger: context.logger);
+            context.CreateConnection();
+            context.clusterTestUtils.FormCluster(primaryIndex, nodeCount, context.logger);
+        }
+
+        /// <summary>Promotes replicaIndex, waits for the demoted node to sync, and asserts the roles swapped.</summary>
+        protected void FailoverTo(int replicaIndex, int oldPrimaryIndex)
+        {
+            context.ClusterFailoverSpinWait(replicaIndex, context.logger);
+            context.clusterTestUtils.WaitForReplicaAofSync(replicaIndex, oldPrimaryIndex, logger: context.logger);
+
+            ClassicAssert.AreEqual("master", context.clusterTestUtils.RoleCommand(context.clusterTestUtils.GetEndPoint(replicaIndex), logger: context.logger).Value);
+            ClassicAssert.AreEqual("slave", context.clusterTestUtils.RoleCommand(context.clusterTestUtils.GetEndPoint(oldPrimaryIndex), logger: context.logger).Value);
         }
 
         protected void MakeReadable(int nodeIndex)

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/TestProjectSetup.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/TestProjectSetup.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Garnet.test.cluster;
+using NUnit.Framework;
+
+[SetUpFixture]
+public class TestProjectSetup
+{
+    [OneTimeSetUp]
+    public void SetPort() => ClusterTestContext.Port = (int)ClusterPortAssignment.ClusterReplicationVectorSets;
+}

--- a/test/cluster/Garnet.test.cluster/ClusterTestContext.cs
+++ b/test/cluster/Garnet.test.cluster/ClusterTestContext.cs
@@ -38,6 +38,7 @@ namespace Garnet.test.cluster
         ClusterReplicationRangeIndex = 7800,
         ClusterMultiLogDiskless = 7900,
         ClusterMigrateRangeIndex = 8000,
+        ClusterReplicationVectorSets = 8100,
     }
 
     public class ClusterTestContext

--- a/test/cluster/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/cluster/Garnet.test.cluster/ClusterTestUtils.cs
@@ -2202,6 +2202,12 @@ namespace Garnet.test.cluster
         }
 
         /// <summary>
+        /// Assigns all slots to primaryIndex and introduces every other node in [0, nodeCount) without attaching replicas.
+        /// </summary>
+        public void FormCluster(int primaryIndex, int nodeCount, ILogger logger = null)
+            => FormCluster(primaryIndex, [.. Enumerable.Range(0, nodeCount).Where(i => i != primaryIndex)], logger);
+
+        /// <summary>
         /// Assigns all slots to primaryIndex and introduces the other nodes without attaching replicas.
         /// </summary>
         public void FormCluster(int primaryIndex, int[] otherIndexes, ILogger logger = null)

--- a/test/cluster/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/cluster/Garnet.test.cluster/ClusterTestUtils.cs
@@ -2201,6 +2201,46 @@ namespace Garnet.test.cluster
             }
         }
 
+        /// <summary>
+        /// Assigns all slots to primaryIndex and introduces the other nodes without attaching replicas.
+        /// </summary>
+        public void FormCluster(int primaryIndex, int[] otherIndexes, ILogger logger = null)
+        {
+            _ = AddDelSlotsRange(primaryIndex, [(0, 16383)], addslot: true, logger: logger);
+            SetConfigEpoch(primaryIndex, primaryIndex + 1, logger: logger);
+
+            foreach (var other in otherIndexes)
+            {
+                SetConfigEpoch(other, other + 1, logger: logger);
+                Meet(primaryIndex, other, logger: logger);
+                WaitUntilNodeIsKnown(primaryIndex, other, logger: logger);
+            }
+        }
+
+        /// <summary>Attaches a replica to a primary and waits until it is in sync.</summary>
+        public void Attach(int replicaIndex, int primaryIndex, bool waitForRecovery = false, ILogger logger = null)
+        {
+            _ = ClusterReplicate(replicaNodeIndex: replicaIndex, primaryNodeIndex: primaryIndex, logger: logger);
+
+            if (waitForRecovery)
+                WaitForReplicaRecovery(replicaIndex, logger);
+
+            WaitForReplicaAofSync(primaryIndex, replicaIndex, logger: logger);
+        }
+
+        /// <summary>Detaches and re-introduces a replica so the next attach starts from scratch.</summary>
+        public void ResetReplica(int replicaIndex, int primaryIndex, ILogger logger = null)
+        {
+            _ = ClusterReset(replicaIndex, soft: true, expiry: 1, logger: logger);
+            BumpEpoch(replicaIndex, logger: logger);
+
+            while (!IsKnown(replicaIndex, primaryIndex, logger: logger))
+            {
+                BackOff(cancellationToken: context.cts.Token);
+                Meet(replicaIndex, primaryIndex, logger: logger);
+            }
+        }
+
         public string ClusterReplicate(int replicaNodeIndex, int primaryNodeIndex, bool async = false, bool failEx = true, ILogger logger = null)
         {
             var primaryId = ClusterMyId(primaryNodeIndex, logger: logger);

--- a/test/cluster/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/cluster/Garnet.test.cluster/ClusterTestUtils.cs
@@ -2966,6 +2966,10 @@ namespace Garnet.test.cluster
         public Role RoleCommand(int nodeIndex, ILogger logger = null)
             => RoleCommand(endpoints[nodeIndex].ToIPEndPoint(), logger);
 
+        /// <summary>Asserts the node's replication role, e.g. "master" or "slave".</summary>
+        public void AssertRole(int nodeIndex, string expectedRole, ILogger logger = null)
+            => ClassicAssert.AreEqual(expectedRole, RoleCommand(nodeIndex, logger).Value, $"node {nodeIndex} should be {expectedRole}");
+
         public Role RoleCommand(IPEndPoint endPoint, ILogger logger = null)
         {
             try


### PR DESCRIPTION
## Problem

A Vector Set index record persists the primary's native DiskANN handle (`IndexPtr`) inside its value. Diskless sync streams log records verbatim into the replica's memory, so the replica receives the **primary's** pointer.

The only hook that zeroes that field is `GarnetRecordTriggers.OnDiskRead`, which by definition never fires for records streamed straight into memory. Since `VectorManager.NeedsRecreate` is exactly `indexPtr == 0`, a foreign pointer is indistinguishable from a healthy local one: the lazy `Service.RecreateIndex` rebuild is skipped and the raw value reaches the P/Invoke unvalidated. In production this faults the replica with SIGSEGV inside `NativeDiskANNMethods.card`.

## Fix

`NetworkClusterSync` clears the pointer as records are deserialized, so the replica rebuilds its own index on first touch.

## Tests

Adds `Garnet.test.cluster.replication.vectorsets`. The shared harness asserts two independent things, because either can hold while the other is broken:

1. **Index ownership** — a node may only dereference a DiskANN handle it allocated itself.
2. **Element-level equality** — every element VADDed on the source exists on the target with a byte-identical embedding, cardinality and dimensionality agree, and VSIM is navigable. Matching cardinality alone is far too weak: an aliased index reports the *source's* count perfectly well.

The pre-existing cluster fixture cannot catch this. It attaches replicas before writing, so each replica builds its own index from replicated VADD payloads; the defect needs an **already-populated** Vector Set to travel over a full sync.

Covers diskless full sync, failover promotion, and async replay. The diskless tests are the executable form of the TLA+ model in `tla/VectorIndexLifetime.tla`, whose counterexamples all share one 6-step trace.

## Validation

- 12/12 pass with the fix.
- **5/12 fail without it** (`VectorSetReadableOnReplicaAfterDisklessFullSync`, `VectorSetReplicatedToEveryReplicaByDisklessFullSync`, `VectorSetsStayPartitionedAcrossDisklessFullSync`, `VectorSetSurvivesFailoverAfterDisklessFullSync`, `VectorSetReplicatedUnderAsyncReplayAfterFullSync`).
- Regressions green: `Garnet.test.cluster.vectorsets` 80/80, `replication.disklesssync` 28/28, `replication` 103/103.

> First of three stacked PRs. #2 makes recovery re-entrant; #3 fixes AOF replay-channel shutdown.
