### PR TITLE
Fix non-string transactions in AOF

### DIFF
--- a/libs/server/Storage/Session/StorageSession.cs
+++ b/libs/server/Storage/Session/StorageSession.cs
@@ -119,7 +119,7 @@ namespace Garnet.server
             if (!storeWrapper.serverOptions.DisableObjects)
             {
                 var objectStoreFunctions = new ObjectSessionFunctions(functionsState, readSessionState);
-                var objectStoreSession = db.Store.NewSession<FixedSpanByteKey, ObjectInput, ObjectOutput, long, ObjectSessionFunctions>(objectStoreFunctions, IsConsistentReadSession);
+                var objectStoreSession = db.Store.NewSession<FixedSpanByteKey, ObjectInput, ObjectOutput, long, ObjectSessionFunctions>(objectStoreFunctions, IsConsistentReadSession, sessionIdOverride: session.ID);
                 objectBasicContext = objectStoreSession.BasicContext;
                 objectTransactionalContext = objectStoreSession.TransactionalContext;
                 objectStoreConsistentReadContext = objectStoreSession.ConsistentReadContext;
@@ -127,10 +127,10 @@ namespace Garnet.server
             }
 
             var unifiedStoreFunctions = new UnifiedSessionFunctions(functionsState, readSessionState);
-            var unifiedStoreSession = db.Store.NewSession<FixedSpanByteKey, UnifiedInput, UnifiedOutput, long, UnifiedSessionFunctions>(unifiedStoreFunctions, IsConsistentReadSession);
+            var unifiedStoreSession = db.Store.NewSession<FixedSpanByteKey, UnifiedInput, UnifiedOutput, long, UnifiedSessionFunctions>(unifiedStoreFunctions, IsConsistentReadSession, sessionIdOverride: session.ID);
 
             var vectorFunctions = new VectorSessionFunctions(functionsState, readSessionState);
-            var vectorSession = db.Store.NewSession<VectorElementKey, VectorInput, VectorOutput, long, VectorSessionFunctions>(vectorFunctions);
+            var vectorSession = db.Store.NewSession<VectorElementKey, VectorInput, VectorOutput, long, VectorSessionFunctions>(vectorFunctions, sessionIdOverride: session.ID);
 
             stringBasicContext = session.BasicContext;
             stringTransactionalContext = session.TransactionalContext;

--- a/libs/storage/Tsavorite/cs/src/core/ClientSession/ClientSession.cs
+++ b/libs/storage/Tsavorite/cs/src/core/ClientSession/ClientSession.cs
@@ -154,7 +154,7 @@ namespace Tsavorite.core
             // By the time Dispose is called, we should have no outstanding locks, so can use the BasicContext's sessionFunctions.
             _ = CompletePending(bContext.sessionFunctions, true);
 
-            store.DisposeClientSession(ID);
+            store.DisposeClientSession(this);
         }
 
         /// <summary>

--- a/libs/storage/Tsavorite/cs/src/core/ClientSession/ManageClientSessions.cs
+++ b/libs/storage/Tsavorite/cs/src/core/ClientSession/ManageClientSessions.cs
@@ -2,16 +2,16 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Threading;
 
 namespace Tsavorite.core
 {
-    public unsafe partial class TsavoriteKV<TStoreFunctions, TAllocator> : TsavoriteBase
+    public partial class TsavoriteKV<TStoreFunctions, TAllocator> : TsavoriteBase
         where TStoreFunctions : IStoreFunctions
         where TAllocator : IAllocator<TStoreFunctions>
     {
-        internal Dictionary<int, SessionInfo> _activeSessions = [];
+        internal ConcurrentDictionary<object, SessionInfo> _activeSessions = [];
 
         /// <summary>
         /// Start a new client session with Tsavorite.
@@ -21,12 +21,14 @@ namespace Tsavorite.core
         /// <param name="readCopyOptions"><see cref="ReadCopyOptions"/> for this session; override those specified at TsavoriteKV level, and may be overridden on individual Read operations</param>
         /// <param name="initialIORecordSize">Initial IO record size for disk reads in this session;
         ///     <see cref="KVSettings.UseDefaultInitialIORecordSize"/> means inherit from the store-level setting, and may be overridden on individual Read operations via <see cref="ReadOptions.InitialIORecordSize"/>.</param>
+        /// <param name="sessionIdOverride">Specifies the id for this session - used to tie related sessions together, should come from earlier allocated session.</param>
         /// <returns>Session instance</returns>
         public ClientSession<TKey, TInput, TOutput, TContext, TFunctions, TStoreFunctions, TAllocator> NewSession<TKey, TInput, TOutput, TContext, TFunctions>(
             TFunctions functions,
             bool enableConsistentRead = false,
             ReadCopyOptions readCopyOptions = default,
-            int initialIORecordSize = KVSettings.UseDefaultInitialIORecordSize)
+            int initialIORecordSize = KVSettings.UseDefaultInitialIORecordSize,
+            int? sessionIdOverride = null)
             where TKey : IKey
 #if NET9_0_OR_GREATER
                 , allows ref struct
@@ -36,40 +38,27 @@ namespace Tsavorite.core
             if (functions == null)
                 throw new ArgumentNullException(nameof(functions));
 
-            int sessionID = Interlocked.Increment(ref maxSessionID);
+            var sessionID = sessionIdOverride ?? Interlocked.Increment(ref maxSessionID);
             var ctx = new TsavoriteExecutionContext<TInput, TOutput, TContext>(sessionID);
             ctx.MergeReadCopyOptions(ReadCopyOptions, readCopyOptions);
             ctx.InitialIORecordSize = initialIORecordSize;
 
-            if (RevivificationManager.IsEnabled)
-            {
-                if (_activeSessions == null)
-                    _ = Interlocked.CompareExchange(ref _activeSessions, [], null);
-            }
             var session = new ClientSession<TKey, TInput, TOutput, TContext, TFunctions, TStoreFunctions, TAllocator>(this, ctx, functions, enableConsistentRead);
-            lock (_activeSessions)
-                _activeSessions.Add(sessionID, new SessionInfo { session = session, isActive = true });
+            _ = _activeSessions.TryAdd(session, new SessionInfo { session = session, isActive = true });
             return session;
         }
 
         /// <summary>
         /// Dispose session with Tsavorite
         /// </summary>
-        /// <param name="sessionID"></param>
+        /// <param name="sessionRef"></param>
         /// <returns></returns>
-        internal void DisposeClientSession(int sessionID)
+        internal void DisposeClientSession(object sessionRef)
         {
-            if (_activeSessions != null)
+            if (_activeSessions.TryRemove(sessionRef, out var sessionInfo))
             {
-                lock (_activeSessions)
-                {
-                    if (_activeSessions.TryGetValue(sessionID, out SessionInfo sessionInfo))
-                    {
-                        var session = sessionInfo.session;
-                        session.MergeRevivificationStatsTo(ref RevivificationManager.stats, reset: true);
-                        _ = _activeSessions.Remove(sessionID);
-                    }
-                }
+                var session = sessionInfo.session;
+                session.MergeRevivificationStatsTo(ref RevivificationManager.stats, reset: true);
             }
         }
 
@@ -78,15 +67,10 @@ namespace Tsavorite.core
         /// </summary>
         public string DumpRevivificationStats()
         {
-            if (_activeSessions != null)
-            {
-                lock (_activeSessions)
-                {
-                    // Merge the session-level stats into the global stats, clear the session-level stats, and keep the cumulative stats.
-                    foreach (var sessionInfo in _activeSessions.Values)
-                        sessionInfo.session.MergeRevivificationStatsTo(ref RevivificationManager.stats, reset: true);
-                }
-            }
+            // Merge the session-level stats into the global stats, clear the session-level stats, and keep the cumulative stats.
+            foreach (var sessionInfo in _activeSessions.Values)
+                sessionInfo.session.MergeRevivificationStatsTo(ref RevivificationManager.stats, reset: true);
+
             return RevivificationManager.stats.Dump();
         }
 
@@ -95,14 +79,9 @@ namespace Tsavorite.core
         /// </summary>
         public void ResetRevivificationStats()
         {
-            if (_activeSessions != null)
-            {
-                lock (_activeSessions)
-                {
-                    foreach (var sessionInfo in _activeSessions.Values)
-                        sessionInfo.session.ResetRevivificationStats();
-                }
-            }
+            foreach (var sessionInfo in _activeSessions.Values)
+                sessionInfo.session.ResetRevivificationStats();
+
             RevivificationManager.stats.Reset();
         }
     }

--- a/libs/storage/Tsavorite/cs/src/core/ClientSession/ManageClientSessions.cs
+++ b/libs/storage/Tsavorite/cs/src/core/ClientSession/ManageClientSessions.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace Tsavorite.core
@@ -11,7 +11,7 @@ namespace Tsavorite.core
         where TStoreFunctions : IStoreFunctions
         where TAllocator : IAllocator<TStoreFunctions>
     {
-        internal ConcurrentDictionary<object, SessionInfo> _activeSessions = [];
+        internal Dictionary<object, SessionInfo> _activeSessions = [];
 
         /// <summary>
         /// Start a new client session with Tsavorite.
@@ -44,7 +44,12 @@ namespace Tsavorite.core
             ctx.InitialIORecordSize = initialIORecordSize;
 
             var session = new ClientSession<TKey, TInput, TOutput, TContext, TFunctions, TStoreFunctions, TAllocator>(this, ctx, functions, enableConsistentRead);
-            _ = _activeSessions.TryAdd(session, new SessionInfo { session = session, isActive = true });
+
+            lock (_activeSessions)
+            {
+                _ = _activeSessions.TryAdd(session, new SessionInfo { session = session, isActive = true });
+            }
+
             return session;
         }
 
@@ -55,10 +60,15 @@ namespace Tsavorite.core
         /// <returns></returns>
         internal void DisposeClientSession(object sessionRef)
         {
-            if (_activeSessions.TryRemove(sessionRef, out var sessionInfo))
+            lock (_activeSessions)
             {
-                var session = sessionInfo.session;
-                session.MergeRevivificationStatsTo(ref RevivificationManager.stats, reset: true);
+                if (_activeSessions.TryGetValue(sessionRef, out var sessionInfo))
+                {
+                    var session = sessionInfo.session;
+                    session.MergeRevivificationStatsTo(ref RevivificationManager.stats, reset: true);
+
+                    _ = _activeSessions.Remove(sessionRef);
+                }
             }
         }
 
@@ -68,8 +78,11 @@ namespace Tsavorite.core
         public string DumpRevivificationStats()
         {
             // Merge the session-level stats into the global stats, clear the session-level stats, and keep the cumulative stats.
-            foreach (var sessionInfo in _activeSessions.Values)
-                sessionInfo.session.MergeRevivificationStatsTo(ref RevivificationManager.stats, reset: true);
+            lock (_activeSessions)
+            {
+                foreach (var sessionInfo in _activeSessions.Values)
+                    sessionInfo.session.MergeRevivificationStatsTo(ref RevivificationManager.stats, reset: true);
+            }
 
             return RevivificationManager.stats.Dump();
         }
@@ -79,8 +92,11 @@ namespace Tsavorite.core
         /// </summary>
         public void ResetRevivificationStats()
         {
-            foreach (var sessionInfo in _activeSessions.Values)
-                sessionInfo.session.ResetRevivificationStats();
+            lock (_activeSessions)
+            {
+                foreach (var sessionInfo in _activeSessions.Values)
+                    sessionInfo.session.ResetRevivificationStats();
+            }
 
             RevivificationManager.stats.Reset();
         }


### PR DESCRIPTION
AOF tracks transaction by client session id.

Unfortunately, unified and object sessions end up with different session ids than the "main" (ie. string) session.

This changes StorageSession to explicitly set session ids on object, unified, and vector (although vector does not participate in AOF) sessions.

This makes some small changes to revivification stat tracking, moving to a `ConcurrentDictionary` keyed by object identity rather than by session id.