### PR TITLE
Extract Vector Set cleanup work channel and work set

### DIFF
--- a/libs/server/Resp/Vector/Cleanup/VectorSetCleanupWorkChannel.cs
+++ b/libs/server/Resp/Vector/Cleanup/VectorSetCleanupWorkChannel.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Garnet.common;
+
+namespace Garnet.server
+{
+    /// <summary>
+    /// An unbounded single-consumer queue of Vector Set cleanup work, where each item is a unit of work.
+    /// </summary>
+    internal sealed class VectorSetCleanupWorkChannel<T>
+    {
+        private readonly Channel<T> channel;
+
+        public VectorSetCleanupWorkChannel()
+        {
+            channel = Channel.CreateUnbounded<T>(new() { SingleWriter = false, SingleReader = true, AllowSynchronousContinuations = false });
+        }
+
+        /// <summary>
+        /// Publish an item. False once completed, i.e. during shutdown.
+        /// </summary>
+        public bool TryPublish(T item) => channel.Writer.TryWrite(item);
+
+        /// <summary>
+        /// Completes when an item may be available. False once completed and drained.
+        /// </summary>
+        public ValueTask<bool> WaitToReadAsync() => channel.Reader.WaitToReadAsync();
+
+        /// <summary>
+        /// Whether any item is queued.
+        /// </summary>
+        public bool HasPending => channel.Reader.TryPeek(out _);
+
+        /// <summary>
+        /// Take the next item, if any.
+        /// </summary>
+        public bool TryRead(out T item) => channel.Reader.TryRead(out item);
+
+        /// <summary>
+        /// Stop accepting items and block until they drain and <paramref name="consumerTask"/> exits.
+        /// </summary>
+        public void CompleteAndWaitForConsumerTask(Task consumerTask)
+        {
+            channel.Writer.Complete();
+            AsyncUtils.BlockingWait(channel.Reader.Completion);
+            AsyncUtils.BlockingWait(consumerTask);
+        }
+    }
+
+    internal static class VectorSetCleanupWorkChannelExtensions
+    {
+        /// <summary>
+        /// Publish an item with no payload, similar to a signal, for a queue whose work is described elsewhere.
+        /// </summary>
+        public static bool TryPublish(this VectorSetCleanupWorkChannel<object> channel) => channel.TryPublish(null);
+
+        /// <summary>
+        /// Discard every queued item, for a consumer whose pass services the whole backlog anyway. Only for
+        /// payload-free queues, since discarding an item that carries one drops the work it describes.
+        /// </summary>
+        public static void DrainPending(this VectorSetCleanupWorkChannel<object> channel)
+        {
+            while (channel.TryRead(out _))
+            {
+            }
+        }
+    }
+}

--- a/libs/server/Resp/Vector/Cleanup/VectorSetCleanupWorkSet.cs
+++ b/libs/server/Resp/Vector/Cleanup/VectorSetCleanupWorkSet.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Garnet.server
+{
+    /// <summary>
+    /// A keyed set of outstanding Vector Set cleanup work.
+    /// </summary>
+    internal sealed class VectorSetCleanupWorkSet<TValue>
+    {
+        private readonly ConcurrentDictionary<byte[], TValue> entries;
+#if NET9_0_OR_GREATER
+        private readonly ConcurrentDictionary<byte[], TValue>.AlternateLookup<ReadOnlySpan<byte>> lookup;
+#endif
+
+        public VectorSetCleanupWorkSet()
+        {
+            entries = new(ByteArrayComparer.Instance);
+#if NET9_0_OR_GREATER
+            lookup = entries.GetAlternateLookup<ReadOnlySpan<byte>>();
+#endif
+        }
+
+        /// <summary>
+        /// Whether work is still pending for <paramref name="key"/>.
+        /// </summary>
+        public bool Contains(ReadOnlySpan<byte> key)
+        {
+#if NET9_0_OR_GREATER
+            return lookup.ContainsKey(key);
+#else
+            return entries.ContainsKey(key.ToArray());
+#endif
+        }
+
+        /// <summary>
+        /// Block until no work is pending for <paramref name="key"/>. Entries are removed only once the work
+        /// has been performed, so returning implies completion, not merely dequeue.
+        ///
+        /// Do not call this while holding any Vector Set related locks, we will deadlock.
+        /// </summary>
+        public void WaitForCompletion(ReadOnlySpan<byte> key)
+        {
+            while (Contains(key))
+            {
+                _ = Thread.Yield();
+            }
+        }
+
+        /// <summary>
+        /// Add work for <paramref name="key"/>. False if work is already pending for it.
+        /// </summary>
+        public bool TryAdd(byte[] key, TValue value) => entries.TryAdd(key, value);
+
+        /// <summary>
+        /// Remove the entry, marking its work done. False if it was not present.
+        /// </summary>
+        public bool TryComplete(byte[] key) => entries.TryRemove(key, out _);
+
+        /// <summary>
+        /// Iterate the pending work, so a consumer can service the whole backlog in one pass.
+        /// </summary>
+        public IEnumerator<KeyValuePair<byte[], TValue>> GetEnumerator() => entries.GetEnumerator();
+    }
+}

--- a/libs/server/Resp/Vector/VectorManager.Cleanup.cs
+++ b/libs/server/Resp/Vector/VectorManager.Cleanup.cs
@@ -7,7 +7,6 @@ using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 using Garnet.common;
 using Garnet.networking;
@@ -87,13 +86,10 @@ namespace Garnet.server
             }
         }
 
-        private readonly Channel<object> cleanupTaskChannel;
-        private readonly Channel<(ulong Context, TaskCompletionSource MarkCompleted)> requestCleanupTaskChannel;
-        private readonly Channel<object> requestDropTaskChannel;
-        private readonly ConcurrentDictionary<byte[], (ulong Context, nint IndexPtr)> requestedDrops;
-#if NET9_0_OR_GREATER
-        private readonly ConcurrentDictionary<byte[], (ulong Context, nint IndexPtr)>.AlternateLookup<ReadOnlySpan<byte>> requestedDropsLookup;
-#endif
+        private readonly VectorSetCleanupWorkChannel<object> cleanupTaskChannel;
+        private readonly VectorSetCleanupWorkChannel<(ulong Context, TaskCompletionSource MarkCompleted)> requestCleanupTaskChannel;
+        private readonly VectorSetCleanupWorkChannel<object> requestDropTaskChannel;
+        private readonly VectorSetCleanupWorkSet<(ulong Context, nint IndexPtr)> requestedDrops;
         private readonly ConcurrentDictionary<ulong, byte[]> potentiallyDeleted;
         private readonly Task cleanupTask;
         private readonly Task requestCleanupTask;
@@ -138,12 +134,10 @@ namespace Garnet.server
         /// </summary>
         private async Task RunRequestDropTaskAsync()
         {
-            while (await requestDropTaskChannel.Reader.WaitToReadAsync().ConfigureAwait(false))
+            while (await requestDropTaskChannel.WaitToReadAsync().ConfigureAwait(false))
             {
-                // Drain all wake up signals
-                while (requestDropTaskChannel.Reader.TryRead(out _))
-                {
-                }
+                // Every pass services the whole of requestedDrops, so the backlog collapses into one pass
+                requestDropTaskChannel.DrainPending();
 
                 // TODO: this doesn't work with non-RESP impls... which maybe we don't care about?
                 using var dropSession = (RespServerSession)getTempSession();
@@ -176,7 +170,7 @@ namespace Garnet.server
                         finally
                         {
                             vectorSetLocks.ReleaseLock(lockToken);
-                            if (!requestedDrops.TryRemove(k, out _))
+                            if (!requestedDrops.TryComplete(k))
                             {
                                 logger?.LogCritical("Drop for {key} raced with some other cleanup, this should never happen", SpanByte.ToShortString(k));
                             }
@@ -200,7 +194,7 @@ namespace Garnet.server
         /// </summary>
         private async Task RunRequestCleanupTaskAsync()
         {
-            while (await requestCleanupTaskChannel.Reader.WaitToReadAsync().ConfigureAwait(false))
+            while (await requestCleanupTaskChannel.WaitToReadAsync().ConfigureAwait(false))
             {
                 Volatile.Write(ref requestCleanupTaskRunning, true);
 
@@ -226,7 +220,7 @@ namespace Garnet.server
                     lock (this)
                     {
                         // Read all pending requests so we can do one update
-                        while (requestCleanupTaskChannel.Reader.TryRead(out var t))
+                        while (requestCleanupTaskChannel.TryRead(out var t))
                         {
                             if (t.MarkCompleted != null)
                             {
@@ -265,7 +259,7 @@ namespace Garnet.server
                     }
 
                     // Pump the cleanup task once we're done
-                    _ = cleanupTaskChannel.Writer.TryWrite(null);
+                    _ = cleanupTaskChannel.TryPublish();
                 }
                 catch (Exception e)
                 {
@@ -296,10 +290,14 @@ namespace Garnet.server
         /// </summary>
         private async Task RunCleanupTaskAsync()
         {
-            // Each drop index will queue a null object here
-            // We'll handle multiple at once if possible, but using a channel simplifies cancellation and dispose
-            await foreach (var ignored in cleanupTaskChannel.Reader.ReadAllAsync().ConfigureAwait(false))
+            while (await cleanupTaskChannel.WaitToReadAsync().ConfigureAwait(false))
             {
+                // Each item is one outstanding scan
+                if (!cleanupTaskChannel.TryRead(out _))
+                {
+                    continue;
+                }
+
                 await cleanupGate.WaitAsync().ConfigureAwait(false);
 
                 try
@@ -384,7 +382,7 @@ namespace Garnet.server
         /// (if any) to finish. Callers (e.g., cluster re-attach paths) MUST balance every
         /// invocation with <see cref="ResumeCleanup"/>, ideally in a finally block.
         ///
-        /// While paused, drops still enqueue items into <see cref="cleanupTaskChannel"/>;
+        /// While paused, drops still publish to <see cref="cleanupTaskChannel"/>;
         /// the cleanup task wakes, awaits the gate until the pause is lifted, then
         /// processes the backlog — so no work is lost.
         ///
@@ -409,39 +407,21 @@ namespace Garnet.server
         /// <summary>
         /// True if a pending request to drop the DiskANN index behind this _specific_ key exists.
         /// </summary>
-        public bool DropRequested(ReadOnlySpan<byte> key)
-        {
-#if NET9_0_OR_GREATER
-            return requestedDropsLookup.ContainsKey(key);
-#else
-            return requestedDrops.ContainsKey(key.ToArray());
-#endif
-        }
+        public bool DropRequested(ReadOnlySpan<byte> key) => requestedDrops.Contains(key);
 
         /// <summary>
         /// Block until <see cref="DropRequested(ReadOnlySpan{byte})"/> would return false.
         /// 
         /// Do not call this while holding any Vector Set related locks, we will deadlock.
         /// </summary>
-        public void WaitForDiskANNIndexDrop(ReadOnlySpan<byte> key)
-        {
-#if NET9_0_OR_GREATER
-            while (requestedDropsLookup.ContainsKey(key))
-#else
-            var keyBytes = key.ToArray();
-            while (requestedDrops.ContainsKey(keyBytes))
-#endif
-            {
-                _ = Thread.Yield();
-            }
-        }
+        public void WaitForDiskANNIndexDrop(ReadOnlySpan<byte> key) => requestedDrops.WaitForCompletion(key);
 
         /// <summary>
         /// For testing purposes, block until all cleanup requests are processed.
         /// </summary>
         internal void WaitForCleanupRequests()
         {
-            while (!potentiallyDeleted.IsEmpty || requestCleanupTaskChannel.Reader.TryPeek(out _) || Volatile.Read(ref requestCleanupTaskRunning) || Interlocked.CompareExchange(ref postCheckpointTasksRunning, 0, 0) != 0)
+            while (!potentiallyDeleted.IsEmpty || requestCleanupTaskChannel.HasPending || Volatile.Read(ref requestCleanupTaskRunning) || Interlocked.CompareExchange(ref postCheckpointTasksRunning, 0, 0) != 0)
             {
                 _ = Thread.Yield();
             }
@@ -524,7 +504,7 @@ namespace Garnet.server
                                 if (needsDelete)
                                 {
                                     // No need to wait for marking, since the record is already "deleted"
-                                    if (!self.requestCleanupTaskChannel.Writer.TryWrite((context, null)))
+                                    if (!self.requestCleanupTaskChannel.TryPublish((context, null)))
                                     {
                                         self.logger?.LogWarning("Could not request delete of abandoned Vector Set {key}", SpanByte.ToShortString(key));
                                     }

--- a/libs/server/Resp/Vector/VectorManager.cs
+++ b/libs/server/Resp/Vector/VectorManager.cs
@@ -205,18 +205,15 @@ namespace Garnet.server
             vectorSetLocks = new(vectorSetReplayCount);
 
             this.getTempSession = getTempSession;
-            cleanupTaskChannel = Channel.CreateUnbounded<object>(new() { SingleWriter = false, SingleReader = true, AllowSynchronousContinuations = false });
-            requestCleanupTaskChannel = Channel.CreateUnbounded<(ulong Context, TaskCompletionSource Completion)>(new() { SingleWriter = false, SingleReader = true, AllowSynchronousContinuations = false });
-            requestDropTaskChannel = Channel.CreateUnbounded<object>(new() { SingleWriter = false, SingleReader = true, AllowSynchronousContinuations = false });
+            cleanupTaskChannel = new();
+            requestCleanupTaskChannel = new();
+            requestDropTaskChannel = new();
 
             cleanupTask = RunCleanupTaskAsync();
             requestCleanupTask = RunRequestCleanupTaskAsync();
             requestDropTask = RunRequestDropTaskAsync();
 
-            requestedDrops = new(ByteArrayComparer.Instance);
-#if NET9_0_OR_GREATER
-            requestedDropsLookup = requestedDrops.GetAlternateLookup<ReadOnlySpan<byte>>();
-#endif
+            requestedDrops = new();
 
             potentiallyDeleted = [];
 
@@ -368,7 +365,7 @@ namespace Garnet.server
             }
 
             // Resume any cleanups we didn't complete before recovery
-            _ = cleanupTaskChannel.Writer.TryWrite(null);
+            _ = cleanupTaskChannel.TryPublish();
         }
 
         /// <summary>
@@ -423,23 +420,17 @@ namespace Garnet.server
             replicationBlockEvent.Dispose();
 
             // Wait for any _drops_ in progress to finish
-            requestDropTaskChannel.Writer.Complete();
-            AsyncUtils.BlockingWait(requestDropTaskChannel.Reader.Completion);
-            AsyncUtils.BlockingWait(requestDropTask);
+            requestDropTaskChannel.CompleteAndWaitForConsumerTask(requestDropTask);
 
             // Wait for any _marking_ of cleanup state to finish. PauseCleanupAsync callers MUST
             // have called ResumeCleanup before reaching here, otherwise the cleanup task
             // is permanently blocked on cleanupGate.WaitAsync() and Dispose will hang.
-            requestCleanupTaskChannel.Writer.Complete();
-            AsyncUtils.BlockingWait(requestCleanupTaskChannel.Reader.Completion);
-            AsyncUtils.BlockingWait(requestCleanupTask);
+            requestCleanupTaskChannel.CompleteAndWaitForConsumerTask(requestCleanupTask);
 
             // Wait for any in progress cleanup to finish. PauseCleanupAsync callers MUST
             // have called ResumeCleanup before reaching here, otherwise the cleanup task
             // is permanently blocked on cleanupGate.WaitAsync() and Dispose will hang.
-            cleanupTaskChannel.Writer.Complete();
-            AsyncUtils.BlockingWait(cleanupTaskChannel.Reader.Completion);
-            AsyncUtils.BlockingWait(cleanupTask);
+            cleanupTaskChannel.CompleteAndWaitForConsumerTask(cleanupTask);
 
             // Cleanup task has fully drained, so nothing else can take this gate.
             cleanupGate.Dispose();
@@ -643,7 +634,7 @@ namespace Garnet.server
 
             var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            if (!requestCleanupTaskChannel.Writer.TryWrite((context, tcs)))
+            if (!requestCleanupTaskChannel.TryPublish((context, tcs)))
             {
                 throw new GarnetException("Could not submit request for Vector Set cleanup, aborting delete");
             }
@@ -691,7 +682,7 @@ namespace Garnet.server
                     throw new GarnetException($"Drop triggered multiple times for same index: {SpanByte.ToShortString(key)}");
                 }
 
-                _ = requestDropTaskChannel.Writer.TryWrite(null);
+                _ = requestDropTaskChannel.TryPublish();
             }
         }
 

--- a/test/standalone/Garnet.test.vectorset/VectorSetCleanupWorkChannelTests.cs
+++ b/test/standalone/Garnet.test.vectorset/VectorSetCleanupWorkChannelTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Threading.Tasks;
+using Garnet.server;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace Garnet.test
+{
+    /// <summary>
+    /// Unit tests for <see cref="VectorSetCleanupWorkChannel{T}"/>.
+    /// </summary>
+    [TestFixture]
+    public class VectorSetCleanupWorkChannelTests
+    {
+        [Test]
+        public async Task PublishedItemIsReadable()
+        {
+            var channel = new VectorSetCleanupWorkChannel<int>();
+
+            ClassicAssert.IsFalse(channel.HasPending);
+            ClassicAssert.IsTrue(channel.TryPublish(7));
+
+            ClassicAssert.IsTrue(channel.HasPending);
+            ClassicAssert.IsTrue(await channel.WaitToReadAsync());
+
+            ClassicAssert.IsTrue(channel.TryRead(out var item));
+            ClassicAssert.AreEqual(7, item);
+
+            ClassicAssert.IsFalse(channel.HasPending);
+            ClassicAssert.IsFalse(channel.TryRead(out _));
+        }
+
+        [Test]
+        public async Task CompletedChannelRejectsPublishesAndReleasesWaiters()
+        {
+            var channel = new VectorSetCleanupWorkChannel<int>();
+            channel.CompleteAndWaitForConsumerTask(Task.CompletedTask);
+
+            ClassicAssert.IsFalse(channel.TryPublish(7));
+            ClassicAssert.IsFalse(await channel.WaitToReadAsync());
+        }
+
+        [Test]
+        public void CompleteAndWaitForConsumerTaskDrainsBeforeReturning()
+        {
+            var channel = new VectorSetCleanupWorkChannel<int>();
+            var consumed = 0;
+
+            var consumer = Task.Run(async () =>
+            {
+                while (await channel.WaitToReadAsync())
+                {
+                    while (channel.TryRead(out _))
+                    {
+                        consumed++;
+                    }
+                }
+            });
+
+            _ = channel.TryPublish(1);
+            _ = channel.TryPublish(2);
+
+            channel.CompleteAndWaitForConsumerTask(consumer);
+
+            ClassicAssert.IsTrue(consumer.IsCompleted);
+            ClassicAssert.AreEqual(2, consumed);
+        }
+    }
+}

--- a/test/standalone/Garnet.test.vectorset/VectorSetCleanupWorkSetTests.cs
+++ b/test/standalone/Garnet.test.vectorset/VectorSetCleanupWorkSetTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Garnet.server;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace Garnet.test
+{
+    /// <summary>
+    /// Unit tests for <see cref="VectorSetCleanupWorkSet{TValue}"/>.
+    /// </summary>
+    [TestFixture]
+    public class VectorSetCleanupWorkSetTests
+    {
+        private static byte[] Key(string s) => Encoding.UTF8.GetBytes(s);
+
+        [Test]
+        public void AddedWorkIsPendingUntilCompleted()
+        {
+            var workSet = new VectorSetCleanupWorkSet<int>();
+
+            ClassicAssert.IsFalse(workSet.Contains(Key("a")));
+            ClassicAssert.IsFalse(workSet.TryComplete(Key("a")));
+
+            ClassicAssert.IsTrue(workSet.TryAdd(Key("a"), 1));
+            ClassicAssert.IsTrue(workSet.Contains(Key("a")));
+            ClassicAssert.IsFalse(workSet.TryAdd(Key("a"), 2));
+
+            ClassicAssert.IsTrue(workSet.TryComplete(Key("a")));
+            ClassicAssert.IsFalse(workSet.Contains(Key("a")));
+        }
+
+        [Test]
+        public void EntriesCanBeEnumerated()
+        {
+            var workSet = new VectorSetCleanupWorkSet<int>();
+
+            _ = workSet.TryAdd(Key("a"), 1);
+            _ = workSet.TryAdd(Key("b"), 2);
+
+            var values = new List<int>();
+            foreach (var (_, value) in workSet)
+            {
+                values.Add(value);
+            }
+
+            CollectionAssert.AreEquivalent(new[] { 1, 2 }, values);
+        }
+
+        [Test]
+        public async Task WaitForCompletionBlocksUntilTheEntryIsCompleted()
+        {
+            var workSet = new VectorSetCleanupWorkSet<int>();
+
+            _ = workSet.TryAdd(Key("a"), 1);
+
+            var waiter = Task.Run(() => workSet.WaitForCompletion(Key("a")));
+            ClassicAssert.IsFalse(waiter.IsCompleted);
+
+            _ = workSet.TryComplete(Key("a"));
+            await waiter;
+        }
+    }
+}


### PR DESCRIPTION
Pulls the ad-hoc `Channel` and `ConcurrentDictionary` plumbing in the Vector Set cleanup pipeline behind two small types, and uses them in `VectorManager`. Behaviour is unchanged.

### `VectorSetCleanupWorkChannel<T>`

Replaces all three queues. They differ only in how the consumer reads:

| queue | payload | read shape |
|---|---|---|
| `requestDropTaskChannel` | none - a wake-up | whole backlog per pass |
| `requestCleanupTaskChannel` | `(ulong Context, TaskCompletionSource)` | whole backlog per pass |
| `cleanupTaskChannel` | none, but one item = one scan | one item per iteration |

The first two service all outstanding work in one pass, so a redundant item costs nothing and the backlog collapses - which gives

```csharp
// Drain all wake up signals
while (requestDropTaskChannel.Reader.TryRead(out _)) { }
```

a home as `requestDropTaskChannel.DrainPending()`. The third acts on the item itself, so it takes one per iteration.

Two of the queues carry no payload, because the work they refer to lives elsewhere - in `requestedDrops` for the drop queue, and in the marked contexts for the cleanup queue. Both `DrainPending()` and the payload-free `TryPublish()` are extension methods on `VectorSetCleanupWorkChannel<object>` rather than members, so neither can be called on `requestCleanupTaskChannel`: publishing a `default` tuple there would queue a null `TaskCompletionSource`, and discarding its backlog would strand every waiter on it.

The type also folds the three-step shutdown

```csharp
requestDropTaskChannel.Writer.Complete();
AsyncUtils.BlockingWait(requestDropTaskChannel.Reader.Completion);
AsyncUtils.BlockingWait(requestDropTask);
```

into `requestDropTaskChannel.CompleteAndWaitForConsumerTask(requestDropTask)`, and does not expose the underlying `ChannelReader`/`ChannelWriter`.

### `VectorSetCleanupWorkSet<TValue>`

Wraps `requestedDrops`, moving the `NET9_0_OR_GREATER` alternate-lookup branching and the poll-until-absent loop out of `VectorManager`. `DropRequested` and `WaitForDiskANNIndexDrop` become one-liners over `Contains` / `WaitForCompletion`.

### Tests

Unit tests over both types.
