### PR TITLE
Build: Bump version to 2.1.7

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
 	<!-- VersionPrefix property for builds and packages -->
 	<PropertyGroup>
-		<VersionPrefix>2.1.6</VersionPrefix>
+		<VersionPrefix>2.1.7</VersionPrefix>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Bump `VersionPrefix` from `2.1.6` to `2.1.7` for the next Garnet patch release.