### PR TITLE
[V1] Backport #1949: Fix NetworkWriter.AsyncFlushPages hanging FlushEvent waiters on send failure

### DIFF
--- a/libs/client/Garnet.client.csproj
+++ b/libs/client/Garnet.client.csproj
@@ -13,4 +13,8 @@
     <ProjectReference Include="..\storage\Tsavorite\cs\src\core\Tsavorite.core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Garnet.test" Key="0024000004800000940000000602000000240000525341310004000001000100011b1661238d3d3c76232193c8aa2de8c05b8930d6dfe8cd88797a8f5624fdf14a1643141f31da05c0f67961b0e3a64c7120001d2f8579f01ac788b0ff545790d44854abe02f42bfe36a056166a75c6a694db8c5b6609cff8a2dbb429855a1d9f79d4d8ec3e145c74bfdd903274b7344beea93eab86b422652f8dd8eecf530d2" />
+  </ItemGroup>
+
 </Project>

--- a/libs/client/NetworkWriter.cs
+++ b/libs/client/NetworkWriter.cs
@@ -333,6 +333,9 @@ namespace Garnet.client
                     {
                         logger?.LogError(ex, "Exception calling networkSender.SendResponse in AsyncFlushPages");
                         networkHandler.Dispose();
+                        // Still signal completion for this page so FlushEvent waiters (e.g. GarnetClient
+                        // callers blocked in InternalExecuteNoResponse) are not left hanging indefinitely.
+                        AsyncFlushPageCallback(asyncResult);
                     }
                 }
                 if (flushPage == endPage) break;

--- a/test/Garnet.test/GarnetClientTests.cs
+++ b/test/Garnet.test/GarnetClientTests.cs
@@ -4,11 +4,14 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Allure.NUnit;
+using Garnet.client;
 using Garnet.common;
+using Garnet.networking;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 
@@ -569,6 +572,96 @@ namespace Garnet.test
 
             result = await db.ExecuteForStringResultAsync("PING").ConfigureAwait(false);
             ClassicAssert.AreEqual("PONG", result);
+        }
+
+        /// <summary>
+        /// Regression test for: NetworkWriter.AsyncFlushPages swallows send failures without
+        /// releasing the flush-completion event, hanging callers blocked on FlushEvent (e.g.
+        /// GarnetClient.InternalExecuteNoResponse, used by cluster PUBLISH forwarding). A
+        /// waiter is registered on flushEvent (mirroring a caller already blocked when the
+        /// connection dies) before the failing flush is triggered; if AsyncFlushPageCallback
+        /// is not invoked when networkSender.SendResponse throws, that waiter is never
+        /// released and only unblocks via our cancellation-token timeout (which the
+        /// assertions below turn into a test failure instead of a hang).
+        /// </summary>
+        [Test]
+        public void AsyncFlushPagesSignalsFlushEventOnSendFailure()
+        {
+            using var server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir);
+            server.Start();
+
+            using var db = new GarnetClient(TestUtils.EndPoint, sendPageSize: 1 << 12);
+            db.Connect();
+
+            var networkWriter = (NetworkWriter)typeof(GarnetClient)
+                .GetField("networkWriter", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(db);
+
+            networkWriter.epoch.Resume();
+            try
+            {
+                // Reserve some space in the send buffer so AsyncFlushPages below has a real
+                // (non-empty) range to send, exercising the networkSender.SendResponse call
+                // rather than the empty-range fast path.
+                var (_, address) = networkWriter.TryAllocate(64, out var flushEvent);
+                ClassicAssert.GreaterOrEqual(address, 0);
+                var untilAddress = networkWriter.GetTailAddress();
+
+                // Simulate the connection being disposed/broken concurrently with the flush,
+                // as happens in production when a gossip timeout tears down the connection:
+                // make the send throw.
+                typeof(NetworkWriter)
+                    .GetField("networkSender", BindingFlags.NonPublic | BindingFlags.Instance)
+                    .SetValue(networkWriter, new ThrowingNetworkSender());
+
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+                // WaitAsync registers with the underlying SemaphoreSlim synchronously, before
+                // returning - so there is no window between "registered as a waiter" and
+                // "flush triggered" for a racing Set()/Dispose() to be missed, and no
+                // separate thread or readiness rendezvous is needed.
+                var waitTask = flushEvent.WaitAsync(cts.Token);
+
+                networkWriter.AsyncFlushPages(0, untilAddress);
+
+                var completed = waitTask.Wait(TimeSpan.FromSeconds(5));
+                ClassicAssert.IsTrue(completed,
+                    "FlushEvent was not signaled after a failed flush (regression)");
+                ClassicAssert.IsFalse(waitTask.IsFaulted, $"Wait faulted: {waitTask.Exception}");
+            }
+            finally
+            {
+                networkWriter.epoch.Suspend();
+            }
+        }
+
+        /// <summary>
+        /// Network sender stub whose SendResponse always throws, simulating the underlying
+        /// connection being disposed/broken concurrently with a page flush.
+        /// </summary>
+        sealed unsafe class ThrowingNetworkSender : INetworkSender
+        {
+            readonly MaxSizeSettings maxSizeSettings = new();
+
+            public MaxSizeSettings GetMaxSizeSettings => maxSizeSettings;
+            public string RemoteEndpointName => "";
+            public string LocalEndpointName => "";
+            public bool IsLocalConnection() => true;
+            public void Dispose() { }
+            public void DisposeNetworkSender(bool waitForSendCompletion) { }
+            public void Enter() { }
+            public void EnterAndGetResponseObject(out byte* head, out byte* tail) => throw new NotSupportedException();
+            public void Exit() { }
+            public void ExitAndReturnResponseObject() { }
+            public void GetResponseObject() { }
+            public byte* GetResponseObjectHead() => throw new NotSupportedException();
+            public byte* GetResponseObjectTail() => throw new NotSupportedException();
+            public void ReturnResponseObject() { }
+            public void SendCallback(object context) { }
+            public bool SendResponse(int offset, int size) => throw new NotSupportedException();
+            public void SendResponse(byte[] buffer, int offset, int count, object context)
+                => throw new Exception("Simulated send failure (connection disposed)");
+            public void Throttle() { }
+            public bool TryClose() => false;
         }
     }
 }


### PR DESCRIPTION
Backport of #1949 to `release/v1`, as promised in https://github.com/microsoft/garnet/pull/1949#issuecomment-5064421344. Sorry for the lag, @vazois — #1949 landed on `main` while I was away from it.

### The gap on `release/v1`

`AsyncFlushPages`'s catch block logs the exception and disposes the network handler, but never invokes `AsyncFlushPageCallback` for the page whose send failed. Anything blocked on the corresponding `FlushEvent` is therefore never released — in particular `GarnetClient.InternalExecuteNoResponse`, which cluster PUBLISH forwarding calls on Garnet's own network-processing thread.

I checked this branch directly rather than assuming the fix was still needed: its catch block is character-for-character what `main`'s was before #1949, so the hang is reachable here too. This is the sibling half of #1929 — the other half was already backported as #1953.

### Deviations from #1949

Applied by hand, not cherry-picked, because the test file moved between branches. The exact differences:

- **Production change** (`libs/client/NetworkWriter.cs`, `libs/client/Garnet.client.csproj`) — byte-identical to what landed on `main` in 2255520.
- **Test file path** — `test/Garnet.test/GarnetClientTests.cs` here, `test/standalone/Garnet.test/GarnetClientTests.cs` on `main`.
- **Fixture base** — this branch's `GarnetClientTests` derives from `AllureTestBase` and carries `[AllureNUnit]`; that is pre-existing branch infrastructure, untouched.
- **Two doc-comment sentences reworded.** `main`'s copy describes "a thread parked in `flushEvent.Wait`" and refers to "the previous `Wait()`-on-a-background-thread approach" — both are leftovers from an earlier iteration of that test during #1949's review and describe code that no longer exists. I reworded them to describe what the test actually does. **Test logic is byte-identical**; this is the only semantic difference in the file.

Before porting the test I diffed every API it touches across the 245 commits separating the branches: `INetworkSender` is byte-identical (so the `ThrowingNetworkSender` stub needs no adjustment), `CompletionEvent` differs only by a comment and an added `ToString()` with `WaitAsync` present on both, `NetworkWriter`'s ctor differs only by `main`'s extra `PoolOwnerType` param (not used by the test), and `GarnetClient`'s ctor differs only by `main`'s extra `clientName` param (the test uses named arguments).

The narrow `AsyncFlushPageCallback` double-invocation edge case disclosed in #1949's description applies identically here and is likewise not addressed.

### Test-only note

The test reaches `NetworkWriter`'s private `networkSender` field to inject a sender that throws, so `Garnet.client` gains an `InternalsVisibleTo` entry for `Garnet.test` — same as on `main`. The key is the one already used by `Garnet.host`, `Tsavorite.core`, `GarnetServer` and `GarnetJSON` on this branch, so no new signing material enters a shipping v1 package.

### Verification

On this branch, `net10.0` Debug:

- **Without** the `NetworkWriter.cs` change: fails after 3s — the cancellation token fires because the `FlushEvent` waiter is never released. I reverted just that hunk and re-ran to confirm this, rather than assuming the test would have caught the bug.
- **With** it: passes in 96ms.
- `GarnetClientTests`: **20/20**. All three `*GarnetClientTests` fixtures (`GarnetClientTests`, `RespListGarnetClientTests`, `RespSortedSetGarnetClientTests`): **69/69**.
- `dotnet format --verify-no-changes`: clean on both touched projects.

To be upfront about the limits: my environment is macOS/arm64 with only the .NET 10 runtime installed. `net8.0` **builds** cleanly there (0 warnings, with `TreatWarningsAsErrors` set repo-wide) but I could not **run** its tests, and I have no Linux or Windows coverage — CI on this PR is the first place those get exercised.
