### PR TITLE
Prevent live Unix servers from sharing a TCP port

### DIFF
--- a/libs/server/Servers/GarnetServerTcp.cs
+++ b/libs/server/Servers/GarnetServerTcp.cs
@@ -102,8 +102,15 @@ namespace Garnet.server
                 // TCP Initialization & Port Reuse
                 listenSocket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
-                // Set reuse BEFORE Bind to handle TIME_WAIT states
+                // Set reuse BEFORE Bind to handle TIME_WAIT states.
                 listenSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+
+                // On Unix, .NET's ReuseAddress sets both SO_REUSEADDR and SO_REUSEPORT.
+                // Keep address reuse for restarts, but do not let two live servers share a port.
+                if (OperatingSystem.IsLinux())
+                    listenSocket.SetRawSocketOption(1 /* SOL_SOCKET */, 15 /* SO_REUSEPORT */, BitConverter.GetBytes(0));
+                else if (OperatingSystem.IsMacOS() || OperatingSystem.IsFreeBSD())
+                    listenSocket.SetRawSocketOption(0xffff /* SOL_SOCKET */, 0x0200 /* SO_REUSEPORT */, BitConverter.GetBytes(0));
             }
 
             acceptEventArg = new SocketAsyncEventArgs();

--- a/test/standalone/Garnet.test/GarnetServerTcpTests.cs
+++ b/test/standalone/Garnet.test/GarnetServerTcpTests.cs
@@ -10,8 +10,14 @@ using NUnit.Framework;
 namespace Garnet.test
 {
     [TestFixture, NonParallelizable]
-    public class GarnetServerTcpTests
+    public class GarnetServerTcpTests : TestBase
     {
+        [TearDown]
+        public void TearDown()
+        {
+            TestUtils.OnTearDown();
+        }
+
         static IPEndPoint GetEndPoint(bool ipv6)
         {
             if (OperatingSystem.IsWindows())

--- a/test/standalone/Garnet.test/GarnetServerTcpTests.cs
+++ b/test/standalone/Garnet.test/GarnetServerTcpTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using Garnet.server;
+using NUnit.Framework;
+
+namespace Garnet.test
+{
+    [TestFixture, NonParallelizable]
+    public class GarnetServerTcpTests
+    {
+        static IPEndPoint GetEndPoint(bool ipv6)
+        {
+            if (OperatingSystem.IsWindows())
+                Assert.Ignore("Tests Unix listener reuse semantics.");
+            if (ipv6 && !Socket.OSSupportsIPv6)
+                Assert.Ignore("IPv6 is unavailable.");
+
+            return new IPEndPoint(ipv6 ? IPAddress.IPv6Loopback : IPAddress.Loopback, TestUtils.TestPort);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void StartRejectsAnAlreadyListeningEndpoint(bool ipv6)
+        {
+            var endpoint = GetEndPoint(ipv6);
+            using var first = new GarnetServerTcp(endpoint);
+            using var second = new GarnetServerTcp(endpoint);
+            first.Start();
+
+            var exception = Assert.Throws<SocketException>(() => second.Start());
+            Assert.That(exception.SocketErrorCode, Is.EqualTo(SocketError.AddressAlreadyInUse));
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void StartReusesEndpointAfterAnAcceptedConnectionCloses(bool ipv6)
+        {
+            var endpoint = GetEndPoint(ipv6);
+            using (var listener = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
+            {
+                listener.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                listener.Bind(endpoint);
+                listener.Listen(1);
+                using var client = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                client.ReceiveTimeout = 5000;
+                client.Connect(endpoint);
+                using var accepted = listener.Accept();
+                accepted.ReceiveTimeout = 5000;
+
+                // The server side closes first, leaving its accepted connection in TIME_WAIT.
+                accepted.Shutdown(SocketShutdown.Send);
+                Assert.That(client.Receive(new byte[1]), Is.Zero);
+                client.Shutdown(SocketShutdown.Send);
+                Assert.That(accepted.Receive(new byte[1]), Is.Zero);
+            }
+
+            using var server = new GarnetServerTcp(endpoint);
+            Assert.DoesNotThrow(() => server.Start());
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void StartReusesEndpointAfterListenerCloses(bool ipv6)
+        {
+            var endpoint = GetEndPoint(ipv6);
+            using var first = new GarnetServerTcp(endpoint);
+            using var second = new GarnetServerTcp(endpoint);
+            first.Start();
+            first.Close();
+
+            Assert.DoesNotThrow(() => second.Start());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2119.

Disable native `SO_REUSEPORT` after setting managed `ReuseAddress` on Linux, macOS, and FreeBSD. This retains `SO_REUSEADDR` for immediate restarts while preventing two live Garnet listeners from sharing an endpoint. Windows and Unix-domain sockets are unchanged.

Adds IPv4/IPv6 regressions for duplicate listeners, restarting a closed listener, and restarting after a server-side connection enters `TIME_WAIT`. Both duplicate-listener cases fail before the fix.

Validation on macOS arm64:
- All six new cases pass on .NET 8 and .NET 10.
- Listener/configuration selection: 52 passed and one existing Azure-config skip on each framework.
- Four hostname-resolution cases also fail against the unmodified source; those are excluded from the final selection.
- Whitespace formatting and `git diff --check` pass.

Linux, FreeBSD, and Windows were not tested locally.
