### PR TITLE
Bump version to 2.1.4

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- VersionPrefix property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>2.1.3</VersionPrefix>
+		<VersionPrefix>2.1.4</VersionPrefix>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Increments `VersionPrefix` in `Version.props` from 2.1.3 to 2.1.4 to cut a new patch release.