### PR TITLE
Validate CLIENT SETINFO attribute values

### DIFF
--- a/libs/server/Resp/ClientCommands.cs
+++ b/libs/server/Resp/ClientCommands.cs
@@ -546,18 +546,27 @@ namespace Garnet.server
             }
 
             var option = parseState.GetArgSliceByRef(0);
-            var value = parseState.GetString(1);
-            if (option.Span.SequenceEqual(CmdStrings.LIB_NAME) || option.Span.SequenceEqual(CmdStrings.lib_name)) // Can't use EqualsUpperCaseSpanIgnoringCase as `-` is not upper case
+            var isLibName = option.Span.EqualsUpperCaseSpanIgnoringCase(CmdStrings.LIB_NAME, allowNonAlphabeticChars: true);
+            var isLibVer = option.Span.EqualsUpperCaseSpanIgnoringCase(CmdStrings.LIB_VER, allowNonAlphabeticChars: true);
+            if (!isLibName && !isLibVer)
+            {
+                return AbortWithErrorMessage(CmdStrings.RESP_SYNTAX_ERROR);
+            }
+
+            ref var valueSlice = ref parseState.GetArgSliceByRef(1);
+            if (!IsValidClientAttr(valueSlice.ReadOnlySpan))
+            {
+                return AbortWithErrorMessage(CmdStrings.GenericErrInvalidClientAttr, parseState.GetString(0));
+            }
+
+            var value = ParseUtils.ReadString(valueSlice);
+            if (isLibName)
             {
                 this.clientLibName = value;
             }
-            else if (option.Span.SequenceEqual(CmdStrings.LIB_VER) || option.Span.SequenceEqual(CmdStrings.lib_ver))
-            {
-                this.clientLibVersion = value;
-            }
             else
             {
-                return AbortWithErrorMessage(CmdStrings.RESP_SYNTAX_ERROR);
+                this.clientLibVersion = value;
             }
 
             while (!RespWriteUtils.TryWriteDirect(CmdStrings.RESP_OK, ref dcurr, dend))
@@ -565,6 +574,9 @@ namespace Garnet.server
 
             return true;
         }
+
+        private static bool IsValidClientAttr(ReadOnlySpan<byte> value)
+            => value.IndexOfAnyExceptInRange((byte)33, (byte)126) < 0;
 
         /// <summary>
         /// CLIENT UNBLOCK

--- a/libs/server/Resp/CmdStrings.cs
+++ b/libs/server/Resp/CmdStrings.cs
@@ -144,9 +144,7 @@ namespace Garnet.server
         public static ReadOnlySpan<byte> WITHDIST => "WITHDIST"u8;
         public static ReadOnlySpan<byte> WITHHASH => "WITHHASH"u8;
         public static ReadOnlySpan<byte> LIB_NAME => "LIB-NAME"u8;
-        public static ReadOnlySpan<byte> lib_name => "lib-name"u8;
         public static ReadOnlySpan<byte> LIB_VER => "LIB-VER"u8;
-        public static ReadOnlySpan<byte> lib_ver => "lib-ver"u8;
         public static ReadOnlySpan<byte> RIGHT => "RIGHT"u8;
         public static ReadOnlySpan<byte> LEFT => "LEFT"u8;
         public static ReadOnlySpan<byte> BYLEX => "BYLEX"u8;
@@ -323,6 +321,7 @@ namespace Garnet.server
         /// Response string templates
         /// </summary>
         public const string GenericErrWrongNumArgs = "ERR wrong number of arguments for '{0}' command";
+        public const string GenericErrInvalidClientAttr = "ERR {0} cannot contain spaces, newlines or special characters.";
         public const string GenericErrUnknownOptionConfigSet = "ERR Unknown option or number of arguments for CONFIG SET - '{0}'";
         public const string GenericErrUnknownOption = "ERR Unknown option or number of arguments for '{0}' command";
         public const string GenericErrUnsupportedOption = "ERR Unsupported option {0}";

--- a/test/standalone/Garnet.test.acl/Resp/ACL/BasicTests.cs
+++ b/test/standalone/Garnet.test.acl/Resp/ACL/BasicTests.cs
@@ -215,6 +215,51 @@ namespace Garnet.test.Resp.ACL
             ClassicAssert.IsTrue(exc.Message.StartsWith("NOPERM"), $"Expected NOPERM for denied CLIENT SETINFO, got: {exc.Message}");
         }
 
+        [Test]
+        public void ClientSetInfoRejectsInvalidAttributeValue()
+        {
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
+            var db = redis.GetDatabase(0);
+
+            var exc = Assert.Throws<RedisServerException>(() => db.Execute("CLIENT", "SETINFO", "LIB-NAME", "foo\nbar"));
+            ClassicAssert.IsTrue(exc.Message.StartsWith("ERR LIB-NAME cannot contain spaces"), $"Expected invalid client attribute error, got: {exc.Message}");
+
+            exc = Assert.Throws<RedisServerException>(() => db.Execute("CLIENT", "SETINFO", "LIB-VER", "1.0 2.0"));
+            ClassicAssert.IsTrue(exc.Message.StartsWith("ERR LIB-VER cannot contain spaces"), $"Expected invalid client attribute error, got: {exc.Message}");
+
+            exc = Assert.Throws<RedisServerException>(() => db.Execute("CLIENT", "SETINFO", "CRLF-INJ\r\n-ERR injected", "a b"));
+            ClassicAssert.IsTrue(exc.Message.StartsWith("ERR syntax error"), $"Expected syntax error for unknown attribute, got: {exc.Message}");
+
+            exc = Assert.Throws<RedisServerException>(() => db.Execute("CLIENT", "SETINFO", "LIB-VER", "\u007f"));
+            ClassicAssert.IsTrue(exc.Message.StartsWith("ERR LIB-VER cannot contain spaces"), $"Expected DEL to be rejected, got: {exc.Message}");
+
+            db.Execute("CLIENT", "SETINFO", "LIB-NAME", "a!~b");
+            var clientInfo = (string)db.Execute("CLIENT", "INFO");
+            ClassicAssert.IsTrue(clientInfo.Contains("lib-name=a!~b"), $"Expected boundary bytes 33-126 to be accepted, CLIENT INFO: {clientInfo}");
+
+            db.Execute("CLIENT", "SETINFO", "LIB-NAME", "my-lib");
+            db.Execute("CLIENT", "SETINFO", "LIB-VER", "1.2.3");
+            clientInfo = (string)db.Execute("CLIENT", "INFO");
+            ClassicAssert.IsTrue(clientInfo.Contains("lib-name=my-lib"), $"Expected lib-name=my-lib in CLIENT INFO, got: {clientInfo}");
+            ClassicAssert.IsTrue(clientInfo.Contains("lib-ver=1.2.3"), $"Expected lib-ver=1.2.3 in CLIENT INFO, got: {clientInfo}");
+
+            db.Execute("CLIENT", "SETINFO", "lib-ver", "9.9.9");
+            clientInfo = (string)db.Execute("CLIENT", "INFO");
+            ClassicAssert.IsTrue(clientInfo.Contains("lib-ver=9.9.9"), $"Expected case-insensitive attribute matching, CLIENT INFO: {clientInfo}");
+
+            exc = Assert.Throws<RedisServerException>(() => db.Execute("CLIENT", "SETINFO", "LIB-NAME", "bad\nvalue"));
+            ClassicAssert.IsTrue(exc.Message.StartsWith("ERR LIB-NAME cannot contain spaces"), $"Expected invalid client attribute error, got: {exc.Message}");
+            clientInfo = (string)db.Execute("CLIENT", "INFO");
+            ClassicAssert.IsTrue(clientInfo.Contains("lib-name=my-lib"), $"Failed SETINFO must not overwrite the stored value, CLIENT INFO: {clientInfo}");
+
+            db.Execute("CLIENT", "SETINFO", "LIB-NAME", "");
+            clientInfo = (string)db.Execute("CLIENT", "INFO");
+            ClassicAssert.IsTrue(clientInfo.Contains(" lib-name= "), $"Expected empty lib-name to clear the attribute, CLIENT INFO: {clientInfo}");
+
+            var clientList = (string)db.Execute("CLIENT", "LIST");
+            ClassicAssert.IsFalse(clientList.Contains("\r"), $"CLIENT LIST must stay line-clean, got: {clientList}");
+        }
+
         private static ConfigurationOptions GetLimitedUserConfig()
             => TestUtils.GetConfig(disablePubSub: true, authUsername: TestUserA, authPassword: DummyPassword);
 

--- a/website/docs/commands/client.md
+++ b/website/docs/commands/client.md
@@ -89,7 +89,10 @@ Currently the supported attributes are:
 
 #### Resp Reply
 
-Simple string reply: OK if the section value was successfully set.
+One of the following:
+
+* Simple string reply: OK if the section value was successfully set.
+* Simple error reply: `ERR <attr> cannot contain spaces, newlines or special characters.` if the value contains spaces, newlines or special characters; `ERR syntax error` if the attribute is not recognized.
 
 ---
 


### PR DESCRIPTION
CLIENT SETINFO stored LIB-NAME/LIB-VER values without validation and echoed them verbatim into CLIENT LIST/CLIENT INFO, so a client could inject arbitrary reply lines into administrative output.

- Values are validated as printable ASCII (33-126) on the raw bytes, matching Redis `validateClientAttr`, and rejected with `ERR <attr> cannot contain spaces, newlines or special characters.` mirroring Redis's wording.
- Attribute dispatch precedes value validation, so the echoed attribute in errors is always a case-variant of a matched constant; unknown attributes keep the syntax-error path.
- Attribute matching is case-insensitive (`lib-name` accepted), matching Redis subcommand lookup.
- Note: high-byte (128-255) values were previously accepted and ASCII-mangled in CLIENT LIST; they are now rejected, matching Redis.

Regression tests cover CRLF injection, control/high bytes, boundary bytes 33/126, failed-SETINFO preservation, empty-value clearing, case-insensitive matching, and CLIENT LIST line-cleanliness. Command docs updated accordingly.

Signed-off-by: Tristan Su <sooqing@gmail.com>
