### PR TITLE
Bump SE.Redis to 3.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.17.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Validators" Version="8.17.0" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.12.8" />
+    <PackageVersion Include="StackExchange.Redis" Version="3.2.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
     <PackageVersion Include="System.Interactive.Async" Version="6.0.1" />
     <PackageVersion Include="System.Text.Json" Version="10.0.5" />

--- a/test/cluster/Garnet.test.cluster.migrate/ClusterMigrateTests.cs
+++ b/test/cluster/Garnet.test.cluster.migrate/ClusterMigrateTests.cs
@@ -647,7 +647,7 @@ namespace Garnet.test.cluster
 
             try
             {
-                var result = (string)server.Execute("zadd", args);
+                var result = (string)server.Execute(0, "zadd", args);
                 data.Sort((x, y) => x.Item1.CompareTo(y.Item1));
                 return (result, data);
             }
@@ -672,7 +672,7 @@ namespace Garnet.test.cluster
 
             try
             {
-                var result = server.Execute("zcount", args, CommandFlags.NoRedirect);
+                var result = server.Execute(0, "zcount", args, CommandFlags.NoRedirect);
                 count = int.Parse((string)result);
                 address = ((IPEndPoint)server.EndPoint).Address.ToString();
                 port = ((IPEndPoint)server.EndPoint).Port;
@@ -725,7 +725,7 @@ namespace Garnet.test.cluster
             ];
             try
             {
-                var result = server.Execute("zrange", args, CommandFlags.NoRedirect);
+                var result = server.Execute(0, "zrange", args, CommandFlags.NoRedirect);
                 address = ((IPEndPoint)server.EndPoint).Address.ToString();
                 port = ((IPEndPoint)server.EndPoint).Port;
                 slot = ClusterTestUtils.HashSlot(key);
@@ -2183,9 +2183,9 @@ namespace Garnet.test.cluster
 
             foreach (var value in values)
             {
-                var result = (string)sourceServer.Execute("set", key, value);
+                var result = (string)sourceServer.Execute(0, "set", [key, value]);
                 ClassicAssert.AreEqual("OK", result);
-                result = (string)sourceServer.Execute("get", key);
+                result = (string)sourceServer.Execute(0, "get", [key]);
                 ClassicAssert.AreEqual(Encoding.ASCII.GetString(value), result);
             }
 
@@ -2204,9 +2204,9 @@ namespace Garnet.test.cluster
                 values = context.GenerateIncreasingSizeValues(6, 7);
                 foreach (var value in values)
                 {
-                    var result = (string)sourceServer.Execute("set", key, value);
+                    var result = (string)sourceServer.Execute(0, "set", [key, value]);
                     ClassicAssert.AreEqual("OK", result);
-                    result = (string)sourceServer.Execute("get", key);
+                    result = (string)sourceServer.Execute(0, "get", [key]);
                     ClassicAssert.AreEqual(Encoding.ASCII.GetString(value), result);
                 }
 
@@ -2223,7 +2223,7 @@ namespace Garnet.test.cluster
 
             foreach (var value in values)
             {
-                var result = (string)targetServer.Execute("get", key);
+                var result = (string)targetServer.Execute(0, "get", [key]);
                 ClassicAssert.AreEqual(Encoding.ASCII.GetString(value), result);
             }
         }
@@ -2255,9 +2255,9 @@ namespace Garnet.test.cluster
             var value = "12345";
             var value2 = "67890";
             var slot = HashSlotUtils.HashSlot(Encoding.ASCII.GetBytes(key));
-            var resp = sourceServer.Execute("set", key, value);
+            var resp = sourceServer.Execute(0, "set", [key, value]);
             ClassicAssert.AreEqual("OK", (string)resp);
-            resp = sourceServer.Execute("get", key);
+            resp = sourceServer.Execute(0, "get", [key]);
             ClassicAssert.AreEqual(value, (string)resp);
 
             try
@@ -2273,7 +2273,7 @@ namespace Garnet.test.cluster
                 }
 
                 // At this point we should have switched to MIGRATING state but not yet started migration, hence we can still operate on the key
-                _ = sourceServer.Execute("DELRMW", [key, value2]);
+                _ = sourceServer.Execute(0, "DELRMW", [key, value2]);
 
                 // Re-enable to signal migration to continue
                 ExceptionInjectionHelper.EnableException(ExceptionInjectionType.Migration_Slot_End_Scan_Range_Acquisition);
@@ -2286,7 +2286,7 @@ namespace Garnet.test.cluster
                 ExceptionInjectionHelper.DisableException(ExceptionInjectionType.Migration_Slot_End_Scan_Range_Acquisition);
             }
 
-            resp = targetServer.Execute("get", key);
+            resp = targetServer.Execute(0, "get", [key]);
             ClassicAssert.AreEqual(value2, (string)resp);
         }
 #endif
@@ -2337,7 +2337,7 @@ namespace Garnet.test.cluster
 
             try
             {
-                var resp = server.Execute("migrate", args);
+                var resp = server.Execute(0, "migrate", args);
                 ClassicAssert.AreEqual("OK", (string)resp);
             }
             catch (Exception ex)
@@ -2405,7 +2405,7 @@ namespace Garnet.test.cluster
 
             try
             {
-                var resp = server.Execute("migrate", args);
+                var resp = server.Execute(0, "migrate", args);
                 Assert.Fail($"Migration with invalid hostname '{invalidHostname}' should fail");
             }
             catch (RedisServerException ex)
@@ -2595,10 +2595,10 @@ namespace Garnet.test.cluster
             context.clusterTestUtils.RandomBytesRestrictedToSlot(ref keepObjectKey, keepSlot);
 
             var server = context.clusterTestUtils.GetServer(0);
-            _ = server.Execute("SET", delStringKey, "raw-del");
-            _ = server.Execute("SADD", delObjectKey, "del-m1", "del-m2", "del-m3");
-            _ = server.Execute("SET", keepStringKey, "raw-keep");
-            _ = server.Execute("SADD", keepObjectKey, "keep-m1", "keep-m2", "keep-m3");
+            _ = server.Execute(0, "SET", [delStringKey, "raw-del"]);
+            _ = server.Execute(0, "SADD", [delObjectKey, "del-m1", "del-m2", "del-m3"]);
+            _ = server.Execute(0, "SET", [keepStringKey, "raw-keep"]);
+            _ = server.Execute(0, "SADD", [keepObjectKey, "keep-m1", "keep-m2", "keep-m3"]);
 
             // Both slots should each contain their two keys before deletion.
             ClassicAssert.AreEqual(2, context.clusterTestUtils.CountKeysInSlot(0, delSlot, context.logger),
@@ -2620,17 +2620,17 @@ namespace Garnet.test.cluster
                 "Keys in keepSlot must NOT be collateral-deleted by DELKEYSINSLOT on delSlot");
 
             // Direct GET / EXISTS confirm the delSlot keys are gone.
-            var delStringRes = server.Execute("GET", delStringKey);
+            var delStringRes = server.Execute(0, "GET", [delStringKey]);
             ClassicAssert.IsTrue(delStringRes.IsNull, "delSlot string key should no longer exist after DELKEYSINSLOT");
-            var delObjectRes = (long)server.Execute("EXISTS", delObjectKey);
+            var delObjectRes = (long)server.Execute(0, "EXISTS", [delObjectKey]);
             ClassicAssert.AreEqual(0, delObjectRes, "delSlot object key should no longer exist after DELKEYSINSLOT");
 
             // Direct GET / EXISTS confirm the keepSlot keys still exist with their original payloads.
-            var keepStringRes = (string)server.Execute("GET", keepStringKey);
+            var keepStringRes = (string)server.Execute(0, "GET", [keepStringKey]);
             ClassicAssert.AreEqual("raw-keep", keepStringRes, "keepSlot string key value should be unchanged");
-            var keepObjectExists = (long)server.Execute("EXISTS", keepObjectKey);
+            var keepObjectExists = (long)server.Execute(0, "EXISTS", [keepObjectKey]);
             ClassicAssert.AreEqual(1, keepObjectExists, "keepSlot object key should still exist after DELKEYSINSLOT");
-            var keepObjectCard = (long)server.Execute("SCARD", keepObjectKey);
+            var keepObjectCard = (long)server.Execute(0, "SCARD", [keepObjectKey]);
             ClassicAssert.AreEqual(3, keepObjectCard, "keepSlot object key should still contain all 3 members");
         }
     }

--- a/test/cluster/Garnet.test.cluster.migrate/RedirectTests/ClusterSlotVerificationTests.cs
+++ b/test/cluster/Garnet.test.cluster.migrate/RedirectTests/ClusterSlotVerificationTests.cs
@@ -320,7 +320,7 @@ namespace Garnet.test.cluster
                 void SERedisClusterDown(BaseCommand command)
                 {
                     AssertSlotsNotAssigned(requestNodeIndex);
-                    var ex = Assert.Throws<RedisServerException>(() => context.clusterTestUtils.GetServer(requestNodeIndex).Execute(command.Command, command.GetSingleSlotRequest()),
+                    var ex = Assert.Throws<RedisServerException>(() => context.clusterTestUtils.GetServer(requestNodeIndex).Execute(0, command.Command, command.GetSingleSlotRequest()),
                         $"Expected exception was not thrown. Command: {command.Command} \n{ClusterState()}");
                     ClassicAssert.AreEqual("CLUSTERDOWN Hash slot not served", ex.Message, command.Command);
                 }
@@ -353,7 +353,7 @@ namespace Garnet.test.cluster
 
                 try
                 {
-                    var resp = (string)context.clusterTestUtils.GetServer(requestNodeIndex).Execute("DEL", [.. command.GetSingleSlotKeys], CommandFlags.NoRedirect);
+                    var resp = (string)context.clusterTestUtils.GetServer(requestNodeIndex).Execute(0, "DEL", [.. command.GetSingleSlotKeys], CommandFlags.NoRedirect);
                 }
                 catch (Exception ex)
                 {
@@ -367,11 +367,11 @@ namespace Garnet.test.cluster
                     {
                         if (command.RequiresObjectParameters)
                         {
-                            _ = context.clusterTestUtils.GetServer(requestNodeIndex).Execute(command.Command, command.GetSingleSlotObjectRequest());
+                            _ = context.clusterTestUtils.GetServer(requestNodeIndex).Execute(0, command.Command, command.GetSingleSlotObjectRequest());
                         }
                         else
                         {
-                            _ = context.clusterTestUtils.GetServer(requestNodeIndex).Execute(command.Command, command.GetSingleSlotRequest());
+                            _ = context.clusterTestUtils.GetServer(requestNodeIndex).Execute(0, command.Command, command.GetSingleSlotRequest());
                         }
                     }
                     catch (Exception ex)
@@ -423,7 +423,7 @@ namespace Garnet.test.cluster
                 {
                     if (!command.IsArrayCommand)
                         return;
-                    var ex = Assert.Throws<RedisServerException>(() => context.clusterTestUtils.GetServer(requestNodeIndex).Execute(command.Command, command.GetCrossSlotRequest()),
+                    var ex = Assert.Throws<RedisServerException>(() => context.clusterTestUtils.GetServer(requestNodeIndex).Execute(0, command.Command, command.GetCrossSlotRequest()),
                         $"Expected exception was not thrown. Command: {command.Command} \n{ClusterState()}");
                     ClassicAssert.AreEqual("CROSSSLOT Keys in request do not hash to the same slot", ex.Message, command.Command);
                 }
@@ -460,7 +460,7 @@ namespace Garnet.test.cluster
 
                 void SERedisMOVEDTest(BaseCommand command)
                 {
-                    var ex = Assert.Throws<RedisServerException>(() => context.clusterTestUtils.GetServer(requestNodeIndex).Execute(command.Command, command.GetSingleSlotRequest(), CommandFlags.NoRedirect),
+                    var ex = Assert.Throws<RedisServerException>(() => context.clusterTestUtils.GetServer(requestNodeIndex).Execute(0, command.Command, command.GetSingleSlotRequest(), CommandFlags.NoRedirect),
                         $"Expected exception was not thrown. Command: {command.Command} \n{ClusterState()}");
                     ClassicAssert.IsTrue(ex.Message.StartsWith("Key has MOVED"), command.Command);
                     var tokens = ex.Message.Split(' ');
@@ -511,7 +511,7 @@ namespace Garnet.test.cluster
                     ResetSlot();
                     try
                     {
-                        var resp = (string)context.clusterTestUtils.GetServer(requestNodeIndex).Execute("DEL", [.. command.GetSingleSlotKeys], CommandFlags.NoRedirect);
+                        var resp = (string)context.clusterTestUtils.GetServer(requestNodeIndex).Execute(0, "DEL", [.. command.GetSingleSlotKeys], CommandFlags.NoRedirect);
                     }
                     catch (Exception ex)
                     {
@@ -522,7 +522,7 @@ namespace Garnet.test.cluster
 
                 void SERedisASKTest(BaseCommand command)
                 {
-                    var ex = Assert.Throws<RedisConnectionException>(() => context.clusterTestUtils.GetServer(requestNodeIndex).Execute(command.Command, command.GetSingleSlotRequest(), CommandFlags.NoRedirect),
+                    var ex = Assert.Throws<RedisConnectionException>(() => context.clusterTestUtils.GetServer(requestNodeIndex).Execute(0, command.Command, command.GetSingleSlotRequest(), CommandFlags.NoRedirect),
                         $"Expected exception was not thrown. Command: {command.Command} \n{ClusterState()}");
                     var tokens = ex.Message.Split(' ');
                     ClassicAssert.IsTrue(tokens.Length > 10 && tokens[0].Equals("Endpoint"), command.Command + " => " + ex.Message);
@@ -568,7 +568,7 @@ namespace Garnet.test.cluster
                         var setupParameters = setup.Slice(1).ToArray();
                         try
                         {
-                            _ = context.clusterTestUtils.GetServer(requestNodeIndex).Execute(setup[0], setupParameters, CommandFlags.NoRedirect);
+                            _ = context.clusterTestUtils.GetServer(requestNodeIndex).Execute(0, setup[0], setupParameters, CommandFlags.NoRedirect);
                         }
                         catch (Exception ex)
                         {
@@ -580,7 +580,7 @@ namespace Garnet.test.cluster
                     ConfigureSlotForMigration();
                     try
                     {
-                        var ex = Assert.Throws<RedisServerException>(() => context.clusterTestUtils.GetServer(requestNodeIndex).Execute(command.Command, command.GetSingleSlotRequest(), CommandFlags.NoRedirect),
+                        var ex = Assert.Throws<RedisServerException>(() => context.clusterTestUtils.GetServer(requestNodeIndex).Execute(0, command.Command, command.GetSingleSlotRequest(), CommandFlags.NoRedirect),
                         $"Expected exception was not thrown. Command: {command.Command} \n{ClusterState()}");
                         ClassicAssert.AreEqual("TRYAGAIN Multiple keys request during rehashing of slot", ex.Message, command.Command, $"\n{ClusterState()}");
                     }
@@ -589,7 +589,7 @@ namespace Garnet.test.cluster
                         ResetSlot();
                         try
                         {
-                            _ = context.clusterTestUtils.GetServer(requestNodeIndex).Execute("DEL", [.. command.GetSingleSlotKeys], CommandFlags.NoRedirect);
+                            _ = context.clusterTestUtils.GetServer(requestNodeIndex).Execute(0, "DEL", [.. command.GetSingleSlotKeys], CommandFlags.NoRedirect);
                         }
                         catch (Exception ex)
                         {

--- a/test/cluster/Garnet.test.cluster.multilog/MultiLogTests/ClusterReplicationShardedLog.cs
+++ b/test/cluster/Garnet.test.cluster.multilog/MultiLogTests/ClusterReplicationShardedLog.cs
@@ -201,7 +201,7 @@ namespace Garnet.test.cluster.MultiLogTests
             context.PopulatePrimary(ref context.kvPairs, keyLength, kvpairCount, 0);
 
             var primaryServer = context.clusterTestUtils.GetServer(primaryNodeIndex);
-            var expectedKeys = (string[])primaryServer.Execute("KEYS", ["*"]);
+            var expectedKeys = (string[])primaryServer.Execute(0, "KEYS", ["*"]);
             await context.nodes[primaryNodeIndex].Store.CommitAOFAsync(default).ConfigureAwait(false);
 
             // Shutdown node
@@ -220,7 +220,7 @@ namespace Garnet.test.cluster.MultiLogTests
             context.CreateConnection(useTLS: useTLS);
 
             primaryServer = context.clusterTestUtils.GetServer(primaryNodeIndex);
-            var keys = (string[])primaryServer.Execute("KEYS", ["*"]);
+            var keys = (string[])primaryServer.Execute(0, "KEYS", ["*"]);
             Array.Sort(keys);
             Array.Sort(expectedKeys);
             ClassicAssert.AreEqual(expectedKeys.Length, keys.Length);

--- a/test/cluster/Garnet.test.cluster.replication/ReplicationTests/ClusterReplicationBaseTests.cs
+++ b/test/cluster/Garnet.test.cluster.replication/ReplicationTests/ClusterReplicationBaseTests.cs
@@ -1192,14 +1192,14 @@ namespace Garnet.test.cluster
             _ = context.clusterTestUtils.SimpleSetupCluster(primary_count, replica_count, logger: context.logger);
 
             var primaryServer = context.clusterTestUtils.GetServer(primaryNodeIndex);
-            _ = primaryServer.Execute("EVAL", "redis.call('SET', KEYS[1], ARGV[1])", "1", "foo", "bar");
-            _ = primaryServer.Execute("EVAL", "redis.call('SET', KEYS[1], ARGV[1])", "1", "fizz", "buzz");
+            _ = primaryServer.Execute(0, "EVAL", ["redis.call('SET', KEYS[1], ARGV[1])", "1", "foo", "bar"]);
+            _ = primaryServer.Execute(0, "EVAL", ["redis.call('SET', KEYS[1], ARGV[1])", "1", "fizz", "buzz"]);
 
             context.clusterTestUtils.WaitForReplicaAofSync(primaryNodeIndex, replicaNodeIndex, context.logger);
 
             var replicaServer = context.clusterTestUtils.GetServer(replicaNodeIndex);
-            var res1 = (string)replicaServer.Execute("EVAL", "return redis.call('GET', KEYS[1])", "1", "foo");
-            var res2 = (string)replicaServer.Execute("EVAL", "return redis.call('GET', KEYS[1])", "1", "fizz");
+            var res1 = (string)replicaServer.Execute(0, "EVAL", ["return redis.call('GET', KEYS[1])", "1", "foo"]);
+            var res2 = (string)replicaServer.Execute(0, "EVAL", ["return redis.call('GET', KEYS[1])", "1", "fizz"]);
 
             ClassicAssert.AreEqual("bar", res1);
             ClassicAssert.AreEqual("buzz", res2);
@@ -1268,14 +1268,14 @@ namespace Garnet.test.cluster
                 ClusterReplicate();
 
             // Validate primary keys
-            var resp = primaryServer.Execute("KEYS", ["*"]);
+            var resp = primaryServer.Execute(0, "KEYS", ["*"]);
             ClassicAssert.AreEqual(expectedKeys, (string[])resp);
             context.clusterTestUtils.WaitForReplicaAofSync(primaryNodeIndex, replicaNodeIndex, context.logger);
             replicaServer = context.clusterTestUtils.GetServer(replicaNodeIndex);
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             while (true)
             {
-                resp = replicaServer.Execute("KEYS", ["*"]);
+                resp = replicaServer.Execute(0, "KEYS", ["*"]);
                 if (expectedKeys.Length == ((string[])resp).Length)
                     break;
                 ClusterTestUtils.BackOff(cts.Token);
@@ -1287,9 +1287,9 @@ namespace Garnet.test.cluster
 
             void ExecuteRateLimit()
             {
-                var resp = primaryServer.Execute("RATELIMIT", [expectedKeys[0], "1000000000", "1000000000"]);
+                var resp = primaryServer.Execute(0, "RATELIMIT", [expectedKeys[0], "1000000000", "1000000000"]);
                 ClassicAssert.AreEqual("ALLOWED", (string)resp);
-                resp = primaryServer.Execute("RATELIMIT", [expectedKeys[1], "1000000000", "1000000000"]);
+                resp = primaryServer.Execute(0, "RATELIMIT", [expectedKeys[1], "1000000000", "1000000000"]);
                 ClassicAssert.AreEqual("ALLOWED", (string)resp);
             }
 
@@ -1519,9 +1519,9 @@ namespace Garnet.test.cluster
                 while (start++ < end)
                 {
                     var key = start.ToString();
-                    var resp = primaryServer.Execute("SET", [key, key]);
+                    var resp = primaryServer.Execute(0, "SET", [key, key]);
                     ClassicAssert.AreEqual("OK", (string)resp);
-                    resp = primaryServer.Execute("GET", key);
+                    resp = primaryServer.Execute(0, "GET", [key]);
                     ClassicAssert.AreEqual(key, (string)resp);
                 }
             }
@@ -1566,8 +1566,8 @@ namespace Garnet.test.cluster
 
             void ValidateKeys()
             {
-                var resp = (string[])primaryServer.Execute("KEYS", ["*"]);
-                var resp2 = (string[])replicaServer.Execute("KEYS", ["*"]);
+                var resp = (string[])primaryServer.Execute(0, "KEYS", ["*"]);
+                var resp2 = (string[])replicaServer.Execute(0, "KEYS", ["*"]);
                 ClassicAssert.AreEqual(resp.Length, resp2.Length);
                 Array.Sort(resp);
                 Array.Sort(resp2);
@@ -1660,17 +1660,17 @@ namespace Garnet.test.cluster
                 while (start++ < end)
                 {
                     var key = start.ToString();
-                    var resp = server.Execute("SET", [key, key]);
+                    var resp = server.Execute(0, "SET", [key, key]);
                     ClassicAssert.AreEqual("OK", (string)resp);
-                    resp = server.Execute("GET", key);
+                    resp = server.Execute(0, "GET", [key]);
                     ClassicAssert.AreEqual(key, (string)resp);
                 }
             }
 
             void ValidateKeys()
             {
-                var resp = (string[])primaryServer.Execute("KEYS", ["*"]);
-                var resp2 = (string[])replicaServer.Execute("KEYS", ["*"]);
+                var resp = (string[])primaryServer.Execute(0, "KEYS", ["*"]);
+                var resp2 = (string[])replicaServer.Execute(0, "KEYS", ["*"]);
                 ClassicAssert.AreEqual(resp.Length, resp2.Length);
                 Array.Sort(resp);
                 Array.Sort(resp2);

--- a/test/cluster/Garnet.test.cluster.vectorsets/VectorSets/ClusterVectorSetTests.cs
+++ b/test/cluster/Garnet.test.cluster.vectorsets/VectorSets/ClusterVectorSetTests.cs
@@ -2345,14 +2345,14 @@ namespace Garnet.test.cluster
             var primaryServer = connection.GetServer(primary);
             var secondaryServer = connection.GetServer(secondary);
 
-            var addRes = (int)await primaryServer.ExecuteAsync("VADD", [Key, "VALUES", "3", "1", "2", "3", Element]).ConfigureAwait(false);
+            var addRes = (int)await primaryServer.ExecuteAsync(0, "VADD", [Key, "VALUES", "3", "1", "2", "3", Element]).ConfigureAwait(false);
             ClassicAssert.AreEqual(1, addRes);
-            var setRes = (int)await primaryServer.ExecuteAsync("VSETATTR", [Key, Element, "{\"foo\":\"bar\"}"]).ConfigureAwait(false);
+            var setRes = (int)await primaryServer.ExecuteAsync(0, "VSETATTR", [Key, Element, "{\"foo\":\"bar\"}"]).ConfigureAwait(false);
             ClassicAssert.AreEqual(1, setRes);
 
             context.clusterTestUtils.WaitForReplicaAofSync(PrimaryIndex, SecondaryIndex);
 
-            var getRes = (string)await secondaryServer.ExecuteAsync("VGETATTR", [Key, Element]).ConfigureAwait(false);
+            var getRes = (string)await secondaryServer.ExecuteAsync(0, "VGETATTR", [Key, Element]).ConfigureAwait(false);
             ClassicAssert.AreEqual("{\"foo\":\"bar\"}", getRes);
         }
 

--- a/test/cluster/Garnet.test.cluster/ClusterManagementTests.cs
+++ b/test/cluster/Garnet.test.cluster/ClusterManagementTests.cs
@@ -339,8 +339,8 @@ namespace Garnet.test.cluster
             byte[] key = new byte[16];
             context.clusterTestUtils.RandomBytesRestrictedToSlot(ref key, node.Slots.First().From);
 
-            context.clusterTestUtils.GetServer(0).Execute("SET", key, "1234");
-            string res = context.clusterTestUtils.GetServer(0).Execute("GET", key).ToString();
+            context.clusterTestUtils.GetServer(0).Execute(0, "SET", [key, "1234"]);
+            string res = context.clusterTestUtils.GetServer(0).Execute(0, "GET", [key]).ToString();
             ClassicAssert.AreEqual("1234", res);
 
             VerifyClusterResetFails(true);
@@ -382,7 +382,7 @@ namespace Garnet.test.cluster
         }
 
         [Test, Order(4)]
-        public void ClusterResetAfterFLushAllTest()
+        public void ClusterResetAfterFlushAllTest()
         {
             var node_count = 4;
             context.CreateInstances(node_count);
@@ -999,17 +999,17 @@ namespace Garnet.test.cluster
             var value = "myvalue";
 
             // Set value
-            var result = (string)context.clusterTestUtils.GetServer(primaryIndex).Execute("SET", key, value);
+            var result = (string)context.clusterTestUtils.GetServer(primaryIndex).Execute(0, "SET", [key, value]);
             ClassicAssert.AreEqual("OK", result);
 
             // Get value
-            result = (string)context.clusterTestUtils.GetServer(primaryIndex).Execute("GET", key);
+            result = (string)context.clusterTestUtils.GetServer(primaryIndex).Execute(0, "GET", [key]);
             ClassicAssert.AreEqual(value, result);
 
             // Get value from replica
             while (true)
             {
-                result = (string)context.clusterTestUtils.GetServer(replicaIndex).Execute("GET", key);
+                result = (string)context.clusterTestUtils.GetServer(replicaIndex).Execute(0, "GET", [key]);
                 if (result == value)
                     break;
             }
@@ -1023,13 +1023,13 @@ namespace Garnet.test.cluster
             Assert.DoesNotThrow(() => context.clusterTestUtils.GetServer(primaryIndex).FlushAllDatabases());
 
             // Get value
-            result = (string)context.clusterTestUtils.GetServer(primaryIndex).Execute("GET", key);
+            result = (string)context.clusterTestUtils.GetServer(primaryIndex).Execute(0, "GET", [key]);
             ClassicAssert.IsNull(result);
 
             // Get value from replica
             while (true)
             {
-                result = (string)context.clusterTestUtils.GetServer(replicaIndex).Execute("GET", key);
+                result = (string)context.clusterTestUtils.GetServer(replicaIndex).Execute(0, "GET", [key]);
                 if (result == null)
                     break;
             }
@@ -1130,13 +1130,13 @@ namespace Garnet.test.cluster
             {
                 db.HashSet(key, elements);
 
-                var result = primaryServer.Execute("HPEXPIRE", key, "500", "FIELDS", "2", "field1", "field2");
+                var result = primaryServer.Execute(0, "HPEXPIRE", [key, "500", "FIELDS", "2", "field1", "field2"]);
                 var results = (RedisResult[])result;
                 ClassicAssert.AreEqual(2, results.Length);
                 ClassicAssert.AreEqual(1, (long)results[0]);
                 ClassicAssert.AreEqual(1, (long)results[1]);
 
-                result = primaryServer.Execute("HPEXPIRE", key, "500", "FIELDS", "2", "field3", "field4");
+                result = primaryServer.Execute(0, "HPEXPIRE", [key, "500", "FIELDS", "2", "field3", "field4"]);
                 results = (RedisResult[])result;
                 ClassicAssert.AreEqual(2, results.Length);
                 ClassicAssert.AreEqual(1, (long)results[0]);
@@ -1149,7 +1149,7 @@ namespace Garnet.test.cluster
                 var expectedFieldsAndValues = elements.AsSpan().Slice(4).ToArray()
                     .SelectMany(e => new[] { e.Name.ToString(), e.Value.ToString() })
                     .ToArray();
-                var fields = (string[])primaryServer.Execute("HGETALL", [key]);
+                var fields = (string[])primaryServer.Execute(0, "HGETALL", [key]);
                 ClassicAssert.AreEqual(4, fields.Length);
                 ClassicAssert.AreEqual(expectedFieldsAndValues, fields);
 
@@ -1157,7 +1157,7 @@ namespace Garnet.test.cluster
                 context.clusterTestUtils.WaitForReplicaAofSync(primaryNodeIndex, replicaNodeIndex, context.logger, cancellationToken);
 
                 // Check if replica is caught up
-                fields = (string[])replicaServer.Execute("HGETALL", [key]);
+                fields = (string[])replicaServer.Execute(0, "HGETALL", [key]);
                 ClassicAssert.AreEqual(4, fields.Length);
                 ClassicAssert.AreEqual(expectedFieldsAndValues, fields);
             }
@@ -1166,10 +1166,10 @@ namespace Garnet.test.cluster
             {
                 if (useManualCollect)
                 {
-                    Assert.Throws<RedisServerException>(() => replicaServer.Execute("HCOLLECT", ["*"], CommandFlags.NoRedirect),
+                    Assert.Throws<RedisServerException>(() => replicaServer.Execute(0, "HCOLLECT", ["*"], CommandFlags.NoRedirect),
                         $"Expected exception was not thrown");
 
-                    resp = (string)primaryServer.Execute("HCOLLECT", ["*"]);
+                    resp = (string)primaryServer.Execute(0, "HCOLLECT", ["*"]);
                     ClassicAssert.AreEqual("OK", resp);
                 }
             }

--- a/test/cluster/Garnet.test.cluster/ClusterNegativeTests.cs
+++ b/test/cluster/Garnet.test.cluster/ClusterNegativeTests.cs
@@ -616,13 +616,13 @@ namespace Garnet.test.cluster
 
             ClassicAssert.AreNotEqual(primaryEndpoint, replicaEndpoint, "Should have different endpoints for nodes");
 
-            using var primaryConnection = ConnectionMultiplexer.Connect($"{primaryEndpoint.Address}:{primaryEndpoint.Port},user={UserName},password={Password}");
+            using var primaryConnection = ConnectionMultiplexer.Connect($"{primaryEndpoint.Address}:{primaryEndpoint.Port},user={UserName},password={Password},allowAdmin=true");
             var primaryServer = primaryConnection.GetServer(primaryEndpoint);
 
             ClassicAssert.AreEqual("OK", (string)primaryServer.Execute("CLUSTER", ["ADDSLOTSRANGE", "0", "16383"], flags: CommandFlags.NoRedirect));
             ClassicAssert.AreEqual("OK", (string)primaryServer.Execute("CLUSTER", ["MEET", replicaEndpoint.Address.ToString(), replicaEndpoint.Port.ToString()], flags: CommandFlags.NoRedirect));
 
-            using var replicaConnection = ConnectionMultiplexer.Connect($"{replicaEndpoint.Address}:{replicaEndpoint.Port},user={UserName},password={Password}");
+            using var replicaConnection = ConnectionMultiplexer.Connect($"{replicaEndpoint.Address}:{replicaEndpoint.Port},user={UserName},password={Password},allowAdmin=true");
             var replicaServer = replicaConnection.GetServer(replicaEndpoint);
 
             // Try to replicate from a server that doesn't exist

--- a/test/cluster/Garnet.test.cluster/ClusterPubSubForwardTests.cs
+++ b/test/cluster/Garnet.test.cluster/ClusterPubSubForwardTests.cs
@@ -92,7 +92,7 @@ namespace Garnet.test.cluster
             while (baselineDeadline.Elapsed < TimeSpan.FromSeconds(15))
             {
                 Assert.DoesNotThrow(
-                    () => pubRedis.GetServer(publisherEndpoint).Execute("PUBLISH", channelName, message),
+                    () => pubRedis.GetServer(publisherEndpoint).Execute(0, "PUBLISH", [channelName, message]),
                     "Baseline publish threw while both nodes were up");
                 if (delivered.Wait(TimeSpan.FromMilliseconds(500)))
                 {
@@ -133,7 +133,7 @@ namespace Garnet.test.cluster
                 // (2) Attempt to forward-publish from the surviving node.
                 try
                 {
-                    _ = pubRedis.GetServer(publisherEndpoint).Execute("PUBLISH", channelName, message);
+                    _ = pubRedis.GetServer(publisherEndpoint).Execute(0, "PUBLISH", [channelName, message]);
                     if (sw.Elapsed >= settle)
                         lateSuccesses++;
                 }

--- a/test/cluster/Garnet.test.cluster/ClusterTestContext.cs
+++ b/test/cluster/Garnet.test.cluster/ClusterTestContext.cs
@@ -941,16 +941,16 @@ namespace Garnet.test.cluster
         {
             try
             {
-                var resp = server.Execute("MULTI");
+                var resp = server.Execute(0, "MULTI", []);
                 ClassicAssert.AreEqual("OK", (string)resp);
 
                 foreach (var key in keys)
                 {
-                    resp = server.Execute("GET", key);
+                    resp = server.Execute(0, "GET", [key]);
                     ClassicAssert.AreEqual("QUEUED", (string)resp);
                 }
 
-                resp = server.Execute("EXEC");
+                resp = server.Execute(0, "EXEC", []);
                 return (string[])resp;
             }
             catch (Exception ex)
@@ -971,7 +971,7 @@ namespace Garnet.test.cluster
                     args[1 + (i * 2)] = keys[i];
                     args[1 + (i * 2) + 1] = values[i];
                 }
-                var resp = server.Execute("BULKINCRBY", args);
+                var resp = server.Execute(0, "BULKINCRBY", args);
                 ClassicAssert.AreEqual("OK", (string)resp);
             }
             catch (Exception ex)
@@ -988,7 +988,7 @@ namespace Garnet.test.cluster
                 args[0] = keys.Length;
                 for (var i = 0; i < keys.Length; i++)
                     args[1 + i] = keys[i];
-                var resp = server.Execute("BULKREAD", args);
+                var resp = server.Execute(0, "BULKREAD", args);
                 var result = (string[])resp;
                 ClassicAssert.AreEqual(keys.Length, result.Length);
                 return result;

--- a/test/cluster/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/cluster/Garnet.test.cluster/ClusterTestUtils.cs
@@ -3141,7 +3141,7 @@ namespace Garnet.test.cluster
             var server = redis.GetServer(endPoint);
             try
             {
-                var result = server.InfoRawAsync("persistence").Result;
+                var result = server.InfoRaw("persistence");
                 return ProcessPersistenceInfo(result);
             }
             catch (Exception ex)
@@ -3275,7 +3275,7 @@ namespace Garnet.test.cluster
             try
             {
                 var server = redis.GetServer(endPoint);
-                var result = server.InfoRawAsync("store").Result;
+                var result = server.InfoRaw("store");
                 var data = result.Split('\n');
                 foreach (var line in data)
                 {

--- a/test/cluster/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/cluster/Garnet.test.cluster/ClusterTestUtils.cs
@@ -813,7 +813,8 @@ namespace Garnet.test.cluster
                 disablePubSub: disablePubSub,
                 authUsername: authUsername,
                 authPassword: authPassword,
-                certificates: certificates);
+                certificates: certificates,
+                protocol: RedisProtocol.Resp2);
         }
 
         public void Dispose()

--- a/test/cluster/Garnet.test.cluster/ClusterTestUtils.cs
+++ b/test/cluster/Garnet.test.cluster/ClusterTestUtils.cs
@@ -181,7 +181,7 @@ namespace Garnet.test.cluster
             try
             {
                 var server = GetServer(endPoint);
-                var resp = server.Execute(cmd, args, flags: flags);
+                var resp = server.Execute(0, cmd, args, flags: flags);
                 return resp;
             }
             catch (Exception ex)
@@ -198,7 +198,7 @@ namespace Garnet.test.cluster
             try
             {
                 var server = GetServer(endPoint);
-                var resp = await server.ExecuteAsync(cmd, args, flags: flags).ConfigureAwait(false);
+                var resp = await server.ExecuteAsync(0, cmd, args, flags: flags).ConfigureAwait(false);
                 return resp;
             }
             catch (Exception ex)
@@ -667,15 +667,15 @@ namespace Garnet.test.cluster
             {
                 var server = GetServer(nodeIndex);
 
-                var txnblockResp = (string)server.Execute("MULTI", new List<object>(), CommandFlags.NoRedirect);
+                var txnblockResp = (string)server.Execute(0, "MULTI", new List<object>(), CommandFlags.NoRedirect);
                 ClassicAssert.AreEqual(txnblockResp, "OK");
                 foreach (var cmd in commands)
                 {
-                    var respCmd = (string)server.Execute(cmd.Item1, cmd.Item2, CommandFlags.NoRedirect);
+                    var respCmd = (string)server.Execute(0, cmd.Item1, cmd.Item2, CommandFlags.NoRedirect);
                     ClassicAssert.AreEqual(respCmd, "QUEUED");
                 }
 
-                result = server.Execute("EXEC", new List<object>(), CommandFlags.NoRedirect);
+                result = server.Execute(0, "EXEC", new List<object>(), CommandFlags.NoRedirect);
             }
             catch (Exception ex)
             {
@@ -2022,7 +2022,7 @@ namespace Garnet.test.cluster
 
             try
             {
-                var resp = server.Execute("migrate", args);
+                var resp = server.Execute(0, "migrate", args);
                 ClassicAssert.AreEqual((string)resp, "OK");
             }
             catch (Exception ex)
@@ -2050,7 +2050,7 @@ namespace Garnet.test.cluster
             var elapsed = Stopwatch.GetTimestamp();
             try
             {
-                var resp = server.Execute("migrate", args);
+                var resp = server.Execute(0, "migrate", args);
                 ClassicAssert.AreEqual((string)resp, "OK");
             }
             catch (Exception ex)
@@ -2631,14 +2631,14 @@ namespace Garnet.test.cluster
                 if (expiry == -1)
                 {
                     ICollection<object> args = [key, value];
-                    var resp = (string)server.Execute("set", args, CommandFlags.NoRedirect);
+                    var resp = (string)server.Execute(0, "set", args, CommandFlags.NoRedirect);
                     ClassicAssert.AreEqual("OK", resp);
                     return ResponseState.OK;
                 }
                 else
                 {
                     ICollection<object> args = [key, expiry, value];
-                    var resp = (string)server.Execute("setex", args, CommandFlags.NoRedirect);
+                    var resp = (string)server.Execute(0, "setex", args, CommandFlags.NoRedirect);
                     ClassicAssert.AreEqual("OK", resp);
                     return ResponseState.OK;
                 }
@@ -2708,7 +2708,7 @@ namespace Garnet.test.cluster
             try
             {
                 ICollection<object> args = new List<object>() { (object)key };
-                result = (string)server.Execute("get", args, CommandFlags.NoRedirect);
+                result = (string)server.Execute(0, "get", args, CommandFlags.NoRedirect);
                 slot = HashSlot(key);
                 responseState = ResponseState.OK;
                 return result;
@@ -2769,7 +2769,7 @@ namespace Garnet.test.cluster
 
             try
             {
-                return (string)server.Execute("mset", args, CommandFlags.NoRedirect);
+                return (string)server.Execute(0, "mset", args, CommandFlags.NoRedirect);
             }
             catch (Exception e)
             {
@@ -2814,7 +2814,7 @@ namespace Garnet.test.cluster
 
             try
             {
-                var result = server.Execute("mget", args, CommandFlags.NoRedirect);
+                var result = server.Execute(0, "mget", args, CommandFlags.NoRedirect);
                 getResult = [.. ((RedisResult[])result).Select(x => (byte[])x)];
                 return "OK";
             }
@@ -2855,7 +2855,7 @@ namespace Garnet.test.cluster
 
                 for (int i = elements.Count - 1; i >= 0; i--) args.Add(elements[i]);
 
-                var result = (int)server.Execute("LPUSH", args);
+                var result = (int)server.Execute(0, "LPUSH", args);
                 ClassicAssert.AreEqual(elements.Count, result);
                 return result;
             }
@@ -2874,7 +2874,7 @@ namespace Garnet.test.cluster
                 var server = GetServer(nodeIndex);
                 var args = new List<object>() { key, "0", "-1" };
 
-                var result = server.Execute("LRANGE", args);
+                var result = server.Execute(0, "LRANGE", args);
                 return [.. ((int[])result)];
             }
             catch (Exception ex)
@@ -2894,7 +2894,7 @@ namespace Garnet.test.cluster
 
                 for (int i = elements.Count - 1; i >= 0; i--) args.Add(elements[i]);
 
-                var result = (int)server.Execute("SADD", args);
+                var result = (int)server.Execute(0, "SADD", args);
                 ClassicAssert.AreEqual(elements.Count, result);
             }
             catch (Exception ex)
@@ -2911,7 +2911,7 @@ namespace Garnet.test.cluster
                 var server = GetServer(nodeIndex);
                 var args = new List<object>() { key };
 
-                var result = server.Execute("SMEMBERS", args);
+                var result = server.Execute(0, "SMEMBERS", args);
                 return [.. ((int[])result)];
             }
             catch (Exception ex)
@@ -3547,7 +3547,7 @@ namespace Garnet.test.cluster
             try
             {
                 var server = redis.GetServer(endPoint);
-                return (int)server.Execute("incrby", key, value);
+                return (int)server.Execute(0, "incrby", [key, value]);
             }
             catch (Exception ex)
             {
@@ -3640,7 +3640,7 @@ namespace Garnet.test.cluster
             try
             {
                 var server = redis.GetServer(endPoint);
-                var count = (int)server.Execute("DBSIZE");
+                var count = (int)server.Execute(0, "DBSIZE", []);
                 return count;
             }
             catch (Exception ex)

--- a/test/standalone/Garnet.test.collections/RespHashTests.cs
+++ b/test/standalone/Garnet.test.collections/RespHashTests.cs
@@ -860,8 +860,8 @@ namespace Garnet.test
 
             var result1 = db.HashGetAllAsync(hashkey);
 
-            ClassicAssert.IsEmpty(redis.Wait(result0));
-            var result = redis.Wait(result1).ToStringDictionary();
+            ClassicAssert.IsEmpty(await result0.ConfigureAwait(false));
+            var result = (await result1.ConfigureAwait(false)).ToStringDictionary();
             ClassicAssert.AreEqual(2, result.Count);
             ClassicAssert.AreEqual("abc", result["foo"]);
             ClassicAssert.AreEqual("def", result["bar"]);

--- a/test/standalone/Garnet.test.collections/RespSortedSetGeoTests.cs
+++ b/test/standalone/Garnet.test.collections/RespSortedSetGeoTests.cs
@@ -200,7 +200,7 @@ namespace Garnet.test
             db.GeoAdd(new RedisKey("Sicily"), 13.361389, 38.115556, new RedisValue("Palermo"), CommandFlags.None);
             var response = db.GeoPosition(new RedisKey("Sicily"), ["Palermo", "Unknown"]);
             ClassicAssert.AreEqual(2, response.Length);
-            ClassicAssert.AreEqual(default(GeoPosition), response[1]);
+            ClassicAssert.AreEqual(default(GeoPosition?), response[1]);
 
             var memresponse = db.Execute("MEMORY", "USAGE", "Sicily");
             var actualValue = ResultType.Integer == memresponse.Resp2Type ? Int32.Parse(memresponse.ToString()) : -1;

--- a/test/standalone/Garnet.test.extensions/RespRevivificationTests.cs
+++ b/test/standalone/Garnet.test.extensions/RespRevivificationTests.cs
@@ -50,7 +50,7 @@ namespace Garnet.test
         [Test]
         public async Task RevivificationWithRmwWorksAsync()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             Func<IDatabase, Task> testRmwWorksViaSETNX = async (db) =>
             {
                 // This should work since the key is tombstoned and we are reusing the tombstone record
@@ -67,7 +67,7 @@ namespace Garnet.test
         [Test]
         public async Task RevivificationWithRmwWorksWhenNeedingShrinkingAndThenExpanding()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             Func<IDatabase, Task> testRmwWorksViaSETNX = async (db) =>
             {
                 // This should work since the key is tombstoned and we are reusing the tombstone record
@@ -95,7 +95,7 @@ namespace Garnet.test
         [Test]
         public async Task RevivificationWithRMWWorksViaSetIfGreater()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             Func<IDatabase, Task> testRmwWorksViaSetIfGreater = async (db) =>
             {
 
@@ -112,7 +112,7 @@ namespace Garnet.test
         [Test]
         public async Task RevivificationWithRMWWorksViaAppend()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             Func<IDatabase, Task> testRmwWorksViaAppend = async (db) =>
             {
                 // new value is below 12 bytes so it should reuse in initial update
@@ -126,7 +126,7 @@ namespace Garnet.test
         [Test]
         public async Task RevivificationWithRMWWorksViaSetBit()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             Func<IDatabase, Task> testRmwWorksViaSetBit = async (db) =>
             {
                 // we need something that allocates 12 bytes internally in SETBIT
@@ -140,7 +140,7 @@ namespace Garnet.test
         [Test]
         public async Task RevivificationWithRMWWorksViaBitfield()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             Func<IDatabase, Task> testRmwWorksViaBitfield = async (db) =>
             {
                 // we need something that allocates 12 bytes internally in BITFIELD
@@ -179,7 +179,7 @@ namespace Garnet.test
             server.Dispose(false);
             SetupServerWithReviv(false);
 
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             await db.ExecuteAsync("SET", "foo", "c", "PX", 500).ConfigureAwait(false);
@@ -213,7 +213,7 @@ namespace Garnet.test
             server.Dispose(false);
             SetupServerWithReviv(inChainOnly: true);
 
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
 
             var db = redis.GetDatabase(0);
 
@@ -253,7 +253,7 @@ namespace Garnet.test
             server.Dispose(false);
             SetupServerWithReviv(inChainOnly: true);
 
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
 
             var db = redis.GetDatabase(0);
 

--- a/test/standalone/Garnet.test.scripting/LuaScriptTests.cs
+++ b/test/standalone/Garnet.test.scripting/LuaScriptTests.cs
@@ -1088,7 +1088,7 @@ return redis.status_reply("OK")
             {
                 var hash = string.Join("", hashBytes.Select(static x => x.ToString("X2")));
 
-                var exists = (RedisValue[])server.Execute("SCRIPT", "EXISTS", hash, "foo", "bar");
+                var exists = (RedisValue[])server.Execute(0, "SCRIPT", ["EXISTS", hash, "foo", "bar"]);
 
                 ClassicAssert.AreEqual(3, exists.Length);
                 ClassicAssert.AreEqual(1, (long)exists[0]);
@@ -1100,7 +1100,7 @@ return redis.status_reply("OK")
             {
                 var hash = string.Join("", hashBytes.Select(static x => x.ToString("x2")));
 
-                var exists = (RedisValue[])server.Execute("SCRIPT", "EXISTS", hash, "foo", "bar");
+                var exists = (RedisValue[])server.Execute(0, "SCRIPT", ["EXISTS", hash, "foo", "bar"]);
 
                 ClassicAssert.AreEqual(3, exists.Length);
                 ClassicAssert.AreEqual(1, (long)exists[0]);

--- a/test/standalone/Garnet.test.scripting/MultiDatabaseTests.cs
+++ b/test/standalone/Garnet.test.scripting/MultiDatabaseTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -173,6 +174,7 @@ namespace Garnet.test
         }
 
         [Test]
+        [SuppressMessage("Usage", "SER304:Repeated queued operations may suit the variadic overload", Justification = "Separate ops are intentional")]
         public void MultiDatabaseSimpleTransactionTest()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
@@ -180,8 +182,8 @@ namespace Garnet.test
 
             var tran = db1.CreateTransaction();
 
-            tran.StringSetAsync("db2:key1", "db2:val1");
-            tran.StringSetAsync("db2:key2", "db2:val2");
+            _ = tran.StringSetAsync("db2:key1", "db2:val1");
+            _ = tran.StringSetAsync("db2:key2", "db2:val2");
 
             var committed = tran.Execute();
             ClassicAssert.IsTrue(committed);

--- a/test/standalone/Garnet.test.scripting/MultiDatabaseTests.cs
+++ b/test/standalone/Garnet.test.scripting/MultiDatabaseTests.cs
@@ -399,7 +399,7 @@ namespace Garnet.test
             var db2data = new RedisValue[] { "db2:a", "db2:b", "db2:c", "db2:d" };
             var db12data = new RedisValue[] { "db12:a", "db12:b", "db12:c", "db12:d" };
 
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
 
             var db1 = redis.GetDatabase(0);
             var result = db1.StringSet(db1Key1, "db1:val1");
@@ -1334,7 +1334,7 @@ namespace Garnet.test
         [Test]
         public void MultiDatabaseSaveInProgressTest()
         {
-            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true)))
             {
                 var db1 = redis.GetDatabase(0);
                 var db2 = redis.GetDatabase(1);
@@ -1413,7 +1413,7 @@ namespace Garnet.test
         [Test]
         public void MultiDatabaseGeneralSaveBlocksGeneralSaveTest()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db0 = redis.GetDatabase(0);
             var db1 = redis.GetDatabase(1);
 
@@ -1481,7 +1481,7 @@ namespace Garnet.test
             long expectedLastSave;
             long actualLastSave;
 
-            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true)))
             {
                 // Add object & raw string data to DB 0
                 var db1 = redis.GetDatabase(0);
@@ -1523,7 +1523,7 @@ namespace Garnet.test
                 actualLastSave = lastSave;
 
                 // Verify DB 0 was not saved
-                lastSaveStr = db1.Execute("LASTSAVE").ToString();
+                lastSaveStr = db1.Execute("LASTSAVE", "0").ToString();
                 parsed = long.TryParse(lastSaveStr, out lastSave);
                 ClassicAssert.IsTrue(parsed);
                 ClassicAssert.AreEqual(0, lastSave);
@@ -1534,7 +1534,7 @@ namespace Garnet.test
             server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, tryRecover: true);
             server.Start();
 
-            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig()))
+            using (var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true)))
             {
                 var lastSave = 0L;
                 string lastSaveStr;
@@ -1579,7 +1579,7 @@ namespace Garnet.test
                 var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
                 while (!cts.IsCancellationRequested)
                 {
-                    lastSaveStr = db1.Execute("LASTSAVE").ToString();
+                    lastSaveStr = db1.Execute("LASTSAVE", "0").ToString();
                     parsed = long.TryParse(lastSaveStr, out lastSave);
                     ClassicAssert.IsTrue(parsed);
                     if (lastSave != 0)

--- a/test/standalone/Garnet.test.scripting/RespAofTests.cs
+++ b/test/standalone/Garnet.test.scripting/RespAofTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -158,6 +159,7 @@ namespace Garnet.test
         }
 
         [Test]
+        [SuppressMessage("Usage", "SER304:Repeated queued operations may suit the variadic overload", Justification = "Separate ops are intentional")]
         public void AofTransactionStoreAutoCommitCommitWaitRecoverTest()
         {
             server.Dispose(false);
@@ -168,8 +170,8 @@ namespace Garnet.test
             {
                 var db = redis.GetDatabase(0);
                 var transaction = db.CreateTransaction();
-                transaction.StringSetAsync("SeAofUpsertRecoverTestKey1", "SeAofUpsertRecoverTestValue1");
-                transaction.StringSetAsync("SeAofUpsertRecoverTestKey2", "SeAofUpsertRecoverTestValue2");
+                _ = transaction.StringSetAsync("SeAofUpsertRecoverTestKey1", "SeAofUpsertRecoverTestValue1");
+                _ = transaction.StringSetAsync("SeAofUpsertRecoverTestKey2", "SeAofUpsertRecoverTestValue2");
 
                 ClassicAssert.IsTrue(transaction.Execute());
             }

--- a/test/standalone/Garnet.test.scripting/TransactionTests.cs
+++ b/test/standalone/Garnet.test.scripting/TransactionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Garnet.server;
@@ -40,6 +41,7 @@ namespace Garnet.test
         }
 
         [Test]
+        [SuppressMessage("Usage", "SER304:Repeated queued operations may suit the variadic overload", Justification = "Separate ops are intentional")]
         public void TxnSetTest()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
@@ -49,8 +51,8 @@ namespace Garnet.test
             string value1 = "abcdefg1";
             string value2 = "abcdefg2";
 
-            tran.StringSetAsync("mykey1", value1);
-            tran.StringSetAsync("mykey2", value2);
+            _ = tran.StringSetAsync("mykey1", value1);
+            _ = tran.StringSetAsync("mykey2", value2);
             bool committed = tran.Execute();
 
             string string1 = db.StringGet("mykey1");
@@ -82,6 +84,7 @@ namespace Garnet.test
         }
 
         [Test]
+        [SuppressMessage("Usage", "SER304:Repeated queued operations may suit the variadic overload", Justification = "Separate ops are intentional")]
         public void TxnGetTest()
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());

--- a/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
+++ b/test/standalone/Garnet.test.vectorset/RespVectorSetTests.cs
@@ -682,7 +682,7 @@ namespace Garnet.test
         [Test]
         public void VSIMWithAttribs()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: RedisProtocol.Resp2));
             var db = redis.GetDatabase();
 
             var res1 = db.Execute("VADD", ["foo", "REDUCE", "50", "VALUES", "75", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", "4.0", "1.0", "2.0", "3.0", new byte[] { 0, 0, 0, 0 }, "CAS", "NOQUANT", "EF", "16", "M", "32", "SETATTR", "hello world"]);
@@ -854,7 +854,7 @@ namespace Garnet.test
             const int VectorCount = 100;
             const int Select = 10;
 
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: RedisProtocol.Resp2));
             var db = redis.GetDatabase(0);
 
             _ = db.KeyDelete(VectorSet);

--- a/test/standalone/Garnet.test/RespAdminCommandsTests.cs
+++ b/test/standalone/Garnet.test/RespAdminCommandsTests.cs
@@ -640,7 +640,7 @@ namespace Garnet.test
         {
             using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
             var db = redis.GetDatabase(0);
-            Assert.Throws<RedisServerException>(() => db.Execute("TIME HELLO").ToString());
+            Assert.Throws<RedisServerException>(() => db.Execute("TIME", "HELLO").ToString());
         }
 
         [Test]
@@ -690,7 +690,7 @@ namespace Garnet.test
         [TestCase("cluster-node-timeout", "60")]
         public void SimpleConfigGet(string parameter, string parameterValue)
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             var result = (string[])db.Execute("CONFIG", "GET", parameter);
@@ -706,7 +706,7 @@ namespace Garnet.test
         [Test]
         public void ConfigWrongNumberOfArguments()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
             var ex = Assert.Throws<RedisServerException>(() => db.Execute("CONFIG"));
             var expectedMessage = string.Format(CmdStrings.GenericErrWrongNumArgs,
@@ -717,7 +717,7 @@ namespace Garnet.test
         [Test]
         public void ConfigGetWrongNumberOfArguments()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
             var ex = Assert.Throws<RedisServerException>(() => db.Execute("CONFIG", "GET"));
             var expectedMessage = Encoding.ASCII.GetBytes(string.Format(CmdStrings.GenericErrWrongNumArgs,

--- a/test/standalone/Garnet.test/RespCommandStatsTests.cs
+++ b/test/standalone/Garnet.test/RespCommandStatsTests.cs
@@ -44,7 +44,7 @@ namespace Garnet.test
             // When CommandStatsMonitor is off, INFO COMMANDSTATS should return a disabled message
             StartServer(commandStatsMonitor: false);
 
-            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             IDatabase db = redis.GetDatabase(0);
 
             db.StringSet("key1", "value1");
@@ -59,7 +59,7 @@ namespace Garnet.test
         {
             StartServer();
 
-            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             IDatabase db = redis.GetDatabase(0);
 
             int setCount = 10;
@@ -92,7 +92,7 @@ namespace Garnet.test
         {
             StartServer();
 
-            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             IDatabase db = redis.GetDatabase(0);
 
             // SETRANGE with a non-integer offset triggers AbortWithErrorMessage,
@@ -121,7 +121,7 @@ namespace Garnet.test
         {
             StartServer();
 
-            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             IDatabase db = redis.GetDatabase(0);
 
             for (int i = 0; i < 100; i++)
@@ -147,7 +147,7 @@ namespace Garnet.test
         {
             StartServer();
 
-            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             IDatabase db = redis.GetDatabase(0);
 
             // Execute various commands
@@ -172,7 +172,7 @@ namespace Garnet.test
             // Use periodic sampling to cover the MetricsSamplingFrequency > 0 aggregation path
             StartServer(metricsSamplingFreq: 1);
 
-            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             IDatabase db = redis.GetDatabase(0);
 
             // Execute 5 successful SETs
@@ -201,7 +201,7 @@ namespace Garnet.test
         {
             StartServer();
 
-            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             IDatabase db = redis.GetDatabase(0);
 
             string infoResult = db.Execute("INFO", "SERVER").ToString();
@@ -214,7 +214,7 @@ namespace Garnet.test
         {
             StartServer();
 
-            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             IDatabase db = redis.GetDatabase(0);
 
             db.StringSet("k", "v");

--- a/test/standalone/Garnet.test/RespConfigTests.cs
+++ b/test/standalone/Garnet.test/RespConfigTests.cs
@@ -72,7 +72,7 @@ namespace Garnet.test
         [TestCase("500m", "1500M", "128GB", "44d")]
         public void ConfigSetMemorySizeTest(string smallerSize, string largerSize, string largerThanBufferSize, string malformedSize)
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
             var option = "memory";
             var metricName = "Log.AllocatedPageCount";
@@ -182,7 +182,7 @@ namespace Garnet.test
         [TestCase("4Mb", "1024mB", "129MB", "0.3gb")]
         public void ConfigSetIndexSizeTest(string smallerSize, string largerSize, string illegalSize, string malformedSize)
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
             var metricType = InfoMetricsType.STORE;
             var option = "index";
@@ -748,7 +748,7 @@ namespace Garnet.test
         [Test]
         public void ConfigGetSetRuntimeOptionsTest()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             static string Get(IDatabase db, string requestName, string expectedEchoName = null)
@@ -864,7 +864,7 @@ namespace Garnet.test
         [Test]
         public void ConfigSetSlowLogThresholdTakesEffectAtRuntime()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             // The server starts with the slow log disabled.
@@ -887,7 +887,7 @@ namespace Garnet.test
         [Test]
         public void ConfigSetRuntimeOptionValidationTest()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             // Out-of-range integer (min is 0).
@@ -919,7 +919,7 @@ namespace Garnet.test
         [Test]
         public void ConfigGetAllAndReadOnlyRejectionTest()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             // CONFIG SET on read-only parameters is rejected.
@@ -956,7 +956,7 @@ namespace Garnet.test
         [Test]
         public void ConfigAofReadOnlyParametersTest()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             string[] readOnly =
@@ -994,7 +994,7 @@ namespace Garnet.test
         [Test]
         public void ConfigAofRuntimeAdjustableParametersTest()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             static string Get(IDatabase db, string name)
@@ -1052,7 +1052,7 @@ namespace Garnet.test
         {
             server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableAOF: true, commitFrequencyMs: 0);
             server.Start();
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             ClassicAssert.AreEqual("0", Get(db, "aof-commit-freq"));
@@ -1076,7 +1076,7 @@ namespace Garnet.test
         {
             server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, enableAOF: true, commitFrequencyMs: 100);
             server.Start();
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             ClassicAssert.AreEqual("100", Get(db, "aof-commit-freq"));
@@ -1105,7 +1105,7 @@ namespace Garnet.test
         {
             server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir, expiredKeyDeletionScanFrequencySecs: -1);
             server.Start();
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             ClassicAssert.AreEqual("-1", Get(db, "expired-key-deletion-scan-freq"));
@@ -1134,7 +1134,7 @@ namespace Garnet.test
         {
             server = TestUtils.CreateGarnetServer(TestUtils.MethodTestDir);
             server.Start();
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             ClassicAssert.AreEqual("0", Get(db, "expired-object-collection-freq"));

--- a/test/standalone/Garnet.test/RespEtagTests.cs
+++ b/test/standalone/Garnet.test/RespEtagTests.cs
@@ -820,7 +820,7 @@ namespace Garnet.test
         [Test]
         public void SetExpiryForEtagSetData()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             string origValue = "abcdefghij";

--- a/test/standalone/Garnet.test/RespInfoTests.cs
+++ b/test/standalone/Garnet.test/RespInfoTests.cs
@@ -37,7 +37,7 @@ namespace Garnet.test
         public void ResetStatsTest(RedisProtocol protocol)
         {
             TimeSpan metricsUpdateDelay = TimeSpan.FromSeconds(1.1);
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol));
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol, allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             var infoResult = db.Execute("INFO").ToString();
@@ -77,7 +77,7 @@ namespace Garnet.test
         [Test]
         public void UptimeIncreasesAcrossInfoCalls()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             static long ParseUptime(string info) =>
@@ -100,7 +100,7 @@ namespace Garnet.test
         [TestCase("EVERYTHING", RedisProtocol.Resp3)]
         public void InfoSectionOptionsTest(string option, RedisProtocol protocol)
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol));
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol, allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             var infoResult = db.Execute("INFO", option).ToString();
@@ -140,7 +140,7 @@ namespace Garnet.test
         [TestCase(RedisProtocol.Resp3)]
         public void InfoDefaultMatchesNoArgsTest(RedisProtocol protocol)
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol));
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol, allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             var infoNoArgs = db.Execute("INFO").ToString();
@@ -157,7 +157,7 @@ namespace Garnet.test
         [Test]
         public void InfoAllWithModulesEqualsEverythingTest()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             var infoEverything = db.Execute("INFO", "EVERYTHING").ToString();
@@ -186,7 +186,7 @@ namespace Garnet.test
         public async Task InfoHlogScanTest()
         {
             var metricsUpdateDelay = TimeSpan.FromSeconds(1.1);
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             // hydrate
@@ -272,7 +272,7 @@ namespace Garnet.test
         [TestCase(RedisProtocol.Resp3)]
         public void InfoKeyspaceEmptyDatabaseTest(RedisProtocol protocol)
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol));
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol, allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             var info = db.Execute("INFO", "KEYSPACE").ToString();
@@ -286,7 +286,7 @@ namespace Garnet.test
         [TestCase(RedisProtocol.Resp3)]
         public void InfoKeyspaceCountsTest(RedisProtocol protocol)
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol));
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol, allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             // 3 string keys (2 with a TTL) + 2 list (object) keys (1 with a TTL) => keys=5, expires=3
@@ -313,7 +313,7 @@ namespace Garnet.test
         [Test]
         public void InfoKeyspaceExpiredKeysNotCountedTest()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             db.StringSet("live", "v");
@@ -346,7 +346,7 @@ namespace Garnet.test
         [Test]
         public void InfoKeyspaceMultiDatabaseTest()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
 
             var db0 = redis.GetDatabase(0);
             var db1 = redis.GetDatabase(1);

--- a/test/standalone/Garnet.test/RespPubSubTests.cs
+++ b/test/standalone/Garnet.test/RespPubSubTests.cs
@@ -177,10 +177,10 @@ namespace Garnet.test
             var db = redis.GetDatabase(0);
             var server = redis.GetServers()[0];
 
-            var multiChannelResult = server.Execute("PUBSUB", ["NUMSUB"]);
+            var multiChannelResult = server.Execute(0, "PUBSUB", ["NUMSUB"]);
             ClassicAssert.AreEqual(0, multiChannelResult.Length);
 
-            multiChannelResult = server.Execute("PUBSUB", ["NUMSUB", "messagesA", "messagesB"]);
+            multiChannelResult = server.Execute(0, "PUBSUB", ["NUMSUB", "messagesA", "messagesB"]);
             ClassicAssert.AreEqual(4, multiChannelResult.Length);
             ClassicAssert.AreEqual("messagesA", multiChannelResult[0].ToString());
             ClassicAssert.AreEqual("0", multiChannelResult[1].ToString());
@@ -193,7 +193,7 @@ namespace Garnet.test
             var result = server.SubscriptionSubscriberCount(RedisChannel.Literal("messagesA"));
             ClassicAssert.AreEqual(1, result);
 
-            multiChannelResult = server.Execute("PUBSUB", ["NUMSUB", "messagesA", "messagesB"]);
+            multiChannelResult = server.Execute(0, "PUBSUB", ["NUMSUB", "messagesA", "messagesB"]);
             ClassicAssert.AreEqual(4, multiChannelResult.Length);
             ClassicAssert.AreEqual("messagesA", multiChannelResult[0].ToString());
             ClassicAssert.AreEqual("1", multiChannelResult[1].ToString());

--- a/test/standalone/Garnet.test/RespScanCommandsTests.cs
+++ b/test/standalone/Garnet.test/RespScanCommandsTests.cs
@@ -50,7 +50,7 @@ namespace Garnet.test
         [Test]
         public void SeKeysTest()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             // add keys in main store
@@ -88,7 +88,7 @@ namespace Garnet.test
         public void SeKeysCursorTest()
         {
             // Test a large number of keys
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             // set 10_000 strings
@@ -116,7 +116,7 @@ namespace Garnet.test
         [Test]
         public void SeKeysNoDuplicatesUnderRcu()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             const int KeyCount = 2_000;
@@ -180,7 +180,7 @@ namespace Garnet.test
         [TestCase(false, Description = "Key is still live when deleted")]
         public void SeKeysDoesNotListDeletedKeyWithSupersededRecord(bool expireBeforeDelete)
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             var key = new RedisKey("del:superseded");
@@ -242,7 +242,7 @@ namespace Garnet.test
         [Test]
         public void SeKeysDoesNotListDeletedObjectKeyWithSupersededRecord()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             var key = new RedisKey("del:objsuperseded");
@@ -336,7 +336,7 @@ namespace Garnet.test
         [Test]
         public void CanUsePatternsInKeysTest()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             //h?llo matches hello, hallo and hxllo
@@ -388,7 +388,7 @@ namespace Garnet.test
         [Test]
         public void SeKeysPatternTest()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
             db.StringSet(new RedisKey("keyone"), new RedisValue("valueone"));
             db.StringSet(new RedisKey("keytwo"), new RedisValue("valuetwo"));
@@ -401,7 +401,7 @@ namespace Garnet.test
         [Test]
         public void SeKeysPatternMatchingTest()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
             db.StringSet(new RedisKey("he**"), new RedisValue("keyvalueone"));
             db.StringSet(new RedisKey(@"he\*\*"), new RedisValue("keyvaluetwo"));
@@ -424,7 +424,7 @@ namespace Garnet.test
         [Test]
         public void SeKeysPatternMatchingTestVerbatim()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
             db.StringSet(new RedisKey("he**"), new RedisValue("keyvalueone"));
             db.StringSet(new RedisKey(@"he**foo"), new RedisValue("keyvaluetwo"));

--- a/test/standalone/Garnet.test/RespSlowLogTests.cs
+++ b/test/standalone/Garnet.test/RespSlowLogTests.cs
@@ -31,7 +31,7 @@ namespace Garnet.test
         [Test]
         public void TestSlowLogHelp()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             var result = (string[])db.Execute("SLOWLOG", "HELP");
@@ -42,7 +42,7 @@ namespace Garnet.test
         [Test]
         public void TestSlowLogGet()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
             var result = db.Execute("SLOWLOG", "GET");
             ClassicAssert.AreEqual(0, ((string[])result).Length);
@@ -51,7 +51,7 @@ namespace Garnet.test
         [Test]
         public void TestSlowLogGetCount()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
             var result = db.Execute("SLOWLOG", "GET", -1);
             ClassicAssert.AreEqual(0, ((string[])result).Length);
@@ -60,7 +60,7 @@ namespace Garnet.test
         [Test]
         public void TestSlowLogGetWithEntry()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
             var result = db.Execute("SLOWLOG", "GET", -1);
             ClassicAssert.AreEqual(0, ((string[])result).Length);
@@ -92,7 +92,7 @@ namespace Garnet.test
         [Test]
         public void TestSlowLogLen()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
             var result = db.Execute("SLOWLOG", "LEN");
             ClassicAssert.AreEqual(0, (int)result);
@@ -101,7 +101,7 @@ namespace Garnet.test
         [Test]
         public void TestSlowLogReset()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
             var result = db.Execute("SLOWLOG", "RESET");
             ClassicAssert.AreEqual("OK", (string)result);

--- a/test/standalone/Garnet.test/RespTests.cs
+++ b/test/standalone/Garnet.test/RespTests.cs
@@ -694,7 +694,7 @@ namespace Garnet.test
         [Test]
         public void SetExpiry()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             string origValue = "abcdefghij";
@@ -2678,7 +2678,7 @@ namespace Garnet.test
         [TestCase("PEXPIRE")]
         public void KeyExpireObjectTest(string command)
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             var key = "keyA";
@@ -4310,7 +4310,7 @@ namespace Garnet.test
         [TestCase(RedisProtocol.Resp3)]
         public void ClientListTest(RedisProtocol protocol)
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol));
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(protocol: protocol, allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             // List everything
@@ -4337,7 +4337,7 @@ namespace Garnet.test
         [Test]
         public void ClientListErrorTest()
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             // Bad option
@@ -4392,7 +4392,7 @@ namespace Garnet.test
         [Test]
         public async Task ClientKillTestAsync()
         {
-            using var mainConnection = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var mainConnection = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var mainDB = mainConnection.GetDatabase(0);
             var mainId = (long)mainDB.Execute("CLIENT", "ID");
 
@@ -4594,7 +4594,7 @@ namespace Garnet.test
         [Test]
         public void ClientKillErrors()
         {
-            using var mainConnection = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var mainConnection = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var mainDB = mainConnection.GetDatabase(0);
 
             // Errors that match Redis behavior
@@ -5399,7 +5399,7 @@ namespace Garnet.test
         [TestCase(20, Description = "Probable unblock failed case")]
         public async Task MultipleClientsUnblockAndAddTest(int numberOfItems)
         {
-            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var redis = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var db = redis.GetDatabase(0);
 
             var key = "blockingList";
@@ -5459,7 +5459,7 @@ namespace Garnet.test
         [TestCase(999999, Description = "Unblock with non-existent client ID")]
         public void ClientUnblockInvalidIdTest(int invalidId)
         {
-            using var mainConnection = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var mainConnection = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var mainDB = mainConnection.GetDatabase(0);
 
             var unblockResult = (int)mainDB.Execute("CLIENT", "UNBLOCK", invalidId);
@@ -5469,7 +5469,7 @@ namespace Garnet.test
         [Test]
         public void ClientUnblockInvalidModeTest()
         {
-            using var mainConnection = ConnectionMultiplexer.Connect(TestUtils.GetConfig());
+            using var mainConnection = ConnectionMultiplexer.Connect(TestUtils.GetConfig(allowAdmin: true));
             var mainDB = mainConnection.GetDatabase(0);
 
             Assert.Throws<RedisServerException>(() => mainDB.Execute("CLIENT", "UNBLOCK", 123, "INVALID"));


### PR DESCRIPTION
Pulling in latest SE.Redis for fixes needed in #2110.

Fixes things flagged by new analyzers, places where a DB must now be explicitly passed, and places where we were assuming RESP2 implicitly (RESP3 is now the default if SE.Redis thinks it's supported).  SE.Redis also validates admin commands for `Execute(Async)`, so admin commands are enabled for more (but not all) tests now.

See https://github.com/StackExchange/StackExchange.Redis/releases/tag/3.0.0 for the "big" changes.