### PR TITLE
Keep the Vector Set replay channel alive across AofProcessor disposal

### DIFF
--- a/libs/server/AOF/AofProcessor.cs
+++ b/libs/server/AOF/AofProcessor.cs
@@ -152,8 +152,10 @@ namespace Garnet.server
         /// </summary>
         public void Dispose()
         {
+            // Drain but don't shut down: the VectorManager belongs to the database, and startup AOF
+            // recovery builds a transient AofProcessor. Completing the replay channel here would make
+            // HandleVectorSetAddReplication silently drop every VADD replicated afterwards.
             activeVectorManager?.WaitForVectorOperationsToComplete();
-            activeVectorManager?.ShutdownReplayTasks();
             activeRangeIndexManager?.DisposeIncompleteStreamReassembly();
             aofReplayCoordinator?.Dispose();
         }

--- a/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetRecoveryTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication.vectorsets/ReplicationTests/ClusterVectorSetRecoveryTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace Garnet.test.cluster
+{
+    /// <summary>
+    /// Restart recovery for clustered Vector Sets. A checkpointed IndexPtr belongs to the old
+    /// process and must be discarded so lazy rebuild creates a local index before replication resumes.
+    /// </summary>
+    [TestFixture]
+    [NonParallelizable]
+    public class ClusterVectorSetRecoveryTests : VectorSetReplicationTestBase
+    {
+        private const int PrimaryIndex = 0;
+        private const int ReplicaIndex = 1;
+
+        protected override Dictionary<string, LogLevel> MonitorTests => new()
+        {
+            [nameof(ReplicaRebuildsVectorSetIndexAfterRestart)] = LogLevel.Trace,
+            [nameof(PrimaryRebuildsVectorSetIndexAfterRestart)] = LogLevel.Trace,
+            [nameof(VectorSetSurvivesRestartOfBothNodes)] = LogLevel.Trace,
+        };
+
+        private void SetupRecoverableCluster(int nodeCount)
+        {
+            context.CreateInstances(
+                nodeCount,
+                enableAOF: true,
+                tryRecover: true,
+                OnDemandCheckpoint: true,
+                enableDisklessSync: false,
+                timeout: timeout);
+            context.CreateConnection();
+
+            FormCluster(PrimaryIndex, [.. Enumerable.Range(1, nodeCount - 1)]);
+        }
+
+        private void Restart(int nodeIndex)
+        {
+            context.RestartNode(nodeIndex, ensureAofFlush: true);
+            context.CreateConnection();
+        }
+
+        /// <summary>
+        /// Forces a checkpoint so restart recovers persisted records instead of replaying the whole AOF.
+        /// </summary>
+        private void Checkpoint(int nodeIndex)
+        {
+            WaitForVectorReplay(nodeIndex);
+            TakeCheckpoint(nodeIndex);
+        }
+
+        /// <summary>A recovered handle must differ from the dead process's handle.</summary>
+        private void AssertIndexRebuiltAfterRestart(int nodeIndex, string key, nint beforeRestart)
+        {
+            var after = ReadPersistedIndexPtr(nodeIndex, key);
+
+            ClassicAssert.AreNotEqual(
+                beforeRestart,
+                after,
+                $"node {nodeIndex} recovered '{key}' still holding the DiskANN handle from its previous incarnation (0x{beforeRestart:x}); that address space is gone");
+        }
+
+        /// <summary>
+        /// Restarts the replica while the primary stays up; it must rebuild, keep every element,
+        /// and agree with the primary.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void ReplicaRebuildsVectorSetIndexAfterRestart()
+        {
+            const string Key = "{vsdisk}restartreplica";
+            const int Elements = 250;
+
+            SetupRecoverableCluster(2);
+            Attach(ReplicaIndex, PrimaryIndex);
+
+            PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_17);
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
+
+            Checkpoint(PrimaryIndex);
+            var replicaPtrBefore = ReadPersistedIndexPtr(ReplicaIndex, Key);
+
+            Restart(ReplicaIndex);
+            context.clusterTestUtils.WaitForReplicaRecovery(ReplicaIndex, context.logger);
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
+
+            MakeReadable(ReplicaIndex);
+
+            // Reading first drives lazy rebuild, so inspect the pointer afterwards.
+            AssertVectorSetsMatch(PrimaryIndex, ReplicaIndex, Key);
+            AssertIndexRebuiltAfterRestart(ReplicaIndex, Key, replicaPtrBefore);
+            AssertOwnsItsIndex(ReplicaIndex, PrimaryIndex, Key);
+        }
+
+        /// <summary>
+        /// Restarts the primary under a live replica, then verifies recovery can still accept
+        /// writes and seed a newly attached replica.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void PrimaryRebuildsVectorSetIndexAfterRestart()
+        {
+            const string Key = "{vsdisk}restartprimary";
+            const int Elements = 250;
+            const int SpareIndex = 2;
+
+            SetupRecoverableCluster(3);
+            Attach(ReplicaIndex, PrimaryIndex);
+
+            PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_18);
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
+
+            Checkpoint(PrimaryIndex);
+            var primaryPtrBefore = ReadPersistedIndexPtr(PrimaryIndex, Key);
+
+            Restart(PrimaryIndex);
+
+            ClassicAssert.AreEqual(Elements, VectorSetSize(PrimaryIndex, Key), "the restarted primary lost elements of the recovered Vector Set");
+            AssertIndexRebuiltAfterRestart(PrimaryIndex, Key, primaryPtrBefore);
+
+            PopulateVectorSet(PrimaryIndex, Key, count: 50, seed: 2026_07_29_19);
+
+            Attach(SpareIndex, PrimaryIndex);
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, SpareIndex, logger: context.logger);
+
+            MakeReadable(SpareIndex);
+            AssertFullyReplicated(PrimaryIndex, SpareIndex, Key);
+        }
+
+        /// <summary>
+        /// Restarts both nodes from checkpoints; both must discard old handles and still match element for element.
+        /// </summary>
+        [Test]
+        [Category("REPLICATION")]
+        [CancelAfter(180_000)]
+        public void VectorSetSurvivesRestartOfBothNodes()
+        {
+            const string Key = "{vsdisk}restartboth";
+            const int Elements = 200;
+
+            SetupRecoverableCluster(2);
+            Attach(ReplicaIndex, PrimaryIndex);
+
+            PopulateVectorSet(PrimaryIndex, Key, Elements, seed: 2026_07_29_20);
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
+
+            MakeReadable(ReplicaIndex);
+            AssertFullyReplicated(PrimaryIndex, ReplicaIndex, Key);
+
+            Checkpoint(PrimaryIndex);
+            Checkpoint(ReplicaIndex);
+
+            var primaryPtrBefore = ReadPersistedIndexPtr(PrimaryIndex, Key);
+            var replicaPtrBefore = ReadPersistedIndexPtr(ReplicaIndex, Key);
+
+            Restart(PrimaryIndex);
+            Restart(ReplicaIndex);
+
+            context.clusterTestUtils.WaitForReplicaRecovery(ReplicaIndex, context.logger);
+            context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, ReplicaIndex, logger: context.logger);
+
+            MakeReadable(ReplicaIndex);
+            AssertVectorSetsMatch(PrimaryIndex, ReplicaIndex, Key);
+
+            AssertIndexRebuiltAfterRestart(PrimaryIndex, Key, primaryPtrBefore);
+            AssertIndexRebuiltAfterRestart(ReplicaIndex, Key, replicaPtrBefore);
+            AssertOwnsItsIndex(ReplicaIndex, PrimaryIndex, Key);
+        }
+    }
+}


### PR DESCRIPTION
> **Stacked on #1996** (which is stacked on #1995) — review those first; this PR targets `tiagonapoli/vs-2-recovery-reentrancy`, so its diff shows only this change.

## Problem

`AofProcessor.Dispose()` called `VectorManager.ShutdownReplayTasks()`, which is a **permanent** shutdown — it completes the replication replay channel writer and parks the replay tasks for good.

But the `VectorManager` belongs to the **database**, not to the processor, and a node constructs and disposes several `AofProcessor`s over its lifetime. `SingleDatabaseManager.ReplayAOF` builds a transient one during startup AOF recovery.

So on any node started with `Recover` enabled — a normal production replica config — the channel was already closed before the node began serving. From that point `HandleVectorSetAddReplication` could no longer queue:

```csharp
var queued = replicationReplayChannel.Writer.TryWrite(...);
if (!queued) replicationBlockEvent.Decrement();   // no log, no error
```

It **discards whatever it cannot queue, silently**. The node dropped every VADD replicated to it while continuing to report healthy AOF offsets — silent data loss with no signal at all.

## Fix

`Dispose()` now only drains. `VectorManager.Dispose()` still performs the real shutdown when the database goes away.

## Tests

Adds `ClusterVectorSetRecoveryTests`, which restarts the replica, the primary, and both nodes with `tryRecover: true` — the configuration that exposed this.

Note these tests also depend on #1996: without it, an aborted recovery leaves the store corrupt enough that a subsequent read dies with `AccessViolationException` in `TsavoriteKV.TraceBackForKeyMatch`, taking down the test host. That is why this is the top of the stack.

## Validation

- 19/19 pass with the fix (full suite, top of stack).
- **All 3 recovery tests fail without it.**
- Regressions green: `Garnet.test.cluster.vectorsets` 80/80, `replication.disklesssync` 28/28, `replication` 103/103. `ShutdownReplayTasks()` is left public but now has no callers.
