### PR TITLE
Move Tsavorite.test.epoch into Tsavorite.slnx and run it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,32 +222,32 @@ jobs:
         os: [ ubuntu-latest, windows-latest ]
         framework: [ 'net8.0', 'net10.0' ]
         configuration: [ 'Debug', 'Release' ]
-        test: [ 'Tsavorite.test', 'Tsavorite.test.recordops', 'Tsavorite.test.session', 'Tsavorite.test.session.context', 'Tsavorite.test.hlog', 'Tsavorite.test.recovery' ]
+        test: [ 'Tsavorite.test', 'Tsavorite.test.recordops', 'Tsavorite.test.session', 'Tsavorite.test.session.context', 'Tsavorite.test.hlog', 'Tsavorite.test.recovery', 'Tsavorite.test.epoch' ]
     if: needs.changes.outputs.tsavorite == 'true'
     steps:
       - name: Check out code
         uses: actions/checkout@v6
       - name: Set environment variable for Linux
         run: echo "RunAzureTests=yes" >> $GITHUB_ENV
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.test != 'Tsavorite.test.recordops' && matrix.test != 'Tsavorite.test.session' && matrix.test != 'Tsavorite.test.session.context' && matrix.test != 'Tsavorite.test.recovery' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.test != 'Tsavorite.test.recordops' && matrix.test != 'Tsavorite.test.session' && matrix.test != 'Tsavorite.test.session.context' && matrix.test != 'Tsavorite.test.recovery' && matrix.test != 'Tsavorite.test.epoch' }}
       - name: Set environment variable for Windows
         run: echo ("RunAzureTests=yes") >> $env:GITHUB_ENV
-        if: ${{ matrix.os == 'windows-latest' && matrix.test != 'Tsavorite.test.recordops' && matrix.test != 'Tsavorite.test.session' && matrix.test != 'Tsavorite.test.session.context' && matrix.test != 'Tsavorite.test.recovery' }}
+        if: ${{ matrix.os == 'windows-latest' && matrix.test != 'Tsavorite.test.recordops' && matrix.test != 'Tsavorite.test.session' && matrix.test != 'Tsavorite.test.session.context' && matrix.test != 'Tsavorite.test.recovery' && matrix.test != 'Tsavorite.test.epoch' }}
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
       - name: Setup Node.js for Azurite
-        if: ${{ matrix.test != 'Tsavorite.test.recordops' && matrix.test != 'Tsavorite.test.session' && matrix.test != 'Tsavorite.test.session.context' && matrix.test != 'Tsavorite.test.recovery' }}
+        if: ${{ matrix.test != 'Tsavorite.test.recordops' && matrix.test != 'Tsavorite.test.session' && matrix.test != 'Tsavorite.test.session.context' && matrix.test != 'Tsavorite.test.recovery' && matrix.test != 'Tsavorite.test.epoch' }}
         uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: Cache Azurite
-        if: ${{ matrix.test != 'Tsavorite.test.recordops' && matrix.test != 'Tsavorite.test.session' && matrix.test != 'Tsavorite.test.session.context' && matrix.test != 'Tsavorite.test.recovery' }}
+        if: ${{ matrix.test != 'Tsavorite.test.recordops' && matrix.test != 'Tsavorite.test.session' && matrix.test != 'Tsavorite.test.session.context' && matrix.test != 'Tsavorite.test.recovery' && matrix.test != 'Tsavorite.test.epoch' }}
         uses: actions/cache@v5
         with:
           path: ${{ runner.os == 'Windows' && '%APPDATA%\npm-cache' || '~/.npm' }}
           key: azurite-${{ runner.os }}
       - name: Install and Run Azurite
-        if: ${{ matrix.test != 'Tsavorite.test.recordops' && matrix.test != 'Tsavorite.test.session' && matrix.test != 'Tsavorite.test.session.context' && matrix.test != 'Tsavorite.test.recovery' }}
+        if: ${{ matrix.test != 'Tsavorite.test.recordops' && matrix.test != 'Tsavorite.test.session' && matrix.test != 'Tsavorite.test.session.context' && matrix.test != 'Tsavorite.test.recovery' && matrix.test != 'Tsavorite.test.epoch' }}
         shell: bash
         run: |
           npm install -g azurite
@@ -271,6 +271,7 @@ jobs:
             'Tsavorite.test.session.context' = 'libs/storage/Tsavorite/cs/test/test.session.context'
             'Tsavorite.test.hlog' = 'libs/storage/Tsavorite/cs/test/test.hlog'
             'Tsavorite.test.recovery' = 'libs/storage/Tsavorite/cs/test/test.recovery'
+            'Tsavorite.test.epoch' = 'libs/storage/Tsavorite/cs/test/test.epoch'
           }
           $dir = $tsavoriteDirMap['${{ matrix.test }}']
           echo "TSAVORITE_TEST_DIR=$dir" >> $env:GITHUB_ENV

--- a/Garnet.slnx
+++ b/Garnet.slnx
@@ -77,7 +77,6 @@
     <File Path="Version.props" />
   </Folder>
   <Folder Name="/test/">
-    <Project Path="libs/storage/Tsavorite/cs/test/test.epoch/Tsavorite.test.epoch.csproj" />
     <Project Path="test/Garnet.fuzz/Garnet.fuzz.csproj" />
     <Project Path="test/standalone/BfTreeInterop.test/BfTreeInterop.test.csproj" />
     <Project Path="test/standalone/Garnet.test/Garnet.test.csproj" />

--- a/libs/storage/Tsavorite/cs/Tsavorite.slnx
+++ b/libs/storage/Tsavorite/cs/Tsavorite.slnx
@@ -17,6 +17,7 @@
     <Project Path="test/test.session/Tsavorite.test.session.csproj" />
     <Project Path="test/test.session.context/Tsavorite.test.session.context.csproj" />
     <Project Path="test/test.hlog/Tsavorite.test.hlog.csproj" />
+    <Project Path="test/test.epoch/Tsavorite.test.epoch.csproj" />
     <Project Path="test/test.recovery/Tsavorite.test.recovery.csproj" />
     <Project Path="test/test.stress/Tsavorite.test.stress.csproj" />
     <Project Path="test/stress/MLPAStress/MLPAStress.csproj" />

--- a/libs/storage/Tsavorite/cs/test/test.epoch/Tsavorite.test.epoch.csproj
+++ b/libs/storage/Tsavorite/cs/test/test.epoch/Tsavorite.test.epoch.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\core\Tsavorite.core.csproj" />
-    <ProjectReference Include="..\..\..\..\..\..\test\standalone\Garnet.test\Garnet.test.csproj" />
+    <ProjectReference Include="..\Tsavorite.test.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Why did `Tsavorite.test.epoch` end up in `Garnet.slnx`?

Because it took a `ProjectReference` on `Garnet.test.csproj`:

```xml
<ProjectReference Include="..\..\src\core\Tsavorite.core.csproj" />
<ProjectReference Include="..\..\..\..\..\..\test\standalone\Garnet.test\Garnet.test.csproj" />
```

The only thing it needs from there is `Garnet.test.TestBase`, the ~30-line
running-test tracker that `EpochTestBase` derives from. But that reference pulls
the entire transitive closure of `Garnet.test` — `Garnet.client`, `Garnet.common`,
`Garnet.host`, `Garnet.server`, `GarnetServer`, `GarnetJSON`, `NoOpModule`,
`GarnetRoaringBitmap`, `Garnet.fuzz`, plus `StackExchange.Redis`,
`Microsoft.CodeAnalysis` and `diskann-garnet` — into the project. Landing that in
`Tsavorite.slnx` would make the standalone Tsavorite build (and CI's dedicated
`Build Tsavorite` job, which restores only that solution) compile the whole Garnet
server stack. So the project got parked in `Garnet.slnx` instead.

## Every other Tsavorite test project already solves this

The `TestBase` dependency is not unique to the epoch tests — ~77 files across the
Tsavorite test tree do `using Garnet.test; class Foo : TestBase`. None of them
reference `Garnet.test.csproj`. The convention is hub-and-spoke:

- `Tsavorite.test.csproj` source-links the single file:
  `<Compile Include="..\..\..\..\..\test\standalone\Garnet.test\TestBase.cs" Link="TestBase.cs" />`
- `test.hlog`, `test.recovery`, `test.recordops`, `test.session`,
  `test.session.context` and `test.stress` each `ProjectReference` `Tsavorite.test.csproj`
  and inherit it.

`Tsavorite.test.epoch` was the sole exception, and that single edge is what pinned
it into the wrong solution.

## The knock-on bug

The misplacement also meant **the epoch tests ran in no CI matrix at all**:

- the Garnet test matrix lists explicit project names and does not include `Tsavorite.test.epoch`;
- the Tsavorite test matrix only covers projects in `Tsavorite.slnx`.

`Garnet.slnx` compiled the assembly, and nothing ever executed it. The 15 tests
added alongside the `LightEpoch` slot-claim CAS hardening have never guarded a
single PR.

## Changes

- `Tsavorite.test.epoch.csproj`: replace the `Garnet.test` `ProjectReference` with a `ProjectReference` to `Tsavorite.test.csproj`, matching every sibling Tsavorite test project.
- Move the project entry from the `Garnet.slnx` `/test/` folder to the `Tsavorite.slnx` `/test/` folder.
- Add `Tsavorite.test.epoch` to the Tsavorite CI test matrix and its directory map. It touches no blob storage, so it joins the set excluded from the Azurite setup / `RunAzureTests` steps.

`playground/LightEpochLitmus` is left where it is — it is a Garnet-side playground
executable and belongs in `Garnet.slnx`.

## Validation

- `dotnet build libs/storage/Tsavorite/cs/Tsavorite.slnx -c Debug` — succeeds, 0 warnings.
- `dotnet test libs/storage/Tsavorite/cs/test/test.epoch -f net10.0 -c Debug` — 15/15 pass.
- `dotnet format libs/storage/Tsavorite/cs/Tsavorite.slnx --verify-no-changes` — clean.
- `dotnet restore Garnet.slnx` — still resolves after the removal; nothing referenced the epoch test project.
