### PR TITLE
Read version 2 cluster endpoints before enabling writers

### DIFF
--- a/libs/cluster/Server/ClusterConfig.cs
+++ b/libs/cluster/Server/ClusterConfig.cs
@@ -42,9 +42,14 @@ namespace Garnet.cluster
 
         /// <summary>
         /// Version of the cluster config serialization format.
-        /// Increment when the binary layout of <see cref="ToByteArray"/>/<see cref="FromByteArray"/> changes.
+        /// Increment when the binary layout of <see cref="ToByteArray(byte)"/>/<see cref="FromByteArray"/> changes.
         /// </summary>
-        public const byte ClusterConfigVersion = 1;
+        public const byte ClusterConfigVersion = 2;
+
+        /// <summary>
+        /// Production write version, retained until all nodes can read version 2.
+        /// </summary>
+        public const byte DefaultClusterConfigVersion = 1;
 
         /// <summary>
         /// 
@@ -104,6 +109,8 @@ namespace Garnet.cluster
         {
             workers[RESERVED_WORKER_ID].Address = "unassigned";
             workers[RESERVED_WORKER_ID].Port = 0;
+            workers[RESERVED_WORKER_ID].ClusterAddress = "unassigned";
+            workers[RESERVED_WORKER_ID].ClusterPort = 0;
             workers[RESERVED_WORKER_ID].Nodeid = null;
             workers[RESERVED_WORKER_ID].ConfigEpoch = 0;
             workers[RESERVED_WORKER_ID].Role = NodeRole.UNASSIGNED;
@@ -142,6 +149,11 @@ namespace Garnet.cluster
             newWorkers[LOCAL_WORKER_ID].ReplicaOfNodeId = replicaOfNodeId;
             newWorkers[LOCAL_WORKER_ID].ReplicationOffset = 0;
             newWorkers[LOCAL_WORKER_ID].hostname = hostname;
+            if (workers[LOCAL_WORKER_ID].Nodeid == null)
+            {
+                newWorkers[LOCAL_WORKER_ID].ClusterAddress = address;
+                newWorkers[LOCAL_WORKER_ID].ClusterPort = port;
+            }
             return new ClusterConfig(slotMap, newWorkers);
         }
 
@@ -1144,6 +1156,8 @@ namespace Garnet.cluster
             // Insert or update worker information
             newWorkers[workerId].Address = worker.Address;
             newWorkers[workerId].Port = worker.Port;
+            newWorkers[workerId].ClusterAddress = worker.ClusterAddress;
+            newWorkers[workerId].ClusterPort = worker.ClusterPort;
             newWorkers[workerId].Nodeid = worker.Nodeid;
             newWorkers[workerId].ConfigEpoch = worker.ConfigEpoch;
             newWorkers[workerId].Role = worker.Role;

--- a/libs/cluster/Server/ClusterConfigSerializer.cs
+++ b/libs/cluster/Server/ClusterConfigSerializer.cs
@@ -26,15 +26,30 @@ namespace Garnet.cluster
         }
 
         /// <summary>
+        /// Check whether a cluster config serialization version can be read.
+        /// </summary>
+        /// <param name="version">Serialization version.</param>
+        public static bool IsSupportedVersion(byte version) => version is 1 or 2;
+
+        /// <summary>
         /// Serialize config to byte array
         /// </summary>
-        public byte[] ToByteArray()
+        public byte[] ToByteArray() => ToByteArray(DefaultClusterConfigVersion);
+
+        /// <summary>
+        /// Serialize config using the specified format version.
+        /// </summary>
+        /// <param name="version">Serialization version.</param>
+        public byte[] ToByteArray(byte version)
         {
+            if (!IsSupportedVersion(version))
+                throw new ArgumentOutOfRangeException(nameof(version), version, "Unsupported ClusterConfig version");
+
             var ms = new MemoryStream();
             var writer = new BinaryWriter(ms);
 
             // Write serialization format version
-            writer.Write(ClusterConfigVersion);
+            writer.Write(version);
 
             SerializeSlotMap(ref ms, ref writer);
 
@@ -69,6 +84,12 @@ namespace Garnet.cluster
                 if (worker.hostname != null)
                     //256 bytes
                     writer.Write(worker.hostname);
+
+                if (version >= 2)
+                {
+                    writer.Write(worker.ClusterAddress);
+                    writer.Write(worker.ClusterPort);
+                }
             }
 
             byte[] byteArray = ms.ToArray();
@@ -133,8 +154,8 @@ namespace Garnet.cluster
             if (other.Length < 1)
                 throw new InvalidDataException("Invalid ClusterConfig payload: too short to contain a version");
             var version = reader.ReadByte();
-            if (version != ClusterConfigVersion)
-                throw new InvalidDataException($"Incompatible ClusterConfig version: expected {ClusterConfigVersion}, got {version}");
+            if (!IsSupportedVersion(version))
+                throw new InvalidDataException($"Incompatible ClusterConfig version: expected 1 or {ClusterConfigVersion}, got {version}");
 
             var newSlotMap = DeserializeSlotMap(ref reader);
 
@@ -157,6 +178,9 @@ namespace Garnet.cluster
                 isNull = reader.ReadByte();
                 if (isNull > 0)
                     newWorkers[i].hostname = reader.ReadString();
+
+                newWorkers[i].ClusterAddress = version >= 2 ? reader.ReadString() : newWorkers[i].Address;
+                newWorkers[i].ClusterPort = version >= 2 ? reader.ReadInt32() : newWorkers[i].Port;
             }
 
             reader.Dispose();

--- a/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
+++ b/libs/cluster/Server/Failover/ReplicaFailoverSession.cs
@@ -213,7 +213,7 @@ namespace Garnet.cluster
                         var returnedConfigArray = resp.Span.ToArray();
 
                         // Validate config version before full deserialization
-                        if (!ClusterConfig.TryPeekVersion(returnedConfigArray, out var version) || version != ClusterConfig.ClusterConfigVersion)
+                        if (!ClusterConfig.TryPeekVersion(returnedConfigArray, out var version) || !ClusterConfig.IsSupportedVersion(version))
                         {
                             logger?.LogWarning("Received failover gossip response with incompatible config version: {version}", version);
                         }

--- a/libs/cluster/Server/Gossip/GarnetServerNode.cs
+++ b/libs/cluster/Server/Gossip/GarnetServerNode.cs
@@ -195,7 +195,7 @@ namespace Garnet.cluster
                     var returnedConfigArray = resp.Span.ToArray();
 
                     // Validate config version before full deserialization
-                    if (!ClusterConfig.TryPeekVersion(returnedConfigArray, out var version) || version != ClusterConfig.ClusterConfigVersion)
+                    if (!ClusterConfig.TryPeekVersion(returnedConfigArray, out var version) || !ClusterConfig.IsSupportedVersion(version))
                     {
                         logger?.LogWarning("Received gossip response with incompatible config version: {version}", version);
                         return;

--- a/libs/cluster/Server/Gossip/Gossip.cs
+++ b/libs/cluster/Server/Gossip/Gossip.cs
@@ -194,7 +194,7 @@ namespace Garnet.cluster
                     var respArray = resp.Span.ToArray();
 
                     // Validate config version before full deserialization
-                    if (!ClusterConfig.TryPeekVersion(respArray, out var version) || version != ClusterConfig.ClusterConfigVersion)
+                    if (!ClusterConfig.TryPeekVersion(respArray, out var version) || !ClusterConfig.IsSupportedVersion(version))
                     {
                         logger?.LogWarning("MEET response has incompatible config version: {version}", version);
                         if (created) gsn?.Dispose();

--- a/libs/cluster/Server/Worker.cs
+++ b/libs/cluster/Server/Worker.cs
@@ -35,14 +35,24 @@ namespace Garnet.cluster
         public string Nodeid;
 
         /// <summary>
-        /// IP address
+        /// Client IP address
         /// </summary>
         public string Address;
 
         /// <summary>
-        /// Port
+        /// Client port
         /// </summary>
         public int Port;
+
+        /// <summary>
+        /// Cluster IP address stored in version 2 configs; not yet used for routing.
+        /// </summary>
+        public string ClusterAddress;
+
+        /// <summary>
+        /// Cluster port stored in version 2 configs; not yet used for routing.
+        /// </summary>
+        public int ClusterPort;
 
         /// <summary>
         /// Configuration epoch.

--- a/libs/cluster/Session/RespClusterBasicCommands.cs
+++ b/libs/cluster/Session/RespClusterBasicCommands.cs
@@ -387,7 +387,7 @@ namespace Garnet.cluster
             if (gossipMessage.Length > 0)
             {
                 // Validate config version before full deserialization
-                if (!ClusterConfig.TryPeekVersion(gossipMessage, out var version) || version != ClusterConfig.ClusterConfigVersion)
+                if (!ClusterConfig.TryPeekVersion(gossipMessage, out var version) || !ClusterConfig.IsSupportedVersion(version))
                 {
                     logger?.LogWarning("Received gossip with incompatible config version: {version}", version);
                 }

--- a/test/cluster/Garnet.test.cluster/ClusterConfigTests.cs
+++ b/test/cluster/Garnet.test.cluster/ClusterConfigTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -173,11 +175,229 @@ namespace Garnet.test.cluster
 
             // Verify version byte at start of payload
             Assert.That(ClusterConfig.TryPeekVersion(configBytes, out var version), Is.True);
-            Assert.That(version, Is.EqualTo(ClusterConfig.ClusterConfigVersion));
+            Assert.That(version, Is.EqualTo(1));
 
             // Round-trip should succeed
             var restored = ClusterConfig.FromByteArray(configBytes);
             Assert.That(restored.LocalNodeId, Is.EqualTo(config.LocalNodeId));
+        }
+
+        [TestCase(1)]
+        [TestCase(2)]
+        [Category("CLUSTER-CONFIG")]
+        public void ClusterConfigWorkerFormatTest(byte version)
+        {
+            var workers = CreateFormatWorkers();
+            var expected = SerializeFormatFixture(version, workers);
+            var config = new ClusterConfig(new HashSlot[ClusterConfig.MAX_HASH_SLOT_VALUE], workers);
+
+            Assert.That(config.ToByteArray(version), Is.EqualTo(expected));
+            Assert.That(config.ToByteArray(), Is.EqualTo(SerializeFormatFixture(1, workers)));
+
+            var restored = ClusterConfig.FromByteArray(expected);
+            if (version == 1)
+            {
+                for (var i = 1; i < workers.Length; i++)
+                {
+                    workers[i].ClusterAddress = workers[i].Address;
+                    workers[i].ClusterPort = workers[i].Port;
+                }
+            }
+
+            Assert.That(restored.ToByteArray(2), Is.EqualTo(SerializeFormatFixture(2, workers)));
+            Assert.That(restored.Copy().ToByteArray(2), Is.EqualTo(restored.ToByteArray(2)));
+            Assert.That(restored.ToByteArray(), Is.EqualTo(SerializeFormatFixture(1, workers)));
+
+            var initialized = restored.InitializeLocalWorker(workers[1].Nodeid, workers[1].Address,
+                workers[1].Port, workers[1].ConfigEpoch, workers[1].Role, null, workers[1].hostname);
+            workers[1].ReplicationOffset = 0;
+            Assert.That(initialized.ToByteArray(2), Is.EqualTo(SerializeFormatFixture(2, workers)));
+        }
+
+        [Test]
+        [Category("CLUSTER-CONFIG")]
+        public void ClusterConfigClusterFieldsDoNotChangeRoutingTest()
+        {
+            var config = ClusterConfig.FromByteArray(SerializeFormatFixture(2, CreateFormatWorkers()));
+            config = config.AssignSlots([0], ClusterConfig.LOCAL_WORKER_ID, SlotState.STABLE);
+
+            Assert.That(config.GetWorkerAddress(1), Is.EqualTo(("203.0.113.1", 17001)));
+            Assert.That(config.GetEndpointFromSlot(0, Garnet.server.ClusterPreferredEndpointType.Ip), Is.EqualTo(("203.0.113.1", 17001)));
+            Assert.That(config.AskEndpointFromSlot(0, Garnet.server.ClusterPreferredEndpointType.Ip), Is.EqualTo(("203.0.113.1", 17001)));
+            Assert.That(config.GetEndpointFromSlot(0, Garnet.server.ClusterPreferredEndpointType.Hostname), Is.EqualTo(("node.example.com", 17001)));
+            Assert.That(config.GetReplicaEndpoints(config.LocalNodeId).Single(), Is.EqualTo(("203.0.113.2", 17002)));
+            Assert.That(config.GetWorkerInfoForGossip().Single(), Is.EqualTo((new string('b', 40), "203.0.113.2", 17002)));
+            Assert.That(config.GetClusterInfo(null), Does.Contain("203.0.113.1:17001@27001,node.example.com"));
+        }
+
+        [Test]
+        [Category("CLUSTER-CONFIG")]
+        public void ClusterConfigMergePreservesClusterFieldsTest()
+        {
+            var workers = CreateFormatWorkers();
+            var receiver = new ClusterConfig().InitializeLocalWorker(workers[1].Nodeid, workers[1].Address,
+                workers[1].Port, workers[1].ConfigEpoch, workers[1].Role, null, workers[1].hostname);
+            var senderWorkers = new Worker[] { default, workers[2] };
+            var sender = ClusterConfig.FromByteArray(SerializeFormatFixture(2, senderWorkers));
+
+            receiver = receiver.Merge(sender, []);
+            workers[1].ClusterAddress = workers[1].Address;
+            workers[1].ClusterPort = workers[1].Port;
+            workers[1].ReplicationOffset = 0;
+            workers[2].ReplicationOffset = 0;
+            Assert.That(receiver.ToByteArray(2), Is.EqualTo(SerializeFormatFixture(2, workers)));
+
+            workers[2].ConfigEpoch++;
+            workers[2].ClusterAddress = "127.0.0.3";
+            workers[2].ClusterPort = 7003;
+            senderWorkers[1] = workers[2];
+            sender = ClusterConfig.FromByteArray(SerializeFormatFixture(2, senderWorkers));
+            receiver = receiver.Merge(sender, []);
+            Assert.That(receiver.ToByteArray(2), Is.EqualTo(SerializeFormatFixture(2, workers)));
+        }
+
+        [TestCase(0)]
+        [TestCase(3)]
+        [TestCase(255)]
+        [Category("CLUSTER-CONFIG")]
+        public void ClusterConfigUnsupportedVersionTest(byte version)
+        {
+            var config = new ClusterConfig();
+            Assert.That(ClusterConfig.IsSupportedVersion(version), Is.False);
+            Assert.Throws<ArgumentOutOfRangeException>(() => config.ToByteArray(version));
+            Assert.Throws<InvalidDataException>(() => ClusterConfig.FromByteArray([version]));
+        }
+
+        [Test]
+        [Category("CLUSTER-CONFIG")]
+        public void ClusterConfigTruncatedVersion2WorkerTest()
+        {
+            var bytes = SerializeFormatFixture(2, CreateFormatWorkers());
+            Assert.Throws<EndOfStreamException>(() => ClusterConfig.FromByteArray(bytes[..^1]));
+        }
+
+        [TestCase(1, true)]
+        [TestCase(2, true)]
+        [TestCase(0, false)]
+        [TestCase(3, false)]
+        [TestCase(255, false)]
+        [Category("CLUSTER-CONFIG")]
+        public void ClusterConfigGossipVersionTest(byte version, bool supported)
+        {
+            context.CreateInstances(1);
+            context.CreateConnection();
+            var workers = CreateFormatWorkers();
+            var server = context.clusterTestUtils.GetServer(context.endpoints[0].ToIPEndPoint());
+            var response = (byte[])server.Execute("CLUSTER", "GOSSIP", "WITHMEET", SerializeFormatFixture(version, workers));
+
+            Assert.That(ClusterConfig.IsSupportedVersion(version), Is.EqualTo(supported));
+            Assert.That(response[0], Is.EqualTo(1));
+            var nodes = context.clusterTestUtils.ClusterNodes(0);
+            Assert.That(nodes.Nodes.Any(node => node.NodeId == workers[1].Nodeid), Is.EqualTo(supported));
+        }
+
+        [TestCase(1)]
+        [TestCase(2)]
+        [Category("CLUSTER-CONFIG")]
+        public void ClusterConfigDiskVersionTest(byte version)
+        {
+            context.CreateInstances(1);
+            context.CreateConnection();
+            var nodeId = context.clusterTestUtils.ClusterNodes(0).Nodes.Single(node => node.IsMyself).NodeId;
+            context.nodes[0].Dispose(false);
+            context.nodes[0] = null;
+
+            var workers = CreateFormatWorkers();
+            workers[1].Nodeid = nodeId;
+            workers[1].Address = "127.0.0.1";
+            workers[1].Port = ClusterTestContext.Port;
+            var bytes = SerializeFormatFixture(version, [default, workers[1]]);
+            var configPath = Directory.GetFiles(context.TestFolder, "nodes.conf*", SearchOption.AllDirectories).Single();
+            using (var stream = new FileStream(configPath, FileMode.Open, FileAccess.Write))
+            using (var writer = new BinaryWriter(stream))
+            {
+                writer.Write(bytes.Length);
+                writer.Write(bytes);
+            }
+
+            context.nodes[0] = context.CreateInstance(context.clusterTestUtils.GetEndPoint(0), cleanClusterConfig: false);
+            context.nodes[0].Start();
+            context.CreateConnection();
+            Assert.That(context.clusterTestUtils.ClusterNodes(0).Nodes.Single(node => node.IsMyself).NodeId, Is.EqualTo(nodeId));
+
+            var server = context.clusterTestUtils.GetServer(context.endpoints[0].ToIPEndPoint());
+            var response = (byte[])server.Execute("CLUSTER", "GOSSIP", Array.Empty<byte>());
+            Assert.That(response[0], Is.EqualTo(1));
+            Assert.That(server.Execute("CLUSTER", "BUMPEPOCH").ToString(), Is.EqualTo("OK"));
+            context.nodes[0].Dispose(false);
+            context.nodes[0] = null;
+            Assert.That(File.ReadAllBytes(configPath)[sizeof(int)], Is.EqualTo(1));
+        }
+
+        private static Worker[] CreateFormatWorkers()
+        {
+            var primaryId = new string('a', 40);
+            return
+            [
+                default,
+                new Worker
+                {
+                    Nodeid = primaryId,
+                    Address = "203.0.113.1",
+                    Port = 17001,
+                    ClusterAddress = "127.0.0.1",
+                    ClusterPort = 7001,
+                    ConfigEpoch = 1,
+                    Role = Garnet.cluster.NodeRole.PRIMARY,
+                    ReplicationOffset = 100,
+                    hostname = "node.example.com"
+                },
+                new Worker
+                {
+                    Nodeid = new string('b', 40),
+                    Address = "203.0.113.2",
+                    Port = 17002,
+                    ClusterAddress = "127.0.0.2",
+                    ClusterPort = 7002,
+                    ConfigEpoch = 2,
+                    Role = Garnet.cluster.NodeRole.REPLICA,
+                    ReplicaOfNodeId = primaryId,
+                    ReplicationOffset = 90
+                }
+            ];
+        }
+
+        private static byte[] SerializeFormatFixture(byte version, Worker[] workers)
+        {
+            using var stream = new MemoryStream();
+            using var writer = new BinaryWriter(stream);
+            writer.Write(version);
+            writer.Write((ushort)1);
+            writer.Write((ushort)ClusterConfig.MAX_HASH_SLOT_VALUE);
+            writer.Write((ushort)0);
+            writer.Write((byte)SlotState.OFFLINE);
+            writer.Write(workers.Length);
+            foreach (var worker in workers.Skip(1))
+            {
+                writer.Write(worker.Nodeid);
+                writer.Write(worker.Address);
+                writer.Write(worker.Port);
+                writer.Write(worker.ConfigEpoch);
+                writer.Write((byte)worker.Role);
+                writer.Write(worker.ReplicaOfNodeId != null);
+                if (worker.ReplicaOfNodeId != null)
+                    writer.Write(worker.ReplicaOfNodeId);
+                writer.Write(worker.ReplicationOffset);
+                writer.Write(worker.hostname != null);
+                if (worker.hostname != null)
+                    writer.Write(worker.hostname);
+                if (version == 2)
+                {
+                    writer.Write(worker.ClusterAddress);
+                    writer.Write(worker.ClusterPort);
+                }
+            }
+            return stream.ToArray();
         }
 
         [Test, Order(5)]

--- a/website/docs/cluster/overview.md
+++ b/website/docs/cluster/overview.md
@@ -50,6 +50,16 @@ in the cluster.
 
 For more information about the cluster configuration please see the description of *CLUSTER NODES* command.
 
+### Cluster Configuration Format
+
+Garnet reads cluster configuration versions 1 and 2 from disk and gossip. Version 2 stores
+`ClusterAddress` and `ClusterPort` in each worker record, alongside the existing client-facing
+`Address` and `Port`. Version 1 reads initialize the cluster fields from `Address` and `Port`.
+
+Production persistence and gossip still write version 1, and routing behavior is unchanged.
+Writing version 2 and using separate cluster endpoints require a follow-up change after all
+nodes support reading version 2.
+
 ## Control Plane
 
 It is important to keep in mind that Garnet's cluster mode design is currently _passive_: this means that it does not implement leader election, and simply responds to cluster 


### PR DESCRIPTION
## Why

Support deployments where clients reach cluster nodes through a load balancer using different addresses or ports from those used for node-to-node communication. Each advertised client endpoint must route to its corresponding node, while gossip, replication, and migration continue using directly reachable peer endpoints.

This change prepares readers for that separation so existing clusters can upgrade before a follow-up starts writing and using the new endpoint fields.

## What

- Add version 2 cluster configuration support with `ClusterAddress` and `ClusterPort` alongside the existing address and port fields.
- Accept both versions during recovery and cluster communication. Version 1 configurations initialize the new fields from the existing endpoint.
- Continue writing version 1 and retain existing routing behavior. This change does not enable separate endpoints or configure a load balancer.

## Validation

- 81 cluster configuration and management tests passed on .NET 10.
- Cross-version serialization, persisted configuration recovery, and mixed-version cluster communication were exercised against Garnet v2.1.7 and upstream `main`.
- [Garnet .NET CI](https://github.com/microsoft/garnet/actions/runs/34644233024) completed with two Windows vector-set test failures: `VectorSetMigrateManyBySlot` and `MigrateVectorStressAsync`.

Assisted-By: GitHub Copilot
