### PR TITLE
Remove the LightEpoch EntryAt accessor

### DIFF
--- a/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.EntryTable.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.EntryTable.cs
@@ -2,17 +2,27 @@
 // Licensed under the MIT license.
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 
 namespace Tsavorite.core
 {
     public sealed unsafe partial class LightEpoch
     {
         /// <summary>
-        /// The epoch table slot at <paramref name="index"/>, by reference.
+        /// Asserts that a slot is reserved for the calling thread.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private ref Entry EntryAt(int index) => ref *(tableAligned + index);
+        [Conditional("DEBUG")]
+        private static void DebugAssertEntryReserved(int index, string message = "No epoch table entry is reserved for this thread")
+        {
+            Debug.Assert(index != kInvalidIndex, message, "No slot is reserved for this thread.");
+            Debug.Assert(index > kInvalidIndex && index <= kTableSize, message, $"Slot {index} is out of range.");
+        }
+
+        /// <summary>
+        /// Asserts that no slot is reserved for the calling thread.
+        /// </summary>
+        [Conditional("DEBUG")]
+        private static void DebugAssertEntryNotReserved(int index, string message = "An epoch table entry is already reserved for this thread")
+            => Debug.Assert(index == kInvalidIndex, message, $"Slot {index} is already reserved for this thread.");
 
         /// <summary>
         /// Asserts that the slot at <paramref name="index"/> is acquired by the calling thread.
@@ -20,7 +30,8 @@ namespace Tsavorite.core
         [Conditional("DEBUG")]
         private void DebugAssertEpochAcquired(int index, string message = "Epoch table entry is not acquired by this thread")
         {
-            ref var entry = ref EntryAt(index);
+            DebugAssertEntryReserved(index, message);
+            ref var entry = ref *(tableAligned + index);
             Debug.Assert(entry.localCurrentEpoch > 0, message, "The slot has no announced epoch.");
             Debug.Assert(entry.threadId == Metadata.threadId, message, "The slot does not carry this thread's id.");
         }

--- a/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.TestHooks.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.TestHooks.cs
@@ -20,18 +20,18 @@ namespace Tsavorite.core
         internal long TestHookThisThreadAnnouncedEpoch()
         {
             var entry = Metadata.Entries.GetRef(instanceId);
-            return entry == kInvalidIndex ? 0 : EntryAt(entry).localCurrentEpoch;
+            return entry == kInvalidIndex ? 0 : (*(tableAligned + entry)).localCurrentEpoch;
         }
 
         /// <summary>
         /// The epoch announced in epoch table slot <paramref name="entry"/>, or 0 if the slot is free.
         /// </summary>
-        internal long TestHookAnnouncedEpochAt(int entry) => EntryAt(entry).localCurrentEpoch;
+        internal long TestHookAnnouncedEpochAt(int entry) => (*(tableAligned + entry)).localCurrentEpoch;
 
         /// <summary>
         /// The thread id recorded in epoch table slot <paramref name="entry"/>, or 0 if the slot is free.
         /// </summary>
-        internal int TestHookThreadIdAt(int entry) => EntryAt(entry).threadId;
+        internal int TestHookThreadIdAt(int entry) => (*(tableAligned + entry)).threadId;
 
         /// <summary>
         /// Capacity of the drain list.

--- a/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Epochs/LightEpoch.cs
@@ -299,12 +299,11 @@ namespace Tsavorite.core
         {
             ref var entry = ref Metadata.Entries.GetRef(instanceId);
 
-            Debug.Assert(entry > 0, "Trying to refresh unacquired epoch");
-            DebugAssertEpochAcquired(entry);
+            DebugAssertEpochAcquired(entry, "Trying to refresh unacquired epoch");
 
             // Refresh the announced epoch to CurrentEpoch
             var epoch = Volatile.Read(ref CurrentEpoch);
-            Volatile.Write(ref EntryAt(entry).localCurrentEpoch, epoch);
+            Volatile.Write(ref (*(tableAligned + entry)).localCurrentEpoch, epoch);
 
             // Max epoch across all threads may have advanced, so check for pending drain actions to process
             if (drainCount > 0)
@@ -441,7 +440,7 @@ namespace Tsavorite.core
 
             for (var index = 1; index <= kTableSize; index++)
             {
-                var entry_epoch = Volatile.Read(ref EntryAt(index).localCurrentEpoch);
+                var entry_epoch = Volatile.Read(ref (*(tableAligned + index)).localCurrentEpoch);
                 if (0 != entry_epoch)
                 {
                     if (entry_epoch < oldestOngoingCall)
@@ -515,7 +514,7 @@ namespace Tsavorite.core
         void Acquire()
         {
             ref var entry = ref Metadata.Entries.GetRef(instanceId);
-            Debug.Assert(entry == kInvalidIndex,
+            DebugAssertEntryNotReserved(entry,
                 "Trying to acquire protected epoch. Make sure you do not re-enter Tsavorite from callbacks or IDevice implementations. If using tasks, use TaskCreationOptions.RunContinuationsAsynchronously.");
 
             // Reserve an entry in the epoch table for this thread and set localCurrentEpoch
@@ -547,7 +546,7 @@ namespace Tsavorite.core
             // of the two. A release store guarantees that the threadId clear cannot be reordered after
             // it. Were the order to flip, another thread could claim the slot and write its own threadId
             // in the gap, and this thread's clear would then land on top and wipe it.
-            Volatile.Write(ref EntryAt(entry).localCurrentEpoch, 0);
+            Volatile.Write(ref (*(tableAligned + entry)).localCurrentEpoch, 0);
 
             entry = kInvalidIndex;
             if (waiterCount > 0)
@@ -608,15 +607,15 @@ namespace Tsavorite.core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         bool TryClaimEntry(int entry)
         {
-            if (EntryAt(entry).localCurrentEpoch != 0)
+            if ((*(tableAligned + entry)).localCurrentEpoch != 0)
                 return false;
 
             var epoch = Volatile.Read(ref CurrentEpoch);
-            if (Interlocked.CompareExchange(ref EntryAt(entry).localCurrentEpoch, epoch, 0) != 0)
+            if (Interlocked.CompareExchange(ref (*(tableAligned + entry)).localCurrentEpoch, epoch, 0) != 0)
                 return false;
 
             // The slot is now exclusively ours, so threadId needs no interlocked write.
-            EntryAt(entry).threadId = Metadata.threadId;
+            (*(tableAligned + entry)).threadId = Metadata.threadId;
             return true;
         }
 


### PR DESCRIPTION
## Summary

Follow-up cleanup to `LightEpoch` after #2015. Cosmetic only.

- **Remove `EntryAt`** and inline every epoch table access as `*(tableAligned + i)`. An `AggressiveInlining` accessor on the epoch hot path adds an inline frame in every caller and eats into the JIT's inlining budget for no benefit, so the raw dereference stays.
