### PR TITLE
Make Vector Set recovery re-entrant so disk-based full sync sanitizes handles

### DIFF
--- a/libs/cluster/Server/Replication/ReplicaOps/ReplicaDiskbasedSync.cs
+++ b/libs/cluster/Server/Replication/ReplicaOps/ReplicaDiskbasedSync.cs
@@ -320,8 +320,9 @@ namespace Garnet.cluster
                 logger?.LogInformation("Initializing AOF");
                 storeWrapper.appendOnlyFile.Log.Initialize(beginAddress, recoveredReplicationOffset);
 
-                // Before we can use the replication offset, we must wait for queued Vector Set ops to complete
-                storeWrapper.DefaultDatabase.VectorManager?.WaitForVectorOperationsToComplete();
+                // The store was recovered again, so recovered Vector Set contexts need reconciling just
+                // as they are on the startup path.
+                storeWrapper.RecoverVectorSets();
 
                 // Before we can use the replication offset, we must wait for queued Vector Set ops to complete
                 storeWrapper.DefaultDatabase.VectorManager?.WaitForVectorOperationsToComplete();

--- a/libs/server/Resp/Vector/VectorManager.cs
+++ b/libs/server/Resp/Vector/VectorManager.cs
@@ -288,7 +288,9 @@ namespace Garnet.server
                     }
                 }
 
-                recoveredMetadata = null;
+                // Cleared, not released: a replica re-recovers the store on every disk-based full sync,
+                // and the recovery record triggers write into these before ResumePostRecovery runs.
+                recoveredMetadata.Clear();
 
                 // If we come up and contexts are marked for migration, that means the migration FAILED
                 // and we'd like those contexts back ASAP
@@ -358,7 +360,7 @@ namespace Garnet.server
                     }
                 }
 
-                recoveredIndexes = null;
+                recoveredIndexes.Clear();
             }
 
             if (needsUpdated)

--- a/libs/server/StoreWrapper.cs
+++ b/libs/server/StoreWrapper.cs
@@ -381,6 +381,12 @@ namespace Garnet.server
         }
 
         /// <summary>
+        /// Reconcile recovered Vector Set state with the store. Must run after every store recovery,
+        /// including a replica's disk-based full sync.
+        /// </summary>
+        public void RecoverVectorSets() => databaseManager.RecoverVectorSets();
+
+        /// <summary>
         /// Take checkpoint of all active databases (or a specified database)
         /// </summary>
         /// <param name="background">True if method can return before checkpoint is taken</param>

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDiskBasedSyncTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetDiskBasedSyncTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace Garnet.test.cluster
+{
+    /// <summary>
+    /// Disk-based full-sync coverage for populated Vector Sets. The replica recovers a shipped
+    /// checkpoint, so OnDiskRead must zero IndexPtr and force lazy rebuild.
+    /// </summary>
+    [TestFixture]
+    [NonParallelizable]
+    public class ClusterVectorSetDiskBasedSyncTests : VectorSetReplicationTestBase
+    {
+        private const int PrimaryIndex = 0;
+        private const int ReplicaIndex = 1;
+
+        protected override Dictionary<string, LogLevel> MonitorTests => new()
+        {
+            [nameof(VectorSetReplicatedToReplicaByDiskBasedFullSync)] = LogLevel.Trace,
+            [nameof(VectorSetsStayPartitionedAcrossDiskBasedFullSync)] = LogLevel.Trace,
+            [nameof(VectorSetReplicatedToEveryReplicaByDiskBasedFullSync)] = LogLevel.Trace,
+            [nameof(VectorSetReplicatedAfterDiskBasedReAttach)] = LogLevel.Trace,
+        };
+
+        /// <summary>
+        /// Creates a checkpoint-sync cluster; OnDemandCheckpoint gives the primary a checkpoint to ship.
+        /// </summary>
+        private void SetupDiskBasedCluster(int nodeCount)
+        {
+            context.CreateInstances(
+                nodeCount,
+                enableAOF: true,
+                enableDisklessSync: false,
+                OnDemandCheckpoint: true,
+                timeout: timeout);
+            context.CreateConnection();
+
+            FormCluster(PrimaryIndex, [.. Enumerable.Range(1, nodeCount - 1)]);
+        }
+
+        /// <summary>
+        /// Populates before the replica exists so the attach carries the index record in a checkpoint.
+        /// The replica must rebuild its own index and keep every element.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetReplicatedToReplicaByDiskBasedFullSync()
+        {
+            const string Key = "{vsdisk}diskbased";
+            const int Elements = 400;
+
+            SetupDiskBasedCluster(2);
+
+            PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_10);
+            TakeCheckpoint(PrimaryIndex);
+
+            var before = DiskBasedFullSyncCount();
+            Attach(ReplicaIndex, PrimaryIndex, waitForRecovery: true);
+            AssertTookDiskBasedFullSync(before);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
+        }
+
+        /// <summary>
+        /// Several differently sized sets travel in one checkpoint. Element checks catch any
+        /// per-record recovery mix-up that aliases one set's index to another.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetsStayPartitionedAcrossDiskBasedFullSync()
+        {
+            const string SmallKey = "{vsdisk}dbsmall";
+            const string MediumKey = "{vsdisk}dbmedium";
+            const string LargeKey = "{vsdisk}dblarge";
+            const int SmallElements = 10;
+            const int MediumElements = 120;
+            const int LargeElements = 350;
+
+            SetupDiskBasedCluster(2);
+
+            PopulateVectorSet(PrimaryIndex, LargeKey, LargeElements, seed: 2026_07_29_11);
+            PopulateVectorSet(PrimaryIndex, SmallKey, SmallElements, seed: 2026_07_29_12);
+            PopulateVectorSet(PrimaryIndex, MediumKey, MediumElements, seed: 2026_07_29_13);
+            TakeCheckpoint(PrimaryIndex);
+
+            var before = DiskBasedFullSyncCount();
+            Attach(ReplicaIndex, PrimaryIndex, waitForRecovery: true);
+            AssertTookDiskBasedFullSync(before);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, SmallKey);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, MediumKey);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, LargeKey);
+
+            ClassicAssert.AreEqual(SmallElements, VectorSetSize(ReplicaIndex, SmallKey));
+            ClassicAssert.AreEqual(MediumElements, VectorSetSize(ReplicaIndex, MediumKey));
+            ClassicAssert.AreEqual(LargeElements, VectorSetSize(ReplicaIndex, LargeKey));
+        }
+
+        /// <summary>
+        /// Several replicas each take a checkpoint from the same populated primary; no two nodes may share a handle.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetReplicatedToEveryReplicaByDiskBasedFullSync()
+        {
+            const string Key = "{vsdisk}dbfanout";
+            const int Elements = 200;
+            const int ReplicaCount = 3;
+
+            SetupDiskBasedCluster(1 + ReplicaCount);
+
+            PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_14);
+            TakeCheckpoint(PrimaryIndex);
+
+            var before = DiskBasedFullSyncCount();
+
+            for (var replica = 1; replica <= ReplicaCount; replica++)
+            {
+                Attach(replica, PrimaryIndex, waitForRecovery: true);
+            }
+
+            AssertTookDiskBasedFullSync(before);
+
+            for (var replica = 1; replica <= ReplicaCount; replica++)
+            {
+                MakeReadable(replica);
+                AssertFullyReplicated(PrimaryIndex, replica, Key);
+            }
+
+            for (var a = 0; a <= ReplicaCount; a++)
+            {
+                for (var b = a + 1; b <= ReplicaCount; b++)
+                {
+                    AssertOwnsItsIndex(b, a, Key);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Detaches an already-synced replica and forces checkpoint re-sync. It must discard
+        /// prior index state and rebuild from the checkpoint.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetReplicatedAfterDiskBasedReAttach()
+        {
+            const string Key = "{vsdisk}dbreattach";
+            const int Elements = 300;
+
+            SetupDiskBasedCluster(2);
+            Attach(ReplicaIndex, PrimaryIndex);
+
+            PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_15);
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
+
+            var before = DiskBasedFullSyncCount();
+
+            ResetReplica(ReplicaIndex, PrimaryIndex);
+            PushPrimaryAhead(PrimaryIndex);
+            PopulateVectorSet(PrimaryIndex, Key, count: 100, seed: 2026_07_29_16);
+            TakeCheckpoint(PrimaryIndex);
+            Attach(ReplicaIndex, PrimaryIndex, waitForRecovery: true);
+
+            AssertTookDiskBasedFullSync(before);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
+        }
+    }
+}


### PR DESCRIPTION
> **Stacked on #1** — review that one first; this PR targets `tiagonapoli/vs-1-diskless`, so its diff shows only this change.

## Problem

`VectorManager` collects the contexts it sees during recovery into `recoveredIndexes` / `recoveredMetadata`, and `ResumePostRecovery` reconciles them against the recovered store. Both were **released** at the end of that method, on the assumption that a process recovers exactly once.

A replica does not. It re-recovers the store on **every disk-based full sync**, and nothing re-ran `ResumePostRecovery` on that path.

So the second recovery threw `NullReferenceException` out of `RecoveredVectorSetIndexKey`. That exception escaped `ClearBitsOnPage` — the per-record walk that fires `OnDiskRead` — so **the walk aborted after the first record on the page**. Every Vector Set record behind it kept the primary's raw DiskANN handle.

Instrumented recovery of three vector sets, before the fix:

```
CBOP page=0 startLA=0 endLA=16777216 until=156296 endOff=156296 snapFrom=64
  rec off=64   size=8224  ->  msf_            (context metadata)
  rec off=8288 size=88    ->  {vsdisk}dblarge (sanitized OK)
  EX System.NullReferenceException
     at VectorManager.RecoveredVectorSetIndexKey(LogRecord&) VectorManager.cs:384
     at GarnetRecordTriggers.OnRecoverySnapshotRead(LogRecord&)
     at TsavoriteKV.ClearBitsOnPage(...) Recovery.cs:1259
```

`dbsmall` and `dbmedium` were never visited, and came up on the replica holding `IndexPtr == primary's pointer`.

The half-finished recovery also leaked the checkpoint file handle, which is what made teardown hang ~60s deleting the directory. The disk-based fixture went **1m07s → 7s**.

**This path matters more than the diskless one in practice, since `ReplicaDisklessSync` defaults to `false`.**

## Fix

- Recovery state is **cleared** rather than released, so a second recovery starts from a clean slate instead of a null reference.
- A replica's disk-based recovery reconciles it via the new `StoreWrapper.RecoverVectorSets()`, mirroring what the startup path already did.

## Validation

- 16/16 pass with the fix.
- **All 4 disk-based tests fail without it.**
- Regressions green: `Garnet.test.cluster.vectorsets` 80/80, `replication.disklesssync` 28/28, `replication` 103/103.
