### PR TITLE
Suppress CredScan finding for testcert.key.pem test certificate

### DIFF
--- a/.azure/pipelines/credscan-exclusion.json
+++ b/.azure/pipelines/credscan-exclusion.json
@@ -10,6 +10,10 @@
       "_justification": "Legitimate app certificate file with private key required for the app to function. This is sample test application"
     },
     {
+      "file": "testcert.key.pem",
+      "_justification": "PEM-encoded private key for the self-signed certificate used by TLS unit tests."
+    },
+    {
       "file": "AclConfigurationFileTests.cs",
       "_justification": "Passwords and secrets for a test users created and used for only running the tests."
     },


### PR DESCRIPTION
The PEM certificate support added in #1937 introduced test/testcerts/testcert.key.pem, a PEM-encoded private key for the self-signed certificate used by TLS unit tests. CredScan flags its private key, breaking the compliance build. Add it to the CredScan exclusion list alongside the other test certificate/key files.
