### PR TITLE
Preserve live record framing during revivification

### DIFF
--- a/libs/storage/Tsavorite/cs/src/core/Allocator/LogRecord.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/LogRecord.cs
@@ -1503,7 +1503,7 @@ namespace Tsavorite.core
         /// <remarks>This is 'readonly' because it does not alter the fields of this object, only what they point to.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly void PrepareForRevivification(ref RecordSizeInfo sizeInfo)
-            => DataHeaderRef.InitializeForRevivification(ref sizeInfo, physicalAddress);
+            => DataHeaderRef.InitializeForRevivification(ref sizeInfo);
 
         /// <summary>
         /// Sets the lengths of Overflow Keys and Values and Object values into the disk-image copy of the log record before the main-log page is flushed.

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/RecordDataHeader.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/RecordDataHeader.cs
@@ -625,11 +625,8 @@ namespace Tsavorite.core
             return Size;
         }
 
-        /// <summary>Prepare the header for revivification: clear filler, namespace, and recordType; preserve inline bits and lengths.
-        /// This is called only when an existing allocation is being reused (revivification or retry on CAS failure), so preserves length info.
-        /// <para>Atomicity: builds the cleaned RDH in a local then publishes via a single 8-byte word write (<c>word = local.word</c>).
-        /// Concurrent scanners observe either the pre-revivification or post-revivification state, never an intermediate.</para></summary>
-        internal void InitializeForRevivification(ref RecordSizeInfo sizeInfo, long recordBaseAddress)
+        /// <summary>Prepare size metadata for reuse while preserving live framing for concurrent physical scans.</summary>
+        internal void InitializeForRevivification(ref RecordSizeInfo sizeInfo)
         {
             Debug.Assert(KeyIsInline, "Expected Key to be inline in InitializeForRevivification");
             Debug.Assert(ValueIsInline, "Expected Value to be inline in InitializeForRevivification");
@@ -637,15 +634,6 @@ namespace Tsavorite.core
 
             var recordLength = GetRecordLength();
             Debug.Assert(sizeInfo.AllocatedInlineRecordSize <= recordLength, "Cannot exceed previous Record size in InitializeForRevivification");
-
-            // Build the cleaned RDH in a local: clear FillerWords + Namespace + RecordType bytes; preserve inline bits + lengths.
-            var localDataHeader = this;
-            localDataHeader.FillerWords = 0;
-            localDataHeader.SetNamespaceByteRaw(0);
-            localDataHeader.RecordType = 0;
-
-            // Single atomic publish via word assignment through `ref this`.
-            word = localDataHeader.word;
 
             // Ensure the AllocatedInlineRecordSize retains recordLength when LogRecord.InitializeRecord is called
             sizeInfo.AllocatedInlineRecordSize = recordLength;

--- a/libs/storage/Tsavorite/cs/test/test.hlog/LogRecordTests.cs
+++ b/libs/storage/Tsavorite/cs/test/test.hlog/LogRecordTests.cs
@@ -167,6 +167,60 @@ namespace Tsavorite.test.LogRecordTests
             }
         }
 
+        [TestCase(0, 38, 0, 0)]
+        [TestCase(0, 37, 0, 1)]
+        [TestCase(29, 41, 0, 0)]
+        [TestCase(29, 37, 0, 4)]
+        [TestCase(0, 38, 24, 0)]
+        [TestCase(0, 7, 24, 7)]
+        [TestCase(29, 41, 24, 0)]
+        [TestCase(29, 7, 24, 2)]
+        [Category(LogRecordCategory), Category(SmokeTestCategory)]
+        public void RevivificationPreparationPreservesLiveFraming(int extendedNamespaceSize, int valueSize, int explicitFillerLength, int implicitFillerLength)
+        {
+            nativePointer = (long)NativeMemory.AlignedAlloc(512, Constants.kCacheLineBytes);
+            NativeMemory.Clear((void*)nativePointer, 512);
+
+            var oldSizeInfo = new RecordSizeInfo { FieldInfo = new() { KeySize = initialKeyLen, ValueSize = valueSize, ExtendedNamespaceSize = extendedNamespaceSize, RecordType = 7 } };
+            UpdateRecordSizeInfo(ref oldSizeInfo);
+            oldSizeInfo.AllocatedInlineRecordSize += explicitFillerLength;
+
+            var newSizeInfo = new RecordSizeInfo { FieldInfo = new() { KeySize = initialKeyLen, ValueSize = 8 } };
+            UpdateRecordSizeInfo(ref newSizeInfo);
+            ref var dataHeader = ref *(RecordDataHeader*)(nativePointer + RecordInfo.Size);
+
+            _ = dataHeader.Initialize(in oldSizeInfo, out _, out _, out _, nativePointer);
+            var oldRecordLength = dataHeader.GetRecordLength();
+            Assert.That(dataHeader.KeyLength, Is.EqualTo(oldSizeInfo.InlineKeySize));
+            Assert.That(dataHeader.ValueLength, Is.EqualTo(oldSizeInfo.InlineValueSize));
+            Assert.That(dataHeader.ExtendedNamespaceLength, Is.EqualTo(oldSizeInfo.FieldInfo.ExtendedNamespaceSize));
+            Assert.That(dataHeader.RecordType, Is.EqualTo(oldSizeInfo.FieldInfo.RecordType));
+            Assert.That(dataHeader.GetUnalignedComponentSum(), Is.EqualTo(oldSizeInfo.ActualInlineRecordSize));
+            Assert.That(oldRecordLength, Is.EqualTo(oldSizeInfo.AllocatedInlineRecordSize));
+            Assert.That(dataHeader.GetExplicitFillerLength(), Is.EqualTo(explicitFillerLength));
+            var totalFillerLength = dataHeader.GetTotalFillerLength();
+            Assert.That(totalFillerLength, Is.EqualTo(explicitFillerLength + implicitFillerLength));
+            var expectedKeyLength = dataHeader.KeyLength;
+            var expectedValueLength = dataHeader.ValueLength;
+            var logRecord = new LogRecord(nativePointer);
+            logRecord.PrepareForRevivification(ref newSizeInfo);
+
+            Assert.That(dataHeader.GetRecordLength(), Is.EqualTo(oldRecordLength));
+            Assert.That(dataHeader.KeyLength, Is.EqualTo(expectedKeyLength));
+            Assert.That(dataHeader.ValueLength, Is.EqualTo(expectedValueLength));
+            Assert.That(dataHeader.ExtendedNamespaceLength, Is.EqualTo(oldSizeInfo.FieldInfo.ExtendedNamespaceSize));
+            Assert.That(dataHeader.GetExplicitFillerLength(), Is.EqualTo(explicitFillerLength));
+            Assert.That(dataHeader.GetTotalFillerLength(), Is.EqualTo(totalFillerLength));
+            Assert.That(dataHeader.RecordType, Is.EqualTo(oldSizeInfo.FieldInfo.RecordType));
+            Assert.That(newSizeInfo.AllocatedInlineRecordSize, Is.EqualTo(oldRecordLength));
+
+            Span<byte> key = stackalloc byte[initialKeyLen];
+            key.Fill(0x42);
+            logRecord.InitializeHeadersForNewRecord(inNewVersion: false, previousAddress: 64);
+            logRecord.InitializeRecord(TestSpanByteKey.FromPinnedSpan(key), in newSizeInfo);
+            Assert.That(dataHeader.GetRecordLength(), Is.EqualTo(oldRecordLength));
+        }
+
         [Test]
         [Category(LogRecordCategory), Category(SmokeTestCategory)]
         //[Repeat(900)]


### PR DESCRIPTION
Physical log walkers read `AllocatedSize` before checking whether a record is sealed or invalid, so a record being prepared for reuse must keep a stable extent. `InitializeForRevivification` cleared filler, namespace, and record type without transferring those byte counts, temporarily shortening the visible allocation — worst on the retry-of-failed-CAS path, where the whole allocation sits in `FillerWords` and clearing it collapsed `GetRecordLength()` to 16 bytes.

## Fix

Preparation no longer touches the header; it only grows `RecordSizeInfo.AllocatedInlineRecordSize` to the full length of the reused allocation. Nothing reads the header before `LogRecord.InitializeRecord` republishes it from that size info, so the extent never changes.

## Evidence

`RevivificationPreparationPreservesLiveFraming` covers the eight-case matrix of aligned/unaligned content, with/without namespace, and with/without explicit filler, asserting the extent is unchanged after both preparation and record initialization.
