### PR TITLE
Fix vector set index reads killing the RESP session

### DIFF
--- a/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
+++ b/libs/server/Storage/Functions/MainStore/PrivateMethods.cs
@@ -109,6 +109,10 @@ namespace Garnet.server
                 case RespCommand.VREM:
                 case RespCommand.VDIM:
                 case RespCommand.VSETATTR:
+                case RespCommand.VCARD:
+                case RespCommand.VISMEMBER:
+                case RespCommand.VLINKS:
+                case RespCommand.VRANDMEMBER:
                 case RespCommand.GET:
                 case RespCommand.RIGET:
                 case RespCommand.RISET:


### PR DESCRIPTION
`CopyRespToWithInput` was missing `VCARD`, `VISMEMBER`, `VLINKS` and `VRANDMEMBER`, so reading the index for those commands hit the `default:` arm and threw `GarnetException("Unsupported operation on input")` — which escapes `ProcessMessages` and disposes the whole `RespServerSession`.

That's the frequent `Garnet.test.vectorset` CI failure: `InterruptedVectorSetDelete` calls `VISMEMBER`, the session dies, and the next command reports `SocketClosed` (usually at `VSIM`).

Repro matrix went from 6/10 containers failing to 0/600 iterations; full vectorset suite passes 391/391.
