### PR TITLE
Fix concurrent VADD deadlock on disk-tiered vector sets

### DIFF
--- a/libs/server/Resp/Vector/VectorManager.Locking.cs
+++ b/libs/server/Resp/Vector/VectorManager.Locking.cs
@@ -74,11 +74,24 @@ namespace Garnet.server
         /// Returns a disposable that prevents the index from being deleted while undisposed.
         /// </summary>
         internal VectorSetLock ReadVectorIndex(StorageSession storageSession, ReadOnlySpan<byte> key, ref StringInput input, scoped Span<byte> indexSpan, out GarnetStatus status)
+            => ReadVectorIndexCore(storageSession, key, ref input, indexSpan, nonBlocking: false, out status, out _);
+
+        /// <summary>
+        /// Core of <see cref="ReadVectorIndex"/>. When <paramref name="nonBlocking"/> is <c>true</c>, the per-set
+        /// lock is taken with the non-spinning <c>TryAcquire*</c> path: if it cannot be acquired immediately
+        /// (another thread holds it — typically a network VADD recreating a disk-tiered index and blocked on a
+        /// pending disk read), this returns a default (empty) lock with <paramref name="wouldBlock"/> set to
+        /// <c>true</c> instead of spin-waiting. Callers that run on the thread pool use this so they can yield
+        /// their pool thread and retry asynchronously rather than consuming the pool and starving the disk-IO
+        /// completion that releases the lock.
+        /// </summary>
+        private VectorSetLock ReadVectorIndexCore(StorageSession storageSession, ReadOnlySpan<byte> key, ref StringInput input, scoped Span<byte> indexSpan, bool nonBlocking, out GarnetStatus status, out bool wouldBlock)
         {
             Debug.Assert(indexSpan.Length == IndexSizeBytes, "Insufficient space for index");
 
             Debug.Assert(ActiveThreadSession == null, "Shouldn't enter context when already in one");
             ActiveThreadSession = storageSession;
+            wouldBlock = false;
             try
             {
                 var keyHash = storageSession.stringBasicContext.GetKeyHash((FixedSpanByteKey)key);
@@ -97,14 +110,38 @@ namespace Garnet.server
                     ReadOptimizedLock.LockToken lockToken;
                     if (takeExclusiveLock)
                     {
-                        vectorSetLocks.AcquireExclusiveLock(keyHash, out lockToken);
+                        if (nonBlocking)
+                        {
+                            if (!vectorSetLocks.TryAcquireExclusiveLock(keyHash, out lockToken))
+                            {
+                                status = default;
+                                wouldBlock = true;
+                                return default;
+                            }
+                        }
+                        else
+                        {
+                            vectorSetLocks.AcquireExclusiveLock(keyHash, out lockToken);
+                        }
 
                         // If we pass through _again_, don't start with an exclusive lock
                         takeExclusiveLock = false;
                     }
                     else
                     {
-                        vectorSetLocks.AcquireSharedLock(keyHash, out lockToken);
+                        if (nonBlocking)
+                        {
+                            if (!vectorSetLocks.TryAcquireSharedLock(keyHash, out lockToken))
+                            {
+                                status = default;
+                                wouldBlock = true;
+                                return default;
+                            }
+                        }
+                        else
+                        {
+                            vectorSetLocks.AcquireSharedLock(keyHash, out lockToken);
+                        }
                     }
 
                     GarnetStatus readRes;
@@ -149,6 +186,15 @@ namespace Garnet.server
                         {
                             vectorSetLocks.ReleaseLock(lockToken);
                             takeExclusiveLock = false;
+
+                            if (nonBlocking)
+                            {
+                                // Don't spin on a pool thread waiting for the drop to finish; report contention so
+                                // the caller yields its pool thread and retries.
+                                status = default;
+                                wouldBlock = true;
+                                return default;
+                            }
 
                             WaitForDiskANNIndexDrop(key);
                             continue;

--- a/libs/server/Resp/Vector/VectorManager.Quantization.cs
+++ b/libs/server/Resp/Vector/VectorManager.Quantization.cs
@@ -34,7 +34,22 @@ namespace Garnet.server
         private readonly record struct QuantizationState(ReadOnlyMemory<byte> Key, QuantizationStep Step, int StepIndex);
 
         private readonly Channel<QuantizationState> quantizationChannel;
+
+        /// <summary>
+        /// Worker tasks that drain <see cref="quantizationChannel"/>. They run on the .NET thread pool, but a
+        /// worker that cannot immediately acquire a vector set's lock yields its pool thread and retries
+        /// asynchronously (see <see cref="StartQuantizationTasks"/>) instead of spin-waiting on it. A network VADD
+        /// that recreates a disk-tiered index blocks on a pending disk read while holding that lock exclusively;
+        /// if the workers spin-waited on the pool they would consume every pool thread and starve the disk-IO
+        /// completion that releases the lock, deadlocking concurrent VADD. Cooperative yielding keeps pool threads
+        /// available for that completion.
+        /// </summary>
         private readonly Task[] quantizationTasks;
+
+        /// <summary>
+        /// Number of quantization worker tasks, also used as the backfill shard count.
+        /// </summary>
+        private readonly int quantizationTaskCount;
 
         private int quantizationRequestsProcessed;
         private int quantizationBackfillsProcessed;
@@ -72,66 +87,100 @@ namespace Garnet.server
                         throw new GarnetException($"Could not switch VectorManager cleanup session to {self.dbId}, initialization failed");
                     }
 
-                    Span<byte> indexSpan = GC.AllocateArray<byte>(IndexSizeBytes, pinned: true);
+                    // Pinned once and reused; the synchronous per-request body views it as a Span. Kept as a byte[]
+                    // (not a Span) because it must survive the awaits in the cooperative retry loop below.
+                    var indexArray = GC.AllocateArray<byte>(IndexSizeBytes, pinned: true);
 
                     while (reader.TryRead(out var state))
                     {
-                        try
+                        // Cooperative acquisition. TryProcessQuantizationRequest returns false only when the vector
+                        // set lock is currently held by another thread - typically a network VADD that is recreating
+                        // a disk-tiered index and is blocked on a pending disk read while holding the lock exclusively.
+                        // Instead of spin-waiting on a pool thread (which would consume the pool and starve the
+                        // disk-IO completion that releases the lock, deadlocking concurrent VADD), yield the pool
+                        // thread and retry so a completion can always be scheduled.
+                        for (var attempt = 0; !TryProcessQuantizationRequest(self, session, writer, state, indexArray); attempt++)
                         {
-                            unsafe
+                            if (attempt < 16)
+                                await Task.Yield();
+                            else
+                                await Task.Delay(1).ConfigureAwait(false);
+                        }
+                    }
+                }
+            }
+
+            // Processes a single request under a non-blocking lock acquisition. Returns true when the request was
+            // handled (or is terminal, e.g. the index was dropped), and false when the set lock was contended and
+            // the caller should yield its pool thread and retry. All ref struct / Span / native interop stays inside
+            // this synchronous method so it never straddles an await.
+            static bool TryProcessQuantizationRequest(VectorManager self, RespServerSession session, ChannelWriter<QuantizationState> writer, QuantizationState state, byte[] indexArray)
+            {
+                try
+                {
+                    unsafe
+                    {
+                        fixed (byte* keyPtr = state.Key.Span)
+                        {
+                            var keySpan = SpanByte.FromPinnedPointer(keyPtr, state.Key.Length);
+
+                            // Dummy command, we just need something Vector Set-y
+                            StringInput input = default;
+                            input.header.cmd = RespCommand.VSIM;
+
+                            Span<byte> indexSpan = indexArray;
+
+                            using (self.ReadVectorIndexCore(session.storageSession, keySpan, ref input, indexSpan, nonBlocking: true, out var res, out var contended))
                             {
-                                fixed (byte* keyPtr = state.Key.Span)
+                                // The lock is held by another thread (often a network VADD blocked on a pending disk
+                                // read during index recreate). Report back so the caller yields and retries rather
+                                // than spinning on a pool thread.
+                                if (contended)
+                                    return false;
+
+                                if (res != GarnetStatus.OK)
                                 {
-                                    var keySpan = SpanByte.FromPinnedPointer(keyPtr, state.Key.Length);
+                                    // Index was dropped before quantization request could be processed, ignore request
+                                    return true;
+                                }
 
-                                    // Dummy command, we just need something Vector Set-y
-                                    StringInput input = default;
-                                    input.header.cmd = RespCommand.VSIM;
+                                ReadIndex(indexSpan, out var context, out _, out _, out _, out _, out _, out _, out _, out var indexPtr);
 
-                                    using (self.ReadVectorIndex(session.storageSession, keySpan, ref input, indexSpan, out var res))
-                                    {
-                                        if (res != GarnetStatus.OK)
+                                switch (state.Step)
+                                {
+                                    case QuantizationStep.BuildQuantizationTable:
+                                        if (self.Service.BuildQuantizationTable(context, indexPtr))
                                         {
-                                            // Index was dropped before quantization request could be processed, ignore request
-                                            continue;
+                                            _ = Interlocked.Increment(ref self.quantizationRequestsProcessed);
+
+                                            // Schedule backfill after quantization table is available
+                                            for (var i = 0; i < self.quantizationTaskCount; i++)
+                                            {
+                                                _ = writer.TryWrite(new(state.Key, QuantizationStep.BackfillQuantizedVectors, i));
+                                            }
                                         }
 
-                                        ReadIndex(indexSpan, out var context, out _, out _, out _, out _, out _, out _, out _, out var indexPtr);
+                                        break;
 
-                                        switch (state.Step)
-                                        {
-                                            case QuantizationStep.BuildQuantizationTable:
-                                                if (self.Service.BuildQuantizationTable(context, indexPtr))
-                                                {
-                                                    _ = Interlocked.Increment(ref self.quantizationRequestsProcessed);
+                                    case QuantizationStep.BackfillQuantizedVectors:
+                                        self.Service.BackfillQuantizedVectors(context, indexPtr, state.StepIndex, self.quantizationTaskCount);
 
-                                                    // Schedule backfill after quantization table is available
-                                                    for (var i = 0; i < self.quantizationTasks.Length; i++)
-                                                    {
-                                                        _ = writer.TryWrite(new(state.Key, QuantizationStep.BackfillQuantizedVectors, i));
-                                                    }
-                                                }
-
-                                                break;
-
-                                            case QuantizationStep.BackfillQuantizedVectors:
-                                                self.Service.BackfillQuantizedVectors(context, indexPtr, state.StepIndex, self.quantizationTasks.Length);
-
-                                                _ = Interlocked.Increment(ref self.quantizationBackfillsProcessed);
-                                                break;
-                                            default:
-                                                self.logger?.LogError("Unexpected step: {step}", state.Step);
-                                                break;
-                                        }
-                                    }
+                                        _ = Interlocked.Increment(ref self.quantizationBackfillsProcessed);
+                                        break;
+                                    default:
+                                        self.logger?.LogError("Unexpected step: {step}", state.Step);
+                                        break;
                                 }
                             }
                         }
-                        catch (Exception ex)
-                        {
-                            self.logger?.LogError(ex, "During Vector Set quantization");
-                        }
                     }
+
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    self.logger?.LogError(ex, "During Vector Set quantization");
+                    return true;
                 }
             }
         }

--- a/libs/server/Resp/Vector/VectorManager.cs
+++ b/libs/server/Resp/Vector/VectorManager.cs
@@ -224,9 +224,8 @@ namespace Garnet.server
 
             if (serverOptions.VectorSetQuantizationTaskCount < 0 || serverOptions.VectorSetQuantizationTaskCount > Environment.ProcessorCount)
                 throw new GarnetException($"VectorSetQuantizationTaskCount should be in range [0,{Environment.ProcessorCount}]!");
-            var vectorSetQuantizationTaskCount = serverOptions.VectorSetQuantizationTaskCount == 0 ? Environment.ProcessorCount : serverOptions.VectorSetQuantizationTaskCount;
-            quantizationTaskCount = vectorSetQuantizationTaskCount;
-            quantizationTasks = new Task[vectorSetQuantizationTaskCount];
+            quantizationTaskCount = serverOptions.VectorSetQuantizationTaskCount == 0 ? Environment.ProcessorCount : serverOptions.VectorSetQuantizationTaskCount;
+            quantizationTasks = new Task[quantizationTaskCount];
 
             // So Dispose's Task.WhenAll is safe even if StartQuantizationTasks never ran.
             Array.Fill(quantizationTasks, Task.CompletedTask);

--- a/libs/server/Resp/Vector/VectorManager.cs
+++ b/libs/server/Resp/Vector/VectorManager.cs
@@ -225,7 +225,10 @@ namespace Garnet.server
             if (serverOptions.VectorSetQuantizationTaskCount < 0 || serverOptions.VectorSetQuantizationTaskCount > Environment.ProcessorCount)
                 throw new GarnetException($"VectorSetQuantizationTaskCount should be in range [0,{Environment.ProcessorCount}]!");
             var vectorSetQuantizationTaskCount = serverOptions.VectorSetQuantizationTaskCount == 0 ? Environment.ProcessorCount : serverOptions.VectorSetQuantizationTaskCount;
+            quantizationTaskCount = vectorSetQuantizationTaskCount;
             quantizationTasks = new Task[vectorSetQuantizationTaskCount];
+
+            // So Dispose's Task.WhenAll is safe even if StartQuantizationTasks never ran.
             Array.Fill(quantizationTasks, Task.CompletedTask);
 
             logger?.LogInformation("Created VectorManager");
@@ -487,7 +490,7 @@ namespace Garnet.server
             // Cleanup task has fully drained, so nothing else can take this gate.
             cleanupGate.Dispose();
 
-            // drain quantization task
+            // drain quantization work and stop the worker tasks
             _ = quantizationChannel.Writer.TryComplete();
             while (quantizationChannel.Reader.TryRead(out _)) { }
             AsyncUtils.BlockingWait(Task.WhenAll(quantizationTasks));

--- a/test/standalone/Garnet.test.vectorset/ConcurrentVaddDiskSpillTests.cs
+++ b/test/standalone/Garnet.test.vectorset/ConcurrentVaddDiskSpillTests.cs
@@ -56,61 +56,85 @@ namespace Garnet.test
         [Test]
         public void ConcurrentVaddToSpilledSetMakesProgress()
         {
-            using var server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, lowMemory: true, enableVectorSetPreview: true);
-            server.Start();
+            var server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, lowMemory: true, enableVectorSetPreview: true);
 
-            const int threads = 8, dim = 32;
-            const int runSeconds = 60;
-            const int stallLimitSeconds = 45;
-            var cfg = TestUtils.GetConfig(allowAdmin: true);
-            cfg.SyncTimeout = 60000;
-            using var redis = ConnectionMultiplexer.Connect(cfg);
-
-            var stop = new CancellationTokenSource();
-            var deadline = DateTime.UtcNow.AddSeconds(runSeconds);
-            var workers = new Task[threads];
-            for (var t = 0; t < threads; t++)
+            // Under a regression the quantization workers spin-wait on the vector-set lock permanently and
+            // VectorManager.Dispose() blocks on Task.WhenAll of them, so disposing the server inline (via a using)
+            // on the deadlock path would hang teardown before NUnit could report the failure. The deadlock branch
+            // below instead disposes on a background task with a bounded wait and, if that does not complete,
+            // abandons the wedged server (its workers are background thread-pool tasks that do not block process
+            // exit, and OnTearDown resets the leaked epoch instances). This keeps the failure deterministic without
+            // spawning a separate, killable process.
+            var disposeServer = true;
+            try
             {
-                var tid = t;
-                workers[tid] = Task.Run(() =>
+                server.Start();
+
+                const int threads = 8, dim = 32;
+                const int runSeconds = 60;
+                const int stallLimitSeconds = 45;
+                var cfg = TestUtils.GetConfig(allowAdmin: true);
+                cfg.SyncTimeout = 60000;
+                using var redis = ConnectionMultiplexer.Connect(cfg);
+
+                var stop = new CancellationTokenSource();
+                var deadline = DateTime.UtcNow.AddSeconds(runSeconds);
+                var workers = new Task[threads];
+                for (var t = 0; t < threads; t++)
                 {
-                    var db = redis.GetDatabase(0);
-                    var r = new Random(tid);
-                    var id = new byte[4];
-                    var k = 0;
-                    while (!stop.IsCancellationRequested && DateTime.UtcNow < deadline)
+                    var tid = t;
+                    workers[tid] = Task.Run(() =>
                     {
-                        BinaryPrimitives.WriteInt32LittleEndian(id, tid * 10_000_000 + k++);
-                        db.Execute("VADD", ["hk", "FP32", Vec(r, dim), (byte[])id.Clone(), "BIN", "EF", "64", "M", "16", "XDISTANCE_METRIC", "COSINE"]);
-                        Interlocked.Increment(ref done);
-                    }
-                });
-            }
-
-            long last = 0;
-            var stalledSeconds = 0;
-            while (true)
-            {
-                var allDone = true;
-                foreach (var w in workers)
-                    if (!w.IsCompleted) allDone = false;
-                if (allDone) break;
-                Thread.Sleep(2000);
-                var cur = Interlocked.Read(ref done);
-                stalledSeconds = cur == last ? stalledSeconds + 2 : 0;
-                last = cur;
-                if (stalledSeconds >= stallLimitSeconds)
-                {
-                    stop.Cancel();
-                    Assert.Fail($"DEADLOCK: {threads} concurrent VADD workers made no progress for {stalledSeconds}s at {cur} inserts " +
-                                "(a server VADD is blocked in VectorManager.ReadCallbackUnmanaged on a pending-read completion that is starved of a thread).");
+                        var db = redis.GetDatabase(0);
+                        var r = new Random(tid);
+                        var id = new byte[4];
+                        var k = 0;
+                        while (!stop.IsCancellationRequested && DateTime.UtcNow < deadline)
+                        {
+                            BinaryPrimitives.WriteInt32LittleEndian(id, tid * 10_000_000 + k++);
+                            db.Execute("VADD", ["hk", "FP32", Vec(r, dim), (byte[])id.Clone(), "BIN", "EF", "64", "M", "16", "XDISTANCE_METRIC", "COSINE"]);
+                            Interlocked.Increment(ref done);
+                        }
+                    });
                 }
-            }
-            stop.Cancel();
 
-            Task.WaitAll(workers);
-            Assert.That(Interlocked.Read(ref done), Is.GreaterThan(1000),
-                "Workers did not perform enough inserts to exercise the object-log spill path.");
+                long last = 0;
+                var stalledSeconds = 0;
+                while (true)
+                {
+                    var allDone = true;
+                    foreach (var w in workers)
+                        if (!w.IsCompleted) allDone = false;
+                    if (allDone) break;
+                    Thread.Sleep(2000);
+                    var cur = Interlocked.Read(ref done);
+                    stalledSeconds = cur == last ? stalledSeconds + 2 : 0;
+                    last = cur;
+                    if (stalledSeconds >= stallLimitSeconds)
+                    {
+                        stop.Cancel();
+
+                        // Bounded shutdown path (see the note above): attempt disposal off the test thread and wait
+                        // only briefly. A regressed deadlock makes VectorManager.Dispose() block forever, so the
+                        // finally block must not run it and this must not wait on it.
+                        disposeServer = false;
+                        _ = Task.Run(() => server.Dispose()).Wait(TimeSpan.FromSeconds(10));
+
+                        Assert.Fail($"DEADLOCK: {threads} concurrent VADD workers made no progress for {stalledSeconds}s at {cur} inserts " +
+                                    "(a server VADD is blocked in VectorManager.ReadCallbackUnmanaged on a pending-read completion that is starved of a thread).");
+                    }
+                }
+                stop.Cancel();
+
+                Task.WaitAll(workers);
+                Assert.That(Interlocked.Read(ref done), Is.GreaterThan(1000),
+                    "Workers did not perform enough inserts to exercise the object-log spill path.");
+            }
+            finally
+            {
+                if (disposeServer)
+                    server.Dispose();
+            }
         }
     }
 }

--- a/test/standalone/Garnet.test.vectorset/ConcurrentVaddDiskSpillTests.cs
+++ b/test/standalone/Garnet.test.vectorset/ConcurrentVaddDiskSpillTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using StackExchange.Redis;
+
+namespace Garnet.test
+{
+    /// <summary>
+    /// Regression tests for concurrent VADD to a vector set whose records spill to the object log.
+    /// Concurrent inserts historically deadlocked: a server VADD that recreates a disk-tiered index blocks
+    /// on a pending disk read while holding the vector-set lock exclusively, and the quantization workers,
+    /// which run on .NET thread-pool threads, spin-waited on that same lock and consumed every pool thread so
+    /// the disk-read completion (also a pool work item) could never be scheduled. The fix makes the quantization
+    /// workers acquire the lock non-blockingly and yield their pool thread (await) on contention instead of
+    /// spin-waiting, so a disk-IO completion can always be scheduled and release the lock.
+    /// </summary>
+    [TestFixture]
+    public class ConcurrentVaddDiskSpillTests : TestBase
+    {
+        [SetUp]
+        public void Setup()
+        {
+            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            TestUtils.OnTearDown();
+        }
+
+        static byte[] Vec(Random r, int dim)
+        {
+            var v = new float[dim];
+            double n = 0;
+            for (var i = 0; i < dim; i++) { v[i] = (float)(r.NextDouble() * 2 - 1); n += (double)v[i] * v[i]; }
+            n = Math.Sqrt(n);
+            for (var i = 0; i < dim; i++) v[i] = (float)(v[i] / n);
+            return MemoryMarshal.Cast<float, byte>(v.AsSpan()).ToArray();
+        }
+
+        long done;
+
+        /// <summary>
+        /// Liveness smoke test: concurrent VADD to a single set whose ~8 KB DiskANN records spill to the object
+        /// log (the 4 KB-page lowMemory helper) must keep making forward progress. The historical deadlock stalls
+        /// all workers permanently; progress is otherwise continuous (disk-bound but always moving), so a sustained
+        /// no-progress window flags the hang.
+        /// </summary>
+        [Test]
+        public void ConcurrentVaddToSpilledSetMakesProgress()
+        {
+            using var server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, lowMemory: true, enableVectorSetPreview: true);
+            server.Start();
+
+            const int threads = 8, dim = 32;
+            const int runSeconds = 60;
+            const int stallLimitSeconds = 45;
+            var cfg = TestUtils.GetConfig(allowAdmin: true);
+            cfg.SyncTimeout = 60000;
+            using var redis = ConnectionMultiplexer.Connect(cfg);
+
+            var stop = new CancellationTokenSource();
+            var deadline = DateTime.UtcNow.AddSeconds(runSeconds);
+            var workers = new Task[threads];
+            for (var t = 0; t < threads; t++)
+            {
+                var tid = t;
+                workers[tid] = Task.Run(() =>
+                {
+                    var db = redis.GetDatabase(0);
+                    var r = new Random(tid);
+                    var id = new byte[4];
+                    var k = 0;
+                    while (!stop.IsCancellationRequested && DateTime.UtcNow < deadline)
+                    {
+                        BinaryPrimitives.WriteInt32LittleEndian(id, tid * 10_000_000 + k++);
+                        db.Execute("VADD", ["hk", "FP32", Vec(r, dim), (byte[])id.Clone(), "BIN", "EF", "64", "M", "16", "XDISTANCE_METRIC", "COSINE"]);
+                        Interlocked.Increment(ref done);
+                    }
+                });
+            }
+
+            long last = 0;
+            var stalledSeconds = 0;
+            while (true)
+            {
+                var allDone = true;
+                foreach (var w in workers)
+                    if (!w.IsCompleted) allDone = false;
+                if (allDone) break;
+                Thread.Sleep(2000);
+                var cur = Interlocked.Read(ref done);
+                stalledSeconds = cur == last ? stalledSeconds + 2 : 0;
+                last = cur;
+                if (stalledSeconds >= stallLimitSeconds)
+                {
+                    stop.Cancel();
+                    Assert.Fail($"DEADLOCK: {threads} concurrent VADD workers made no progress for {stalledSeconds}s at {cur} inserts " +
+                                "(a server VADD is blocked in VectorManager.ReadCallbackUnmanaged on a pending-read completion that is starved of a thread).");
+                }
+            }
+            stop.Cancel();
+
+            Task.WaitAll(workers);
+            Assert.That(Interlocked.Read(ref done), Is.GreaterThan(1000),
+                "Workers did not perform enough inserts to exercise the object-log spill path.");
+        }
+    }
+}

--- a/test/standalone/Garnet.test.vectorset/ConcurrentVaddDiskSpillTests.cs
+++ b/test/standalone/Garnet.test.vectorset/ConcurrentVaddDiskSpillTests.cs
@@ -73,6 +73,13 @@ namespace Garnet.test
                 const int threads = 8, dim = 32;
                 const int runSeconds = 60;
                 const int stallLimitSeconds = 45;
+
+                // Records spill to the object log within the first few inserts (4 KB pages vs ~8 KB records), so a
+                // small floor already proves the spill/flush path ran; it only guards against the workers never
+                // executing (e.g. VADD rejected). It is kept well below the throughput of a heavily loaded,
+                // disk-bound CI runner (observed ~800 inserts here) so slow hardware cannot make it flake. The
+                // deadlock itself is detected by the no-progress stall monitor below, not by this count.
+                const int minInserts = 100;
                 var cfg = TestUtils.GetConfig(allowAdmin: true);
                 cfg.SyncTimeout = 60000;
                 using var redis = ConnectionMultiplexer.Connect(cfg);
@@ -127,7 +134,7 @@ namespace Garnet.test
                 stop.Cancel();
 
                 Task.WaitAll(workers);
-                Assert.That(Interlocked.Read(ref done), Is.GreaterThan(1000),
+                Assert.That(Interlocked.Read(ref done), Is.GreaterThan(minInserts),
                     "Workers did not perform enough inserts to exercise the object-log spill path.");
             }
             finally


### PR DESCRIPTION
## Summary

Fixes the **deadlock** defect reported in gist `badrishc/1da9f5175490b3cbd74b93c89f03cb6e`: concurrent `VADD` to a single vector set whose ~8 KB DiskANN records spill to the object log (small `--memory`/`--page` + `--storage-tier`, or the `lowMemory` test helper) can hang the server through **.NET thread-pool starvation**.

This PR supersedes #2017, which bundled this fix with an unrelated object-log flush/overflow change. That flush work is being carried separately (to be reworked on top of the no-copy `tedhar/aof-chunk` effort), so only the deadlock fix and its regression test are included here.

## The defect

A full process dump of the reproduced hang shows the cause is thread-pool starvation, not a lock-correctness bug:

- The quantization workers (`StartQuantizationTasks`) run as `Task`s on **thread-pool** threads and **spin-wait** (`Thread.Yield()`) on the per-set `ReadOptimizedLock` via `ReadVectorIndex`.
- Meanwhile a network `VADD` recreating a disk-tiered index (`RecreateIndex`, `indexPtr == 0`) blocks in `CompletePending(wait: true)` on a pending object-log **disk read while holding that same lock exclusively**.
- Every `VADD` with a quant type enqueues a `BuildQuantizationTable` request, so up to `ProcessorCount` workers pile onto the one hot set. With all pool threads spinning or blocked, the disk-read IO completion — itself a pool work item — can never be scheduled, the semaphore never signals, and the exclusive lock is never released. Permanent, self-reinforcing deadlock.

**Proof of mechanism:** setting `ThreadPool.SetMinThreads(512, 512)` in the repro clears the hang (CPU drops from ~37 busy cores to ~1.4 and inserts resume, disk-bound).

## Fix

Keep the quantization workers on the thread pool, but make them acquire the vector-set lock **cooperatively** so they can never starve the pool. Instead of spin-waiting, a worker tries the non-blocking `TryAcquire*` path and, on contention, **yields its pool thread** (`await`) and retries. A blocked pool thread is then always freed for the disk-IO completion that releases the lock, so concurrent `VADD` makes progress. Quantization parallelism and backfill sharding are preserved, and **no non-pool background threads are introduced**.

- **`VectorManager.Locking.cs`** — split `ReadVectorIndex` into a thin wrapper plus `ReadVectorIndexCore(nonBlocking, out wouldBlock)`. In non-blocking mode it uses `TryAcquireSharedLock`/`TryAcquireExclusiveLock` and reports contention (`wouldBlock`) instead of spin-waiting, and likewise reports contention rather than spinning on a pending index drop. The blocking path (all existing network callers such as `VSIM`) is byte-for-byte unchanged.
- **`VectorManager.Quantization.cs`** — the worker loop drains the channel and processes each request through a **synchronous** `TryProcessQuantizationRequest` helper (all ref-struct / `Span` / native interop stays off the `await` path). On contention the helper returns `false` and the async loop `await`s `Task.Yield()` (then `Task.Delay(1)` after a few spins) before retrying.
- **`VectorManager.cs`** — `quantizationTasks` seeded with `Task.CompletedTask` in the constructor so `Dispose`'s `Task.WhenAll` drain is always safe.

**Is the exclusive lock the cause?** It is an **amplifier/coupler, not the root**. The root anti-pattern is *waiting by spinning on a pool thread*: the `ProcessorCount`-scale quantization workers were the dominant amplifier (proven in the dump), converting one blocked disk-read-under-lock into `ProcessorCount` busy-spinners that each pin a pool thread. The exclusive lock is *necessary but not sufficient* — fixing the **waiters** (this change) breaks the cycle. A deeper alternative would fix the **holder** (not hold the exclusive lock across the blocking disk read during recreate); that is larger and left as a follow-up.

## Validation

- `Garnet.server` and the vectorset test project build clean on **net8.0** and **net10.0**, 0 warnings (`TreatWarningsAsErrors` on).
- New regression test **`ConcurrentVaddToSpilledSetMakesProgress`**: 8 concurrent `VADD` workers hammer one set whose records spill to the object log and must keep making forward progress; the historical deadlock stalls all workers permanently and fails the test. Passes on net10.0 Debug (~62 s).
- `dotnet format --verify-no-changes` clean on all changed files.

## Notes

Scope is intentionally the deadlock only; the object-log flush overflow `NullReferenceException` from the same gist is handled separately.
