### PR TITLE
Fix BfTree cargo probe fallback

### DIFF
--- a/libs/native/bftree-garnet/BfTreeInterop.csproj
+++ b/libs/native/bftree-garnet/BfTreeInterop.csproj
@@ -31,6 +31,7 @@
   <Target Name="BuildRustCdylib" BeforeTargets="Build" Condition="'$(IsCrossTargetingBuild)' == 'true' or '$(TargetFrameworks)' == ''">
     <Exec Command="cargo --version"
           IgnoreExitCode="true"
+          IgnoreStandardErrorWarningFormat="true"
           StandardOutputImportance="low"
           StandardErrorImportance="low">
       <Output TaskParameter="ExitCode" PropertyName="CargoProbeExitCode" />


### PR DESCRIPTION
## Root cause

`BfTreeInterop.csproj` probes `cargo --version` with `IgnoreExitCode="true"` so developer builds can fall back to the checked-in native binary when Rust is unavailable. When rustup cannot download the pinned `1.94.0` toolchain, it writes canonical `error:` lines to stderr. MSBuild `Exec` promotes those lines to build errors even though the probe exit code is ignored and the prebuilt binary exists.

## Fix

Set `IgnoreStandardErrorWarningFormat="true"` only on the cargo probe `Exec`, so rustup probe diagnostics do not become MSBuild errors. The real `cargo build --release --locked` `Exec` is unchanged, so source builds still fail loudly on genuine Rust compilation errors.

## Validation

- `dotnet build libs\native\bftree-garnet\BfTreeInterop.csproj -c Debug --nologo -v q` — succeeded, 0 warnings/errors.
- `dotnet build libs\native\bftree-garnet\BfTreeInterop.csproj -c Release --nologo -v q` — succeeded, 0 warnings/errors.
- `dotnet restore Garnet.slnx --nologo -v q` — succeeded.
- `dotnet build Garnet.slnx -c Debug --no-restore --nologo -v q` — succeeded, 0 warnings/errors.
- `dotnet build test\standalone\BfTreeInterop.test\BfTreeInterop.test.csproj -c Debug -f net10.0 --no-restore --nologo -v q` — succeeded and copied `runtimes\win-x64\native\bftree_garnet.dll`.
- `dotnet test test\standalone\BfTreeInterop.test\BfTreeInterop.test.csproj -c Debug -f net10.0 --no-build --nologo -v q` — passed 46/46 tests.
- With `RUSTUP_TOOLCHAIN=stable`, `cargo --version` exits 0, confirming a working Rust toolchain still passes the probe.
