### PR TITLE
Fix negative bitmap index normalization

### DIFF
--- a/libs/server/Resp/Bitmap/BitmapManager.cs
+++ b/libs/server/Resp/Bitmap/BitmapManager.cs
@@ -66,36 +66,18 @@ namespace Garnet.server
         internal static bool TryValidateBitPosOffsets(long startOffset, long endOffset, byte offsetType, bool hasStartOffset, bool hasEndOffset)
         {
             // BYTE mode uses byte index bounds; BIT mode uses bit index bounds.
-            var maxOffset = offsetType == 0x1
-                ? MaxOffsetForBitmapLength
-                : MaxBitmapPayloadBytes - 1L;
+            var maxLength = offsetType == 0x1
+                ? MaxOffsetForBitmapLength + 1
+                : MaxBitmapPayloadBytes;
+            var maxOffset = maxLength - 1;
 
-            if (hasStartOffset && (startOffset < -maxOffset || startOffset > maxOffset))
+            if (hasStartOffset && (startOffset < -maxLength || startOffset > maxOffset))
                 return true;
 
-            if (hasEndOffset && (endOffset < -maxOffset || endOffset > maxOffset))
+            if (hasEndOffset && (endOffset < -maxLength || endOffset > maxOffset))
                 return true;
 
             return false;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void NormalizeBitCountOffsets(ref long startOffset, ref long endOffset, byte offsetType)
-        {
-            // BYTE mode uses byte index bounds; BIT mode uses bit index bounds.
-            var maxOffset = offsetType == 0x1
-                ? MaxOffsetForBitmapLength
-                : MaxBitmapPayloadBytes - 1L;
-
-            if (startOffset < -maxOffset)
-                startOffset = -maxOffset;
-            else if (startOffset > maxOffset)
-                startOffset = maxOffset;
-
-            if (endOffset < -maxOffset)
-                endOffset = -maxOffset;
-            else if (endOffset > maxOffset)
-                endOffset = maxOffset;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -195,7 +177,7 @@ namespace Garnet.server
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static long ProcessNegativeOffset(long offset, long valLen)
-            => valLen <= 0 ? 0 : (offset % valLen) + valLen;
+            => valLen <= 0 || offset <= -valLen ? 0 : valLen + offset;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static byte reverse(byte n)

--- a/libs/server/Resp/Bitmap/BitmapManagerBitCount.cs
+++ b/libs/server/Resp/Bitmap/BitmapManagerBitCount.cs
@@ -65,7 +65,8 @@ namespace Garnet.server
         {
             long count = 0;
 
-            NormalizeBitCountOffsets(ref startOffset, ref endOffset, offsetType);
+            if (startOffset < 0 && endOffset < 0 && startOffset > endOffset)
+                return 0;
 
             // BYTE indexing
             if (offsetType == 0x0)

--- a/test/standalone/Garnet.test.complexstring/GarnetBitmapTests.cs
+++ b/test/standalone/Garnet.test.complexstring/GarnetBitmapTests.cs
@@ -358,8 +358,12 @@ namespace Garnet.test
         private static unsafe long Count(byte* bitmap, int bitmapLen, int startOffset = 0, int endOffset = -1)
         {
             long count = 0;
-            int start = startOffset < 0 ? (startOffset % bitmapLen) + bitmapLen : startOffset;
-            int end = endOffset < 0 ? (endOffset % bitmapLen) + bitmapLen : endOffset;
+            if (startOffset < 0 && endOffset < 0 && startOffset > endOffset)
+                return 0;
+
+            int start = startOffset < 0 ? Math.Max(bitmapLen + startOffset, 0) : startOffset;
+            int end = endOffset < 0 ? Math.Max(bitmapLen + endOffset, 0) : endOffset;
+            end = Math.Min(end, bitmapLen - 1);
 
             if (start >= bitmapLen) // If startOffset greater that valLen always bitcount zero
                 return 0;
@@ -590,8 +594,9 @@ namespace Garnet.test
         private static unsafe long Bitpos(byte[] bitmap, int startOffset = 0, int endOffset = -1, bool set = true)
         {
             long pos = 0;
-            var start = startOffset < 0 ? (startOffset % bitmap.Length) + bitmap.Length : startOffset;
-            var end = endOffset < 0 ? (endOffset % bitmap.Length) + bitmap.Length : endOffset;
+            var start = startOffset < 0 ? Math.Max(bitmap.Length + startOffset, 0) : startOffset;
+            var end = endOffset < 0 ? Math.Max(bitmap.Length + endOffset, 0) : endOffset;
+            end = Math.Min(end, bitmap.Length - 1);
 
             if (start >= bitmap.Length) // If startOffset greater that valLen alway bitcount zero
                 return -1;
@@ -2364,11 +2369,27 @@ namespace Garnet.test
             var offset = (long)int.MaxValue + 1024;
             var count = (long)db.Execute("BITCOUNT", key, (-offset).ToString(), "-1", "BIT");
 
-            // The out-of-range negative start is clamped to -MaxOffsetForBitmapLength and then
-            // wrapped modulo the bit length (Garnet's negative-offset semantics), landing on bit
-            // index 1; the end (-1) wraps to bit index 7. So bits 1..7 of 0xFF are counted => 7.
-            // (This previously asserted 8 only because of a byte-mask underflow in BitCountDriver.)
-            ClassicAssert.AreEqual(7, count);
+            // Negative offsets before the start of the value clamp to bit index 0.
+            ClassicAssert.AreEqual(8, count);
+        }
+
+        [Test]
+        [Category("BITCOUNT")]
+        public void BitmapBitCountNegativeOffsetClampingTest()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            var key = "BitmapBitCountNegativeOffsetClampingTest";
+            _ = db.StringSet(key, new byte[] { 0x80, 0x01 });
+
+            ClassicAssert.AreEqual(1, db.StringBitCount(key, -2, -2, StringIndexType.Byte));
+            ClassicAssert.AreEqual(2, db.StringBitCount(key, -3, -1, StringIndexType.Byte));
+            ClassicAssert.AreEqual(0, db.StringBitCount(key, -1, -2, StringIndexType.Byte));
+
+            ClassicAssert.AreEqual(1, db.StringBitCount(key, -16, -16, StringIndexType.Bit));
+            ClassicAssert.AreEqual(2, db.StringBitCount(key, -17, -1, StringIndexType.Bit));
+            ClassicAssert.AreEqual(0, db.StringBitCount(key, -1, -2, StringIndexType.Bit));
         }
 
         [Test]
@@ -2469,10 +2490,33 @@ namespace Garnet.test
             ClassicAssert.AreEqual(-1, pos);
 
             pos = (long)db.Execute("BITPOS", key, "1", (-maxBitOffset - 1).ToString(), "-1", "BIT");
-            ClassicAssert.AreEqual(-1, pos);
+            ClassicAssert.AreEqual(0, pos);
 
             pos = (long)db.Execute("BITPOS", key, "1", (-maxByteOffset - 1).ToString(), "-1", "BYTE");
+            ClassicAssert.AreEqual(0, pos);
+
+            pos = (long)db.Execute("BITPOS", key, "1", (-maxBitOffset - 2).ToString(), "-1", "BIT");
             ClassicAssert.AreEqual(-1, pos);
+
+            pos = (long)db.Execute("BITPOS", key, "1", (-maxByteOffset - 2).ToString(), "-1", "BYTE");
+            ClassicAssert.AreEqual(-1, pos);
+        }
+
+        [Test]
+        [Category("BITPOS")]
+        public void BitmapBitPosNegativeOffsetClampingTest()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            var db = redis.GetDatabase(0);
+
+            var key = "BitmapBitPosNegativeOffsetClampingTest";
+            _ = db.StringSet(key, new byte[] { 0x80, 0x01 });
+
+            ClassicAssert.AreEqual(0, db.StringBitPosition(key, true, -2, -2, StringIndexType.Byte));
+            ClassicAssert.AreEqual(0, db.StringBitPosition(key, true, -3, -2, StringIndexType.Byte));
+
+            ClassicAssert.AreEqual(0, db.StringBitPosition(key, true, -16, -16, StringIndexType.Bit));
+            ClassicAssert.AreEqual(0, db.StringBitPosition(key, true, -17, -16, StringIndexType.Bit));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- clamp BITCOUNT and BITPOS negative indices before the start to zero instead of wrapping
- preserve the BITPOS early bounds check while accepting the valid negative maximum-length boundary
- add BYTE and BIT regression coverage

## Testing
- BITCOUNT and BITPOS tests (net10.0 Debug)