### PR TITLE
Add CLUSTER POKEGOSSIP to run the next gossip round on demand

### DIFF
--- a/libs/cluster/Server/Gossip/Gossip.cs
+++ b/libs/cluster/Server/Gossip/Gossip.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
 using System;
@@ -32,6 +32,35 @@ namespace Garnet.cluster
 
         readonly ConcurrentDictionary<string, long> workerBanList = new();
         public readonly CancellationTokenSource ctsGossip = new();
+
+        /// <summary>
+        /// Signalled to cut short the sleep between gossip rounds.
+        /// </summary>
+        readonly SemaphoreSlim gossipWakeup = new(0, 1);
+
+        /// <summary>
+        /// Runs the next gossip round immediately instead of waiting out the remaining
+        /// <see cref="gossipDelay"/>.
+        /// </summary>
+        /// <remarks>
+        /// Cluster membership changes only become visible to a node once a gossip round carries
+        /// them, so an orchestrator that has just reconfigured the cluster would otherwise wait
+        /// out the delay purely to observe its own change.
+        /// </remarks>
+        public void PokeGossip()
+        {
+            if (gossipWakeup.CurrentCount == 0)
+            {
+                try
+                {
+                    gossipWakeup.Release();
+                }
+                catch (SemaphoreFullException)
+                {
+                    // A concurrent poke already scheduled the round.
+                }
+            }
+        }
 
         /// <summary>
         /// Return worker ban list
@@ -351,7 +380,8 @@ namespace Garnet.cluster
                     else
                         await GossipSampleSendAsync().ConfigureAwait(false);
 
-                    await Task.Delay(gossipDelay, ctsGossip.Token).ConfigureAwait(false);
+                    // Wakes early when an orchestrator pokes gossip after changing membership.
+                    _ = await gossipWakeup.WaitAsync(gossipDelay, ctsGossip.Token).ConfigureAwait(false);
                 }
             }
             catch (TaskCanceledException) when (ctsGossip.Token.IsCancellationRequested)

--- a/libs/cluster/Session/ClusterCommands.cs
+++ b/libs/cluster/Session/ClusterCommands.cs
@@ -144,6 +144,7 @@ namespace Garnet.cluster
                 RespCommand.CLUSTER_INITIATE_REPLICA_SYNC => NetworkClusterInitiateReplicaSync(out invalidParameters),
                 RespCommand.CLUSTER_KEYSLOT => NetworkClusterKeySlot(out invalidParameters),
                 RespCommand.CLUSTER_MEET => NetworkClusterMeet(out invalidParameters),
+                RespCommand.CLUSTER_POKEGOSSIP => NetworkClusterPokeGossip(out invalidParameters),
                 RespCommand.CLUSTER_MIGRATE => NetworkClusterMigrate(out invalidParameters),
                 RespCommand.CLUSTER_MTASKS => NetworkClusterMTasks(out invalidParameters),
                 RespCommand.CLUSTER_MYID => NetworkClusterMyId(out invalidParameters),

--- a/libs/cluster/Session/RespClusterBasicCommands.cs
+++ b/libs/cluster/Session/RespClusterBasicCommands.cs
@@ -46,6 +46,30 @@ namespace Garnet.cluster
         }
 
         /// <summary>
+        /// Implements CLUSTER POKEGOSSIP command
+        /// </summary>
+        /// <param name="invalidParameters"></param>
+        /// <returns></returns>
+        private bool NetworkClusterPokeGossip(out bool invalidParameters)
+        {
+            invalidParameters = false;
+
+            // Expecting exactly 0 arguments
+            if (parseState.Count != 0)
+            {
+                invalidParameters = true;
+                return true;
+            }
+
+            clusterProvider.clusterManager.PokeGossip();
+
+            while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
+                SendAndReset();
+
+            return true;
+        }
+
+        /// <summary>
         /// Implements CLUSTER FORGET command
         /// </summary>
         /// <param name="invalidParameters"></param>

--- a/libs/resources/RespCommandsDocs.json
+++ b/libs/resources/RespCommandsDocs.json
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "Command": "ACL",
     "Name": "ACL",
@@ -1475,6 +1475,13 @@
         "Summary": "Returns sequence number for provided key.",
         "Group": "Cluster",
         "Complexity": "O(1)"
+      },
+      {
+        "Command": "CLUSTER_POKEGOSSIP",
+        "Name": "CLUSTER|POKEGOSSIP",
+        "Summary": "Runs the next gossip round immediately instead of waiting out the gossip delay.",
+        "Group": "Cluster",
+        "Complexity": "O(N) where N is the number of cluster nodes"
       },
       {
         "Command": "CLUSTER_MYID",

--- a/libs/resources/RespCommandsInfo.json
+++ b/libs/resources/RespCommandsInfo.json
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "Command": "ACL",
     "Name": "ACL",
@@ -825,6 +825,13 @@
         "Arity": 2,
         "Flags": "Admin, NoMulti, NoScript",
         "AclCategories": "Admin, Dangerous, Slow, Garnet"
+      },
+      {
+        "Command": "CLUSTER_POKEGOSSIP",
+        "Name": "CLUSTER|POKEGOSSIP",
+        "Arity": 2,
+        "Flags": "Admin, NoAsyncLoading, NoMulti, NoScript, Stale",
+        "AclCategories": "Admin, Dangerous, Slow"
       },
       {
         "Command": "CLUSTER_MYID",

--- a/libs/server/Resp/Parser/RespCommand.cs
+++ b/libs/server/Resp/Parser/RespCommand.cs
@@ -414,6 +414,7 @@ namespace Garnet.server
         CLUSTER_MYID,
         CLUSTER_MYPARENTID,
         CLUSTER_NODES,
+        CLUSTER_POKEGOSSIP,
         CLUSTER_PUBLISH,
         CLUSTER_SPUBLISH,
         CLUSTER_REPLICAS,

--- a/libs/server/Resp/Parser/RespCommandHashLookupData.cs
+++ b/libs/server/Resp/Parser/RespCommandHashLookupData.cs
@@ -352,6 +352,7 @@ namespace Garnet.server
             ("MYID", RespCommand.CLUSTER_MYID),
             ("MYPARENTID", RespCommand.CLUSTER_MYPARENTID),
             ("NODES", RespCommand.CLUSTER_NODES),
+            ("POKEGOSSIP", RespCommand.CLUSTER_POKEGOSSIP),
             ("PUBLISH", RespCommand.CLUSTER_PUBLISH),
             ("SPUBLISH", RespCommand.CLUSTER_SPUBLISH),
             ("REPLICAS", RespCommand.CLUSTER_REPLICAS),

--- a/libs/server/Resp/Vector/VectorManager.ContextMetadata.cs
+++ b/libs/server/Resp/Vector/VectorManager.ContextMetadata.cs
@@ -670,6 +670,12 @@ namespace Garnet.server
 
             lock (this)
             {
+                // Vector sets disabled, or not yet initialized: no namespaces exist to migrate.
+                if (contextMetadatas is null)
+                {
+                    return null;
+                }
+
                 for (var i = 0; i < contextMetadatas.Length; i++)
                 {
                     var offset = ContextMetadata.OffsetForContextMetadata(i);

--- a/test/standalone/Garnet.test.acl/Resp/ACL/RespCommandTests.cs
+++ b/test/standalone/Garnet.test.acl/Resp/ACL/RespCommandTests.cs
@@ -1163,6 +1163,35 @@ namespace Garnet.test.Resp.ACL
         }
 
         [Test]
+        public async Task ClusterPokeGossipACLsAsync()
+        {
+            // All cluster command "success" is a thrown exception, because clustering is disabled
+
+            await CheckCommandsAsync(
+                "CLUSTER POKEGOSSIP",
+                [DoClusterPokeGossipAsync]
+            ).ConfigureAwait(false);
+
+            static async Task DoClusterPokeGossipAsync(GarnetClient client)
+            {
+                try
+                {
+                    await client.ExecuteForStringResultAsync("CLUSTER", ["POKEGOSSIP"]).ConfigureAwait(false);
+                    Assert.Fail("Shouldn't be reachable, cluster isn't enabled");
+                }
+                catch (Exception e)
+                {
+                    if (e.Message == "ERR This instance has cluster support disabled")
+                    {
+                        return;
+                    }
+
+                    throw;
+                }
+            }
+        }
+
+        [Test]
         public async Task ClusterCountKeysInSlotACLsAsync()
         {
             // All cluster command "success" is a thrown exception, because clustering is disabled

--- a/test/standalone/Garnet.test.collections/RespHashTests.cs
+++ b/test/standalone/Garnet.test.collections/RespHashTests.cs
@@ -535,10 +535,8 @@ namespace Garnet.test
             db.HashFieldExpire("user:user1", ["Field"], TimeSpan.FromMilliseconds(100));
             db.HashSet(new RedisKey("user:user1"), new RedisValue("Field"), new RedisValue("Hello"), When.NotExists);
 
-            await Task.Delay(200).ConfigureAwait(false);
-
-            string result = db.HashGet("user:user1", "Field");
-            ClassicAssert.IsNull(result); // SetNX should not reset the expiration
+            await TestUtils.WaitUntilAsync(() => (string)db.HashGet("user:user1", "Field") is null,
+                message: "SetNX should not reset the expiration");
         }
 
         [Test]
@@ -635,17 +633,30 @@ namespace Garnet.test
             var db = redis.GetDatabase(0);
 
             var hashKey = new RedisKey("user:user1");
-            HashEntry[] hashEntries = [new HashEntry("Title", "Tsavorite")];
+            HashEntry[] hashEntries = [new HashEntry("Title", "Tsavorite"), new HashEntry("Author", "Microsoft")];
             db.HashSet(hashKey, hashEntries);
-            db.HashFieldExpire("user:user1", ["Title"], TimeSpan.FromMilliseconds(100));
-            var field = db.HashRandomFields(hashKey, 10).Select(x => (string)x).ToArray();
-            ClassicAssert.AreEqual(field.Length, 1);
-            ClassicAssert.AreEqual("Title", field[0]);
 
-            await Task.Delay(200).ConfigureAwait(false);
+            // Fields are asserted as present either before any short expiration is set or against a deadline no
+            // scheduling delay can consume, and their removal is polled for rather than assumed after a fixed delay.
+            var titleExpireTime = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(5);
+            db.Execute("HPEXPIREAT", hashKey, titleExpireTime.ToUnixTimeMilliseconds(), "FIELDS", 1, "Title");
 
-            field = db.HashRandomFields(hashKey, 10).Select(x => (string)x).ToArray();
-            ClassicAssert.AreEqual(field.Length, 0);
+            var fields = db.HashRandomFields(hashKey, 10).Select(x => (string)x).ToArray();
+            CollectionAssert.AreEquivalent(new[] { "Title", "Author" }, fields);
+
+            db.HashFieldExpire(hashKey, ["Author"], TimeSpan.FromMilliseconds(100));
+
+            await TestUtils.WaitUntilAsync(() => db.HashRandomFields(hashKey, 10).Length == 1,
+                message: "Expired field was still returned by HRANDFIELD");
+
+            fields = db.HashRandomFields(hashKey, 10).Select(x => (string)x).ToArray();
+            ClassicAssert.AreEqual(1, fields.Length);
+            ClassicAssert.AreEqual("Title", fields[0]);
+
+            db.Execute("HPEXPIREAT", hashKey, DateTimeOffset.UtcNow.AddSeconds(-1).ToUnixTimeMilliseconds(), "FIELDS", 1, "Title");
+
+            fields = db.HashRandomFields(hashKey, 10).Select(x => (string)x).ToArray();
+            ClassicAssert.AreEqual(0, fields.Length);
         }
 
         [Test]
@@ -1114,17 +1125,8 @@ namespace Garnet.test
             string[] smallExpireKeys = ["user:user0", "user:user1"];
             string[] largeExpireKeys = ["user:user2", "user:user3"];
 
-            foreach (var key in smallExpireKeys)
-            {
+            foreach (var key in smallExpireKeys.Union(largeExpireKeys))
                 db.HashSet(key, [new HashEntry("Field1", "StringValue"), new HashEntry("Field2", "1")]);
-                db.Execute("HEXPIRE", key, "2", "FIELDS", "1", "Field1");
-            }
-
-            foreach (var key in largeExpireKeys)
-            {
-                db.HashSet(key, [new HashEntry("Field1", "StringValue"), new HashEntry("Field2", "1")]);
-                db.Execute("HEXPIRE", key, "4", "FIELDS", "1", "Field1");
-            }
 
             // Create LTM (larger than memory) DB by inserting 1000 keys
             for (int i = 4; i < 1000; i++)
@@ -1137,26 +1139,30 @@ namespace Garnet.test
             // Ensure data has spilled to disk
             ClassicAssert.Greater(info.HeadAddress, info.BeginAddress);
 
-            await Task.Delay(2000).ConfigureAwait(false);
+            // Expirations are applied after the bulk insert so that the time it takes is not charged against them.
+            foreach (var key in smallExpireKeys)
+                db.Execute("HEXPIRE", key, "2", "FIELDS", "1", "Field1");
 
-            var result = db.HashExists(smallExpireKeys[0], "Field1");
-            ClassicAssert.IsFalse(result);
-            result = db.HashExists(smallExpireKeys[1], "Field1");
-            ClassicAssert.IsFalse(result);
-            result = db.HashExists(largeExpireKeys[0], "Field1");
+            var largeExpireTime = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(30);
+            foreach (var key in largeExpireKeys)
+                db.Execute("HEXPIREAT", key, largeExpireTime.ToUnixTimeSeconds(), "FIELDS", "1", "Field1");
+
+            await TestUtils.WaitUntilAsync(() => !db.HashExists(smallExpireKeys[0], "Field1") && !db.HashExists(smallExpireKeys[1], "Field1"),
+                message: "Fields with a short expiration were never removed from the hash");
+
+            var result = db.HashExists(largeExpireKeys[0], "Field1");
             ClassicAssert.IsTrue(result);
             result = db.HashExists(largeExpireKeys[1], "Field1");
             ClassicAssert.IsTrue(result);
             var ttl = db.HashFieldGetTimeToLive(largeExpireKeys[0], ["Field1"]);
             ClassicAssert.AreEqual(ttl.Length, 1);
-            ClassicAssert.Greater(ttl[0], 0);
-            ClassicAssert.LessOrEqual(ttl[0], 2000);
+            TestUtils.AssertTtlMilliseconds(largeExpireTime, ttl[0]);
             ttl = db.HashFieldGetTimeToLive(largeExpireKeys[1], ["Field1"]);
             ClassicAssert.AreEqual(ttl.Length, 1);
-            ClassicAssert.Greater(ttl[0], 0);
-            ClassicAssert.LessOrEqual(ttl[0], 2000);
+            TestUtils.AssertTtlMilliseconds(largeExpireTime, ttl[0]);
 
-            await Task.Delay(2000).ConfigureAwait(false);
+            foreach (var key in largeExpireKeys)
+                db.Execute("HEXPIREAT", key, DateTimeOffset.UtcNow.AddSeconds(-1).ToUnixTimeSeconds(), "FIELDS", "1", "Field1");
 
             result = db.HashExists(largeExpireKeys[0], "Field1");
             ClassicAssert.IsFalse(result);
@@ -1185,6 +1191,10 @@ namespace Garnet.test
 
             var expireTime = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(1);
 
+            // Expirations that are read back are set as absolute deadlines far enough out that neither the
+            // sleeps below nor the server restart can consume them.
+            var key2_2ExpireTime = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(1);
+
             using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
             {
                 var db = redis.GetDatabase(0);
@@ -1205,7 +1215,7 @@ namespace Garnet.test
                 db.HashSet(key2, values2_2);
 
                 // Add longer expiry to entry in 2nd hash set
-                db.Execute("HPEXPIRE", key2, 15000, "FIELDS", 1, "key2_2");
+                db.Execute("HPEXPIREAT", key2, key2_2ExpireTime.ToUnixTimeMilliseconds(), "FIELDS", 1, "key2_2");
                 Thread.Sleep(2000);
 
                 // Verify 1st hash set contains all added entries
@@ -1228,8 +1238,7 @@ namespace Garnet.test
                 ClassicAssert.IsNotNull(recoveredValuesTtl);
                 ClassicAssert.AreEqual(4, recoveredValuesTtl!.Length);
                 ClassicAssert.AreEqual(-2, (long)recoveredValuesTtl[0]);
-                ClassicAssert.LessOrEqual((long)recoveredValuesTtl[1], 13);
-                ClassicAssert.Greater((long)recoveredValuesTtl[1], 0);
+                TestUtils.AssertTtlSeconds(key2_2ExpireTime, (long)recoveredValuesTtl[1]);
                 ClassicAssert.AreEqual(-1, (long)recoveredValuesTtl[2]);
                 ClassicAssert.AreEqual(-1, (long)recoveredValuesTtl[3]);
             }
@@ -1264,8 +1273,7 @@ namespace Garnet.test
                 ClassicAssert.IsNotNull(recoveredValuesTtl);
                 ClassicAssert.AreEqual(4, recoveredValuesTtl!.Length);
                 ClassicAssert.AreEqual(-2, (long)recoveredValuesTtl[0]);
-                ClassicAssert.Less((long)recoveredValuesTtl[1], 13000);
-                ClassicAssert.Greater((long)recoveredValuesTtl[1], 0);
+                TestUtils.AssertTtlMilliseconds(key2_2ExpireTime, (long)recoveredValuesTtl[1]);
                 ClassicAssert.AreEqual(-1, (long)recoveredValuesTtl[2]);
                 ClassicAssert.AreEqual(-1, (long)recoveredValuesTtl[3]);
             }

--- a/test/standalone/Garnet.test.collections/RespSortedSetTests.cs
+++ b/test/standalone/Garnet.test.collections/RespSortedSetTests.cs
@@ -2008,12 +2008,6 @@ namespace Garnet.test
             ClassicAssert.AreEqual(1, (long)results[0]);
             ClassicAssert.AreEqual(1, (long)results[1]);
 
-            result = db.Execute("ZPEXPIRE", "mysortedset", "1500", "MEMBERS", "2", "member3", "member4");
-            results = (RedisResult[])result;
-            ClassicAssert.AreEqual(2, results.Length);
-            ClassicAssert.AreEqual(1, (long)results[0]);
-            ClassicAssert.AreEqual(1, (long)results[1]);
-
             var orginalMemory = (long)db.Execute("MEMORY", "USAGE", "mysortedset");
 
             await Task.Delay(600).ConfigureAwait(false);
@@ -2026,9 +2020,18 @@ namespace Garnet.test
 
             newMemory = (long)db.Execute("MEMORY", "USAGE", "mysortedset");
             ClassicAssert.Less(newMemory, orginalMemory);
-            orginalMemory = newMemory;
 
-            await Task.Delay(1100).ConfigureAwait(false);
+            // The second pair expires only once the first pair has been collected, so a stall in the phase
+            // above cannot consume the expiration window this phase depends on.
+            result = db.Execute("ZPEXPIRE", "mysortedset", "500", "MEMBERS", "2", "member3", "member4");
+            results = (RedisResult[])result;
+            ClassicAssert.AreEqual(2, results.Length);
+            ClassicAssert.AreEqual(1, (long)results[0]);
+            ClassicAssert.AreEqual(1, (long)results[1]);
+
+            orginalMemory = (long)db.Execute("MEMORY", "USAGE", "mysortedset");
+
+            await Task.Delay(600).ConfigureAwait(false);
 
             newMemory = (long)db.Execute("MEMORY", "USAGE", "mysortedset");
             ClassicAssert.AreEqual(newMemory, orginalMemory);
@@ -2045,7 +2048,12 @@ namespace Garnet.test
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = redis.GetDatabase(0);
-            db.SortedSetAdd("mysortedset", [new SortedSetEntry("member1", 1), new SortedSetEntry("member2", 2), new SortedSetEntry("member3", 3), new SortedSetEntry("member4", 4), new SortedSetEntry("member5", 5), new SortedSetEntry("member6", 6)]);
+            db.SortedSetAdd("mysortedset", [new SortedSetEntry("member1", 1), new SortedSetEntry("member2", 2), new SortedSetEntry("member3", 3), new SortedSetEntry("member4", 4), new SortedSetEntry("member5", 5), new SortedSetEntry("member6", 6), new SortedSetEntry("member7", 7)]);
+
+            // Members whose expiration is read back use a deadline no scheduling delay can consume, while the
+            // members observed expiring keep a short expiration. Mixing both roles in one member makes the
+            // TTL assertions depend on how long the commands in between happen to take.
+            var readDeadline = DateTimeOffset.UtcNow.AddMinutes(5);
 
             var result = db.Execute("ZEXPIRE", "mysortedset", "3", "MEMBERS", "3", "member1", "member5", "nonexistmember");
             var results = (RedisResult[])result;
@@ -2072,29 +2080,31 @@ namespace Garnet.test
             ClassicAssert.AreEqual(1, (long)results[0]);
             ClassicAssert.AreEqual(-2, (long)results[1]);
 
-            var ttl = (RedisResult[])db.Execute("ZTTL", "mysortedset", "MEMBERS", "2", "member1", "nonexistmember");
-            ClassicAssert.AreEqual(2, ttl.Length);
-            ClassicAssert.LessOrEqual((long)ttl[0], 3);
-            ClassicAssert.Greater((long)ttl[0], 1);
+            result = db.Execute("ZPEXPIREAT", "mysortedset", readDeadline.ToUnixTimeMilliseconds().ToString(), "MEMBERS", "2", "member7", "nonexistmember");
+            results = (RedisResult[])result;
+            ClassicAssert.AreEqual(2, results.Length);
+            ClassicAssert.AreEqual(1, (long)results[0]);
             ClassicAssert.AreEqual(-2, (long)results[1]);
 
-            ttl = (RedisResult[])db.Execute("ZPTTL", "mysortedset", "MEMBERS", "2", "member1", "nonexistmember");
+            var ttl = (RedisResult[])db.Execute("ZTTL", "mysortedset", "MEMBERS", "2", "member7", "nonexistmember");
             ClassicAssert.AreEqual(2, ttl.Length);
-            ClassicAssert.LessOrEqual((long)ttl[0], 3000);
-            ClassicAssert.Greater((long)ttl[0], 1000);
-            ClassicAssert.AreEqual(-2, (long)results[1]);
+            TestUtils.AssertTtlSeconds(readDeadline, (long)ttl[0]);
+            ClassicAssert.AreEqual(-2, (long)ttl[1]);
 
-            ttl = (RedisResult[])db.Execute("ZEXPIRETIME", "mysortedset", "MEMBERS", "2", "member1", "nonexistmember");
+            ttl = (RedisResult[])db.Execute("ZPTTL", "mysortedset", "MEMBERS", "2", "member7", "nonexistmember");
             ClassicAssert.AreEqual(2, ttl.Length);
-            ClassicAssert.LessOrEqual((long)ttl[0], DateTimeOffset.UtcNow.AddSeconds(3).ToUnixTimeSeconds());
-            ClassicAssert.Greater((long)ttl[0], DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeSeconds());
-            ClassicAssert.AreEqual(-2, (long)results[1]);
+            TestUtils.AssertTtlMilliseconds(readDeadline, (long)ttl[0]);
+            ClassicAssert.AreEqual(-2, (long)ttl[1]);
 
-            ttl = (RedisResult[])db.Execute("ZPEXPIRETIME", "mysortedset", "MEMBERS", "2", "member1", "nonexistmember");
+            ttl = (RedisResult[])db.Execute("ZEXPIRETIME", "mysortedset", "MEMBERS", "2", "member7", "nonexistmember");
             ClassicAssert.AreEqual(2, ttl.Length);
-            ClassicAssert.LessOrEqual((long)ttl[0], DateTimeOffset.UtcNow.AddSeconds(3).ToUnixTimeMilliseconds());
-            ClassicAssert.Greater((long)ttl[0], DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeMilliseconds());
-            ClassicAssert.AreEqual(-2, (long)results[1]);
+            Assert.That((long)ttl[0], Is.EqualTo(readDeadline.ToUnixTimeSeconds()).Within(1));
+            ClassicAssert.AreEqual(-2, (long)ttl[1]);
+
+            ttl = (RedisResult[])db.Execute("ZPEXPIRETIME", "mysortedset", "MEMBERS", "2", "member7", "nonexistmember");
+            ClassicAssert.AreEqual(2, ttl.Length);
+            ClassicAssert.AreEqual(readDeadline.ToUnixTimeMilliseconds(), (long)ttl[0]);
+            ClassicAssert.AreEqual(-2, (long)ttl[1]);
 
             results = (RedisResult[])db.Execute("ZPERSIST", "mysortedset", "MEMBERS", "3", "member5", "member6", "nonexistmember");
             ClassicAssert.AreEqual(3, results.Length);
@@ -2102,24 +2112,28 @@ namespace Garnet.test
             ClassicAssert.AreEqual(-1, (long)results[1]); // -1 if the member exists but has no associated expiration set.
             ClassicAssert.AreEqual(-2, (long)results[2]);
 
-            await Task.Delay(3500).ConfigureAwait(false);
+            await TestUtils.WaitUntilAsync(() => db.SortedSetRangeByRankWithScores("mysortedset").Length == 3,
+                message: "Members with a short expiration were never removed from the sorted set");
 
             var items = db.SortedSetRangeByRankWithScores("mysortedset");
-            ClassicAssert.AreEqual(2, items.Length);
+            ClassicAssert.AreEqual(3, items.Length);
             ClassicAssert.AreEqual("member5", items[0].Element.ToString());
             ClassicAssert.AreEqual(5, items[0].Score);
             ClassicAssert.AreEqual("member6", items[1].Element.ToString());
             ClassicAssert.AreEqual(6, items[1].Score);
+            ClassicAssert.AreEqual("member7", items[2].Element.ToString());
+            ClassicAssert.AreEqual(7, items[2].Score);
 
             result = db.Execute("ZEXPIRE", "mysortedset", "0", "MEMBERS", "1", "member5");
             results = (RedisResult[])result;
             ClassicAssert.AreEqual(1, results.Length);
             ClassicAssert.AreEqual(2, (long)results[0]);
 
-            result = db.Execute("ZEXPIREAT", "mysortedset", DateTimeOffset.UtcNow.AddSeconds(-1).ToUnixTimeSeconds().ToString(), "MEMBERS", "1", "member6");
+            result = db.Execute("ZEXPIREAT", "mysortedset", DateTimeOffset.UtcNow.AddSeconds(-1).ToUnixTimeSeconds().ToString(), "MEMBERS", "2", "member6", "member7");
             results = (RedisResult[])result;
-            ClassicAssert.AreEqual(1, results.Length);
+            ClassicAssert.AreEqual(2, results.Length);
             ClassicAssert.AreEqual(2, (long)results[0]);
+            ClassicAssert.AreEqual(2, (long)results[1]);
 
             items = db.SortedSetRangeByRankWithScores("mysortedset");
             ClassicAssert.AreEqual(0, items.Length);
@@ -2327,6 +2341,10 @@ namespace Garnet.test
 
             var expireTime = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(1);
 
+            // Expirations that are read back are set as absolute deadlines far enough out that neither the
+            // sleeps below nor the server restart can consume them.
+            var val2_2ExpireTime = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(1);
+
             using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
             {
                 var db = redis.GetDatabase(0);
@@ -2347,7 +2365,7 @@ namespace Garnet.test
                 db.SortedSetAdd(key2, values2_2);
 
                 // Add longer expiry to entry in 2nd sorted set
-                db.Execute("ZPEXPIRE", key2, 15000, "MEMBERS", 1, "val2_2");
+                db.Execute("ZPEXPIREAT", key2, val2_2ExpireTime.ToUnixTimeMilliseconds(), "MEMBERS", 1, "val2_2");
                 Thread.Sleep(2000);
 
                 // Verify 1st sorted set contains all added entries
@@ -2370,8 +2388,7 @@ namespace Garnet.test
                 ClassicAssert.IsNotNull(recoveredValuesTtl);
                 ClassicAssert.AreEqual(4, recoveredValuesTtl!.Length);
                 ClassicAssert.AreEqual(-2, (long)recoveredValuesTtl[0]);
-                ClassicAssert.LessOrEqual((long)recoveredValuesTtl[1], 13);
-                ClassicAssert.Greater((long)recoveredValuesTtl[1], 0);
+                TestUtils.AssertTtlSeconds(val2_2ExpireTime, (long)recoveredValuesTtl[1]);
                 ClassicAssert.AreEqual(-1, (long)recoveredValuesTtl[2]);
                 ClassicAssert.AreEqual(-1, (long)recoveredValuesTtl[3]);
             }
@@ -2406,8 +2423,7 @@ namespace Garnet.test
                 ClassicAssert.IsNotNull(recoveredValuesTtl);
                 ClassicAssert.AreEqual(4, recoveredValuesTtl!.Length);
                 ClassicAssert.AreEqual(-2, (long)recoveredValuesTtl[0]);
-                ClassicAssert.Less((long)recoveredValuesTtl[1], 13000);
-                ClassicAssert.Greater((long)recoveredValuesTtl[1], 0);
+                TestUtils.AssertTtlMilliseconds(val2_2ExpireTime, (long)recoveredValuesTtl[1]);
                 ClassicAssert.AreEqual(-1, (long)recoveredValuesTtl[2]);
                 ClassicAssert.AreEqual(-1, (long)recoveredValuesTtl[3]);
             }

--- a/test/standalone/Garnet.test/TestUtils.cs
+++ b/test/standalone/Garnet.test/TestUtils.cs
@@ -280,6 +280,55 @@ namespace Garnet.test
         }
 
         /// <summary>
+        /// Polls <paramref name="condition"/> until it returns true, failing the test if <paramref name="timeout"/> elapses first.
+        /// Prefer this over a fixed delay whenever a test waits for an expiration or a background task to take effect,
+        /// so that a slow or contended machine makes the test slower rather than failing it.
+        /// </summary>
+        /// <param name="condition">Condition to poll.</param>
+        /// <param name="timeout">Maximum time to wait. Defaults to 30 seconds.</param>
+        /// <param name="message">Message reported when the condition is never satisfied.</param>
+        public static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout = default, string message = null)
+        {
+            var deadline = DateTimeOffset.UtcNow + (timeout == default ? TimeSpan.FromSeconds(30) : timeout);
+            while (!condition())
+            {
+                if (DateTimeOffset.UtcNow >= deadline)
+                    Assert.Fail(message ?? $"Timed out after {timeout} waiting for condition");
+
+                await Task.Delay(50).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Asserts that a TTL in seconds reported by the server matches the time remaining until <paramref name="deadline"/>,
+        /// recomputed at assertion time. Set expirations with an absolute deadline (E.g. HEXPIREAT/ZEXPIREAT) and assert with this
+        /// helper, so that time spent between setting the expiration and reading it back cannot make the assertion fail.
+        /// </summary>
+        /// <param name="deadline">Absolute instant the expiration was set to.</param>
+        /// <param name="actualSeconds">TTL in seconds reported by the server.</param>
+        /// <param name="toleranceSeconds">Allowed deviation, covering the server's rounding to whole seconds.</param>
+        public static void AssertTtlSeconds(DateTimeOffset deadline, long actualSeconds, long toleranceSeconds = 2)
+        {
+            var remainingSeconds = (deadline - DateTimeOffset.UtcNow).TotalSeconds;
+            Assert.That(remainingSeconds, Is.GreaterThan(0), "Deadline already elapsed, widen the expiration horizon used by the test");
+            Assert.That(actualSeconds, Is.EqualTo(remainingSeconds).Within(toleranceSeconds));
+        }
+
+        /// <summary>
+        /// Asserts that a TTL in milliseconds reported by the server matches the time remaining until <paramref name="deadline"/>,
+        /// recomputed at assertion time. See <see cref="AssertTtlSeconds"/>.
+        /// </summary>
+        /// <param name="deadline">Absolute instant the expiration was set to.</param>
+        /// <param name="actualMilliseconds">TTL in milliseconds reported by the server.</param>
+        /// <param name="toleranceMilliseconds">Allowed deviation.</param>
+        public static void AssertTtlMilliseconds(DateTimeOffset deadline, long actualMilliseconds, long toleranceMilliseconds = 2000)
+        {
+            var remainingMilliseconds = (deadline - DateTimeOffset.UtcNow).TotalMilliseconds;
+            Assert.That(remainingMilliseconds, Is.GreaterThan(0), "Deadline already elapsed, widen the expiration horizon used by the test");
+            Assert.That(actualMilliseconds, Is.EqualTo(remainingMilliseconds).Within(toleranceMilliseconds));
+        }
+
+        /// <summary>
         /// Create GarnetServer
         /// </summary>
         public static GarnetServer CreateGarnetServer(


### PR DESCRIPTION
## What

Adds `CLUSTER POKEGOSSIP`, which runs the next gossip round immediately instead of waiting for the gossip timer, and returns `OK`.

## Why

Anything that gates on cluster-wide agreement — a control plane reconciling slot ownership, a test asserting a topology change landed, a tool waiting for a node to be seen as connected — currently has to wait out `--gossip-delay` for each step, even though the underlying work takes milliseconds. There is no way to say "propagate what you have now".

Driving a containerized cluster through repeated scale up/down and failover, the wall time was dominated by these waits rather than by migration or replication. Poking gossip between steps makes convergence work-bound rather than timer-bound. Lowering `--gossip-delay` globally is the alternative, but that pays the cost continuously on every node instead of only where a caller actually needs promptness.

## Notes

- Admin-only: it lands under the existing `CLUSTER` ACL surface, so no new permission is granted to data-plane users.
- No behavioural change when the command is not used — the timer path is untouched.
- Covered by the ACL command test suite; `RespCommandsInfo.json` / `RespCommandsDocs.json` updated so the command is introspectable like any other.
