### PR TITLE
Fix BLMPOP writing a second reply when force-unblocked via CLIENT UNBLOCK

### DIFF
--- a/libs/server/Resp/Objects/ListCommands.cs
+++ b/libs/server/Resp/Objects/ListCommands.cs
@@ -916,6 +916,7 @@ namespace Garnet.server
             {
                 while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_UNBLOCKED_CLIENT_VIA_CLIENT_UNBLOCK, ref dcurr, dend))
                     SendAndReset();
+                return true;
             }
 
             if (result.IsTypeMismatch)

--- a/test/standalone/Garnet.test/RespTests.cs
+++ b/test/standalone/Garnet.test/RespTests.cs
@@ -5195,6 +5195,47 @@ namespace Garnet.test
         }
 
         [Test]
+        [TestCase("BLMPOP 10 1 keyA LEFT", Description = "BLMPOP replies to CLIENT UNBLOCK ERROR with the error only")]
+        [TestCase("BLPOP keyA 10", Description = "BLPOP replies to CLIENT UNBLOCK ERROR with the error only")]
+        [TestCase("BLMOVE keyA keyB LEFT LEFT 10", Description = "BLMOVE replies to CLIENT UNBLOCK ERROR with the error only")]
+        [TestCase("BZMPOP 10 1 keyA MIN", Description = "BZMPOP replies to CLIENT UNBLOCK ERROR with the error only")]
+        public async Task ClientUnblockWithErrorWritesSingleReplyTest(string blockingCommand)
+        {
+            var expectedError = "-UNBLOCKED client unblocked via CLIENT UNBLOCK\r\n";
+            var expectedPong = "+PONG\r\n";
+
+            using var mainConnection = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
+            var mainDB = mainConnection.GetDatabase(0);
+
+            // Start blocking client
+            using var blockingClient = TestUtils.CreateRequest();
+            var clientIdResponse = Encoding.ASCII.GetString(blockingClient.SendCommand("CLIENT ID"));
+            var clientId = clientIdResponse.Substring(1, clientIdResponse.IndexOf("\r\n") - 1);
+
+            string blockingResponse = null;
+            var blockingTask = taskFactory.StartNew(() =>
+            {
+                var response = blockingClient.SendCommand(blockingCommand);
+                blockingResponse = Encoding.ASCII.GetString(response, 0, expectedError.Length);
+            });
+
+            // Wait for client to enter blocking state
+            await Task.Delay(1000).ConfigureAwait(false);
+
+            // Unblock from main connection
+            var unblockResult = (int)mainDB.Execute("CLIENT", "UNBLOCK", clientId, "ERROR");
+            ClassicAssert.AreEqual(1, unblockResult);
+            blockingTask.Wait();
+
+            ClassicAssert.AreEqual(expectedError, blockingResponse);
+
+            // The error is the only reply the blocking command may write - a second reply (a null)
+            // would shift every subsequent reply on this connection by one
+            var pingResponse = Encoding.ASCII.GetString(blockingClient.SendCommand("PING"), 0, expectedPong.Length);
+            ClassicAssert.AreEqual(expectedPong, pingResponse, $"Expected PING to be answered with +PONG after unblocking {blockingCommand}");
+        }
+
+        [Test]
         [TestCase(0, Description = "Guarantied concurrent unblock test")]
         [TestCase(3, Description = "Random chance unblock sucess/failed case")]
         [TestCase(20, Description = "Probable unblock failed case")]


### PR DESCRIPTION
## Symptom

A connection blocked in `BLMPOP` and released with `CLIENT UNBLOCK <id> ERROR` receives two top-level replies for that one command. Every reply on that connection afterwards is shifted by one, permanently.

```
# terminal 1
$ redis-cli -p 6379
127.0.0.1:6379> CLIENT ID
(integer) 3
127.0.0.1:6379> BLMPOP 30 1 mylist LEFT          # blocks

# terminal 2
$ redis-cli -p 6379 CLIENT UNBLOCK 3 ERROR
(integer) 1

# terminal 1 unblocks, then:
(error) UNBLOCKED client unblocked via CLIENT UNBLOCK
127.0.0.1:6379> PING
(nil)                                            # expected: PONG
127.0.0.1:6379> ECHO hi
PONG                                             # expected: "hi"
```

On the wire, the single `BLMPOP` produces:

```
current:   -UNBLOCKED client unblocked via CLIENT UNBLOCK\r\n$-1\r\n
expected:  -UNBLOCKED client unblocked via CLIENT UNBLOCK\r\n
```

Under RESP3 the stray second reply is `_\r\n` instead of `$-1\r\n`.

`BLPOP`, `BRPOP`, `BLMOVE`, `BRPOPLPUSH`, `BZPOPMIN`, `BZPOPMAX` and `BZMPOP` are not affected.

## Root cause

`libs/server/Resp/Objects/ListCommands.cs:915-919` — the force-unblock branch of `ListBlockingPopMultiple` writes the error but does not return:

```csharp
if (result.IsForceUnblocked)
{
    while (!RespWriteUtils.TryWriteError(CmdStrings.RESP_UNBLOCKED_CLIENT_VIA_CLIENT_UNBLOCK, ref dcurr, dend))
        SendAndReset();
}
```

`CollectionItemResult.ForceUnblocked` (`libs/server/Objects/ItemBroker/CollectionItemResult.cs:91`) leaves `Key` null and `IsTypeMismatch` false, so `Found => Key != default` is false. Execution falls through the `IsTypeMismatch` check into `if (!result.Found) { WriteNull(); return true; }` at line 928 and emits the second reply.

## Fix

Add the missing `return true;`. All four sibling blocking handlers already return from this branch:

- `ListCommands.cs:286` — `ListBlockingPop` (BLPOP/BRPOP)
- `ListCommands.cs:378` — `ListBlockingMove` (BLMOVE/BRPOPLPUSH)
- `SortedSetCommands.cs:1563` — `SortedSetBlockingPop` (BZPOPMIN/BZPOPMAX)
- `SortedSetCommands.cs:1671` — `SortedSetBlockingMPop` (BZMPOP)

`ListBlockingPopMultiple` was the only one of the five missing it. The skipped code is write-only, so nothing else is affected.

## Test

`ClientUnblockWithErrorWritesSingleReplyTest` in `test/standalone/Garnet.test/RespTests.cs` blocks a raw-RESP client (`LightClientRequest`), unblocks it with `CLIENT UNBLOCK <id> ERROR`, asserts the error is the first reply, then sends `PING` on that same connection and asserts `+PONG`. The `PING` check has to be raw RESP — a StackExchange.Redis multiplexer cannot observe an extra reply.

Which assertions are actually red on `main`:

- `BLMPOP 10 1 keyA LEFT` — the final `PING` assertion fails; the client reads the stray `$-1` where `+PONG` belongs. This is the only new assertion that fails without the production change.
- `BLPOP keyA 10`, `BLMOVE keyA keyB LEFT LEFT 10`, `BZMPOP 10 1 keyA MIN` — green on `main` already. They are regression guards so the missing `return` cannot reappear in the siblings.

The `-UNBLOCKED` assertion inside the BLMPOP case also passes on `main`; the error is still written first, and the desync only becomes visible on the next command.