### PR TITLE
[Tsavorite] Handle ObjectAllocator device read failures

### DIFF
--- a/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
@@ -1712,7 +1712,10 @@ namespace Tsavorite.core
             {
                 // Page closing cannot resume after a failure here, so the log would stall silently. Crash instead: a dump is the
                 // only practical way to diagnose this.
-                Environment.FailFast($"OnPagesClosedWorker failed; allocator state is unrecoverable. ClosedUntilAddress={ClosedUntilAddress}, OngoingCloseUntilAddress={OngoingCloseUntilAddress}", ex);
+                Environment.FailFast(
+                    $"OnPagesClosedWorker failed; allocator state is unrecoverable. ClosedUntilAddress={ClosedUntilAddress}, OngoingCloseUntilAddress={OngoingCloseUntilAddress}"
+                    + $"{Environment.NewLine}Caught exception:{Environment.NewLine}{ex}",
+                    ex);
             }
         }
 

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/AllocatorBase.cs
@@ -1712,10 +1712,19 @@ namespace Tsavorite.core
             {
                 // Page closing cannot resume after a failure here, so the log would stall silently. Crash instead: a dump is the
                 // only practical way to diagnose this.
-                Environment.FailFast(
-                    $"OnPagesClosedWorker failed; allocator state is unrecoverable. ClosedUntilAddress={ClosedUntilAddress}, OngoingCloseUntilAddress={OngoingCloseUntilAddress}"
-                    + $"{Environment.NewLine}Caught exception:{Environment.NewLine}{ex}",
-                    ex);
+                var exceptionDetails = ex.GetType().FullName ?? ex.GetType().Name;
+                try
+                {
+                    exceptionDetails = ex.ToString() ?? exceptionDetails;
+                }
+                finally
+                {
+                    // Exception.ToString() is virtual; always fail fast even if an application exception throws while formatting itself.
+                    Environment.FailFast(
+                        $"OnPagesClosedWorker failed; allocator state is unrecoverable. ClosedUntilAddress={ClosedUntilAddress}, OngoingCloseUntilAddress={OngoingCloseUntilAddress}"
+                        + $"{Environment.NewLine}Caught exception:{Environment.NewLine}{exceptionDetails}",
+                        ex);
+                }
             }
         }
 

--- a/libs/storage/Tsavorite/cs/src/core/Allocator/ObjectAllocatorImpl.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Allocator/ObjectAllocatorImpl.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.Extensions.Logging;
@@ -559,25 +560,25 @@ namespace Tsavorite.core
                 return objectLogSegment;
 
             var buffer = bufferPool.Get(sectorSize);
-            PageAsyncReadResult<Empty> result = new() { handle = new CountdownEvent(1) };
             try
             {
-                device.ReadAsync((ulong)addressOfStartOfMainLogPage, (IntPtr)buffer.aligned_pointer, (uint)sectorSize, AsyncReadPageCallback, result);
-                result.handle.Wait();
-                if (result.numBytesRead >= PageHeader.Size)
+                if (!TryReadDevice(device, (ulong)addressOfStartOfMainLogPage, (IntPtr)buffer.aligned_pointer, (uint)sectorSize,
+                    nameof(GetLowestObjectLogSegmentInUse), out var errorCode, out var numBytesRead, out var ioException))
                 {
-                    var pageHeader = *(PageHeader*)buffer.aligned_pointer;
-                    if (pageHeader.objectLogLowestPositionWord != ObjectLogFilePositionInfo.NotSet)
-                    {
-                        var objectLogPosition = new ObjectLogFilePositionInfo(pageHeader.objectLogLowestPositionWord, objectLogTail.SegmentSizeBits);   // TODO verify SegmentSizeBits is correct
-                        objectLogSegment = objectLogPosition.SegmentId;
-                    }
+                    throw CreateReadException(nameof(GetLowestObjectLogSegmentInUse), (ulong)addressOfStartOfMainLogPage, (uint)sectorSize,
+                        errorCode, numBytesRead, ioException);
+                }
+
+                var pageHeader = *(PageHeader*)buffer.aligned_pointer;
+                if (pageHeader.objectLogLowestPositionWord != ObjectLogFilePositionInfo.NotSet)
+                {
+                    var objectLogPosition = new ObjectLogFilePositionInfo(pageHeader.objectLogLowestPositionWord, objectLogTail.SegmentSizeBits);   // TODO verify SegmentSizeBits is correct
+                    objectLogSegment = objectLogPosition.SegmentId;
                 }
             }
             finally
             {
                 bufferPool.Return(buffer);
-                result.DisposeHandle();
             }
 
             return objectLogSegment;
@@ -829,14 +830,18 @@ namespace Tsavorite.core
                 asyncResult.freeBuffer1 = srcBuffer;
 
                 // Read back the first sector if the start is not aligned (this means we already wrote a partially-filled sector with ObjectLog fields set).
-                if (startPadding > 0)
+                // Snapshot files are new, so their unwritten prefix remains zero in the freshly cleared srcBuffer.
+                if (startPadding > 0 && asyncResult.flushRequestState != FlushRequestState.Snapshot)
                 {
                     // TODO: This will potentially overwrite partial sectors (with the same data) if this is a partial flush; a workaround would be difficult.
                     // TODO: Cache the last sector flushed in readBuffers so we can avoid this Read.
-                    PageAsyncReadResult<Empty> result = new() { handle = new CountdownEvent(1) };
-                    device.ReadAsync(alignedMainLogFlushPageAddress + (ulong)alignedStartOffset, (IntPtr)srcBuffer.aligned_pointer, (uint)sectorSize, AsyncReadPageCallback, result);
-                    result.handle.Wait();
-                    result.DisposeHandle();
+                    var readAddress = alignedMainLogFlushPageAddress + (ulong)alignedStartOffset;
+                    if (!TryReadDevice(device, readAddress, (IntPtr)srcBuffer.aligned_pointer, (uint)sectorSize,
+                        "Partial-sector flush read-back", out var errorCode, out var numBytesRead, out var ioException))
+                    {
+                        callback(errorCode, numBytesRead, asyncResult, ioException);
+                        return;
+                    }
                 }
 
                 try
@@ -1157,19 +1162,57 @@ namespace Tsavorite.core
 
         private void AsyncReadPageCallback(uint errorCode, uint numBytes, object context, Exception ioException)
         {
-            if (errorCode != 0)
-            {
-                if (ioException is null)
-                    logger?.LogError($"{nameof(AsyncReadPageCallback)} error: {{errorCode}}", errorCode);
-                else
-                    logger?.LogError($"{nameof(AsyncReadPageCallback)} error: {{exception}}", Utility.GetCallbackExceptionDetail(ioException));
-            }
-
-            // Set the page status to flushed
             var result = (PageAsyncReadResult<Empty>)context;
+            result.errorCode = errorCode;
             result.numBytesRead = numBytes;
+            result.ioException = ioException;
             _ = result.handle.Signal();
         }
+
+        private bool TryReadDevice(IDevice readDevice, ulong sourceAddress, IntPtr destinationAddress, uint readLength, string operation,
+            out uint errorCode, out uint numBytesRead, out Exception ioException)
+        {
+            PageAsyncReadResult<Empty> result = new() { handle = new CountdownEvent(1) };
+            try
+            {
+                readDevice.ReadAsync(sourceAddress, destinationAddress, readLength, AsyncReadPageCallback, result);
+                result.handle.Wait();
+
+                errorCode = result.errorCode;
+                numBytesRead = result.numBytesRead;
+                ioException = result.ioException;
+
+                if (errorCode == 0 && numBytesRead == readLength)
+                    return true;
+
+                if (errorCode == 0)
+                {
+                    errorCode = uint.MaxValue;
+                    ioException = new EndOfStreamException($"{operation} read {numBytesRead} of {readLength} bytes at device offset {sourceAddress}");
+                }
+
+                if (ioException is null)
+                {
+                    logger?.LogError("{operation} failed reading {readLength} bytes at device offset {sourceAddress}: error {errorCode}; transferred {numBytesRead} bytes",
+                        operation, readLength, sourceAddress, errorCode, numBytesRead);
+                }
+                else
+                {
+                    logger?.LogError("{operation} failed reading {readLength} bytes at device offset {sourceAddress}: {exception}; transferred {numBytesRead} bytes",
+                        operation, readLength, sourceAddress, Utility.GetCallbackExceptionDetail(ioException), numBytesRead);
+                }
+
+                return false;
+            }
+            finally
+            {
+                result.DisposeHandle();
+            }
+        }
+
+        private static TsavoriteIOException CreateReadException(string operation, ulong sourceAddress, uint readLength,
+            uint errorCode, uint numBytesRead, Exception ioException)
+            => new($"{operation} failed reading {readLength} bytes at device offset {sourceAddress}: error {errorCode}; transferred {numBytesRead} bytes", ioException);
 
         /// <inheritdoc />
         /// <remarks>This override of the base function reads Overflow keys or values, or Object values.</remarks>

--- a/libs/storage/Tsavorite/cs/src/core/Utilities/PageAsyncResultTypes.cs
+++ b/libs/storage/Tsavorite/cs/src/core/Utilities/PageAsyncResultTypes.cs
@@ -46,6 +46,12 @@ namespace Tsavorite.core
         /// <summary>Number of bytes read.</summary>
         public uint numBytesRead;
 
+        /// <summary>Numeric error code returned by the device read callback.</summary>
+        internal uint errorCode;
+
+        /// <summary>Underlying exception returned by the device read callback, if any.</summary>
+        internal Exception ioException;
+
         /// <summary>The max offset on the main log page to iterate records when determining how many bytes in the ObjectLog to read.</summary>
         internal long maxAddressOffsetOnPage;
 
@@ -54,7 +60,8 @@ namespace Tsavorite.core
 
         /// <inheritdoc/>
         public override string ToString()
-            => $"page {page}, recovPhase {recoveryPhase}, devPgOffset {devicePageOffset}, ctx {context}, countdown {handle?.CurrentCount}, destPtr {destinationPtr} (0x{destinationPtr:X}), maxPtr {maxAddressOffsetOnPage}";
+            => $"page {page}, recovPhase {recoveryPhase}, devPgOffset {devicePageOffset}, ctx {context}, countdown {handle?.CurrentCount}, destPtr {destinationPtr} (0x{destinationPtr:X}),"
+             + $" maxPtr {maxAddressOffsetOnPage}, bytesRead {numBytesRead}, errorCode {errorCode}, ioException {ioException?.GetType().Name}";
 
         /// <summary>Currently nothing to free.</summary>
         public void Free()

--- a/libs/storage/Tsavorite/cs/test/test.recovery/ObjectAllocatorDeviceFailureTests.cs
+++ b/libs/storage/Tsavorite/cs/test/test.recovery/ObjectAllocatorDeviceFailureTests.cs
@@ -1,0 +1,334 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using Garnet.test;
+using NUnit.Framework;
+using Tsavorite.core;
+using static Tsavorite.core.Utility;
+using static Tsavorite.test.TestUtils;
+
+namespace Tsavorite.test
+{
+    using ClassAllocator = ObjectAllocator<StoreFunctions<TestObjectKey.Comparer, DefaultRecordTriggers>>;
+    using ClassStoreFunctions = StoreFunctions<TestObjectKey.Comparer, DefaultRecordTriggers>;
+
+    [TestFixture]
+    internal class ObjectAllocatorDeviceFailureTests : TestBase
+    {
+        private TsavoriteKV<ClassStoreFunctions, ClassAllocator> store;
+        private ControlledReadFailureDevice logDevice;
+        private ControlledReadFailureDevice objectLogDevice;
+        private ManualResetEventSlim flushFailureEvent;
+        private CommitInfo flushFailure;
+
+        [SetUp]
+        public void Setup()
+        {
+            DeleteDirectory(MethodTestDir, wait: true);
+            flushFailure = default;
+            flushFailureEvent = new(false);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            store?.Dispose();
+            store = null;
+            logDevice?.Dispose();
+            logDevice = null;
+            objectLogDevice?.Dispose();
+            objectLogDevice = null;
+            flushFailureEvent?.Dispose();
+            flushFailureEvent = null;
+            OnTearDown();
+        }
+
+        [Test]
+        [Category(TsavoriteKVTestCategory)]
+        [Category(ObjectIdMapCategory)]
+        public void PartialSectorReadFailureStopsFlush([Values] InjectedReadFailure failureMode)
+        {
+            CreateStore(useLargeObjects: false, captureFlushFailures: true);
+
+            using var session = store.NewSession<TestObjectKey, TestObjectInput, TestObjectOutput, Empty, TestObjectFunctions>(new TestObjectFunctions());
+            var context = session.BasicContext;
+
+            _ = context.Upsert(new TestObjectKey { key = 1 }, new TestObjectValue { value = 1 }, Empty.Default);
+            store.Log.Flush(wait: true);
+
+            var lastSuccessfulFlush = store.Log.FlushedUntilAddress;
+            Assert.That(lastSuccessfulFlush, Is.EqualTo(store.Log.TailAddress));
+            Assert.That(lastSuccessfulFlush % logDevice.SectorSize, Is.Not.Zero,
+                "The first flush must end mid-sector so the next flush performs a sector read-back.");
+
+            var writeCountBeforeFailure = logDevice.WriteCount;
+            _ = context.Upsert(new TestObjectKey { key = 2 }, new TestObjectValue { value = 2 }, Empty.Default);
+            var failedFlushUntilAddress = store.Log.TailAddress;
+
+            logDevice.FailNextRead(failureMode);
+            store.Log.Flush(wait: false);
+
+            Assert.That(flushFailureEvent.Wait(TimeSpan.FromSeconds(10)), Is.True, "The failed read was not propagated to the flush callback.");
+            Assert.That(logDevice.FailedReadCount, Is.EqualTo(1));
+            Assert.That(logDevice.LastFailedReadLength, Is.EqualTo(logDevice.SectorSize));
+            Assert.That(logDevice.LastFailedReadAddress, Is.EqualTo((ulong)RoundDown(lastSuccessfulFlush, (int)logDevice.SectorSize)));
+            Assert.That(logDevice.WriteCount, Is.EqualTo(writeCountBeforeFailure), "A failed sector read-back must not submit a replacement main-log write.");
+            Assert.That(store.Log.FlushedUntilAddress, Is.EqualTo(lastSuccessfulFlush), "A failed read-back must not advance FlushedUntilAddress.");
+            Assert.That(flushFailure.FromAddress, Is.EqualTo(lastSuccessfulFlush));
+            Assert.That(flushFailure.UntilAddress, Is.EqualTo(failedFlushUntilAddress));
+
+            if (failureMode == InjectedReadFailure.DeviceError)
+            {
+                Assert.That(flushFailure.ErrorCode, Is.EqualTo(ControlledReadFailureDevice.InjectedErrorCode));
+                Assert.That(flushFailure.Exception, Is.Null);
+            }
+            else
+            {
+                Assert.That(flushFailure.ErrorCode, Is.EqualTo(uint.MaxValue));
+                Assert.That(flushFailure.Exception, Is.TypeOf<EndOfStreamException>());
+            }
+        }
+
+        [Test]
+        [Category(TsavoriteKVTestCategory)]
+        [Category(ObjectIdMapCategory)]
+        public void SnapshotPartialSectorSkipsReadBackOnFreshDevice()
+        {
+            CreateStore(useLargeObjects: false, captureFlushFailures: false);
+
+            using var session = store.NewSession<TestObjectKey, TestObjectInput, TestObjectOutput, Empty, TestObjectFunctions>(new TestObjectFunctions());
+            var context = session.BasicContext;
+
+            _ = context.Upsert(new TestObjectKey { key = 1 }, new TestObjectValue { value = 1 }, Empty.Default);
+            var snapshotStartAddress = store.Log.TailAddress;
+            _ = context.Upsert(new TestObjectKey { key = 2 }, new TestObjectValue { value = 2 }, Empty.Default);
+            var snapshotEndAddress = store.Log.TailAddress;
+
+            using var snapshotLogDevice = new ControlledReadFailureDevice(
+                Devices.CreateLogDevice(Path.Join(MethodTestDir, "ObjectAllocatorDeviceFailureTests.snapshot.log"), deleteOnClose: true));
+            using var snapshotObjectLogDevice = new ControlledReadFailureDevice(
+                Devices.CreateLogDevice(Path.Join(MethodTestDir, "ObjectAllocatorDeviceFailureTests.snapshot.obj.log"), deleteOnClose: true));
+            using var flushBuffers = store.hlogBase.CreateCircularFlushBuffers(snapshotObjectLogDevice, logger: null);
+
+            Assert.That(snapshotStartAddress % snapshotLogDevice.SectorSize, Is.Not.Zero,
+                "The snapshot must start mid-sector to exercise the read-back path.");
+
+            var startPage = store.hlogBase.GetPage(snapshotStartAddress);
+            var endPage = store.hlogBase.GetPage(snapshotEndAddress) + 1;
+            store.hlogBase.AsyncFlushPagesForSnapshot(flushBuffers, startPage, endPage, snapshotStartAddress, snapshotEndAddress,
+                long.MaxValue, snapshotLogDevice, snapshotObjectLogDevice, out var completedTask, throttleCheckpointFlushDelayMs: -1);
+
+            Assert.DoesNotThrowAsync(async () => await completedTask);
+            Assert.That(snapshotLogDevice.ReadCount, Is.Zero, "A fresh snapshot sector has no existing prefix to preserve.");
+            Assert.That(snapshotLogDevice.WriteCount, Is.EqualTo(1));
+            Assert.That(logDevice.ReadCount, Is.Zero, "Snapshot read-back must not read from the allocator's main-log device.");
+        }
+
+        [Test]
+        [Category(TsavoriteKVTestCategory)]
+        [Category(ObjectIdMapCategory)]
+        public void HeaderReadFailureDefersPairedTruncation([Values] InjectedReadFailure failureMode)
+        {
+            const int pageSize = MinKvLogPageSize;
+            CreateStore(useLargeObjects: true, captureFlushFailures: false, segmentSize: pageSize * 2, objectLogSegmentSize: 1L << 22);
+
+            using var session = store.NewSession<TestObjectKey, TestLargeObjectInput, TestLargeObjectOutput, Empty, TestLargeObjectFunctions>(new TestLargeObjectFunctions());
+            var context = session.BasicContext;
+            var input = new TestLargeObjectInput();
+            var output = new TestLargeObjectOutput();
+            long truncateAddress = 0;
+
+            for (var key = 0; key < 400; key++)
+            {
+                var recordAddress = store.Log.TailAddress;
+                if (truncateAddress == 0
+                    && recordAddress > (2 * pageSize) + PageHeader.Size
+                    && store.hlogBase.GetOffsetOnPage(recordAddress) > PageHeader.Size)
+                    truncateAddress = recordAddress;
+
+                _ = context.Upsert(new TestObjectKey { key = key }, ref input, new TestLargeObjectValue(1 << 15), ref output);
+            }
+
+            Assert.That(truncateAddress, Is.GreaterThan(0), "The test did not create a record on the third main-log page.");
+            store.Log.Flush(wait: true);
+            store.Log.ShiftBeginAddress(truncateAddress, truncateLog: false);
+            Assert.That(store.Log.BeginAddress, Is.EqualTo(truncateAddress));
+
+            var truncateMethod = store.hlogBase.GetType().GetMethod("TruncateUntilAddressBlocking", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(truncateMethod, Is.Not.Null);
+
+            logDevice.FailNextRead(failureMode);
+            var invocationException = Assert.Throws<TargetInvocationException>(() => truncateMethod.Invoke(store.hlogBase, [truncateAddress]));
+            Assert.That(invocationException.InnerException, Is.TypeOf<TsavoriteIOException>());
+
+            Assert.That(logDevice.FailedReadCount, Is.EqualTo(1));
+            Assert.That(logDevice.LastFailedReadAddress, Is.EqualTo((ulong)store.hlogBase.GetAddressOfStartOfPageOfAddress(truncateAddress)));
+            Assert.That(logDevice.TruncateUntilAddressCount, Is.Zero, "The main log must not truncate when its page-header read fails.");
+            Assert.That(objectLogDevice.RemoveSegmentCount, Is.Zero, "The object log must not truncate when the paired main-log header read fails.");
+
+            store.Log.Truncate();
+
+            Assert.That(logDevice.TruncateCompleted.Wait(TimeSpan.FromSeconds(10)), Is.True, "The retried main-log truncation did not complete.");
+            Assert.That(objectLogDevice.SegmentRemovalCompleted.Wait(TimeSpan.FromSeconds(10)), Is.True, "The retried object-log truncation did not complete.");
+            Assert.That(logDevice.TruncateUntilAddressCount, Is.EqualTo(1));
+            Assert.That(objectLogDevice.RemoveSegmentCount, Is.GreaterThan(0));
+        }
+
+        private void CreateStore(bool useLargeObjects, bool captureFlushFailures, long segmentSize = 1L << 30, long objectLogSegmentSize = 1L << 30)
+        {
+            logDevice = new(Devices.CreateLogDevice(Path.Join(MethodTestDir, "ObjectAllocatorDeviceFailureTests.log"), deleteOnClose: true));
+            objectLogDevice = new(Devices.CreateLogDevice(Path.Join(MethodTestDir, "ObjectAllocatorDeviceFailureTests.obj.log"), deleteOnClose: true));
+
+            var storeFunctions = useLargeObjects
+                ? StoreFunctions.Create(new TestObjectKey.Comparer(), () => new TestLargeObjectValue.Serializer(), DefaultRecordTriggers.Instance)
+                : StoreFunctions.Create(new TestObjectKey.Comparer(), () => new TestObjectValue.Serializer(), DefaultRecordTriggers.Instance);
+
+            store = new(new()
+            {
+                IndexSize = 1L << 13,
+                LogDevice = logDevice,
+                ObjectLogDevice = objectLogDevice,
+                MutableFraction = 0.1,
+                LogMemorySize = 1L << (MinKvLogPageSizeBits + 5),
+                PageSize = MinKvLogPageSize,
+                SegmentSize = segmentSize,
+                ObjectLogSegmentSize = objectLogSegmentSize,
+                loggerFactory = TestLoggerFactory
+            }, storeFunctions, (allocatorSettings, functions) =>
+            {
+                if (captureFlushFailures)
+                {
+                    allocatorSettings.flushCallback = info =>
+                    {
+                        if (info.ErrorCode == 0)
+                            return;
+                        flushFailure = info;
+                        flushFailureEvent.Set();
+                    };
+                }
+
+                return new(allocatorSettings, functions);
+            });
+        }
+    }
+
+    internal enum InjectedReadFailure
+    {
+        DeviceError,
+        ShortRead
+    }
+
+    internal sealed class ControlledReadFailureDevice : StorageDeviceBase
+    {
+        internal const uint InjectedErrorCode = 38;
+
+        private readonly IDevice underlying;
+        private int failNextRead;
+        private int readCount;
+        private int writeCount;
+        private int failedReadCount;
+        private int truncateUntilAddressCount;
+        private int removeSegmentCount;
+        private int completedRemoveSegmentCount;
+        private InjectedReadFailure failureMode;
+
+        internal readonly ManualResetEventSlim TruncateCompleted = new(false);
+        internal readonly ManualResetEventSlim SegmentRemovalCompleted = new(false);
+
+        internal int ReadCount => Volatile.Read(ref readCount);
+        internal int WriteCount => Volatile.Read(ref writeCount);
+        internal int FailedReadCount => Volatile.Read(ref failedReadCount);
+        internal int TruncateUntilAddressCount => Volatile.Read(ref truncateUntilAddressCount);
+        internal int RemoveSegmentCount => Volatile.Read(ref removeSegmentCount);
+        internal ulong LastFailedReadAddress { get; private set; }
+        internal uint LastFailedReadLength { get; private set; }
+
+        internal ControlledReadFailureDevice(IDevice underlying)
+            : base(underlying.FileName, underlying.SectorSize, underlying.Capacity)
+        {
+            this.underlying = underlying;
+        }
+
+        internal void FailNextRead(InjectedReadFailure mode)
+        {
+            failureMode = mode;
+            _ = Interlocked.Exchange(ref failNextRead, 1);
+        }
+
+        public override void Initialize(long segmentSize, LightEpoch epoch = null, bool omitSegmentIdFromFilename = false)
+        {
+            base.Initialize(segmentSize, epoch, omitSegmentIdFromFilename);
+            underlying.Initialize(segmentSize, epoch, omitSegmentIdFromFilename);
+        }
+
+        public override void RemoveSegmentAsync(int segment, AsyncCallback callback, IAsyncResult result)
+        {
+            _ = Interlocked.Increment(ref removeSegmentCount);
+            underlying.RemoveSegmentAsync(segment, removeResult =>
+            {
+                callback?.Invoke(removeResult);
+                if (Interlocked.Increment(ref completedRemoveSegmentCount) >= StartSegment)
+                    SegmentRemovalCompleted.Set();
+            }, result);
+        }
+
+        public override void TruncateUntilAddress(long toAddress)
+        {
+            _ = Interlocked.Increment(ref truncateUntilAddressCount);
+            try
+            {
+                base.TruncateUntilAddress(toAddress);
+            }
+            finally
+            {
+                TruncateCompleted.Set();
+            }
+        }
+
+        public override void WriteAsync(IntPtr sourceAddress, int segmentId, ulong destinationAddress, uint numBytesToWrite,
+            DeviceIOCompletionCallback callback, object context)
+        {
+            _ = Interlocked.Increment(ref writeCount);
+            underlying.WriteAsync(sourceAddress, segmentId, destinationAddress, numBytesToWrite, callback, context);
+        }
+
+        public override void ReadAsync(int segmentId, ulong sourceAddress, IntPtr destinationAddress, uint readLength,
+            DeviceIOCompletionCallback callback, object context)
+        {
+            _ = Interlocked.Increment(ref readCount);
+            if (Interlocked.Exchange(ref failNextRead, 0) == 1)
+            {
+                _ = Interlocked.Increment(ref failedReadCount);
+                LastFailedReadAddress = SegmentSize > 0 ? (ulong)(segmentId * SegmentSize) + sourceAddress : sourceAddress;
+                LastFailedReadLength = readLength;
+
+                if (failureMode == InjectedReadFailure.DeviceError)
+                    callback(InjectedErrorCode, 0, context, ioException: null);
+                else
+                    callback(0, readLength / 2, context, ioException: null);
+                return;
+            }
+
+            underlying.ReadAsync(segmentId, sourceAddress, destinationAddress, readLength, callback, context);
+        }
+
+        public override bool TryComplete() => underlying.TryComplete();
+
+        public override bool Throttle() => underlying.Throttle();
+
+        public override long GetFileSize(int segment) => underlying.GetFileSize(segment);
+
+        public override void Reset() => underlying.Reset();
+
+        public override void Dispose()
+        {
+            TruncateCompleted.Dispose();
+            SegmentRemovalCompleted.Dispose();
+            underlying.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
### Root Cause

`ObjectAllocatorImpl.AsyncReadPageCallback` logged device read failures but signaled completion without preserving the error. Its header-read and partial-sector read-back callers therefore continued after failed reads. Zero-error short reads were also treated as successful completions.

### Description of Change

Device read completion now carries the error code, transferred byte count, and exception, and existing-data reads succeed only when the requested length is transferred.

**Key changes:**
- Convert zero-error short reads into `EndOfStreamException` failures
- Throw before main-log or object-log truncation when the page-header read fails, preventing success-only `OnTruncate` callbacks and allowing a later retry
- Route partial-sector flush read failures through the existing flush failure pipeline without submitting a replacement write or advancing `FlushedUntilAddress`
- Keep front-partial snapshot writes safe by using the zero-filled pooled buffer for the unwritten prefix of a fresh snapshot device
- Include the caught exception's full `ToString()` output in the `OnPagesClosedWorker` fatal message so CI logs contain its type, message, inner exceptions, and stack trace even when the runtime omits the `FailFast` exception argument; formatting runs inside `try/finally` so a broken custom `ToString()` cannot bypass fail-fast termination
- Add deterministic numeric-error and short-read tests for flush, truncation, retry, and snapshot behavior

### Key Technical Details

**Affected types:**
- `PageAsyncReadResult<TContext>` - carries the full device completion result
- `ObjectAllocatorImpl<TStoreFunctions>` - validates exact reads and prevents unsafe follow-on work
- `AllocatorBase<TStoreFunctions, TAllocator>` - preserves complete page-close exception diagnostics in fail-fast output
- `ObjectAllocatorDeviceFailureTests` - injects device errors and EOF-style short reads

### Testing

- Regression fixture passes on .NET 10 and .NET 8
- Related object-log deletion, scan, compaction, and snapshot recovery tests pass on .NET 10
- `Tsavorite.core` builds successfully for .NET 8 and .NET 10
- Changed-file formatting verification passes

### Issues Fixed

Fixes #2073