### PR TITLE
[release/v1] Fix integer underflow in BITCOUNT ... BIT byte-boundary mask (backport #1994)

### DIFF
--- a/libs/server/Resp/Bitmap/BitmapManagerBitCount.cs
+++ b/libs/server/Resp/Bitmap/BitmapManagerBitCount.cs
@@ -43,7 +43,7 @@ namespace Garnet.server
             long endByte = (endOffset / 8);
 
             int leftBitIndex = (int)(startOffset & 7);
-            int rightBitIndex = (int)((endOffset + 1) & 7);
+            int rightBitIndex = (int)(endOffset & 7) + 1;
 
             if (startByte == endByte)
                 return BitIndexCount(value[startByte], leftBitIndex, rightBitIndex);

--- a/test/Garnet.test/GarnetBitmapTests.cs
+++ b/test/Garnet.test/GarnetBitmapTests.cs
@@ -2138,6 +2138,35 @@ namespace Garnet.test
 
         [Test]
         [Category("BITCOUNT")]
+        public void BitmapBitCountBitBoundaryUnderflowTest()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            var key = "BitmapBitCountBitBoundaryUnderflowTest";
+            // 0x80 = 10000000b: only the most-significant bit (bit index 0) is set.
+            _ = db.StringSet(key, new byte[] { 0x80 });
+
+            // Single-bit range ending on a byte boundary (endOffset % 8 == 7).
+            // Regression: a byte-mask integer underflow made this return 1 for an unset bit.
+            var count = db.StringBitCount(key, 7, 7, StringIndexType.Bit);
+            ClassicAssert.AreEqual(0, count);
+
+            // The set bit (index 0) must still be counted correctly.
+            count = db.StringBitCount(key, 0, 0, StringIndexType.Bit);
+            ClassicAssert.AreEqual(1, count);
+
+            // Full-byte range crossing the boundary must count exactly the one set bit.
+            count = db.StringBitCount(key, 0, 7, StringIndexType.Bit);
+            ClassicAssert.AreEqual(1, count);
+
+            // Full-key BIT range (0 -1) whose end lands on a byte boundary.
+            count = db.StringBitCount(key, 0, -1, StringIndexType.Bit);
+            ClassicAssert.AreEqual(1, count);
+        }
+
+        [Test]
+        [Category("BITCOUNT")]
         public void BitmapBitCountLongBitOffsetParsingTest()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
@@ -2149,7 +2178,11 @@ namespace Garnet.test
             var offset = (long)int.MaxValue + 1024;
             var count = (long)db.Execute("BITCOUNT", key, (-offset).ToString(), "-1", "BIT");
 
-            ClassicAssert.AreEqual(8, count);
+            // The out-of-range negative start is clamped to -MaxOffsetForBitmapLength and then
+            // wrapped modulo the bit length (Garnet's negative-offset semantics), landing on bit
+            // index 1; the end (-1) wraps to bit index 7. So bits 1..7 of 0xFF are counted => 7.
+            // (This previously asserted 8 only because of a byte-mask underflow in BitCountDriver.)
+            ClassicAssert.AreEqual(7, count);
         }
 
         [Test]


### PR DESCRIPTION
Backport of #1994 to `release/v1`.

## Summary

Fixes an integer underflow in `BITCOUNT ... BIT` (`BitmapManagerBitCount.cs`) that returned non-zero counts for **unset** bits whenever a BIT-mode range ended on a byte boundary (`endOffset % 8 == 7`).

The inclusive right bit index was computed as `(int)((endOffset + 1) & 7)`, which wraps to `0` at byte boundaries and produces a wrapping byte-mask underflow. Fixed to use the same formula already used correctly in `BitmapManagerBitPos.cs`:

```csharp
int rightBitIndex = (int)(endOffset & 7) + 1;
```

## Tests
- Added `BitmapBitCountBitBoundaryUnderflowTest` (byte `0x80`) covering single-bit and boundary-crossing BIT ranges.
- Updated `BitmapBitCountLongBitOffsetParsingTest`: its previous expectation of `8` was an artifact of the underflow. Under Garnet''s modulo-wrapping negative-offset semantics the clamped start wraps to bit index 1, so bits 1..7 of `0xFF` = `7`.
- Verified both tests pass on `release/v1` (net10.0). The `NormalizeBitCountOffsets` / `MaxOffsetForBitmapLength` / `ProcessNegativeOffset` semantics are identical on this branch.

Cherry-picked from squash-merge 52aef6e (#1994 on `main`).