### PR TITLE
Fix ZREMRANGEBYRANK missing reply and unnormalized negative ranks

### DIFF
--- a/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
+++ b/libs/server/Objects/SortedSet/SortedSetObjectImpl.cs
@@ -581,14 +581,21 @@ namespace Garnet.server
                 return;
             }
 
-            if (start > sortedSetDict.Count - 1)
-                return;
+            var count = sortedSetDict.Count;
 
-            // Shift from the end of the set
-            start = start < 0 ? sortedSetDict.Count + start : start;
-            stop = stop < 0
-                ? sortedSetDict.Count + stop
-                : stop >= sortedSetDict.Count ? sortedSetDict.Count - 1 : stop;
+            // Convert negative indexes, as Redis does in t_zset.c zremrangeGenericCommand
+            if (start < 0) start += count;
+            if (stop < 0) stop += count;
+            if (start < 0) start = 0;
+
+            // start is non-negative here, so start > stop also covers a stop that is still negative
+            if (start > stop || start >= count)
+            {
+                writer.WriteInt32(0);
+                return;
+            }
+
+            if (stop >= count) stop = count - 1;
 
             // Calculate number of elements
             var elementCount = stop - start + 1;

--- a/test/standalone/Garnet.test.collections/RespSortedSetTests.cs
+++ b/test/standalone/Garnet.test.collections/RespSortedSetTests.cs
@@ -4430,6 +4430,26 @@ namespace Garnet.test
             expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_ERR_GENERIC_VALUE_IS_NOT_INTEGER)}\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
 
+            // start > stop is an empty range, not a negative count
+            response = lightClientRequest.SendCommandChunks("ZREMRANGEBYRANK board 2 0", bytesSent);
+            expectedResponse = ":0\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
+            // Negative indexes that fall before the first element remove nothing
+            response = lightClientRequest.SendCommandChunks("ZREMRANGEBYRANK board -100 -50", bytesSent);
+            expectedResponse = ":0\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
+            response = lightClientRequest.SendCommandChunks("ZCARD board", bytesSent);
+            expectedResponse = ":3\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
+            // A start past the end of the set must still write exactly one reply,
+            // otherwise the trailing PING is answered out of sync
+            response = lightClientRequest.SendCommands("ZREMRANGEBYRANK board 3 5", "PING");
+            expectedResponse = ":0\r\n+PONG\r\n";
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
             response = lightClientRequest.SendCommandChunks("ZREMRANGEBYRANK board 0 1", bytesSent);
             expectedResponse = ":2\r\n";
             TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);


### PR DESCRIPTION
## Symptom

`ZREMRANGEBYRANK` mishandles every rank range that Redis treats as empty or out of bounds. On a three-element set:

```console
$ redis-cli ZADD zk 1 a 2 b 3 c
(integer) 3

# start past the end of the set: Garnet writes zero bytes, redis-cli blocks on the reply
$ redis-cli ZREMRANGEBYRANK zk 3 5
^C                          # Redis: (integer) 0

# start > stop: negative count
$ redis-cli ZREMRANGEBYRANK zk 2 0
(integer) -1                # Redis: (integer) 0

# negative ranks that fall before the first element: removes the whole set
$ redis-cli ZREMRANGEBYRANK zk -100 -50
(integer) 51                # Redis: (integer) 0
$ redis-cli ZCARD zk
(integer) 0                 # Redis: (integer) 3
```

The `-100 -50` case is silent data loss. The `3 5` case desynchronizes the connection: on `GarnetStatus.OK` the RESP layer forwards whatever the object wrote (`libs/server/Resp/Objects/SortedSetCommands.cs:785`, `ProcessOutput`), and the object wrote nothing, so a pipelining client reads the next command's reply as the answer to `ZREMRANGEBYRANK`.

## Root cause

`libs/server/Objects/SortedSet/SortedSetObjectImpl.cs:584-594`

```csharp
if (start > sortedSetDict.Count - 1)
    return;                                  // no reply written

// Shift from the end of the set
start = start < 0 ? sortedSetDict.Count + start : start;
stop = stop < 0
    ? sortedSetDict.Count + stop
    : stop >= sortedSetDict.Count ? sortedSetDict.Count - 1 : stop;

var elementCount = stop - start + 1;
```

Negative indexes are shifted by the set size but never floored at 0, `start > stop` is never rejected, and the early return leaves the `RespMemoryWriter` empty. `elementCount` is then computed from unclamped indexes, so it no longer describes what `Skip(start).Take(elementCount)` actually removed: `-100 -50` gives `start = -97`, `stop = -47`, `elementCount = 51`, and `Skip(-97)` is a no-op, so all three members go.

## Fix

Normalize the indexes before use, in the order `ListObjectImpl.ListRange` already uses for `LRANGE` (`libs/server/Objects/List/ListObjectImpl.cs:143-150`): shift negatives by the count, floor `start` at 0, reply `:0` for an empty range, then clamp `stop` to `count - 1`. It is also the order `zremrangeGenericCommand` uses in Redis, which is worth naming here because the reply values themselves are the compatibility question.

After clamping, `0 <= start <= stop <= count - 1` always holds, so `elementCount` equals the number of members actually removed and every path writes exactly one reply. The `count == 0` case (a set left empty by `DeleteExpiredItems`) now also replies `:0` instead of nothing.

## Test

`CanDoZRemRangeByRank` in `test/standalone/Garnet.test.collections/RespSortedSetTests.cs`, using raw RESP through `LightClientRequest` — a missing or duplicated reply is invisible to a StackExchange.Redis assertion.

Precisely what is red today, and what is not:

- `ZREMRANGEBYRANK board 2 0` expecting `:0` — **fails on main** (`:-1`). It is the first new assertion, so it is what a revert reports.
- `ZREMRANGEBYRANK board -100 -50` expecting `:0` — also wrong on main (`:51`, and `board` is emptied), but the run aborts at the assertion above before reaching it.
- `ZCARD board` expecting `:3` — regression guard.
- `SendCommands("ZREMRANGEBYRANK board 3 5", "PING")` expecting `:0\r\n+PONG\r\n` — regression guard, **not** a red signal. On main that command writes nothing, so `LightClient.CompletePendingRequests` spins on a token that never arrives and the test hangs rather than fails. That is why it is ordered last, behind an assertion that fails cleanly.

None of the new commands remove anything, so the pre-existing assertions after them are unaffected.