### PR TITLE
Validate numkeys in SINTERCARD, ZINTERSTORE and LMPOP/BLMPOP

### DIFF
--- a/libs/server/Resp/Objects/ListCommands.cs
+++ b/libs/server/Resp/Objects/ListCommands.cs
@@ -195,7 +195,7 @@ namespace Garnet.server
             var currTokenId = 0;
 
             // Read count of keys
-            if (!parseState.TryGetInt(currTokenId++, out var numKeys))
+            if (!parseState.TryGetInt(currTokenId++, out var numKeys) || numKeys < 1)
             {
                 var err = string.Format(CmdStrings.GenericErrShouldBeGreaterThanZero, "numkeys");
                 return AbortWithErrorMessage(Encoding.ASCII.GetBytes(err));
@@ -863,7 +863,7 @@ namespace Garnet.server
                 return AbortWithErrorMessage(error);
 
             // Read count of keys
-            if (!parseState.TryGetInt(currTokenId++, out var numKeys))
+            if (!parseState.TryGetInt(currTokenId++, out var numKeys) || numKeys < 1)
             {
                 var err = string.Format(CmdStrings.GenericParamShouldBeGreaterThanZero, "numkeys");
                 return AbortWithErrorMessage(Encoding.ASCII.GetBytes(err));

--- a/libs/server/Resp/Objects/SetCommands.cs
+++ b/libs/server/Resp/Objects/SetCommands.cs
@@ -170,6 +170,11 @@ namespace Garnet.server
                 return AbortWithErrorMessage(CmdStrings.RESP_ERR_GENERIC_VALUE_IS_NOT_INTEGER);
             }
 
+            if (nKeys < 1)
+            {
+                return AbortWithErrorMessage(Encoding.ASCII.GetBytes(string.Format(CmdStrings.GenericErrShouldBeGreaterThanZero, "numkeys")));
+            }
+
             if ((parseState.Count - 1) < nKeys)
             {
                 return AbortWithErrorMessage(Encoding.ASCII.GetBytes(string.Format(CmdStrings.GenericErrShouldBeGreaterThanZero, "numkeys")));

--- a/libs/server/Resp/Objects/SortedSetCommands.cs
+++ b/libs/server/Resp/Objects/SortedSetCommands.cs
@@ -1244,6 +1244,18 @@ namespace Garnet.server
                 return AbortWithErrorMessage(CmdStrings.RESP_ERR_GENERIC_VALUE_IS_NOT_INTEGER);
             }
 
+            if (nKeys < 1)
+            {
+                return AbortWithErrorMessage(CmdStrings.GenericErrAtLeastOneKey, nameof(RespCommand.ZINTERSTORE));
+            }
+
+            // Subtract rather than add, so that a numkeys near int.MaxValue cannot overflow past the
+            // check and reach the slice below. parseState.Count is at least 3 here.
+            if (parseState.Count - 2 < nKeys)
+            {
+                return AbortWithErrorMessage(CmdStrings.RESP_SYNTAX_ERROR);
+            }
+
             var destination = parseState.GetArgSliceByRef(0);
             var keys = parseState.Parameters.Slice(2, nKeys);
 

--- a/test/standalone/Garnet.test.collections/RespListTests.cs
+++ b/test/standalone/Garnet.test.collections/RespListTests.cs
@@ -1480,6 +1480,23 @@ namespace Garnet.test
             // The connection must survive, and the list must be untouched.
             ClassicAssert.AreEqual("PONG", db.Execute("PING").ToString());
             ClassicAssert.AreEqual(3, db.ListLength(key));
+
+            // A negative numkeys used to reach 'new PinnedSpanByte[numKeys]' and throw out of the
+            // command handler, which tore down the connection without writing any reply. A zero
+            // numkeys did not throw, but answered a null array where Redis replies with an error.
+            using var lightClientRequest = TestUtils.CreateRequest();
+            var expectedResponse = $"-{string.Format(CmdStrings.GenericErrShouldBeGreaterThanZero, "numkeys")}\r\n+PONG\r\n";
+
+            var response = lightClientRequest.SendCommands("LMPOP -1 a b", "PING");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
+            response = lightClientRequest.SendCommands("LMPOP 0 LEFT COUNT 5", "PING");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
+            expectedResponse = $"-{string.Format(CmdStrings.GenericParamShouldBeGreaterThanZero, "numkeys")}\r\n+PONG\r\n";
+
+            response = lightClientRequest.SendCommands("BLMPOP 0 -1 a b", "PING");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]

--- a/test/standalone/Garnet.test.collections/RespSetTest.cs
+++ b/test/standalone/Garnet.test.collections/RespSetTest.cs
@@ -749,6 +749,18 @@ namespace Garnet.test
             ex = Assert.Throws<RedisServerException>(() => db.Execute("SINTERCARD", 2, "key1", "key2", "LIMIT"));
 
             ex = Assert.Throws<RedisServerException>(() => db.Execute("SINTERCARD", 2, "key1", "key2", "LIMIT", "not_a_number"));
+
+            // A negative numkeys used to reach Parameters.Slice(1, nKeys) and throw out of the
+            // command handler, which tore down the connection without writing any reply. A zero
+            // numkeys did not throw, but answered ':0' where Redis replies with an error.
+            using var lightClientRequest = TestUtils.CreateRequest();
+            var expectedResponse = $"-{string.Format(CmdStrings.GenericErrShouldBeGreaterThanZero, "numkeys")}\r\n+PONG\r\n";
+
+            var response = lightClientRequest.SendCommands("SINTERCARD -1 key1", "PING");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
+            response = lightClientRequest.SendCommands("SINTERCARD 0 LIMIT 0", "PING");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
         }
 
         [Test]

--- a/test/standalone/Garnet.test.collections/RespSortedSetTests.cs
+++ b/test/standalone/Garnet.test.collections/RespSortedSetTests.cs
@@ -5172,6 +5172,41 @@ namespace Garnet.test
         }
 
         [Test]
+        public void CanDoZInterStoreWithBadNumKeysLC()
+        {
+            using var lightClientRequest = TestUtils.CreateRequest();
+
+            // A negative numkeys, or one that exceeds the number of keys actually sent, used to
+            // reach Parameters.Slice(2, nKeys) and throw out of the command handler, which tore
+            // down the connection without writing any reply. A zero numkeys did not throw, but
+            // reported a syntax error rather than the at-least-one-key error its ZUNIONSTORE
+            // sibling reports.
+            var expectedResponse = $"-{string.Format(CmdStrings.GenericErrAtLeastOneKey, nameof(RespCommand.ZINTERSTORE))}\r\n+PONG\r\n";
+
+            var response = lightClientRequest.SendCommands("ZINTERSTORE dest -1 zset1", "PING");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
+            response = lightClientRequest.SendCommands("ZINTERSTORE dest 0 zset1", "PING");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
+            expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_SYNTAX_ERROR)}\r\n+PONG\r\n";
+
+            response = lightClientRequest.SendCommands("ZINTERSTORE dest 2 zset1", "PING");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
+            response = lightClientRequest.SendCommands("ZINTERSTORE dest 3 zset1 zset2", "PING");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
+            // A numkeys near int.MaxValue overflowed the argument-count check when it was written as
+            // 'parseState.Count < nKeys + 2', so it slipped past and still reached the slice.
+            response = lightClientRequest.SendCommands("ZINTERSTORE dest 2147483647 zset1", "PING");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+
+            response = lightClientRequest.SendCommands("ZINTERSTORE dest 2147483646 zset1", "PING");
+            TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+        }
+
+        [Test]
         public void ZInterResultOrder()
         {
             using var lightClientRequest = TestUtils.CreateRequest();


### PR DESCRIPTION
## Symptom

Against a server built from `main` (8b329e3), three commands close the client connection instead of replying:

```
$ redis-cli -p 3278
127.0.0.1:3278> SINTERCARD -1 key1
Error: Server closed the connection
127.0.0.1:3278> ZINTERSTORE dest -1 zset1
Error: Server closed the connection
127.0.0.1:3278> LMPOP -1 a b
Error: Server closed the connection
```

Each throws out of its command handler, so the session is torn down and **nothing at all is written to the socket**. A pipelining client does not see an error, it sees its remaining replies shift by one. Expected in all three cases is an error reply on a connection that stays open.

Three more inputs do not throw but answer something other than an error:

| command | on `main` | expected |
| --- | --- | --- |
| `SINTERCARD 0 LIMIT 0` | `:0` | `-ERR numkeys should be greater than 0` |
| `LMPOP 0 LEFT COUNT 5` | `*-1` | `-ERR numkeys should be greater than 0` |
| `ZINTERSTORE dest 0 zset1` | `-ERR syntax error` | `-ERR at least 1 input key is needed for 'ZINTERSTORE' command` |

And `ZINTERSTORE dest 2 zset1` — a `numkeys` larger than the number of keys actually sent — also drops the connection, where `ZUNIONSTORE dest 2 zset1` already replies `-ERR syntax error`.

## Root cause

Each handler parses `numkeys` and uses it directly as a span or array length with no lower bound:

- `libs/server/Resp/Objects/SetCommands.cs:178` — `parseState.Parameters.Slice(1, nKeys)`
- `libs/server/Resp/Objects/SortedSetCommands.cs:1248` — `parseState.Parameters.Slice(2, nKeys)`
- `libs/server/Resp/Objects/ListCommands.cs:208` — `new PinnedSpanByte[numKeys]`
- `libs/server/Resp/Objects/ListCommands.cs:878` — `new byte[numKeys][]`

The arity checks above those lines compare against `numkeys` itself and pass vacuously for negative values: SINTERCARD's `(parseState.Count - 1) < nKeys` is false for any negative `nKeys`, and LMPOP's `parseState.Count != numKeys + 2 && parseState.Count != numKeys + 4` happens to match on the shapes above (`LMPOP -1 a b` has `Count == 3 == numKeys + 4`). `Slice` then throws `ArgumentOutOfRangeException`, `new T[negative]` throws `OverflowException`.

ZINTERSTORE additionally has no check that the argument count covers `numkeys`, which is what lets `ZINTERSTORE dest 2 zset1` slice past the end of the parse state.

## Fix

Add the missing `numkeys < 1` guard to each handler, reusing the error string that handler already emits:

- **SINTERCARD** — `ERR numkeys should be greater than 0`, the same string as the `(parseState.Count - 1) < nKeys` check five lines below it, and the same string Redis's `sinterCardCommand` emits.
- **ZINTERSTORE** — `GenericErrAtLeastOneKey`, plus the argument-count check its `SortedSetUnionStore` sibling carries at `libs/server/Resp/Objects/SortedSetCommands.cs:1464-1471`. The count check is written as `parseState.Count - 2 < nKeys` rather than `parseState.Count < nKeys + 2`: the two are equivalent for every value that does not overflow, but the addition form wraps negative for `numkeys` >= 2147483646 and lets it through. `parseState.Count` is at least 3 here, so the subtraction cannot underflow.
- **LMPOP / BLMPOP** — folded into the existing `TryGetInt` condition, the same shape used for the `COUNT` guard in these two handlers, so each keeps the wording it already uses (LMPOP `ERR numkeys should be greater than 0`, BMPOP `` ERR Parameter `numkeys` should be greater than 0 ``). No existing message is reworded.

Happy paths are unchanged: `SINTERCARD 1 s`, `SINTERCARD 1 s LIMIT 2`, `ZINTERSTORE d 1 z` and `LMPOP 1 L LEFT` behave as before, and every existing `CanDoZInterStore` case — including `ZINTERSTORE dest 3 zset1 zset2 nx` — still passes both new ZINTERSTORE guards.

## Tests

Eleven new assertions, **all of which fail on `main` today**. None is a green-state regression guard.

`CanDoSinterCardThowsErrors` (`RespSetTest.cs`)
- `SINTERCARD -1 key1` — connection dropped on `main`
- `SINTERCARD 0 LIMIT 0` — replies `:0` on `main`

`CanDoRejectBadLMPOPCommand` (`RespListTests.cs`)
- `LMPOP -1 a b` — connection dropped on `main`
- `LMPOP 0 LEFT COUNT 5` — replies `*-1` on `main`
- `BLMPOP 0 -1 a b` — connection dropped on `main`

`CanDoZInterStoreWithBadNumKeysLC` (`RespSortedSetTests.cs`, new)
- `ZINTERSTORE dest -1 zset1` — connection dropped on `main`
- `ZINTERSTORE dest 0 zset1` — replies `-ERR syntax error` on `main`
- `ZINTERSTORE dest 2 zset1` — connection dropped on `main`
- `ZINTERSTORE dest 3 zset1 zset2` — connection dropped on `main`
- `ZINTERSTORE dest 2147483647 zset1` — connection dropped on `main`
- `ZINTERSTORE dest 2147483646 zset1` — connection dropped on `main`

The last two are the overflow cases, added after review feedback on this PR: with the addition form of
the count check they slipped past the guard and still reached the slice. 2147483645 is the largest
`numkeys` that does not overflow and is handled correctly either way.

These use `LightClientRequest` rather than StackExchange.Redis on purpose: the pre-fix failure is an *absent* reply on a dropped socket, which a StackExchange.Redis assertion cannot tell apart from a normal error. Each command is pipelined with a following `PING` so the assertion also proves the session survives and the reply stream stays aligned.

## Out of scope

The additive form of this argument-count check predates this PR and appears in other handlers in the
same family on `main`. This PR only changes the check it introduces; auditing the rest belongs in a
separate change, which I am happy to prepare. SINTERCARD and LMPOP/BLMPOP are unaffected either way —
their bound checks do not add to `numkeys`.
