### PR TITLE
Bump version to 2.1.5

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- VersionPrefix property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>2.1.4</VersionPrefix>
+		<VersionPrefix>2.1.5</VersionPrefix>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Bumps `VersionPrefix` in `Version.props` from 2.1.4 to 2.1.5 for the next release.