### PR TITLE
Harden website deps: ignore install/postinstall scripts

### DIFF
--- a/website/.npmrc
+++ b/website/.npmrc
@@ -1,0 +1,2 @@
+# Disable postinstall scripts for supply chain security hardening
+ignore-scripts=true

--- a/website/.yarnrc
+++ b/website/.yarnrc
@@ -1,0 +1,3 @@
+# Disable install/postinstall scripts for supply chain security hardening.
+# Yarn Classic ignores the .npmrc "ignore-scripts" key, so it must be set here too.
+ignore-scripts true


### PR DESCRIPTION
## What
Disable dependency install/postinstall scripts when installing the Docusaurus website dependencies, as supply-chain security hardening.

- `website/.npmrc` → `ignore-scripts=true` (covers `npm` usage / defense in depth)
- `website/.yarnrc` → `ignore-scripts true` (**the effective setting** — Yarn Classic, used by the website and CI, ignores `.npmrc`'s `ignore-scripts` key)

## Why
`postinstall` scripts are a common npm supply-chain attack vector. Skipping them removes that arbitrary-code-execution path during `yarn install`.

> Note: `.npmrc` alone is a no-op under Yarn Classic (verified empirically — lifecycle scripts still ran). `.yarnrc` is required for the hardening to actually take effect for the website build.

## Validation
Matches CI (node 22, `working-directory: website`):
- `yarn install --frozen-lockfile` → `warning Ignored scripts due to flag`
- `yarn build` → `[SUCCESS] Generated static files in "build"` (exit 0)

Only `core-js` (funding message) and macOS-only `fsevents` use install scripts in this tree — both safe to skip, so the build is unaffected.

## Behavioral impact
Every `yarn install` (local + CI) now skips dependency lifecycle scripts.

Closes #2077