### PR TITLE
Avoid int overflow in sorted-set numkeys argument-count checks

### DIFF
--- a/libs/server/Resp/Objects/SortedSetCommands.cs
+++ b/libs/server/Resp/Objects/SortedSetCommands.cs
@@ -431,7 +431,7 @@ namespace Garnet.server
             }
 
             // Validate we have enough arguments (no of keys + (MIN or MAX))
-            if (parseState.Count < numKeys + 2)
+            if (parseState.Count - 2 < numKeys)
             {
                 return AbortWithErrorMessage(CmdStrings.RESP_SYNTAX_ERROR);
             }
@@ -1068,7 +1068,7 @@ namespace Garnet.server
                 return AbortWithErrorMessage(CmdStrings.GenericErrAtLeastOneKey, nameof(RespCommand.ZINTER));
             }
 
-            if (parseState.Count < nKeys + 1)
+            if (parseState.Count - 1 < nKeys)
             {
                 return AbortWithErrorMessage(CmdStrings.RESP_SYNTAX_ERROR);
             }
@@ -1191,7 +1191,7 @@ namespace Garnet.server
                 return AbortWithErrorMessage(CmdStrings.GenericErrAtLeastOneKey, nameof(RespCommand.ZINTERCARD));
             }
 
-            if (parseState.Count < nKeys + 1)
+            if (parseState.Count - 1 < nKeys)
             {
                 return AbortWithErrorMessage(CmdStrings.RESP_SYNTAX_ERROR);
             }
@@ -1363,7 +1363,7 @@ namespace Garnet.server
                 return AbortWithErrorMessage(CmdStrings.GenericErrAtLeastOneKey, nameof(RespCommand.ZUNION));
             }
 
-            if (parseState.Count < nKeys + 1)
+            if (parseState.Count - 1 < nKeys)
             {
                 return AbortWithErrorMessage(CmdStrings.RESP_SYNTAX_ERROR);
             }
@@ -1493,7 +1493,7 @@ namespace Garnet.server
                 return AbortWithErrorMessage(CmdStrings.GenericErrAtLeastOneKey, nameof(RespCommand.ZUNIONSTORE));
             }
 
-            if (parseState.Count < nKeys + 2)
+            if (parseState.Count - 2 < nKeys)
             {
                 return AbortWithErrorMessage(CmdStrings.RESP_SYNTAX_ERROR);
             }

--- a/libs/server/SessionParseStateExtensions.cs
+++ b/libs/server/SessionParseStateExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Garnet.common;
@@ -989,16 +988,25 @@ namespace Garnet.server
             else
             {
                 var keyNumIdx = beginSearchIdx + keySpec.FindKeys.KeyNumIndex;
-                Debug.Assert(keyNumIdx >= 0 && keyNumIdx < parseState.Count);
+                if (keyNumIdx < 0 || keyNumIdx >= parseState.Count)
+                {
+                    return false;
+                }
 
                 var keyNumFound = parseState.TryGetInt(keyNumIdx, out var keyNum);
-                Debug.Assert(keyNumFound);
+                if (!keyNumFound)
+                {
+                    return false;
+                }
 
                 firstKeyIdx += keySpec.FindKeys.FirstKey;
                 lastKeyIdx = firstKeyIdx + ((keyNum - 1) * keyStep);
             }
 
-            Debug.Assert(lastKeyIdx < parseState.Count);
+            if (lastKeyIdx >= parseState.Count)
+            {
+                lastKeyIdx = parseState.Count - 1;
+            }
 
             searchArgs = (firstKeyIdx, lastKeyIdx, keyStep);
             return true;

--- a/test/standalone/Garnet.test.collections/RespSortedSetTests.cs
+++ b/test/standalone/Garnet.test.collections/RespSortedSetTests.cs
@@ -5348,6 +5348,41 @@ namespace Garnet.test
         }
 
         [Test]
+        public void CanDoSortedSetCommandsWithBadNumKeysLC()
+        {
+            using var lightClientRequest = TestUtils.CreateRequest();
+
+            // Same overflow as CanDoZInterStoreWithBadNumKeysLC, for the sibling commands.
+            var expectedResponse = $"-{Encoding.ASCII.GetString(CmdStrings.RESP_SYNTAX_ERROR)}\r\n+PONG\r\n";
+
+            var commands = new[]
+            {
+                "ZMPOP 2147483647 zset1 MIN",
+                "ZUNION 2147483647 zset1",
+                "ZUNIONSTORE dest 2147483647 zset1",
+                "ZINTER 2147483647 zset1",
+                "ZINTERCARD 2147483647 zset1",
+                "ZMPOP 2147483646 zset1 MIN",
+                "ZUNION 2147483646 zset1",
+                "ZUNIONSTORE dest 2147483646 zset1",
+                "ZINTER 2147483646 zset1",
+                "ZINTERCARD 2147483646 zset1",
+            };
+
+            foreach (var command in commands)
+            {
+                var response = lightClientRequest.SendCommands(command, "PING");
+                TestUtils.AssertEqualUpToExpectedLength(expectedResponse, response);
+            }
+
+            // COMMAND GETKEYS applies keynum key-specs before the command handlers run,
+            // so an inflated numkeys must be clamped there too instead of walking the
+            // parse state out of bounds.
+            var getKeysResponse = lightClientRequest.SendCommands("COMMAND GETKEYS ZUNION 2147483647 zset1", "PING");
+            TestUtils.AssertEqualUpToExpectedLength("*1\r\n$5\r\nzset1\r\n+PONG\r\n", getKeysResponse);
+        }
+
+        [Test]
         public void ZInterResultOrder()
         {
             using var lightClientRequest = TestUtils.CreateRequest();


### PR DESCRIPTION
Two sites let a numkeys near `int.MaxValue` slip bounds checks and walk the parse state far out of bounds, crashing the server:

1. The additive argument-count checks in ZMPOP, ZUNION, ZUNIONSTORE, ZINTER, and ZINTERCARD (`parseState.Count < numKeys + k`) wrap negative and pass; the handlers then index `GetArgSliceByRef` with a wild index. ZINTERSTORE was fixed in #2031; the same subtraction form is applied to the five siblings.

2. `TryGetKeySearchArgsFromSimpleKeySpec` computed `lastKeyIdx = firstKeyIdx + ((numkeys - 1) * keyStep)` bounded only by `Debug.Assert`, so `COMMAND GETKEYS ZUNION 2147483647 x` (and cluster slot verification) walked `GetArgSliceByRef` to attacker-controlled indexes before the handlers ran. The asserts are replaced with runtime guards and `lastKeyIdx` is clamped to the parse state.

Repro on a default deployment: `COMMAND GETKEYS ZUNION 2147483647 x`.

Adds regression coverage for numkeys = 2147483646/2147483647 across the five commands and the COMMAND GETKEYS boundary, each followed by `PING` to prove the connection survives.
