### PR TITLE
Fix possible records corruption in VectorSets

### DIFF
--- a/libs/common/VectorElementKey.cs
+++ b/libs/common/VectorElementKey.cs
@@ -95,10 +95,9 @@ namespace Garnet.common
         /// </summary>
         public VectorElementKey(ReadOnlySpan<byte> namespaceBytes, ReadOnlySpan<byte> key)
         {
-            Debug.Assert(namespaceBytes.Length > 0, "Namespace cannot be empty");
+            RecordNamespace.AssertValid(namespaceBytes);
             Debug.Assert(namespaceBytes.Length == 1 || (namespaceBytes.Length % 4) == 0, "Namespace must be either 1-byte or a multiple of 4-bytes long");
-            Debug.Assert(namespaceBytes.Length != 1 || namespaceBytes[0] is > 0 and < 128, "Namespaces of length 1 must be > 0 and < 128");
-            Debug.Assert(namespaceBytes.Length != 4 || BinaryPrimitives.ReadUInt32LittleEndian(namespaceBytes) >= 128, "Namespaces larger than 1 byte must be >= 128");
+            Debug.Assert(namespaceBytes.Length != 4 || BinaryPrimitives.ReadUInt32LittleEndian(namespaceBytes) > RecordNamespace.MaximumSingleByteNamespaceValue, $"A context of {RecordNamespace.MaximumSingleByteNamespaceValue} or less must be stored in a single byte");
 
 #if NET9_0_OR_GREATER
             KeyBytes = key;

--- a/libs/server/Resp/Vector/VectorManager.ContextMetadata.cs
+++ b/libs/server/Resp/Vector/VectorManager.ContextMetadata.cs
@@ -732,7 +732,7 @@ namespace Garnet.server
             Debug.Assert(namespaceBytes.Length >= sizeof(uint), "Insufficient space in provided Span");
             Debug.Assert(context is > 0 and <= uint.MaxValue, "Context must be (0, uint.MaxValue]");
 
-            if (context <= RecordDataHeader.MaximumSingleByteNamespaceValue)
+            if (context <= RecordNamespace.MaximumSingleByteNamespaceValue)
             {
                 namespaceBytes = namespaceBytes[..1];
                 namespaceBytes[0] = (byte)context;
@@ -742,6 +742,8 @@ namespace Garnet.server
                 namespaceBytes = namespaceBytes[0..sizeof(uint)];
                 BinaryPrimitives.WriteUInt32LittleEndian(namespaceBytes, (uint)context);
             }
+
+            RecordNamespace.AssertValid(namespaceBytes);
         }
 
         /// <summary>

--- a/libs/server/Storage/Functions/VectorStore/VectorSessionFunctions.cs
+++ b/libs/server/Storage/Functions/VectorStore/VectorSessionFunctions.cs
@@ -177,7 +177,7 @@ namespace Garnet.server
             if (input.WriteDesiredSize < 0)
             {
                 // Add to value, this is a dynamically sized type - which are only used from Garnet, not DiskANN
-                return new() { KeySize = srcLogRecord.Key.Length, ValueSize = value.Length + (-input.WriteDesiredSize), ExtendedNamespaceSize = GetExtendedNamespaceSize(in srcLogRecord) };
+                return new() { KeySize = srcLogRecord.Key.Length, ValueSize = value.Length + (-input.WriteDesiredSize), ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in srcLogRecord) };
             }
 
             var needsAlignmentPadding = input.AlignmentExpected || input.Callback != 0;
@@ -185,11 +185,11 @@ namespace Garnet.server
             // Constant size indicated
             if (needsAlignmentPadding)
             {
-                return new() { KeySize = srcLogRecord.Key.Length, ValueSize = input.WriteDesiredSize + ValueAlignmentBytes, ExtendedNamespaceSize = GetExtendedNamespaceSize(in srcLogRecord) };
+                return new() { KeySize = srcLogRecord.Key.Length, ValueSize = input.WriteDesiredSize + ValueAlignmentBytes, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in srcLogRecord) };
             }
             else
             {
-                return new() { KeySize = srcLogRecord.Key.Length, ValueSize = input.WriteDesiredSize, ExtendedNamespaceSize = GetExtendedNamespaceSize(in srcLogRecord) };
+                return new() { KeySize = srcLogRecord.Key.Length, ValueSize = input.WriteDesiredSize, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in srcLogRecord) };
             }
         }
 
@@ -211,11 +211,11 @@ namespace Garnet.server
 
             if (!needsAlignmentPadding)
             {
-                return new() { KeySize = key.KeyBytes.Length, ValueSize = effectiveWriteDesiredSize, ExtendedNamespaceSize = GetExtendedNamespaceSize(in key) };
+                return new() { KeySize = key.KeyBytes.Length, ValueSize = effectiveWriteDesiredSize, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
             }
             else
             {
-                return new() { KeySize = key.KeyBytes.Length, ValueSize = effectiveWriteDesiredSize + ValueAlignmentBytes, ExtendedNamespaceSize = GetExtendedNamespaceSize(in key) };
+                return new() { KeySize = key.KeyBytes.Length, ValueSize = effectiveWriteDesiredSize + ValueAlignmentBytes, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
             }
         }
 
@@ -225,7 +225,7 @@ namespace Garnet.server
 #if NET9_0_OR_GREATER
                 , allows ref struct
 #endif
-        => new() { KeySize = key.KeyBytes.Length, ValueSize = value.Length + ValueAlignmentBytes, ExtendedNamespaceSize = GetExtendedNamespaceSize(in key) };
+        => new() { KeySize = key.KeyBytes.Length, ValueSize = value.Length + ValueAlignmentBytes, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
 
         /// <summary>Length of value object, when populated by Upsert using given value and input</summary>
         public readonly RecordFieldInfo GetUpsertFieldInfo<TKey>(TKey key, IHeapObject value, ref VectorInput input)
@@ -242,7 +242,7 @@ namespace Garnet.server
                 , allows ref struct
 #endif
             where TSourceLogRecord : ISourceLogRecord
-        => new() { KeySize = key.KeyBytes.Length, ValueSize = inputLogRecord.ValueSpan.Length, ExtendedNamespaceSize = GetExtendedNamespaceSize(in key) };
+        => new() { KeySize = key.KeyBytes.Length, ValueSize = inputLogRecord.ValueSpan.Length, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
         #endregion Variable Length
 
         #region InitialUpdater
@@ -631,25 +631,6 @@ namespace Garnet.server
         {
         }
         #endregion
-
-        private static int GetExtendedNamespaceSize<TKey>(in TKey key)
-            where TKey : IKey
-#if NET9_0_OR_GREATER
-                , allows ref struct
-#endif
-        {
-            if (!key.HasNamespace)
-            {
-                return 0;
-            }
-
-            if (key.NamespaceBytes.Length == 1 && key.NamespaceBytes[0] < 128)
-            {
-                return 0;
-            }
-
-            return key.NamespaceBytes.Length;
-        }
 
         /// <inheritdoc />
         public void PreSingleKeyConsistentRead(long hash)

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
@@ -1514,8 +1514,9 @@ namespace Tsavorite.core
             }
             catch (Exception ex)
             {
-                logger?.LogCritical(ex, "OnPagesClosedWorker failed, page closing will not resume. ClosedUntilAddress={ClosedUntilAddress} OngoingCloseUntilAddress={OngoingCloseUntilAddress}", ClosedUntilAddress, OngoingCloseUntilAddress);
-                throw;
+                // Page closing cannot resume after a failure here, so the log would stall silently. Crash instead: a dump is the
+                // only practical way to diagnose this.
+                Environment.FailFast($"OnPagesClosedWorker failed; allocator state is unrecoverable. ClosedUntilAddress={ClosedUntilAddress}, OngoingCloseUntilAddress={OngoingCloseUntilAddress}", ex);
             }
         }
 

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/LogRecord.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/LogRecord.cs
@@ -532,6 +532,8 @@ namespace Tsavorite.core
                 , allows ref struct
 #endif
         {
+            RecordNamespace.AssertKeyCorrectlySized(key, in sizeInfo);
+
             // Build the full RDH in a local (Initialize folds indicator bits + lengths + namespace + recordType + FillerWords
             // into a SINGLE atomic word write at the end). We pass `physicalAddress` as baseAddress and the returned addresses
             // are within it (NOT addresses based on the stack variable). Any record-split work for over-large filler writes the
@@ -606,6 +608,8 @@ namespace Tsavorite.core
                 , allows ref struct
 #endif
         {
+            RecordNamespace.AssertKeyCorrectlySized(key, in sizeInfo);
+
             // Build the full RDH in a local; SpanByteAllocator records are always inline keys + inline values, so
             // sizeInfo.KeyIsInline and sizeInfo.ValueIsInline must both be true (Initialize encodes both). We pass
             // `physicalAddress` as baseAddress and the returned addresses are within it (NOT addresses based on the stack variable).

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/ObjectAllocatorImpl.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/ObjectAllocatorImpl.cs
@@ -293,6 +293,7 @@ namespace Tsavorite.core
                 {
                     KeySize = key.KeyBytes.Length,
                     ValueSize = 0,          // This will be inline, and with the length prefix and possible space when rounding up to kRecordAlignment, allows the possibility revivification can reuse the record for a Heap Field
+                    ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key),
                     HasETag = false,
                     HasExpiration = false
                 }

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/RecordDataHeader.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/RecordDataHeader.cs
@@ -111,9 +111,6 @@ namespace Tsavorite.core
         /// <summary>The fixed size of the RecordDataHeader in bytes.</summary>
         public const int Size = 8;
 
-        /// <summary>Largest value that can be stored in <see cref="NamespaceByte"/>, larger values require extended namespace space.</summary>
-        public const byte MaximumSingleByteNamespaceValue = (1 << ExtendedNamespaceIndicatorBit) - 1;
-
         /// <summary>The bit position of the extended-namespace indicator (bit 7 of the namespace byte). The full byte may be split as:
         /// <list type="bullet">
         ///     <item>If bit at this position is 0, the lower 7 bits hold the namespace value itself (single-byte namespace).</item>

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/RecordNamespace.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/RecordNamespace.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Tsavorite.core
+{
+    /// <summary>
+    /// The encoding rules for the namespace carried by an <see cref="IKey"/>. A namespace of a single byte valued
+    /// 1..<see cref="MaximumSingleByteNamespaceValue"/> is held in the record's namespace byte and costs no record space; any other
+    /// namespace is written into the record between the <see cref="RecordDataHeader"/> and the Key, and the namespace byte holds its
+    /// length instead. Callers that size a record must report that length via <see cref="RecordFieldInfo.ExtendedNamespaceSize"/>.
+    /// </summary>
+    public static class RecordNamespace
+    {
+        /// <summary>Largest namespace value that can be held in the record's namespace byte; larger values require extended namespace space.</summary>
+        public const byte MaximumSingleByteNamespaceValue = (1 << RecordDataHeader.ExtendedNamespaceIndicatorBit) - 1;
+
+        /// <summary>Largest extended namespace, in bytes; its size is encoded in the same 7 bits that would otherwise hold a single-byte value.</summary>
+        public const byte MaximumExtendedNamespaceSize = (1 << RecordDataHeader.ExtendedNamespaceIndicatorBit) - 1;
+
+        /// <summary>Asserts <paramref name="namespaceBytes"/> satisfies the <see cref="IKey.NamespaceBytes"/> contract.</summary>
+        [Conditional("DEBUG")]
+        public static void AssertValid(ReadOnlySpan<byte> namespaceBytes)
+        {
+            Debug.Assert(!namespaceBytes.IsEmpty, "Namespace cannot be empty");
+            Debug.Assert(namespaceBytes.Length != 1 || namespaceBytes[0] != 0, "The single-byte namespace value 0 is reserved");
+            Debug.Assert(namespaceBytes.Length <= MaximumExtendedNamespaceSize, $"Namespace size {namespaceBytes.Length} exceeds the maximum of {MaximumExtendedNamespaceSize}");
+        }
+
+        /// <summary>Asserts the caller sized the record for the namespace of <paramref name="key"/>; a mismatch frames the record incorrectly.</summary>
+        [Conditional("DEBUG")]
+        public static void AssertKeyCorrectlySized<TKey>(TKey key, in RecordSizeInfo sizeInfo) where TKey : IKey
+#if NET9_0_OR_GREATER
+                , allows ref struct
+#endif
+        {
+            var expectedExtendedSize = GetExtendedNamespaceSize(in key);
+            Debug.Assert(sizeInfo.FieldInfo.ExtendedNamespaceSize == expectedExtendedSize, $"Extended namespace size {sizeInfo.FieldInfo.ExtendedNamespaceSize} does not match the key's required size {expectedExtendedSize}");
+        }
+
+        /// <summary>The record space the namespace of <paramref name="key"/> requires ahead of the Key data; 0 if it needs none.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetExtendedNamespaceSize<TKey>(in TKey key) where TKey : IKey
+#if NET9_0_OR_GREATER
+                , allows ref struct
+#endif
+            => key.HasNamespace ? GetExtendedNamespaceSize(key.NamespaceBytes) : 0;
+
+        /// <summary>The record space <paramref name="namespaceBytes"/> requires ahead of the Key data; 0 if it needs none.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetExtendedNamespaceSize(ReadOnlySpan<byte> namespaceBytes)
+        {
+            AssertValid(namespaceBytes);
+            return namespaceBytes.Length == 1 && namespaceBytes[0] <= MaximumSingleByteNamespaceValue ? 0 : namespaceBytes.Length;
+        }
+    }
+}

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/SpanByteAllocatorImpl.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/SpanByteAllocatorImpl.cs
@@ -165,6 +165,7 @@ namespace Tsavorite.core
                 {
                     KeySize = key.KeyBytes.Length,
                     ValueSize = 0,  // No payload for the default value
+                    ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key),
                     HasETag = false,
                     HasExpiration = false
                 }

--- a/libs/storage/Tsavorite/cs/src/core/ClientSession/NoOpSessionFunctions.cs
+++ b/libs/storage/Tsavorite/cs/src/core/ClientSession/NoOpSessionFunctions.cs
@@ -98,8 +98,7 @@ namespace Tsavorite.core
                 , allows ref struct
 #endif
             where TSourceLogRecord : ISourceLogRecord
-            // TODO: Namespace!
-            => new() { KeySize = key.KeyBytes.Length, ValueSize = inputLogRecord.DataHeader.ValueIsObject ? ObjectIdMap.ObjectIdSize : inputLogRecord.ValueSpan.Length, ValueIsObject = inputLogRecord.DataHeader.ValueIsObject };
+            => new() { KeySize = key.KeyBytes.Length, ValueSize = inputLogRecord.DataHeader.ValueIsObject ? ObjectIdMap.ObjectIdSize : inputLogRecord.ValueSpan.Length, ValueIsObject = inputLogRecord.DataHeader.ValueIsObject, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
 
         /// <summary>
         /// No reads during compaction

--- a/libs/storage/Tsavorite/cs/src/core/Index/Interfaces/SessionFunctionsBase.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Interfaces/SessionFunctionsBase.cs
@@ -168,16 +168,14 @@ namespace Tsavorite.core
 #if NET9_0_OR_GREATER
                 , allows ref struct
 #endif
-            // TODO: Namespace!
-            => new() { KeySize = key.KeyBytes.Length, ValueSize = value.Length, ValueIsObject = false };
+            => new() { KeySize = key.KeyBytes.Length, ValueSize = value.Length, ValueIsObject = false, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
         /// <inheritdoc/>
         public virtual RecordFieldInfo GetUpsertFieldInfo<TKey>(TKey key, IHeapObject value, ref TInput input)
             where TKey : IKey
 #if NET9_0_OR_GREATER
                 , allows ref struct
 #endif
-            // TODO: Namespace!
-            => new() { KeySize = key.KeyBytes.Length, ValueSize = ObjectIdMap.ObjectIdSize, ValueIsObject = true };
+            => new() { KeySize = key.KeyBytes.Length, ValueSize = ObjectIdMap.ObjectIdSize, ValueIsObject = true, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
         /// <inheritdoc/>
         public virtual RecordFieldInfo GetUpsertFieldInfo<TKey, TSourceLogRecord>(TKey key, in TSourceLogRecord inputLogRecord, ref TInput input)
             where TKey : IKey
@@ -185,8 +183,7 @@ namespace Tsavorite.core
                 , allows ref struct
 #endif
             where TSourceLogRecord : ISourceLogRecord
-            // TODO: Namespace!
-            => new() { KeySize = key.KeyBytes.Length, ValueSize = inputLogRecord.DataHeader.ValueIsObject ? ObjectIdMap.ObjectIdSize : inputLogRecord.ValueSpan.Length, ValueIsObject = inputLogRecord.DataHeader.ValueIsObject };
+            => new() { KeySize = key.KeyBytes.Length, ValueSize = inputLogRecord.DataHeader.ValueIsObject ? ObjectIdMap.ObjectIdSize : inputLogRecord.ValueSpan.Length, ValueIsObject = inputLogRecord.DataHeader.ValueIsObject, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
 
         /// <inheritdoc/>
         public virtual void ConvertOutputToHeap(ref TInput input, ref TOutput output) { }

--- a/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/Helpers.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Index/Tsavorite/Implementation/Helpers.cs
@@ -29,6 +29,7 @@ namespace Tsavorite.core
             var logRecord = log._wrapper.CreateLogRecord(logicalAddress, physicalAddress);
             logRecord.InitializeHeadersForNewRecord(inNewVersion, previousAddress);
             log._wrapper.InitializeRecord(key, logicalAddress, in sizeInfo, ref logRecord);
+            Debug.Assert(logRecord.AllocatedSize == sizeInfo.AllocatedInlineRecordSize, $"Framed record length {logRecord.AllocatedSize} does not match the allocated size {sizeInfo.AllocatedInlineRecordSize}");
             return logRecord;
         }
 

--- a/libs/storage/Tsavorite/cs/src/core/VarLen/SpanByteFunctions.cs
+++ b/libs/storage/Tsavorite/cs/src/core/VarLen/SpanByteFunctions.cs
@@ -31,19 +31,16 @@ namespace Tsavorite.core
 
         /// <inheritdoc/>
         public override RecordFieldInfo GetRMWModifiedFieldInfo<TSourceLogRecord>(in TSourceLogRecord srcLogRecord, ref PinnedSpanByte input)
-            => new() { KeySize = srcLogRecord.Key.Length, ValueSize = input.Length };
+            => new() { KeySize = srcLogRecord.Key.Length, ValueSize = input.Length, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in srcLogRecord) };
         /// <inheritdoc/>
         public override RecordFieldInfo GetRMWInitialFieldInfo<TKey>(TKey key, ref PinnedSpanByte input)
-            // TODO: Namespaces!
-            => new() { KeySize = key.KeyBytes.Length, ValueSize = input.Length };
+            => new() { KeySize = key.KeyBytes.Length, ValueSize = input.Length, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
         /// <inheritdoc/>
         public override RecordFieldInfo GetUpsertFieldInfo<TKey>(TKey key, ReadOnlySpan<byte> value, ref PinnedSpanByte input)
-            // TODO: Namespaces!
-            => new() { KeySize = key.KeyBytes.Length, ValueSize = value.Length };
+            => new() { KeySize = key.KeyBytes.Length, ValueSize = value.Length, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
         /// <inheritdoc/>
         public override RecordFieldInfo GetUpsertFieldInfo<TKey>(TKey key, IHeapObject value, ref PinnedSpanByte input)
-            // TODO: Namespaces!
-            => new() { KeySize = key.KeyBytes.Length, ValueSize = ObjectIdMap.ObjectIdSize, ValueIsObject = true };
+            => new() { KeySize = key.KeyBytes.Length, ValueSize = ObjectIdMap.ObjectIdSize, ValueIsObject = true, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
 
         /// <inheritdoc />
         public override void ConvertOutputToHeap(ref PinnedSpanByte input, ref SpanByteAndMemory output)

--- a/libs/storage/Tsavorite/cs/test/NamespaceTests.cs
+++ b/libs/storage/Tsavorite/cs/test/NamespaceTests.cs
@@ -200,6 +200,66 @@ namespace Tsavorite.test
             AssertCompleted(new(OperationStatus.INPLACE_UPDATED_RECORD), delStatus);
         }
 
+        [TestCase("7f", 0)]
+        [TestCase("80", 1)]
+        [TestCase("a2", 1)]
+        [TestCase("8001", 2)]
+        [TestCase("01020304", 4)]
+        public void ImmutableDeleteEncodesNamespaceWithoutCorruptingRecordLength(string namespaceHex, int expectedExtendedNamespaceSize)
+        {
+            Setup(new() { PageSize = 1L << 12, LogMemorySize = 1L << 13, SegmentSize = 1L << 22 }, TestDeviceType.LocalMemory);
+
+            var key = new KeyWithNamespaceStruct { kfield1 = 13, kfield2 = 14, namespaceArr = Convert.FromHexString(namespaceHex) };
+            var value = new ValueStruct { vfield1 = 23, vfield2 = 24 };
+            Assert.That(bContext.Upsert(key, SpanByte.FromPinnedVariable(ref value), Empty.Default).IsCompletedSuccessfully, Is.True);
+
+            store.Log.ShiftReadOnlyAddress(store.Log.TailAddress, wait: true);
+            var tombstoneAddress = store.Log.TailAddress;
+            Assert.That(bContext.Delete(key, Empty.Default).IsCompletedSuccessfully, Is.True);
+
+            var tombstone = new LogRecord(store.hlogBase.GetPhysicalAddress(tombstoneAddress));
+            Assert.That(tombstone.Info.Tombstone, Is.True);
+            Assert.That(tombstone.DataHeader.ExtendedNamespaceLength, Is.EqualTo(expectedExtendedNamespaceSize));
+            Assert.That(tombstone.NamespaceBytes.SequenceEqual(key.NamespaceBytes), Is.True);
+            Assert.That(store.Log.TailAddress, Is.EqualTo(tombstoneAddress + tombstone.AllocatedSize));
+        }
+
+        [TestCase("80", 1)]
+        [TestCase("a2", 1)]
+        [TestCase("01020304", 4)]
+        public void CopyToTailPreservesExtendedNamespace(string namespaceHex, int expectedExtendedNamespaceSize)
+        {
+            Setup(new() { PageSize = 1L << 12, LogMemorySize = 1L << 13, SegmentSize = 1L << 22 }, TestDeviceType.LocalMemory);
+
+            var key = new KeyWithNamespaceStruct { kfield1 = 13, kfield2 = 14, namespaceArr = Convert.FromHexString(namespaceHex) };
+            var value = new ValueStruct { vfield1 = key.kfield1, vfield2 = key.kfield2 };
+            Assert.That(bContext.Upsert(key, SpanByte.FromPinnedVariable(ref value), Empty.Default).IsCompletedSuccessfully, Is.True);
+            store.Log.FlushAndEvict(wait: true);
+
+            var tailBefore = store.Log.TailAddress;
+            InputStruct input = default;
+            OutputStruct output = default;
+            ReadOptions readOptions = new() { CopyOptions = new(ReadCopyFrom.AllImmutable, ReadCopyTo.MainLog) };
+            var status = bContext.Read(key, ref input, ref output, ref readOptions, out _);
+            Assert.That(status.IsPending, Is.True);
+            (status, output) = CompletePendingResult();
+
+            Assert.That(status.Found, Is.True);
+            Assert.That(status.Record.Copied, Is.True);
+            Assert.That(output.value.vfield1, Is.EqualTo(value.vfield1));
+            Assert.That(output.value.vfield2, Is.EqualTo(value.vfield2));
+
+            var copiedRecord = new LogRecord(store.hlogBase.GetPhysicalAddress(tailBefore));
+            Assert.That(copiedRecord.DataHeader.ExtendedNamespaceLength, Is.EqualTo(expectedExtendedNamespaceSize));
+            Assert.That(copiedRecord.NamespaceBytes.SequenceEqual(key.NamespaceBytes), Is.True);
+            Assert.That(store.Log.TailAddress, Is.EqualTo(tailBefore + copiedRecord.AllocatedSize));
+
+            output = default;
+            status = bContext.Read(key, ref input, ref output);
+            Assert.That(status.IsPending, Is.False);
+            Assert.That(status.Found, Is.True);
+        }
+
         [Test]
         public async Task RecoveryAsync([Values(0, 1, 4, (int)sbyte.MaxValue)] int namespaceSize, [Values] TestDeviceType deviceType)
         {

--- a/libs/storage/Tsavorite/cs/test/TestTypes.cs
+++ b/libs/storage/Tsavorite/cs/test/TestTypes.cs
@@ -244,13 +244,13 @@ namespace Tsavorite.test
 
         /// <inheritdoc/>
         public override unsafe RecordFieldInfo GetRMWModifiedFieldInfo<TSourceLogRecord>(in TSourceLogRecord srcLogRecord, ref InputStruct input)
-            => new() { KeySize = srcLogRecord.Key.Length, ValueSize = sizeof(ValueStruct), ExtendedNamespaceSize = TestNamespaceHelper.GetExtendedNamespaceSize(in srcLogRecord) };
+            => new() { KeySize = srcLogRecord.Key.Length, ValueSize = sizeof(ValueStruct), ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in srcLogRecord) };
         /// <inheritdoc/>
         public override unsafe RecordFieldInfo GetRMWInitialFieldInfo<TKey>(TKey key, ref InputStruct input)
-            => new() { KeySize = key.KeyBytes.Length, ValueSize = sizeof(ValueStruct), ExtendedNamespaceSize = TestNamespaceHelper.GetExtendedNamespaceSize(in key) };
+            => new() { KeySize = key.KeyBytes.Length, ValueSize = sizeof(ValueStruct), ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
         /// <inheritdoc/>
         public override unsafe RecordFieldInfo GetUpsertFieldInfo<TKey>(TKey key, ReadOnlySpan<byte> value, ref InputStruct input)
-            => new() { KeySize = key.KeyBytes.Length, ValueSize = value.Length, ExtendedNamespaceSize = TestNamespaceHelper.GetExtendedNamespaceSize(in key) };
+            => new() { KeySize = key.KeyBytes.Length, ValueSize = value.Length, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
     }
 
     public class FunctionsCompaction : SessionFunctionsBase<InputStruct, OutputStruct, int>
@@ -314,13 +314,13 @@ namespace Tsavorite.test
 
         /// <inheritdoc/>
         public override unsafe RecordFieldInfo GetRMWModifiedFieldInfo<TSourceLogRecord>(in TSourceLogRecord srcLogRecord, ref InputStruct input)
-            => new() { KeySize = srcLogRecord.Key.Length, ValueSize = sizeof(ValueStruct), ExtendedNamespaceSize = TestNamespaceHelper.GetExtendedNamespaceSize(in srcLogRecord) };
+            => new() { KeySize = srcLogRecord.Key.Length, ValueSize = sizeof(ValueStruct), ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in srcLogRecord) };
         /// <inheritdoc/>
         public override unsafe RecordFieldInfo GetRMWInitialFieldInfo<TKey>(TKey key, ref InputStruct input)
-            => new() { KeySize = key.KeyBytes.Length, ValueSize = sizeof(ValueStruct), ExtendedNamespaceSize = TestNamespaceHelper.GetExtendedNamespaceSize(in key) };
+            => new() { KeySize = key.KeyBytes.Length, ValueSize = sizeof(ValueStruct), ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
         /// <inheritdoc/>
         public override unsafe RecordFieldInfo GetUpsertFieldInfo<TKey>(TKey key, ReadOnlySpan<byte> value, ref InputStruct input)
-            => new() { KeySize = key.KeyBytes.Length, ValueSize = value.Length, ExtendedNamespaceSize = TestNamespaceHelper.GetExtendedNamespaceSize(in key) };
+            => new() { KeySize = key.KeyBytes.Length, ValueSize = value.Length, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
     }
 
     public class FunctionsCopyOnWrite : SessionFunctionsBase<InputStruct, OutputStruct, Empty>
@@ -398,13 +398,13 @@ namespace Tsavorite.test
 
         /// <inheritdoc/>
         public override unsafe RecordFieldInfo GetRMWModifiedFieldInfo<TSourceLogRecord>(in TSourceLogRecord srcLogRecord, ref InputStruct input)
-            => new() { KeySize = srcLogRecord.Key.Length, ValueSize = sizeof(ValueStruct), ExtendedNamespaceSize = TestNamespaceHelper.GetExtendedNamespaceSize(in srcLogRecord) };
+            => new() { KeySize = srcLogRecord.Key.Length, ValueSize = sizeof(ValueStruct), ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in srcLogRecord) };
         /// <inheritdoc/>
         public override unsafe RecordFieldInfo GetRMWInitialFieldInfo<TKey>(TKey key, ref InputStruct input)
-            => new() { KeySize = key.KeyBytes.Length, ValueSize = sizeof(ValueStruct), ExtendedNamespaceSize = TestNamespaceHelper.GetExtendedNamespaceSize(in key) };
+            => new() { KeySize = key.KeyBytes.Length, ValueSize = sizeof(ValueStruct), ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
         /// <inheritdoc/>
         public override RecordFieldInfo GetUpsertFieldInfo<TKey>(TKey key, ReadOnlySpan<byte> value, ref InputStruct input)
-            => new() { KeySize = key.KeyBytes.Length, ValueSize = value.Length, ExtendedNamespaceSize = TestNamespaceHelper.GetExtendedNamespaceSize(in key) };
+            => new() { KeySize = key.KeyBytes.Length, ValueSize = value.Length, ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
     }
 
     public class SimpleLongSimpleFunctions : SimpleIntegerFunctionsBase<long>
@@ -481,47 +481,21 @@ namespace Tsavorite.test
         public override unsafe RecordFieldInfo GetRMWModifiedFieldInfo<TSourceLogRecord>(in TSourceLogRecord srcLogRecord, ref TInteger input)
         {
             Assert.That(srcLogRecord.ValueSpan.Length, Is.EqualTo(sizeof(TInteger)));
-            return new() { KeySize = srcLogRecord.Key.Length, ValueSize = sizeof(TInteger), ExtendedNamespaceSize = TestNamespaceHelper.GetExtendedNamespaceSize(in srcLogRecord) };
+            return new() { KeySize = srcLogRecord.Key.Length, ValueSize = sizeof(TInteger), ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in srcLogRecord) };
         }
 
         /// <inheritdoc/>
         public override unsafe RecordFieldInfo GetRMWInitialFieldInfo<TKey>(TKey key, ref TInteger input)
         {
             Assert.That(key.KeyBytes.Length, Is.EqualTo(sizeof(TInteger)));
-            return new() { KeySize = key.KeyBytes.Length, ValueSize = sizeof(TInteger), ExtendedNamespaceSize = TestNamespaceHelper.GetExtendedNamespaceSize(in key) };
+            return new() { KeySize = key.KeyBytes.Length, ValueSize = sizeof(TInteger), ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
         }
 
         /// <inheritdoc/>
         public override unsafe RecordFieldInfo GetUpsertFieldInfo<TKey>(TKey key, ReadOnlySpan<byte> value, ref TInteger input)
         {
             Assert.That(value.Length, Is.EqualTo(sizeof(TInteger)));
-            return new() { KeySize = key.KeyBytes.Length, ValueSize = sizeof(TInteger), ExtendedNamespaceSize = TestNamespaceHelper.GetExtendedNamespaceSize(in key) };
-        }
-    }
-
-    internal static class TestNamespaceHelper
-    {
-        /// <summary>
-        /// Get extended storage needed for the <see cref="IKey.NamespaceBytes"/> carried by <paramref name="key"/>, if any.
-        /// </summary>
-        internal static int GetExtendedNamespaceSize<TKey>(in TKey key)
-            where TKey : IKey
-#if NET9_0_OR_GREATER
-                , allows ref struct
-#endif
-        {
-            if (!key.HasNamespace)
-            {
-                return 0;
-            }
-
-            var nsBytes = key.NamespaceBytes;
-            if (nsBytes.Length > 1 || nsBytes[0] > 127)
-            {
-                return nsBytes.Length;
-            }
-
-            return 0;
+            return new() { KeySize = key.KeyBytes.Length, ValueSize = sizeof(TInteger), ExtendedNamespaceSize = RecordNamespace.GetExtendedNamespaceSize(in key) };
         }
     }
 }


### PR DESCRIPTION
## Problem

A key's namespace is normally a single byte inside the record header, but a bigger one doesn't fit there, so it gets stored as a few extra bytes in the record itself.

Those extra bytes weren't counted when calculating how big the record needed to be. The record was therefore allocated smaller than it actually is, but still accessed as if it had a bigger size, accessing then invalid (or other record's) memory - which at some point causes a crash.

## Fix

- Count the namespace bytes when calculating record size, in the delete paths and in the default session functions.
- Put the "how a namespace is stored" rule in one class, `RecordNamespace`, instead of the four copies that had drifted apart (one of them on the VectorSet path).
- Assert that a record's allocated size matches its real size. This goes on `WriteNewRecordInfo`, which every record creation passes through, so it catches this class of bug in general.
- Unrelated: `FailFast` if `OnPagesClosedWorker` throws, instead of letting the allocator wedge silently. That's why this bug looked like a hang.
