### PR TITLE
Fix LRANGE returning the head element when stop is more negative than the list length

### DIFF
--- a/libs/server/Objects/List/ListObjectImpl.cs
+++ b/libs/server/Objects/List/ListObjectImpl.cs
@@ -144,7 +144,6 @@ namespace Garnet.server
                 if (start < 0) start = 0;
 
                 stop = stop < 0 ? list.Count + stop : stop;
-                if (stop < 0) stop = 0;
                 if (stop >= list.Count) stop = list.Count - 1;
 
                 if (start > stop || 0 == list.Count)

--- a/test/standalone/Garnet.test.collections/RespListTests.cs
+++ b/test/standalone/Garnet.test.collections/RespListTests.cs
@@ -678,6 +678,42 @@ namespace Garnet.test
             ClassicAssert.AreEqual(2, result.Length);
             ClassicAssert.IsTrue(result[0].ToString().Equals("f"));
             ClassicAssert.IsTrue(result[1].ToString().Equals("g"));
+
+            // A stop that is still negative after adding the list length addresses nothing,
+            // so the reply must be an empty array and not the head of the list
+            var key3 = "mylist3";
+            _ = db.ListRightPush(key3, "a");
+            _ = db.ListRightPush(key3, "b");
+            _ = db.ListRightPush(key3, "c");
+
+            result = db.ListRange(key3, 0, -3);
+            ClassicAssert.AreEqual(1, result.Length);
+            ClassicAssert.IsTrue(result[0].ToString().Equals("a"));
+
+            result = db.ListRange(key3, 0, -4);
+            ClassicAssert.AreEqual(0, result.Length);
+
+            result = db.ListRange(key3, 0, -5);
+            ClassicAssert.AreEqual(0, result.Length);
+
+            result = db.ListRange(key3, -5, -4);
+            ClassicAssert.AreEqual(0, result.Length);
+
+            result = db.ListRange(key3, 1, -10);
+            ClassicAssert.AreEqual(0, result.Length);
+
+            var key5 = "mylist5";
+            _ = db.ListRightPush(key5, "a");
+            _ = db.ListRightPush(key5, "b");
+            _ = db.ListRightPush(key5, "c");
+            _ = db.ListRightPush(key5, "d");
+            _ = db.ListRightPush(key5, "e");
+
+            result = db.ListRange(key5, 0, -6);
+            ClassicAssert.AreEqual(0, result.Length);
+
+            result = db.ListRange(key5, 0, -7);
+            ClassicAssert.AreEqual(0, result.Length);
         }
 
         [Test]


### PR DESCRIPTION
`LRANGE` over a range whose `stop` is more negative than the list length returns the first element instead of an empty array.

```
$ redis-cli RPUSH lk a b c
(integer) 3

$ redis-cli LRANGE lk 0 -4
1) "a"            # Garnet; Redis replies (empty array)

$ redis-cli LRANGE lk 0 -5
1) "a"            # Garnet; Redis replies (empty array)
```

`LRANGE lk 0 -3` is the last range that still addresses an element (`a`). Anything past it addresses nothing and should come back empty.

## Root cause

`libs/server/Objects/List/ListObjectImpl.cs:147`

```csharp
start = start < 0 ? list.Count + start : start;
if (start < 0) start = 0;

stop = stop < 0 ? list.Count + stop : stop;
if (stop < 0) stop = 0;                          // <-- this line
if (stop >= list.Count) stop = list.Count - 1;

if (start > stop || 0 == list.Count)
```

A `stop` that is still negative after adding `list.Count` addresses nothing. Clamping it to `0` turns it into the head index, and since `start` was already clamped to `0` two lines above, the `start > stop` guard no longer fires. The range collapses to `[0, 0]` and one element is written.

## Fix

Delete the clamp. `start` is guaranteed `>= 0`, so leaving `stop` negative lets the existing `start > stop` guard fire and write the empty array.

This matches how sorted sets already do it: `ZRANGE` by index in `libs/server/Objects/SortedSet/SortedSetObjectImpl.cs:478-500` normalizes a negative `maxIndex` without clamping it to `0`, and clamps `minIndex` to `0` only *after* its `(minIndex < 0 && maxIndex < 0) || (minIndex > maxIndex)` emptiness check has run. `ListTrim` in the same file (`ListObjectImpl.cs:185`) likewise keeps `end < 0` as its own empty-range term rather than clamping it away.

The `stop >= list.Count` clamp stays where it is, above the `start > stop` check: unlike Redis, Garnet's guard carries no `start >= list.Count` term, so that clamp is what makes `LRANGE lk 5 100` empty.

## Tests

Extended `CanDoLRANGEcorrect` in `test/standalone/Garnet.test.collections/RespListTests.cs`.

Fail on `main` today, pass with the fix — each returns `["a"]` where an empty array is expected:

- `LRANGE key3 0 -4`, `LRANGE key3 0 -5`, `LRANGE key3 -5 -4` on a 3-element list
- `LRANGE key5 0 -6`, `LRANGE key5 0 -7` on a 5-element list

Already pass on `main`, added as regression guards for the boundary on either side:

- `LRANGE key3 0 -3` -> `["a"]`, the last `stop` that still addresses an element
- `LRANGE key3 1 -10` -> empty, which `main` gets right only by accident because `start = 1` exceeded the clamped `stop = 0`

Existing coverage that pins the clamp order stays green: `CanDoLRANGEbasic` asserts `LRANGE key -100 100` -> 3 elements and `LRANGE key 5 100` -> empty on a 3-element list, and `CanReturnEmptyArrayinListLC` asserts `LRANGE mylist 5 10` -> `*0\r\n` on the wire.