### PR TITLE
Update Vector Sets docs to reflect current main behavior

### DIFF
--- a/website/docs/commands/vector-sets.md
+++ b/website/docs/commands/vector-sets.md
@@ -105,8 +105,7 @@ verbatim in search results.
 ### Cluster
 
 Vector Sets participate in cluster sharding by their key. `MIGRATE` is supported and ships both the index stub and
-all internal per-element data. The number of simultaneously open Vector Sets on a single instance is currently capped
-(approximately 15) by an internal context metadata limit.
+all internal per-element data.
 
 ---
 
@@ -129,7 +128,8 @@ VADD key [REDUCE dim] (FP32 vector | XB8 vector | VALUES n v1 ... vN) element
 | Form | Description |
 |------|-------------|
 | `FP32 <bytes>` | Raw little-endian `float32` blob. Length must be a multiple of 4. |
-| `XB8 <bytes>` | Raw `uint8` byte blob. Each byte is one dimension. |
+| `XU8 <bytes>` | Raw `uint8` byte blob. Each byte is one dimension. |
+| `XI8 <bytes>` | Raw `int8` byte blob. Each byte is one dimension. |
 | `VALUES n v1 v2 ... vN` | `n` textual floats. |
 
 #### Options
@@ -138,7 +138,7 @@ VADD key [REDUCE dim] (FP32 vector | XB8 vector | VALUES n v1 ... vN) element
 |--------|---------|-------------|
 | `REDUCE dim` | _disabled_ | Project the input vector down to `dim` dimensions. `dim` must be ≤ the input dimensions. Not allowed with `XPREQ8`. Only honored on the first `VADD` (when the index is created). |
 | `CAS` | _off_ | Accepted for parser compatibility with Redis; currently a no-op. |
-| `NOQUANT` \| `XPREQ8` | _required_ | Quantization (see [Quantization](#quantization)). `Q8` and `BIN` are parsed but rejected with `ERR Unsupported quantization type`. |
+| `NOQUANT` \| `BIN` \| `Q8` \| `XNOQUANT_U8` \| `XNOQUANT_I8` \| `XBIN_I8` \| `XBIN_U8` | `Q8` | Quantization (see [Quantization](#quantization)). |
 | `EF n` | `200` | Build-time exploration factor (DiskANN `R` candidate-list size). Must be in `[1, 1000000]`. |
 | `SETATTR attr` | _none_ | Attach an arbitrary byte string to the element (typically a JSON object). Retrieve later with `VGETATTR` or via `WITHATTRIBS` on `VSIM`. |
 | `M n` | `16` | DiskANN max out-degree per node. Must be in `[4, 4096]`. |
@@ -485,13 +485,15 @@ The active quantizer determines how vectors are stored internally and which inpu
 
 | Token | Status | Notes |
 |-------|--------|-------|
-| `NOQUANT` | ✅ Supported | Store input as `float32`. Works with `FP32`, `XB8`, and `VALUES` inputs (uint8 bytes are widened to floats). |
-| `XPREQ8` | ✅ Supported | Garnet extension: stores the input `uint8` bytes verbatim with no further quantization. Requires `XB8` input and is incompatible with `REDUCE`. |
-| `Q8` | ❌ Rejected | Parsed for compatibility; returns `ERR Unsupported quantization type`. |
-| `BIN` | ❌ Rejected | Parsed for compatibility; returns `ERR Unsupported quantization type`. |
+| `NOQUANT` | ✅ Supported | Store input as `float32`, use unquantized forms for graph search. |
+| `Q8` | ✅ Supported | Store input as `float32`, use 8-bit quantized forms for graph search.  |
+| `BIN` | ✅ Supported | Store input as `float32`, use 1-bit quantized forms for graph search. |
+| `XNOQUANT_U8` | ✅ Supported | Garnet extension: stores input as `uint8` bytes with no further quantization. Incompatible with `REDUCE`. |
+| `XNOQUANT_I8` | ✅ Supported | Garnet extension: stores input as `int8` bytes with no further quantization. Incompatible with `REDUCE`. |
+| `XBIN_U8` | ✅ Supported | Garnet extension: stores input `uint8` bytes, uses 1-bit quantized forms for graph search. Incompatible with `REDUCE`. |
+| `XBIN_I8` | ✅ Supported | Garnet extension: stores input `int8` bytes, uses 1-bit quantized forms for graph search. Incompatible with `REDUCE`. |
 
-If no quantizer is specified on the first `VADD`, the default is `Q8`, which currently fails — supply `NOQUANT` (or
-`XPREQ8` for uint8 data) explicitly.
+If no quantizer is specified on the first `VADD`, the default is `Q8`.  Matching input format and storage format improves performance by removing a conversion step in `VADD`.
 
 ## Distance Metrics
 
@@ -528,8 +530,6 @@ reserved for future implementation:
 
 | Command | Intended behavior |
 |---------|--------------------|
-| `VCARD key` | Cardinality (number of elements). Use `VINFO key` and read the `size` field instead. |
-| `VISMEMBER key element` | Test membership. |
 | `VLINKS key element [WITHSCORES]` | Return the neighbours of `element` in the DiskANN graph. |
 | `VRANDMEMBER key [count]` | Return random element IDs. |
 | `VSETATTR key element attr` | Update an element's attribute in place. Today the only way to set/replace an attribute is to re-run `VADD ... SETATTR`. |
@@ -637,7 +637,7 @@ Or in `garnet.conf`:
 | Maximum `COUNT` | 100,000,000 | `VectorManager.MaxRetrieveCount` |
 | Maximum `FILTER-EF` | 256 | `VectorManager.MaxFilteringScaleFactor` |
 | Maximum elements per Vector Set | 2³² − 1 | DiskANN limit |
-| Concurrent Vector Sets per instance | ~15 | Internal context metadata limit |
+| Concurrent Vector Sets per instance | (2³² − 8)/8 (approx. 500 million) | Internal context metadata limit |
 | Empty Vector Set keys | not allowed | Returns `ERR Vector Set key cannot be empty` (preview restriction) |
 
 ---


### PR DESCRIPTION
Updates the outdated [Vector Sets command documentation](https://microsoft.github.io/garnet/docs/commands/vector-sets) to match the current behavior on `main`.

This is a docs-only PR. It cherry-picks the subset of doc changes from the draft #1992 that are **already true on `main`**, and deliberately excludes the parts of that draft that depend on its unmerged code.

### Included (verified against `main`)
- **Removed the stale ~15 concurrent Vector Sets cap** (Cluster section + Limits table). The actual limit is `uint.MaxValue` contexts / `ContextStep` (8) ≈ 500 million (`VectorManager.cs`, `VectorManager.ContextMetadata.cs`).
- **Input form tokens** now documented as `XU8` / `XI8` (`XB8` remains a backwards-compat alias in the parser).
- **Quantization** table/options updated to reflect all supported quantizers — `NOQUANT`, `Q8`, `BIN`, `XNOQUANT_U8`, `XNOQUANT_I8`, `XBIN_U8`, `XBIN_I8` — with `Q8` as the default. Dropped the stale "Q8/BIN rejected" and "default Q8 fails" notes. The `XNOQUANT_*` / `XBIN_*` variants are correctly noted as incompatible with `REDUCE` (`RespServerSessionVectors.cs`).
- **Removed `VCARD` and `VISMEMBER`** from "Not Yet Implemented" — both are fully functional on `main`.

### Deliberately excluded (not true on `main`)
- **`VLINKS` and `VRANDMEMBER`** remain in "Not Yet Implemented" — they are still `// TODO: implement!` stubs that return `+OK` on `main`.
- **All `dev/vector-sets.md` FFI changes** from #1992 (e.g. `logCallback`, `valueLengthHint`, `search_neighbors`, `random_members`, `beam_width`, in-place filter callback) correspond to that PR's unmerged code and are not present on `main`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>