### PR TITLE
Return NOPERM instead of NOAUTH for ACL-denied commands

### DIFF
--- a/libs/server/Lua/LuaRunner.Functions.cs
+++ b/libs/server/Lua/LuaRunner.Functions.cs
@@ -3168,7 +3168,7 @@ namespace Garnet.server
                 {
                     if (!respServerSession.CheckACLPermissions(RespCommand.SET))
                     {
-                        return LuaWrappedError(1, constStrs.ErrNoAuth);
+                        return LuaWrappedError(1, constStrs.ErrNoPerm);
                     }
 
                     ReadOnlySpan<byte> keySpan;
@@ -3220,7 +3220,7 @@ namespace Garnet.server
                 {
                     if (!respServerSession.CheckACLPermissions(RespCommand.GET))
                     {
-                        return LuaWrappedError(1, constStrs.ErrNoAuth);
+                        return LuaWrappedError(1, constStrs.ErrNoPerm);
                     }
 
                     ReadOnlySpan<byte> keySpan;

--- a/libs/server/Lua/LuaRunner.Strings.cs
+++ b/libs/server/Lua/LuaRunner.Strings.cs
@@ -25,8 +25,8 @@ namespace Garnet.server
             internal int NoSessionAvailable { get; }
             /// <see cref="CmdStrings.LUA_ERR_Please_specify_at_least_one_argument_for_this_redis_lib_call"/>
             internal int PleaseSpecifyRedisCall { get; }
-            /// <see cref="CmdStrings.RESP_ERR_NOAUTH"/>
-            internal int ErrNoAuth { get; }
+            /// <see cref="CmdStrings.RESP_ERR_NOPERM"/>
+            internal int ErrNoPerm { get; }
             /// <see cref="CmdStrings.LUA_ERR_Unknown_Redis_command_called_from_script"/>
             internal int ErrUnknown { get; }
             /// <see cref="CmdStrings.LUA_ERR_Lua_redis_lib_command_arguments_must_be_strings_or_integers"/>
@@ -180,7 +180,7 @@ namespace Garnet.server
                 Err = ConstantStringToRegistry(ref state, CmdStrings.LUA_err);
                 NoSessionAvailable = ConstantStringToRegistry(ref state, CmdStrings.LUA_No_session_available);
                 PleaseSpecifyRedisCall = ConstantStringToRegistry(ref state, CmdStrings.LUA_ERR_Please_specify_at_least_one_argument_for_this_redis_lib_call);
-                ErrNoAuth = ConstantStringToRegistry(ref state, CmdStrings.RESP_ERR_NOAUTH);
+                ErrNoPerm = ConstantStringToRegistry(ref state, CmdStrings.RESP_ERR_NOPERM);
                 ErrUnknown = ConstantStringToRegistry(ref state, CmdStrings.LUA_ERR_Unknown_Redis_command_called_from_script);
                 ErrBadArg = ConstantStringToRegistry(ref state, CmdStrings.LUA_ERR_Lua_redis_lib_command_arguments_must_be_strings_or_integers);
                 ErrWrongNumberOfArgs = ConstantStringToRegistry(ref state, CmdStrings.LUA_ERR_wrong_number_of_arguments);

--- a/libs/server/Resp/CmdStrings.cs
+++ b/libs/server/Resp/CmdStrings.cs
@@ -199,6 +199,7 @@ namespace Garnet.server
         /// Simple error response strings, i.e. these are of the form "-errorString\r\n"
         /// </summary>
         public static ReadOnlySpan<byte> RESP_ERR_NOAUTH => "NOAUTH Authentication required."u8;
+        public static ReadOnlySpan<byte> RESP_ERR_NOPERM => "NOPERM this user has no permissions to run the command"u8;
         public static ReadOnlySpan<byte> RESP_ERR_WRONG_TYPE => "WRONGTYPE Operation against a key holding the wrong kind of value."u8;
         public static ReadOnlySpan<byte> RESP_ERR_WRONG_TYPE_HLL => "WRONGTYPE Key is not a valid HyperLogLog string value."u8;
         public static ReadOnlySpan<byte> RESP_ERR_EXEC_ABORT => "EXECABORT Transaction discarded because of previous errors."u8;

--- a/libs/server/Resp/RespServerSession.cs
+++ b/libs/server/Resp/RespServerSession.cs
@@ -694,8 +694,16 @@ namespace Garnet.server
                     {
                         if (noScriptPassed)
                         {
-                            while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_NOAUTH, ref dcurr, dend))
-                                SendAndReset();
+                            if (_authenticator.IsAuthenticated)
+                            {
+                                while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_NOPERM, ref dcurr, dend))
+                                    SendAndReset();
+                            }
+                            else
+                            {
+                                while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_ERR_NOAUTH, ref dcurr, dend))
+                                    SendAndReset();
+                            }
                         }
                         else
                         {

--- a/test/standalone/Garnet.test.acl/Resp/ACL/BasicTests.cs
+++ b/test/standalone/Garnet.test.acl/Resp/ACL/BasicTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Garnet.server;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
+using StackExchange.Redis;
 
 namespace Garnet.test.Resp.ACL
 {
@@ -164,6 +165,67 @@ namespace Garnet.test.Resp.ACL
                     ClassicAssert.AreEqual(infoIsNoAuth, cmdIsNoAuth, $"Mismatch for command {cmd}");
                 }
             }
+        }
+
+        /// <summary>
+        /// An authenticated user denied a command must be told NOPERM.
+        /// </summary>
+        [Test]
+        public async Task DeniedCommandReturnsNoPermAsync()
+        {
+            await CreateLimitedUserAsync("+@all", "-type").ConfigureAwait(false);
+
+            using var redis = ConnectionMultiplexer.Connect(GetLimitedUserConfig());
+            var db = redis.GetDatabase(0);
+
+            var exc = Assert.Throws<RedisServerException>(() => db.Execute("TYPE", "some-key"));
+            ClassicAssert.IsTrue(exc.Message.StartsWith("NOPERM"), $"Expected NOPERM for an ACL-denied command, got: {exc.Message}");
+        }
+
+        /// <summary>
+        /// A permitted command must still work for the same user.
+        /// </summary>
+        [Test]
+        public async Task PermittedCommandStillWorksAsync()
+        {
+            await CreateLimitedUserAsync("+@all", "-type").ConfigureAwait(false);
+
+            using var redis = ConnectionMultiplexer.Connect(GetLimitedUserConfig());
+            var db = redis.GetDatabase(0);
+
+            ClassicAssert.IsTrue(db.StringSet("some-key", "some-value"));
+            ClassicAssert.AreEqual("some-value", (string)db.StringGet("some-key"));
+        }
+
+        /// <summary>
+        /// A denied CLIENT SETINFO must return NOPERM without breaking connection setup.
+        /// </summary>
+        [Test]
+        public async Task ClientSetInfoDeniedReturnsNoPermAsync()
+        {
+            await CreateLimitedUserAsync("+@all", "-client|setinfo").ConfigureAwait(false);
+
+            using var redis = ConnectionMultiplexer.Connect(GetLimitedUserConfig());
+            var db = redis.GetDatabase(0);
+
+            ClassicAssert.IsTrue(db.StringSet("some-key", "some-value"));
+            ClassicAssert.AreEqual("some-value", (string)db.StringGet("some-key"));
+
+            var exc = Assert.Throws<RedisServerException>(() => db.Execute("CLIENT", "SETINFO", "LIB-NAME", "foo"));
+            ClassicAssert.IsTrue(exc.Message.StartsWith("NOPERM"), $"Expected NOPERM for denied CLIENT SETINFO, got: {exc.Message}");
+        }
+
+        private static ConfigurationOptions GetLimitedUserConfig()
+            => TestUtils.GetConfig(disablePubSub: true, authUsername: TestUserA, authPassword: DummyPassword);
+
+        private static async Task CreateLimitedUserAsync(params string[] permissions)
+        {
+            using var c = TestUtils.GetGarnetClientSession();
+            c.Connect();
+
+            string[] args = ["ACL", "SETUSER", TestUserA, "on", $">{DummyPassword}", "~*", .. permissions];
+            var resp = await c.ExecuteAsync(args).ConfigureAwait(false);
+            ClassicAssert.AreEqual("OK", resp);
         }
     }
 }

--- a/test/standalone/Garnet.test.acl/Resp/ACL/CustomCommandACLTests.cs
+++ b/test/standalone/Garnet.test.acl/Resp/ACL/CustomCommandACLTests.cs
@@ -484,7 +484,7 @@ namespace Garnet.test.Resp.ACL
                 await alice.ExecuteForStringResultAsync("SETWPIFPGT", ["k", "v", "\0\0\0\0\0\0\0\0"]).ConfigureAwait(false);
             });
             ClassicAssert.IsNotNull(denied, "SETWPIFPGT should have been denied by -setwpifpgt");
-            StringAssert.Contains("NOAUTH", denied.Message.ToUpperInvariant());
+            StringAssert.Contains("NOPERM", denied.Message.ToUpperInvariant());
 
             // MYDICTGET is still permitted (only SETWPIFPGT was denied).
             var mydict = await alice.ExecuteForStringResultAsync("MYDICTGET", ["foo", "bar"]).ConfigureAwait(false);
@@ -558,7 +558,7 @@ namespace Garnet.test.Resp.ACL
                 await alice.ExecuteForStringResultAsync("NOOPTXN").ConfigureAwait(false);
             });
             ClassicAssert.IsNotNull(denied, "NOOPTXN should have been denied by -NOOPTXN");
-            StringAssert.Contains("NOAUTH", denied.Message.ToUpperInvariant());
+            StringAssert.Contains("NOPERM", denied.Message.ToUpperInvariant());
         }
 
         [Test]
@@ -586,7 +586,7 @@ namespace Garnet.test.Resp.ACL
                 await alice.ExecuteForStringResultAsync("NOOPPROC").ConfigureAwait(false);
             });
             ClassicAssert.IsNotNull(denied, "NOOPPROC should have been denied by -NOOPPROC");
-            StringAssert.Contains("NOAUTH", denied.Message.ToUpperInvariant());
+            StringAssert.Contains("NOPERM", denied.Message.ToUpperInvariant());
         }
 
         [Test]

--- a/test/standalone/Garnet.test.acl/Resp/ACL/RespCommandTests.cs
+++ b/test/standalone/Garnet.test.acl/Resp/ACL/RespCommandTests.cs
@@ -7684,7 +7684,7 @@ namespace Garnet.test.Resp.ACL
                 }
                 catch (Exception ex)
                 {
-                    if (ex.Message == Encoding.ASCII.GetString(CmdStrings.RESP_ERR_NOAUTH))
+                    if (ex.Message == Encoding.ASCII.GetString(CmdStrings.RESP_ERR_NOPERM))
                         throw;
 
                     ClassicAssert.AreEqual(Encoding.ASCII.GetString(CmdStrings.RESP_ERR_SWAPDB_UNSUPPORTED), ex.Message);
@@ -8219,7 +8219,7 @@ namespace Garnet.test.Resp.ACL
             {
                 foreach (Func<GarnetClient, Task> cmd in commands)
                 {
-                    ClassicAssert.True(await CheckAuthFailureAsync(() => cmd(currentUserClient)).ConfigureAwait(false), message);
+                    ClassicAssert.True(await CheckPermissionFailureAsync(() => cmd(currentUserClient)).ConfigureAwait(false), message);
                 }
 
                 if (!skipAclCheckCmd)
@@ -8272,12 +8272,12 @@ namespace Garnet.test.Resp.ACL
                 ClassicAssert.AreEqual(expectedResult, canRun, $"redis.acl_check_cmd(...) return unexpected result for '{withBar}'");
             }
 
-            // Check that all commands fail with NOAUTH
+            // Check that all commands fail with NOPERM
             static async Task AssertAllDeniedAsync(GarnetClient defaultUserClient, string currentUserName, GarnetClient currentUserClient, Func<GarnetClient, Task>[] commands, string message, bool skipPing, string[] commandAndSubCommand, bool skipAclCheckCmd)
             {
                 foreach (Func<GarnetClient, Task> cmd in commands)
                 {
-                    ClassicAssert.False(await CheckAuthFailureAsync(() => cmd(currentUserClient)).ConfigureAwait(false), message);
+                    ClassicAssert.False(await CheckPermissionFailureAsync(() => cmd(currentUserClient)).ConfigureAwait(false), message);
                 }
 
                 if (!skipAclCheckCmd)
@@ -8370,12 +8370,12 @@ namespace Garnet.test.Resp.ACL
         }
 
         /// <summary>
-        /// Returns true if no AUTH failure.
-        /// Returns false AUTH failure.
+        /// Returns true if no permission failure.
+        /// Returns false on a permission failure.
         /// 
         /// Throws if anything else.
         /// </summary>
-        private static async Task<bool> CheckAuthFailureAsync(Func<Task> act)
+        private static async Task<bool> CheckPermissionFailureAsync(Func<Task> act)
         {
             try
             {
@@ -8384,7 +8384,7 @@ namespace Garnet.test.Resp.ACL
             }
             catch (Exception e)
             {
-                if (e.Message != "NOAUTH Authentication required.")
+                if (e.Message != "NOPERM this user has no permissions to run the command")
                 {
                     throw;
                 }

--- a/test/standalone/Garnet.test.scripting/LuaScriptTests.cs
+++ b/test/standalone/Garnet.test.scripting/LuaScriptTests.cs
@@ -118,7 +118,8 @@ namespace Garnet.test
                 aclFile,
                 [
                     "user default on nopass +@all",
-                    "user deny on nopass +@all -get -acl -cluster|myid"
+                    "user deny on nopass +@all -get -acl -cluster|myid",
+                    "user denyset on nopass +@all -set"
                 ]
             );
 
@@ -1842,13 +1843,24 @@ return retArray";
 
             // Not a lot of sub commands a non-admin can run, so use CLUSTER|MYID and check the exception
             var allowSubExc = ClassicAssert.Throws<RedisServerException>(() => allowDb.ScriptEvaluate("return redis.call('CLUSTER', 'MYID')"));
-            ClassicAssert.False(allowSubExc.Message.Contains("NOAUTH"));
+            ClassicAssert.False(allowSubExc.Message.Contains("NOPERM"));
 
             var exc = ClassicAssert.Throws<RedisServerException>(() => denyDb.ScriptEvaluate("return redis.call('GET', 'foo')"));
-            ClassicAssert.IsTrue(exc.Message.Contains("NOAUTH"));
+            ClassicAssert.IsTrue(exc.Message.Contains("NOPERM"));
 
             var excSub = ClassicAssert.Throws<RedisServerException>(() => denyDb.ScriptEvaluate("return redis.call('CLUSTER', 'MYID')"));
-            ClassicAssert.IsTrue(excSub.Message.Contains("NOAUTH"));
+            ClassicAssert.IsTrue(excSub.Message.Contains("NOPERM"));
+
+            // SET is dispatched through a separate fast path in LuaRunner, so cover it explicitly
+            using var denySetRedis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(authUsername: "denyset"));
+            var denySetDb = denySetRedis.GetDatabase();
+
+            var excSet = ClassicAssert.Throws<RedisServerException>(() => denySetDb.ScriptEvaluate("return redis.call('SET', 'foo', 'bar')"));
+            ClassicAssert.IsTrue(excSet.Message.Contains("NOPERM"), $"Expected NOPERM for denied SET, got: {excSet.Message}");
+
+            var allowSetRes = (string[])denySetDb.ScriptEvaluate("return redis.call('GET', 'foo')");
+            ClassicAssert.AreEqual(1, allowSetRes.Length);
+            ClassicAssert.AreEqual("bar", allowSetRes[0]);
         }
 
         [Test]

--- a/test/standalone/Garnet.test.scripting/LuaScriptTests.cs
+++ b/test/standalone/Garnet.test.scripting/LuaScriptTests.cs
@@ -1855,7 +1855,7 @@ return retArray";
             using var denySetRedis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(authUsername: "denyset"));
             var denySetDb = denySetRedis.GetDatabase();
 
-            var excSet = ClassicAssert.Throws<RedisServerException>(() => denySetDb.ScriptEvaluate("return redis.call('SET', 'foo', 'bar')"));
+            var excSet = ClassicAssert.Throws<RedisServerException>(() => denySetDb.ScriptEvaluate("return redis.call('SET', 'foo', 'baz')"));
             ClassicAssert.IsTrue(excSet.Message.Contains("NOPERM"), $"Expected NOPERM for denied SET, got: {excSet.Message}");
 
             var allowSetRes = (string[])denySetDb.ScriptEvaluate("return redis.call('GET', 'foo')");


### PR DESCRIPTION
### Problem

Garnet always returns `NOAUTH` regardless of which auth failure happened — ACL denial or actual missing authentication. Redis distinguishes the two:

| Scenario | Redis | Garnet (before) | Garnet (this PR) |
| --- | --- | --- | --- |
| Not authenticated | `NOAUTH` | `NOAUTH` | `NOAUTH` |
| Authenticated, command not in user's ACL | `NOPERM` | `NOAUTH` | `NOPERM` |

This broke the redis-py client, which sends `CLIENT SETINFO LIB-NAME`/`LIB-VER` during connection setup and expects `NOPERM` when it's denied. redis-py tolerates `NOPERM` (`NoPermissionError`, a `ResponseError` it catches) but not `NOAUTH` (`AuthenticationError`, a `ConnectionError` it doesn't), so any user whose ACL excludes `CLIENT SETINFO` can't connect to Garnet at all.

### Change

The caller now branches on the session's authentication state:

```csharp
if (_authenticator.IsAuthenticated)
    RESP_ERR_NOPERM   // authenticated, not authorized
else
    RESP_ERR_NOAUTH   // not authenticated
```

- `CmdStrings.cs` — added `RESP_ERR_NOPERM`.
- `RespServerSession.cs` — branch on `IsAuthenticated` when an ACL check fails.
- `LuaRunner.Strings.cs`, `LuaRunner.Functions.cs` — the Lua `SET`/`GET` fast paths hardcoded `NOAUTH`; switched to `NOPERM` for consistency with top-level dispatch.

`NOAUTH` is preserved for unauthenticated sessions, and `NoAuth` commands (`AUTH`, `HELLO`, `QUIT`) are untouched.

### Verification

Compared against Redis 7.4 with redis-py 5.2.1 across unauthenticated, authenticated-and-denied, authenticated-and-allowed, and bad-credential cases. Only authenticated-and-denied changes: `NOAUTH`/`AuthenticationError` → `NOPERM`/`NoPermissionError`. The redis-py default handshake now connects.
